### PR TITLE
Documentation updates for SSL Integration after Debain/Ubuntu install

### DIFF
--- a/docs/docs/installation/debian10.md
+++ b/docs/docs/installation/debian10.md
@@ -58,7 +58,7 @@ If you want to use `erxes` with HTTPS, please go to [this article](https://www.d
 Once you have installed your ssl certificate, you need to update env vars.
 
 1. Log in to your server as `erxes` via `ssh`.
-2. Edit `erxes/build/js/env.js` file where env vars for frontend app are stored.
+2. Edit `erxes/ui/build/js/env.js` file where env vars for frontend app are stored.
    The content of the file should be as follows:
 
 ```javascript
@@ -71,7 +71,7 @@ window.env = {
 };
 ```
 
-3. Update all env vars with HTTPS url in the `ecosystem.json` file.
+3. Update all env vars with HTTPS & WSS url (i.e. `http://` => `https://` & `ws://` => `wss://`) in the `ecosystem.json` file.
 4. Finally, you need to restart pm2 erxes processes by running the following command:
 
 ```sh


### PR DESCRIPTION
SSL Integration document had a wrong path for `env.js` in UI, also added a little more details on what needs to be updated in `ecosystem.json`
