### PR TITLE
Keep sidebar & popover counts synced with management actions in Team Inbox

### DIFF
--- a/src/modules/inbox/components/assignBox/AssignBox.tsx
+++ b/src/modules/inbox/components/assignBox/AssignBox.tsx
@@ -104,13 +104,17 @@ class AssignBox extends React.Component<Props, State> {
   };
 
   removeAssignee = () => {
-    const { clear, targets } = this.props;
+    const { clear, targets, afterSave } = this.props;
 
     clear(targets.map(t => t._id), error => {
       if (error) {
         Alert.error(`Error: ${error.message}`);
       }
     });
+
+    if (afterSave) {
+      afterSave();
+    }
   };
 
   render() {

--- a/src/modules/inbox/components/assignBox/AssignBoxPopover.tsx
+++ b/src/modules/inbox/components/assignBox/AssignBoxPopover.tsx
@@ -2,6 +2,7 @@ import { __ } from 'modules/common/utils';
 import AssignBox from 'modules/inbox/containers/AssignBox';
 import React from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { InboxManagementActionConsumer } from '../../containers/Inbox';
 import { IConversation } from '../../types';
 
 type Props = {
@@ -9,16 +10,21 @@ type Props = {
   trigger: React.ReactNode;
   container?: React.ReactNode;
   afterSave?: () => void;
+  notifyHandler: () => void;
 };
 
 class AssignBoxPopover extends React.Component<Props> {
   private overlayTrigger;
 
   hidePopover = () => {
-    const { afterSave } = this.props;
+    const { afterSave, notifyHandler } = this.props;
 
     if (afterSave) {
       afterSave();
+    }
+
+    if (notifyHandler) {
+      notifyHandler();
     }
 
     this.overlayTrigger.hide();
@@ -53,4 +59,13 @@ class AssignBoxPopover extends React.Component<Props> {
   }
 }
 
-export default AssignBoxPopover;
+export default props => (
+  <InboxManagementActionConsumer>
+    {({ notifyConsumersOfManagementAction }) => (
+      <AssignBoxPopover
+        {...props}
+        notifyHandler={notifyConsumersOfManagementAction}
+      />
+    )}
+  </InboxManagementActionConsumer>
+);

--- a/src/modules/inbox/components/leftSidebar/Sidebar.tsx
+++ b/src/modules/inbox/components/leftSidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import { TAG_TYPES } from 'modules/tags/constants';
 import React from 'react';
 import RTG from 'react-transition-group';
 import { InboxManagementActionConsumer } from '../../containers/Inbox';
+import { StatusFilterPopover } from '../../containers/leftSidebar';
 import { IConversation } from '../../types';
 import {
   AdditionalSidebar,

--- a/src/modules/inbox/components/leftSidebar/Sidebar.tsx
+++ b/src/modules/inbox/components/leftSidebar/Sidebar.tsx
@@ -12,8 +12,8 @@ import Sidebar from 'modules/layout/components/Sidebar';
 import { TAG_TYPES } from 'modules/tags/constants';
 import React from 'react';
 import RTG from 'react-transition-group';
+import { InboxManagementActionConsumer } from '../../containers/Inbox';
 import { IConversation } from '../../types';
-import StatusFilterPopover from './StatusFilterPopover';
 import {
   AdditionalSidebar,
   DropdownWrapper,
@@ -129,7 +129,7 @@ class LeftSidebar extends React.Component<Props, State> {
     return <SidebarActions>{this.renderSidebarActions()}</SidebarActions>;
   }
 
-  renderAdditionalSidebar() {
+  renderAdditionalSidebar(refetchRequired: string) {
     const { integrations, queryParams } = this.props;
 
     return (
@@ -150,6 +150,7 @@ class LeftSidebar extends React.Component<Props, State> {
               counts="byChannels"
               paramKey="channelId"
               queryParams={queryParams}
+              refetchRequired={refetchRequired}
             />
           </FilterToggler>
 
@@ -159,6 +160,7 @@ class LeftSidebar extends React.Component<Props, State> {
               counts="byBrands"
               queryParams={queryParams}
               paramKey="brandId"
+              refetchRequired={refetchRequired}
             />
           </FilterToggler>
 
@@ -168,6 +170,7 @@ class LeftSidebar extends React.Component<Props, State> {
               queryParams={queryParams}
               counts="byIntegrationTypes"
               paramKey="integrationType"
+              refetchRequired={refetchRequired}
             />
           </FilterToggler>
 
@@ -184,6 +187,7 @@ class LeftSidebar extends React.Component<Props, State> {
               counts="byTags"
               paramKey="tag"
               icon="tag"
+              refetchRequired={refetchRequired}
             />
           </FilterToggler>
         </div>
@@ -203,7 +207,13 @@ class LeftSidebar extends React.Component<Props, State> {
 
     return (
       <LeftContent isOpen={this.state.isOpen}>
-        <AdditionalSidebar>{this.renderAdditionalSidebar()}</AdditionalSidebar>
+        <InboxManagementActionConsumer>
+          {({ refetchRequired }) => (
+            <AdditionalSidebar>
+              {this.renderAdditionalSidebar(refetchRequired)}
+            </AdditionalSidebar>
+          )}
+        </InboxManagementActionConsumer>
         <Sidebar wide={true} full={true} header={this.renderSidebarHeader()}>
           <ConversationList
             currentUser={currentUser}

--- a/src/modules/inbox/containers/Inbox.tsx
+++ b/src/modules/inbox/containers/Inbox.tsx
@@ -22,6 +22,44 @@ interface IProps extends IRouteProps {
   loading: boolean;
 }
 
+interface IInboxRefetchController {
+  notifyConsumersOfManagementAction: () => void;
+  refetchRequired: string;
+}
+
+const InboxManagementActionContext = React.createContext(
+  {} as IInboxRefetchController
+);
+
+export const InboxManagementActionConsumer =
+  InboxManagementActionContext.Consumer;
+
+class WithRefetchHandling extends React.Component<
+  any,
+  IInboxRefetchController
+> {
+  constructor(props) {
+    super(props);
+
+    const notifHandler = () => {
+      this.setState({ refetchRequired: new Date().toISOString() });
+    };
+
+    this.state = {
+      notifyConsumersOfManagementAction: notifHandler,
+      refetchRequired: ''
+    };
+  }
+
+  public render() {
+    return (
+      <InboxManagementActionContext.Provider value={this.state}>
+        {this.props.children}
+      </InboxManagementActionContext.Provider>
+    );
+  }
+}
+
 class WithCurrentId extends React.Component<IProps> {
   componentWillReceiveProps(nextProps: IProps) {
     const { conversationsGetLast, loading, history, queryParams } = nextProps;
@@ -50,11 +88,13 @@ class WithCurrentId extends React.Component<IProps> {
           }
 
           return (
-            <Inbox
-              queryParams={queryParams}
-              currentConversationId={_id}
-              currentUser={currentUser}
-            />
+            <WithRefetchHandling>
+              <Inbox
+                queryParams={queryParams}
+                currentConversationId={_id}
+                currentUser={currentUser}
+              />
+            </WithRefetchHandling>
           );
         }}
       </AppConsumer>

--- a/src/modules/inbox/containers/Resolver.tsx
+++ b/src/modules/inbox/containers/Resolver.tsx
@@ -11,6 +11,7 @@ import {
   IConversation
 } from '../types';
 import { refetchSidebarConversationsOptions } from '../utils';
+import { InboxManagementActionConsumer } from './Inbox';
 
 type Props = {
   conversations: IConversation[];
@@ -23,9 +24,11 @@ const ResolverContainer = (props: FinalProps) => {
   const { changeStatusMutation, emptyBulk } = props;
 
   // change conversation status
-  const changeStatus = (conversationIds: string[], status) => {
+  const changeStatus = notifyHandler => (conversationIds: string[], status) => {
     changeStatusMutation({ variables: { _ids: conversationIds, status } })
       .then(() => {
+        notifyHandler();
+
         if (status === CONVERSATION_STATUSES.CLOSED) {
           Alert.success('The conversation has been resolved!');
 
@@ -49,11 +52,19 @@ const ResolverContainer = (props: FinalProps) => {
   };
 
   const updatedProps = {
-    ...props,
-    changeStatus
+    ...props
   };
 
-  return <Resolver {...updatedProps} />;
+  return (
+    <InboxManagementActionConsumer>
+      {({ notifyConsumersOfManagementAction }) => (
+        <Resolver
+          {...updatedProps}
+          changeStatus={changeStatus(notifyConsumersOfManagementAction)}
+        />
+      )}
+    </InboxManagementActionConsumer>
+  );
 };
 
 export default withProps<Props>(

--- a/src/modules/inbox/containers/Tagger.tsx
+++ b/src/modules/inbox/containers/Tagger.tsx
@@ -1,16 +1,22 @@
 import TaggerPopover from 'modules/tags/components/TaggerPopover';
 import React from 'react';
 import { refetchSidebarConversationsOptions } from '../utils';
+import { InboxManagementActionConsumer } from './Inbox';
 
 const Tagger = props => {
   const { refetchQueries } = refetchSidebarConversationsOptions();
 
   return (
-    <TaggerPopover
-      {...props}
-      type="conversation"
-      refetchQueries={refetchQueries}
-    />
+    <InboxManagementActionConsumer>
+      {({ notifyConsumersOfManagementAction }) => (
+        <TaggerPopover
+          {...props}
+          type="conversation"
+          refetchQueries={refetchQueries}
+          successCallback={notifyConsumersOfManagementAction}
+        />
+      )}
+    </InboxManagementActionConsumer>
   );
 };
 

--- a/src/modules/inbox/containers/leftSidebar/StatusFilterPopover.tsx
+++ b/src/modules/inbox/containers/leftSidebar/StatusFilterPopover.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { StatusFilterPopover } from '../../components/leftSidebar';
+import { InboxManagementActionConsumer } from '../Inbox';
+
+type Props = {
+  history: any;
+  queryParams: any;
+};
+
+const StatusFilterPopoverContainer = (props: Props) => {
+  return (
+    <InboxManagementActionConsumer>
+      {({ refetchRequired }) => (
+        <StatusFilterPopover {...props} refetchRequired={refetchRequired} />
+      )}
+    </InboxManagementActionConsumer>
+  );
+};
+
+export default StatusFilterPopoverContainer;

--- a/src/modules/inbox/containers/leftSidebar/index.ts
+++ b/src/modules/inbox/containers/leftSidebar/index.ts
@@ -3,11 +3,13 @@ import ConversationList from './ConversationList';
 import FilterList from './FilterList';
 import FilterToggler from './FilterToggler';
 import Sidebar from './Sidebar';
+import StatusFilterPopover from './StatusFilterPopover';
 
 export {
   FilterList,
   FilterToggler,
   Sidebar,
+  StatusFilterPopover,
   ConversationList,
   ConversationItem
 };


### PR DESCRIPTION
The additional sidebar, status popover, and any other components in the Inbox that show summary data like total conversation count are not up to date with management actions like resolving a conversation or tagging a conversation taken by the logged in user.

This adds a context that any interested component in the Inbox tree can use to either notify other components across the tree that a management action has been performed locally, or to receive such a notification and re-fetch its own data accordingly.

![inbox-management](https://user-images.githubusercontent.com/5217060/62065490-61786d00-b22f-11e9-9fe8-de243db60b69.gif)