### PR TITLE
add sidebar menu to importHistory

### DIFF
--- a/ui/src/modules/settings/importHistory/components/Histories.tsx
+++ b/ui/src/modules/settings/importHistory/components/Histories.tsx
@@ -10,9 +10,9 @@ import Wrapper from 'modules/layout/components/Wrapper';
 import { BarItems } from 'modules/layout/styles';
 import DataImporter from 'modules/settings/importHistory/containers/DataImporter';
 import React from 'react';
-import Sidebar from '../../properties/components/Sidebar';
 import { IImportHistory } from '../types';
 import HistoryRow from './Row';
+import Sidebar from './Sidebar';
 
 type Props = {
   queryParams: any;

--- a/ui/src/modules/settings/importHistory/components/Sidebar.tsx
+++ b/ui/src/modules/settings/importHistory/components/Sidebar.tsx
@@ -3,7 +3,19 @@ import LeftSidebar from 'modules/layout/components/Sidebar';
 import { SidebarList as List } from 'modules/layout/styles';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { FIELDS_GROUPS_CONTENT_TYPES } from '../constants';
+
+const ITEM_TYPES = {
+  CUSTOMER: 'customer',
+  COMPANY: 'company',
+  PRODUCT: 'product',
+  BRAND: 'brand',
+  CHANNEL: 'channel',
+  DEAL: 'deal',
+  PERMISSION: 'permission',
+  TASK: 'task',
+  TICKET: 'ticket',
+  TEAM_MEMBER: 'user',
+};
 
 type Props = {
   currentType: string;
@@ -43,17 +55,33 @@ class Sidebar extends React.Component<Props> {
       <LeftSidebar header={this.renderSidebarHeader()}>
         <LeftSidebar.Section>
           <List>
+            {this.renderListItem(ITEM_TYPES.BRAND, 'Brands')}
             {this.renderListItem(
-              FIELDS_GROUPS_CONTENT_TYPES.CUSTOMER,
+              ITEM_TYPES.CHANNEL,
+              'Channels'
+            )}
+            {this.renderListItem(
+              ITEM_TYPES.CUSTOMER,
               'Customers'
             )}
             {this.renderListItem(
-              FIELDS_GROUPS_CONTENT_TYPES.COMPANY,
+              ITEM_TYPES.COMPANY,
               'Companies'
             )}
             {this.renderListItem(
-              FIELDS_GROUPS_CONTENT_TYPES.PRODUCT,
+              ITEM_TYPES.PERMISSION,
+              'Permissions'
+            )}
+            {this.renderListItem(
+              ITEM_TYPES.PRODUCT,
               'Product & Service'
+            )}
+            {this.renderListItem(ITEM_TYPES.DEAL, 'Deals')}
+            {this.renderListItem(ITEM_TYPES.TASK, 'Tasks')}
+            {this.renderListItem(ITEM_TYPES.TICKET, 'Tickets')}
+            {this.renderListItem(
+              ITEM_TYPES.TEAM_MEMBER,
+              'Team members'
             )}
           </List>
         </LeftSidebar.Section>

--- a/ui/src/modules/settings/properties/constants.ts
+++ b/ui/src/modules/settings/properties/constants.ts
@@ -2,23 +2,9 @@ export const FIELDS_GROUPS_CONTENT_TYPES = {
   CUSTOMER: 'customer',
   COMPANY: 'company',
   PRODUCT: 'product',
-  BRAND: 'brand',
-  CHANNEL: 'channel',
-  DEAL: 'deal',
-  PERMISSION: 'permission',
-  TASK: 'task',
-  TICKET: 'ticket',
-  TEAM_MEMBER: 'user',
   ALL: [
     'customer',
     'company',
     'product',
-    'brand',
-    'channel',
-    'deal',
-    'permission',
-    'task',
-    'ticket',
-    'user'
   ]
 };


### PR DESCRIPTION
ImportHistory sidebar menu was imported from modules/settings/properties/components/Sidebar, which was faulty. A separate sidebar for each module will be fitting.