### PR TITLE
Fix disabled tslint no-shadowed-variable

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,6 @@
     "object-literal-sort-keys": false,
     "curly": false,
     "no-unused-expression": false,
-    "no-shadowed-variable": false,
     "interface-over-type-literal": false,
     "variable-name": false,
     "no-empty": false,


### PR DESCRIPTION
This should fix #615

Enabling/Removing this rule entirely from the `tslint.json` file _did not_ result in any violations. Looks like it wasn't necessary.

```shell
yarn run tslint 'src/**/*.ts'

# No errors!
```

I went ahead and removed it. 