### PR TITLE
Fix notification widget and notification popover being out of sync.

### DIFF
--- a/src/modules/layout/components/QuickNavigation.tsx
+++ b/src/modules/layout/components/QuickNavigation.tsx
@@ -128,7 +128,7 @@ const QuickNavigation = ({
       </Tip>
 
       <NavItem>
-        <Widget currentUser={currentUser} />
+        <Widget />
       </NavItem>
       <NavItem>
         <Link to="/settings">

--- a/src/modules/notifications/components/Widget.tsx
+++ b/src/modules/notifications/components/Widget.tsx
@@ -1,15 +1,17 @@
-import { IUser } from 'modules/auth/types';
 import Icon from 'modules/common/components/Icon';
 import Label from 'modules/common/components/Label';
 import { __ } from 'modules/common/utils';
 import React from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import NotificationsLatest from '../containers/NotificationsLatest';
+import { INotification } from '../types';
 import { NotifButton, PopoverHeader } from './styles';
 
 type Props = {
-  currentUser: IUser;
   unreadCount: number;
+  notifications: INotification[];
+  markAsRead: () => void;
+  isLoading: boolean;
 };
 
 type State = {
@@ -17,11 +19,6 @@ type State = {
 };
 
 class Widget extends React.Component<Props, State> {
-  update = () => {
-    // rerender component
-    this.forceUpdate();
-  };
-
   renderUnreadCount() {
     const { unreadCount } = this.props;
 
@@ -37,12 +34,13 @@ class Widget extends React.Component<Props, State> {
   }
 
   render() {
-    const { currentUser } = this.props;
+    const { notifications, markAsRead, isLoading } = this.props;
 
+    const popoverProps = { notifications, markAsRead, isLoading };
     const popoverNotification = (
       <Popover id="npopover" className="notification-popover">
         <PopoverHeader>{__('Notifications')}</PopoverHeader>
-        <NotificationsLatest currentUser={currentUser} update={this.update} />
+        <NotificationsLatest {...popoverProps} />
       </Popover>
     );
 

--- a/src/modules/notifications/containers/NotificationsLatest.tsx
+++ b/src/modules/notifications/containers/NotificationsLatest.tsx
@@ -1,108 +1,51 @@
 import gql from 'graphql-tag';
-import { IUser } from 'modules/auth/types';
 import Spinner from 'modules/common/components/Spinner';
-import {
-  Alert,
-  sendDesktopNotification,
-  withProps
-} from 'modules/common/utils';
+import { Alert, withProps } from 'modules/common/utils';
 import React from 'react';
 import { compose, graphql } from 'react-apollo';
-import strip from 'strip';
 import NotificationsLatest from '../components/NotificationsLatest';
-import { mutations, queries, subscriptions } from '../graphql';
-import {
-  MarkAsReadMutationResponse,
-  NotificationsQueryResponse
-} from '../types';
+import { mutations } from '../graphql';
+import { INotification, MarkAsReadMutationResponse } from '../types';
 
 type Props = {
-  update?: () => void;
-  currentUser: IUser;
+  notifications: INotification[];
+  markAsRead: () => void;
+  isLoading: boolean;
 };
 
-type FinalProps = {
-  notificationsQuery: NotificationsQueryResponse;
-} & Props &
-  MarkAsReadMutationResponse;
+type FinalProps = Props & MarkAsReadMutationResponse;
 
-const subscription = gql(subscriptions.notificationSubscription);
+const NotificationsLatestContainer = (props: FinalProps) => {
+  const { markAsRead, isLoading, notificationsMarkAsReadMutation } = props;
 
-class NotificationsLatestContainer extends React.Component<FinalProps> {
-  componentWillMount() {
-    const { notificationsQuery, currentUser } = this.props;
-
-    notificationsQuery.subscribeToMore({
-      document: subscription,
-      variables: { userId: currentUser ? currentUser._id : null },
-      updateQuery: (prev, { subscriptionData: { data } }) => {
-        const { notificationInserted } = data;
-        const { title, content } = notificationInserted;
-
-        sendDesktopNotification({ title, content: strip(content || '') });
-
-        notificationsQuery.refetch();
-      }
-    });
+  if (isLoading) {
+    return <Spinner objective={true} />;
   }
 
-  render() {
-    const {
-      notificationsQuery,
-      notificationsMarkAsReadMutation,
-      update
-    } = this.props;
+  const getMutator = contextHandler => notificationIds => {
+    notificationsMarkAsReadMutation({ variables: { _ids: notificationIds } })
+      .then(() => {
+        contextHandler();
+        Alert.success('Notification have been seen');
+      })
+      .catch(error => {
+        Alert.error(error.message);
+      });
+  };
 
-    if (notificationsQuery.loading) {
-      return <Spinner objective={true} />;
-    }
+  const updatedProps = {
+    ...props,
+    markAsRead: getMutator(markAsRead)
+  };
 
-    const markAsRead = notificationIds => {
-      notificationsMarkAsReadMutation({ variables: { _ids: notificationIds } })
-        .then(() => {
-          notificationsQuery.refetch();
-          Alert.success('Notification have been seen');
-        })
-        .catch(error => {
-          Alert.error(error.message);
-        });
-    };
-
-    const updatedProps = {
-      ...this.props,
-
-      markAsRead,
-      update,
-      notifications: notificationsQuery.notifications || []
-    };
-
-    return <NotificationsLatest {...updatedProps} />;
-  }
-}
+  return <NotificationsLatest {...updatedProps} />;
+};
 
 export default withProps<Props>(
   compose(
     graphql<Props, MarkAsReadMutationResponse, { _ids: string[] }>(
       gql(mutations.markAsRead),
-      {
-        name: 'notificationsMarkAsReadMutation',
-        options: {
-          refetchQueries: () => ['notificationCounts']
-        }
-      }
-    ),
-    graphql<
-      Props,
-      NotificationsQueryResponse,
-      { limit: number; requireRead: boolean }
-    >(gql(queries.notifications), {
-      name: 'notificationsQuery',
-      options: () => ({
-        variables: {
-          limit: 10,
-          requireRead: false
-        }
-      })
-    })
+      { name: 'notificationsMarkAsReadMutation' }
+    )
   )(NotificationsLatestContainer)
 );

--- a/src/modules/notifications/containers/Widget.tsx
+++ b/src/modules/notifications/containers/Widget.tsx
@@ -1,63 +1,19 @@
-import gql from 'graphql-tag';
-import { IUser } from 'modules/auth/types';
-import { IRouterProps } from 'modules/common/types';
 import React from 'react';
-import { compose, graphql } from 'react-apollo';
-import { withRouter } from 'react-router';
-import { withProps } from '../../common/utils';
 import Widget from '../components/Widget';
-import { queries, subscriptions } from '../graphql';
-import { NotificationsCountQueryResponse } from '../types';
+import { NotifConsumer } from '../context';
 
-type Props = {
-  currentUser: IUser;
-};
-
-type FinalProps = {
-  notificationCountQuery: NotificationsCountQueryResponse;
-} & IRouterProps &
-  Props;
-
-const subscription = gql(subscriptions.notificationSubscription);
-
-class WidgetContainer extends React.Component<FinalProps> {
-  componentWillMount() {
-    const { notificationCountQuery, currentUser } = this.props;
-
-    notificationCountQuery.subscribeToMore({
-      document: subscription,
-      variables: { userId: currentUser ? currentUser._id : null },
-      updateQuery: () => {
-        notificationCountQuery.refetch();
-      }
-    });
-  }
-
-  render() {
-    const { notificationCountQuery } = this.props;
-
-    const updatedProps = {
-      ...this.props,
-      unreadCount: notificationCountQuery.notificationCounts
-    };
-
-    return <Widget {...updatedProps} />;
-  }
-}
-
-export default withProps<Props>(
-  compose(
-    graphql<Props, NotificationsCountQueryResponse, { requireRead: boolean }>(
-      gql(queries.notificationCounts),
-      {
-        name: 'notificationCountQuery',
-        options: () => ({
-          variables: {
-            requireRead: true
-          },
-          notifyOnNetworkStatusChange: true
-        })
-      }
-    )
-  )(withRouter<FinalProps>(WidgetContainer))
+const WidgetContainer = () => (
+  <NotifConsumer>
+    {({ unreadCount, notifications, markAsRead, isLoading }) => {
+      const updatedProps = {
+        unreadCount,
+        notifications,
+        markAsRead,
+        isLoading
+      };
+      return <Widget {...updatedProps} />;
+    }}
+  </NotifConsumer>
 );
+
+export default WidgetContainer;

--- a/src/modules/notifications/context.tsx
+++ b/src/modules/notifications/context.tsx
@@ -1,0 +1,104 @@
+import gql from 'graphql-tag';
+import { IUser } from 'modules/auth/types';
+import { sendDesktopNotification } from 'modules/common/utils';
+import { INotification } from 'modules/notifications/types';
+import React from 'react';
+import { compose, graphql } from 'react-apollo';
+import strip from 'strip';
+import { queries, subscriptions } from './graphql';
+import {
+  NotificationsCountQueryResponse,
+  NotificationsQueryResponse
+} from './types';
+
+interface IStore {
+  notifications: INotification[];
+  unreadCount: number;
+  markAsRead: () => void;
+  isLoading: boolean;
+}
+
+type Props = {
+  notificationsQuery: NotificationsQueryResponse;
+  notificationCountQuery: NotificationsCountQueryResponse;
+  currentUser: IUser;
+};
+
+const NotifContext = React.createContext({} as IStore);
+
+export const NotifConsumer = NotifContext.Consumer;
+
+class Provider extends React.Component<Props> {
+  componentWillMount() {
+    const {
+      notificationsQuery,
+      notificationCountQuery,
+      currentUser
+    } = this.props;
+
+    notificationsQuery.subscribeToMore({
+      document: gql(subscriptions.notificationSubscription),
+      variables: { userId: currentUser ? currentUser._id : null },
+      updateQuery: (prev, { subscriptionData: { data } }) => {
+        const { notificationInserted } = data;
+        const { title, content } = notificationInserted;
+
+        sendDesktopNotification({ title, content: strip(content || '') });
+
+        notificationsQuery.refetch();
+        notificationCountQuery.refetch();
+      }
+    });
+  }
+
+  markAsRead() {
+    const { notificationsQuery, notificationCountQuery } = this.props;
+
+    notificationsQuery.refetch();
+    notificationCountQuery.refetch();
+  }
+
+  public render() {
+    const { notificationsQuery, notificationCountQuery } = this.props;
+
+    const notifications = notificationsQuery.notifications;
+    const isLoading = notificationsQuery.loading;
+    const unreadCount = notificationCountQuery.notificationCounts;
+    const markAsRead = () => this.markAsRead();
+
+    return (
+      <NotifContext.Provider
+        value={{ notifications, unreadCount, markAsRead, isLoading }}
+      >
+        {this.props.children}
+      </NotifContext.Provider>
+    );
+  }
+}
+
+export const NotifProvider = compose(
+  graphql<
+    {},
+    NotificationsQueryResponse,
+    { limit: number; requireRead: boolean }
+  >(gql(queries.notifications), {
+    name: 'notificationsQuery',
+    options: () => ({
+      variables: {
+        limit: 10,
+        requireRead: false
+      }
+    })
+  }),
+  graphql<{}, NotificationsCountQueryResponse>(
+    gql(queries.notificationCounts),
+    {
+      name: 'notificationCountQuery',
+      options: () => ({
+        variables: {
+          requireRead: true
+        }
+      })
+    }
+  )
+)(Provider);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ import FormRoutes from './modules/forms/routes';
 import InboxRoutes from './modules/inbox/routes';
 import InsightsRoutes from './modules/insights/routes';
 import KnowledgeBaseRoutes from './modules/knowledgeBase/routes';
+import { NotifProvider } from './modules/notifications/context';
 import NotificationRoutes from './modules/notifications/routes';
 import OnboardRoutes from './modules/onboard/routes';
 import SegmentsRoutes from './modules/segments/routes';
@@ -39,7 +40,10 @@ const renderRoutes = currentUser => {
         <OnboardRoutes />
         <MainLayout currentUser={currentUser}>
           <MainWrapper>
-            <MainBar />
+            <NotifProvider currentUser={currentUser}>
+              <MainBar />
+              <NotificationRoutes />
+            </NotifProvider>
             <InboxRoutes />
             <SegmentsRoutes />
             <CustomersRoutes />
@@ -50,7 +54,6 @@ const renderRoutes = currentUser => {
             <FormRoutes />
             <SettingsRoutes />
             <TagsRoutes />
-            <NotificationRoutes />
             <DealsRoutes />
             <TicketRoutes />
             <TaskRoutes />


### PR DESCRIPTION
Both the widget and popover components use their own query, and now their own subscriptions to track notifications. The subscription from the popover is stopped when the popover is not rendered so a new notification could come in (eg: an assignment or @mention on a conversation) which would increment the count in the quick navigation widget but not update the popover content. The new notification would appear to be missing and cannot be dismissed without entering the full screen notification view and checking for unreads.

This adds a provider so both components can share a single set of notification count & content queries and subscriptions for additional new notifications. This also prevents duplicate "notificationInserted" subscriptions from the same client.

You can see here an internal message increments the count and is updated via the "conversationMessageInserted" sub but is not populated in the popover.
![notif-example gif](https://user-images.githubusercontent.com/5217060/63803363-03fe3b80-c915-11e9-9cb4-d6e4b43c6895.gif)
