### PR TITLE
disable caching on `unreadConversationsCountQuery`

### DIFF
--- a/src/modules/layout/containers/Navigation.tsx
+++ b/src/modules/layout/containers/Navigation.tsx
@@ -48,6 +48,7 @@ export default withProps<{ currentUser: IUser }>(
       {
         name: 'unreadConversationsCountQuery',
         options: () => ({
+          fetchPolicy: 'network-only',
           notifyOnNetworkStatusChange: true
         })
       }


### PR DESCRIPTION
This query has no parameters which can change to override cache
but its backing data changes all the time as new conversations are
created by clients so the default settings mean that a logged in user who
is browsing another filter (eg: Resolved conversations) will not see that
new conversations are pending until they return to the default view.