### PR TITLE
Minor updates to localization.

### DIFF
--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -801,5 +801,21 @@
   "Choose messengers": "Choose messengers",
   "erxes allows you to create multiple messengers": "erxes allows you to create multiple messengers",
   "erxes allows you to create multiple brands": "erxes allows you to create multiple brands",
-  "erxes allows you to create multiple channels": "erxes allows you to create multiple channels"
+  "erxes allows you to create multiple channels": "erxes allows you to create multiple channels",
+  "Show the full message": "Zeige die ganze Nachricht",
+  "Snippet": "Ausschnitt",
+  "Add New Brand": "Eine \"brand\" erstellen",
+  "Basic JavaScript": "Webseite",
+  "Google tag manager": "Google Tag Manager",
+  "gtm_b": "So fügen Sie das wiget über GTM ein.",
+  "gtm_li_1": "öffnen Sie die Tags innerhalb von GTM",
+  "gtm_li_2": "erstellen Sie einen neuen tag (zB \"inflow\")",
+  "gtm_li_3": "klicken Sie den tag container und wählen Sie als Typ: Custom HTML",
+  "gtm_li_4": "fügen Sie den unten stehen code ein",
+  "gtm_li_5": "unter Triggering wählen Sie \"Auf allen Seiten\"",
+  "gtm_li_6": "speichern nicht vergessen (oben rechts)",
+  "gtm_li_7": "anschließend müssen sie die Änderungen über Submit bestätigen",
+  "gtm_li_8": "das widget wird nun auf den Webseiten geladen, auf denen GTM aktivier ist",
+  "For websites and web apps with full-page refreshes. Paste the code below before the body tag on every page you want erxes chat to appear": "Für Webseite oder Web-App mit full-page refresh. Bitte fügen Sie den code VOR dem <body> tag auf allen Webseiten ein, auf denen das widget aktiv sein soll.",
+  "To connect Google Tag Manager to erxes, you must have an active Google Tag Manager account with a published container": "Um das widget über Google Tag Manager (GTM) zu installieren benötigen Sie einen aktivierten GTM account mit einem veröffnetlichen container."
 }

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Sind Sie sicher?",
   "Yes, I am": "Ja, bin ich",
   "No, Cancel": "Nein, abbrechen",

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -138,6 +138,7 @@
   "Brand": "Marke",
   "Current Password": "Aktuelles Passwort",
   "Current password": "Aktuelles Passwort",
+  "Set up your password": "Passwort-Einstellung",
   "New Password": "Neues Passwort",
   "Re-type Password to confirm": "Geben Sie das Passwort zur Bestätigung erneut ein",
   "Signature": "Unterschrift",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -940,5 +940,21 @@
   "Engage config": "Engage config",
   "Join a call": "Join a call",
   "Invite to video call": "Invite to video call",
-  "Video call invitation sent": "Video call invitation sent"
+  "Video call invitation sent": "Video call invitation sent",
+  "Show the full message": "Show the full message",
+  "Snippet": "Snippet",
+  "Add New Brand": "Add New Brand",
+  "Basic JavaScript": "Website",
+  "Google tag manager": "Google Tag Manager",
+  "gtm_b": "To install erxes on your website with Google Tag Manager, just follow these steps.",
+  "gtm_li_1": "Navigate to the <b>Tags section</b> of your Google Tag Manager account",
+  "gtm_li_2": "Create a <b>new tag</b> and name it (for example: \"inflow\")",
+  "gtm_li_3": "Click the Tag Configuration section and choose <b>Custom HTML</b>{' '} tag type",
+  "gtm_li_4": "Paste the code below",
+  "gtm_li_5": "Next, click the Triggering section and choose “All Pages”",
+  "gtm_li_6": "Click ‘Save’ button in the top-right corner of the page",
+  "gtm_li_7": "Next click ‘Submit’ button in the top-right corner of the page to save the changes you made",
+  "gtm_li_8": "Now, erxes chat will be installed using your Google Tag Manager account. Just make sure you copy the gtm code to your website",
+  "For websites and web apps with full-page refreshes. Paste the code below before the body tag on every page you want erxes chat to appear": "For websites and web apps with full-page refreshes. Paste the code below before the body tag on every page you want erxes chat to appear",
+  "To connect Google Tag Manager to erxes, you must have an active Google Tag Manager account with a published container": "To connect Google Tag Manager to erxes, you must have an active Google Tag Manager account with a published container"
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Are you sure? This cannot be undone.",
   "Yes, I am": "Yes, I am",
   "No, Cancel": "No, Cancel",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -148,6 +148,7 @@
   "Current Password": "Current Password",
   "Current password": "Current password",
   "New Password": "New Password",
+  "Set up your password": "Set up your password",
   "Re-type Password to confirm": "Re-type Password to confirm",
   "Signature": "Signature",
   "simple": "simple",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Response Close Report": "Respuesta Cerrar Informe",
   "Average time of each staff solving problems that based on customer feedbacks.": "Tiempo promedio que le toma al personal para resolver problemas basados en comentarios del cliente.",
   "First Response Report": "Primer informe de respuesta",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Êtes vous sûr ?",
   "Yes, I am": "Oui, je le suis.",
   "No, Cancel": "Non, Annuler",

--- a/ui/src/locales/hi.json
+++ b/ui/src/locales/hi.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "EN": "Hindi",
   "Are you sure?": "क्या आपको यकीन है?",
   "Yes, I am": "हां मैं हूं",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Sei sicuro?",
   "Yes, I am": "Sì, lo sono",
   "No, Cancel": "No, cancella",

--- a/ui/src/locales/ja.json
+++ b/ui/src/locales/ja.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "本気ですか？",
   "Yes, I am": "はい、そうです",
   "No, Cancel": "いいえ、キャンセル",

--- a/ui/src/locales/ko.json
+++ b/ui/src/locales/ko.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "확실해?",
   "Yes, I am": "예, 나는",
   "No, Cancel": "아니, 취소",

--- a/ui/src/locales/mn.json
+++ b/ui/src/locales/mn.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Та энэ үйлдлийг хийхдээ итгэлтэй байна уу? ",
   "Yes, I am": "Тийм",
   "No, Cancel": "Үгүй",

--- a/ui/src/locales/pt-br.json
+++ b/ui/src/locales/pt-br.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Você tem certeza?",
   "Yes, I am": "Sim, eu tenho",
   "No, Cancel": "Não, cancelar",

--- a/ui/src/locales/ru.json
+++ b/ui/src/locales/ru.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "Уверены ли вы?",
   "Yes, I am": "Да, я",
   "No, Cancel": "Нет, Отменить",

--- a/ui/src/locales/vi.json
+++ b/ui/src/locales/vi.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "EN": "Vietnamese",
   "Are you sure?": "Bạn có chắc không?",
   "Yes, I am": "Đúng là tôi",

--- a/ui/src/locales/yi.json
+++ b/ui/src/locales/yi.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "EN": "Indonesian",
   "Are you sure?": "Apakah Anda yakin?",
   "Yes, I am": "Ya, benar",

--- a/ui/src/locales/zh-cn.json
+++ b/ui/src/locales/zh-cn.json
@@ -1,4 +1,5 @@
 {
+  "Homepage link": "https://www.erxes.io",
   "Are you sure?": "你确定吗？",
   "Yes, I am": "我是",
   "No, Cancel": "不，取消",

--- a/ui/src/modules/common/components/ConfirmDialog.tsx
+++ b/ui/src/modules/common/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { __ } from 'modules/common/utils';
 import React from 'react';
 import Modal from 'react-bootstrap/Modal';
 import styled from 'styled-components';
@@ -76,7 +77,7 @@ class ConfirmDialog extends React.Component<Props, State> {
 
   render() {
     const {
-      confirmation = 'Are you sure? This cannot be undone.'
+      confirmation = 'Are you sure?'
     } = this.props;
 
     const {
@@ -98,7 +99,7 @@ class ConfirmDialog extends React.Component<Props, State> {
           <IconWrapper>
             <Icon icon="exclamation-triangle" />
           </IconWrapper>
-          {confirmation}
+          {__(confirmation)}
         </ModalBody>
         <ModalFooter>
           <Button

--- a/ui/src/modules/common/components/filter/Filter.tsx
+++ b/ui/src/modules/common/components/filter/Filter.tsx
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import Chip from 'modules/common/components/Chip';
-import { router } from 'modules/common/utils';
+import { __, router } from 'modules/common/utils';
 import { cleanIntegrationKind } from 'modules/settings/integrations/containers/utils';
 import React from 'react';
 import { withRouter } from 'react-router-dom';
@@ -30,9 +30,12 @@ function Filter({ queryParams = {}, history }: IProps) {
 
     const onClick = () => onClickClose([paramKey]);
 
+    const intlChipText = __(paramKey);
+    const useIntlChipText = intlChipText !== queryParams[paramKey];
+
     return (
       <Chip capitalize={true} onClick={onClick}>
-        {bool ? paramKey : cleanIntegrationKind(queryParams[paramKey])}
+        {bool ? paramKey : (useIntlChipText ? intlChipText : cleanIntegrationKind(queryParams[paramKey]))}
       </Chip>
     );
   };

--- a/ui/src/modules/engage/components/MessengerForm.tsx
+++ b/ui/src/modules/engage/components/MessengerForm.tsx
@@ -4,7 +4,7 @@ import FormControl from 'modules/common/components/form/Control';
 import FormGroup from 'modules/common/components/form/Group';
 import ControlLabel from 'modules/common/components/form/Label';
 import { FlexItem, FlexPad } from 'modules/common/components/step/styles';
-import { Alert } from 'modules/common/utils';
+import { __, Alert } from 'modules/common/utils';
 import {
   EMAIL_CONTENT,
   MESSENGER_KINDS,
@@ -126,7 +126,7 @@ class MessengerForm extends React.Component<Props, State> {
       <FlexItem>
         <FlexPad overflow="auto" direction="column" count="3">
           <FormGroup>
-            <ControlLabel>Message:</ControlLabel>
+            <ControlLabel>{__('Message:')}</ControlLabel>
 
             <EditorCK
               content={this.props.content}
@@ -175,7 +175,7 @@ class MessengerForm extends React.Component<Props, State> {
           {this.renderKind(this.props.hasKind)}
 
           <FormGroup>
-            <ControlLabel>Sent as:</ControlLabel>
+            <ControlLabel>{__('Sent as:')}</ControlLabel>
             <FormControl
               componentClass="select"
               onChange={onChangeSentAs}
@@ -184,7 +184,7 @@ class MessengerForm extends React.Component<Props, State> {
               <option />{' '}
               {SENT_AS_CHOICES.SELECT_OPTIONS.map(s => (
                 <option key={s.value} value={s.value}>
-                  {s.text}
+                  {__(s.text)}
                 </option>
               ))}
             </FormControl>

--- a/ui/src/modules/knowledgeBase/components/article/ArticleForm.tsx
+++ b/ui/src/modules/knowledgeBase/components/article/ArticleForm.tsx
@@ -94,7 +94,7 @@ class ArticleForm extends React.Component<Props, State> {
     return (
       <>
         <FormGroup>
-          <ControlLabel required={true}>Title</ControlLabel>
+          <ControlLabel required={true}>{__('Title')}</ControlLabel>
           <FormControl
             {...formProps}
             name="title"
@@ -105,7 +105,7 @@ class ArticleForm extends React.Component<Props, State> {
         </FormGroup>
 
         <FormGroup>
-          <ControlLabel>Summary</ControlLabel>
+          <ControlLabel>{__('Summary')}</ControlLabel>
           <FormControl
             {...formProps}
             name="summary"
@@ -116,7 +116,7 @@ class ArticleForm extends React.Component<Props, State> {
         <FlexContent>
           <FlexItem count={4}>
             <FormGroup>
-              <ControlLabel required={true}>Reactions</ControlLabel>
+              <ControlLabel required={true}>{__('Reactions')}</ControlLabel>
               <Select
                 multi={true}
                 value={reactionChoices}
@@ -129,7 +129,7 @@ class ArticleForm extends React.Component<Props, State> {
           </FlexItem>
           <FlexItem count={2} hasSpace={true}>
             <FormGroup>
-              <ControlLabel required={true}>Status</ControlLabel>
+              <ControlLabel required={true}>{__('Status')}</ControlLabel>
               <FormControl
                 {...formProps}
                 name="status"
@@ -148,7 +148,7 @@ class ArticleForm extends React.Component<Props, State> {
           </FlexItem>
         </FlexContent>
         <FormGroup>
-          <ControlLabel required={true}>Content</ControlLabel>
+          <ControlLabel required={true}>{__('Content')}</ControlLabel>
           <EditorCK content={content} onChange={this.onChange} height={300} />
         </FormGroup>
 
@@ -159,7 +159,7 @@ class ArticleForm extends React.Component<Props, State> {
             onClick={this.props.closeModal}
             icon="cancel-1"
           >
-            Cancel
+            {__('Cancel')}
           </Button>
 
           {renderButton({

--- a/ui/src/modules/layout/components/AuthLayout.tsx
+++ b/ui/src/modules/layout/components/AuthLayout.tsx
@@ -64,13 +64,13 @@ class AuthLayout extends React.Component<Props, {}> {
             <Col md={6}>
               <AuthDescription>
                 <img src="/images/logo.png" alt="erxes" />
-                <h1>Open Source Growth Marketing Platform</h1>
+                <h1>{__('Open Source Growth Marketing Platform')}</h1>
                 <p>
                   {__(
                     'Marketing, sales, and customer service platform designed to help your business attract more engaged customers. Replace Hubspot with the mission and community-driven ecosystem.'
                   )}
                 </p>
-                <a href="http://erxes.io/">« Go to home page</a>
+                <a href={__('Homepage link')}>« {__('Go to home page')}</a>
               </AuthDescription>
             </Col>
             <Col md={{ span: 5, offset: 1 }}>{content}</Col>

--- a/ui/src/modules/settings/brands/components/BrandRow.tsx
+++ b/ui/src/modules/settings/brands/components/BrandRow.tsx
@@ -50,7 +50,7 @@ class BrandRow extends React.Component<Props> {
         <Link to={`?_id=${brand._id}`}>{brand.name}</Link>
         <ActionButtons>
           {this.renderEditAction()}
-          <Tip text="Delete" placement="bottom">
+          <Tip text={__('Delete')} placement="bottom">
             <Button btnStyle="link" onClick={this.remove} icon="cancel-1" />
           </Tip>
         </ActionButtons>

--- a/ui/src/modules/settings/brands/components/Brands.tsx
+++ b/ui/src/modules/settings/brands/components/Brands.tsx
@@ -91,8 +91,10 @@ class Brands extends React.Component<Props, {}> {
         mainHead={
           <HeaderDescription
             icon="/images/actions/32.svg"
-            title="Brands"
-            description="Add unlimited Brands with unlimited support to further your growth and accelerate your business."
+            title={__('Brands')}
+            description={__(
+              'Add unlimited Brands with unlimited support to further your growth and accelerate your business.'
+            )}
           />
         }
         actionBar={

--- a/ui/src/modules/settings/brands/components/Sidebar.tsx
+++ b/ui/src/modules/settings/brands/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import ModalTrigger from 'modules/common/components/ModalTrigger';
 import Spinner from 'modules/common/components/Spinner';
 import { TopHeader } from 'modules/common/styles/main';
 import { IButtonMutateProps } from 'modules/common/types';
+import { __ } from 'modules/common/utils';
 import LeftSidebar from 'modules/layout/components/Sidebar';
 import { SidebarList as List } from 'modules/layout/styles';
 import React from 'react';
@@ -44,7 +45,7 @@ class Sidebar extends React.Component<Props, {}> {
         uppercase={false}
         icon="plus-circle"
       >
-        Add New Brand
+        {__('Add New Brand')}
       </Button>
     );
 

--- a/ui/src/modules/settings/channels/components/Channels.tsx
+++ b/ui/src/modules/settings/channels/components/Channels.tsx
@@ -82,8 +82,10 @@ class Channels extends React.Component<Props, {}> {
         mainHead={
           <HeaderDescription
             icon="/images/actions/31.svg"
-            title="Channels"
-            description="Channels are important to know how and where your team members are spread out. Manage your channels and stay at the top of your game."
+            title={__('Channels')}
+            description={__(
+              'Channels are important to know how and where your team members are spread out. Manage your channels and stay at the top of your game.'
+            )}
           />
         }
         leftSidebar={

--- a/ui/src/modules/settings/integrations/components/InstallCode.tsx
+++ b/ui/src/modules/settings/integrations/components/InstallCode.tsx
@@ -224,31 +224,26 @@ class InstallCode extends React.PureComponent<Props, State> {
       return (
         <div>
           <b>
-            To install erxes on your website with Google Tag Manager, just
-            follow these steps.
+            {__('gtm_b')}
           </b>
           <ol>
             <li>
-              Navigate to the <b>Tags section</b> of your Google Tag Manager
-              account
+              {__('gtm_li_1')}
             </li>
             <li>
-              Create a <b>new tag</b> and name it (for example: "erxes-chat")
+              {__('gtm_li_2')}
             </li>
             <li>
-              Click the Tag Configuration section and choose <b>Custom HTML</b>{' '}
-              tag type
+              {__('gtm_li_3')}
             </li>
-            <li>Paste the code below </li>
-            <li>Next, click the Triggering section and choose “All Pages”</li>
-            <li>Click ‘Save’ button in the top-right corner of the page</li>
+            <li>{__('gtm_li_4')}</li>
+            <li>{__('gtm_li_5')}</li>
+            <li>{__('gtm_li_6')}</li>
             <li>
-              Next click ‘Submit’ button in the top-right corner of the page to
-              save the changes you made
+              {__('gtm_li_7')}
             </li>
             <li>
-              Now, erxes chat will be installed using your Google Tag Manager
-              account. Just make sure you copy the gtm code to your web.
+              {__('gtm_li_8')}
             </li>
           </ol>
         </div>
@@ -481,7 +476,7 @@ class InstallCode extends React.PureComponent<Props, State> {
     switch (currentTab) {
       case 'basic':
         description =
-          'For websites and web apps with full-page refreshes. Paste the code below before the body tag on every page you want erxes chat to appear';
+          __('For websites and web apps with full-page refreshes. Paste the code below before the body tag on every page you want erxes chat to appear');
         script = basicCode;
         action = copied;
         break;
@@ -493,7 +488,7 @@ class InstallCode extends React.PureComponent<Props, State> {
         break;
       case 'googletag':
         description =
-          'To connect Google Tag Manager to erxes, you must have an active Google Tag Manager account with a published container';
+          __('To connect Google Tag Manager to erxes, you must have an active Google Tag Manager account with a published container');
         extraContent = true;
         script = basicCode;
         action = contentCopied;

--- a/ui/src/modules/settings/team/components/UserConfirmation.tsx
+++ b/ui/src/modules/settings/team/components/UserConfirmation.tsx
@@ -52,19 +52,19 @@ class Confirmation extends React.Component<{
         <h2>{__('Set up your password')}</h2>
         <form onSubmit={this.onSubmit}>
           <FormGroup>
-            <ControlLabel>Full name</ControlLabel>
+            <ControlLabel>{__('Full name')}</ControlLabel>
             <FormControl id="fullName" />
           </FormGroup>
           <FormGroup>
-            <ControlLabel>Username</ControlLabel>
+            <ControlLabel>{__('Username')}</ControlLabel>
             <FormControl id="username" />
           </FormGroup>
           <FormGroup>
-            <ControlLabel>Password</ControlLabel>
+            <ControlLabel>{__('New Password')}</ControlLabel>
             <FormControl type="password" id="password" />
           </FormGroup>
           <FormGroup>
-            <ControlLabel>Password Confirmation</ControlLabel>
+            <ControlLabel>{__('Re-type Password to confirm')}</ControlLabel>
             <FormControl type="password" id="passwordConfirmation" />
           </FormGroup>
           <Button btnStyle="success" type="submit" block={true}>


### PR DESCRIPTION
This PR addresses:

- Some spots in the UI where localization exists but is not used (eg: buttons like Cancel and Delete are hard-coded in English).
- A few missing keys are added (eg: "Add new brand" button), but only with English and German languages.
- The filter chip component is updated so that flags in the query params are also localized (eg: "unassigned=true" will now localize the string "unassigned" instead of ignoring it's value "true", and a localization for "unassigned" already exists in the locale files).