### PR TITLE
Replace redis

### DIFF
--- a/ui/src/modules/settings/importHistory/containers/HistoryDetail.tsx
+++ b/ui/src/modules/settings/importHistory/containers/HistoryDetail.tsx
@@ -4,10 +4,8 @@ import { withProps } from 'modules/common/utils';
 import React from 'react';
 import { graphql } from 'react-apollo';
 import HistoryDetail from '../components/HistoryDetail';
-import { queries, subscriptions } from '../graphql';
+import { queries } from '../graphql';
 import { ImportHistoryDetailQueryResponse } from '../types';
-
-const subscription = gql(subscriptions.importSubscription);
 
 class HistoryDetailContainer extends React.Component<
   { id: string } & {
@@ -19,30 +17,8 @@ class HistoryDetailContainer extends React.Component<
     super(props);
 
     this.state = {
-      percentage: 0
+      percentage: 0,
     };
-  }
-
-  componentWillMount() {
-    const { importHistoryDetailQuery, id } = this.props;
-
-    importHistoryDetailQuery.subscribeToMore({
-      document: subscription,
-      variables: { _id: id },
-
-      updateQuery: (prev, { subscriptionData: { data } }) => {
-        const { importHistoryChanged } = data;
-        const { percentage, status } = importHistoryChanged;
-
-        if (status === 'Done') {
-          return importHistoryDetailQuery.refetch();
-        }
-
-        if (percentage.toFixed(0) !== this.state.percentage) {
-          this.setState({ percentage: percentage.toFixed(0) });
-        }
-      }
-    });
   }
 
   render() {
@@ -70,10 +46,10 @@ export default withProps<{ id: string }>(
         options: ({ id }) => ({
           fetchPolicy: 'network-only',
           variables: {
-            _id: id
+            _id: id,
           },
-          pollInterval: 20000
-        })
+          pollInterval: 3000,
+        }),
       }
     )
   )(HistoryDetailContainer)

--- a/ui/src/modules/settings/importHistory/containers/ImportIndicator.tsx
+++ b/ui/src/modules/settings/importHistory/containers/ImportIndicator.tsx
@@ -8,7 +8,7 @@ import ImportIndicator from '../components/ImportIndicator';
 import { mutations, queries } from '../graphql';
 import {
   CancelMutationResponse,
-  ImportHistoryDetailQueryResponse,
+  ImportHistoryDetailQueryResponse
 } from '../types';
 
 type Props = {
@@ -33,7 +33,7 @@ class ImportIndicatorContainer extends React.Component<
     super(props);
 
     this.state = {
-      percentage: 0,
+      percentage: 0
     };
   }
 
@@ -43,40 +43,12 @@ class ImportIndicatorContainer extends React.Component<
     localStorage.setItem('erxes_import_data_type', '');
   }
 
-  componentWillReceiveProps() {
-    const { importHistoryDetailQuery } = this.props;
-
-    const importHistory = importHistoryDetailQuery.importHistoryDetail || {};
-    const queryError = importHistoryDetailQuery.error;
-    const queryErrorMessage =
-      queryError && queryError.message ? queryError.message : '';
-    const { status, errorMsgs } = importHistory;
-
-    if (status === 'Error') {
-      this.clearStorage();
-
-      this.setState({ errors: errorMsgs });
-    }
-
-    if (queryErrorMessage.includes('not found')) {
-      this.clearStorage();
-
-      return this.props.doneIndicatorAction();
-    }
-
-    if (status === 'Done') {
-      this.clearStorage();
-
-      importHistoryDetailQuery.refetch();
-    }
-  }
-
   render() {
     const {
       importHistoryDetailQuery,
       importCancel,
       closeLoadingBar,
-      isRemovingImport,
+      isRemovingImport
     } = this.props;
 
     const importHistory = importHistoryDetailQuery.importHistoryDetail || {};
@@ -84,16 +56,16 @@ class ImportIndicatorContainer extends React.Component<
     const percentage =
       Math.trunc(importHistory.percentage) || this.state.percentage;
 
-    const cancelImport = (id) => {
+    const cancelImport = id => {
       confirm().then(() => {
         importCancel({
-          variables: { _id: id },
+          variables: { _id: id }
         })
           .then(() => {
             Alert.success('You canceled importing action.');
             closeLoadingBar();
           })
-          .catch((e) => {
+          .catch(e => {
             Alert.error(e.message);
             closeLoadingBar();
           });
@@ -122,22 +94,22 @@ const ImportIndicatorWithProps = withProps<{ id: string; close?: () => void }>(
         options: ({ id }) => ({
           fetchPolicy: 'network-only',
           variables: {
-            _id: id,
+            _id: id
           },
-          pollInterval: 3000,
-        }),
+          pollInterval: 3000
+        })
       }
     ),
     graphql<Props, CancelMutationResponse, { _id: string }>(
       gql(mutations.importCancel),
       {
-        name: 'importCancel',
+        name: 'importCancel'
       }
     )
   )(ImportIndicatorContainer)
 );
 
-const WithConsumer = (props) => {
+const WithConsumer = props => {
   return (
     <AppConsumer>
       {({ closeLoadingBar, isRemovingImport, doneIndicatorAction }) => (

--- a/ui/src/modules/settings/importHistory/types.ts
+++ b/ui/src/modules/settings/importHistory/types.ts
@@ -29,6 +29,7 @@ export type ImportHistoryDetailQueryResponse = {
   importHistoryDetail: IImportHistory;
   loading: boolean;
   subscribeToMore: any;
+  error: any;
   refetch: () => void;
 };
 


### PR DESCRIPTION
Made Redis, RabbitMQ optional

Reason:
Requiring big dependencies for simple usages becoming the installation process slow and hard.

Solution:
If there is a REDIS_HOST env variable available then Redis will be used otherwise just runtime variable will be used.

If there is a RABBITMQ_HOST env variable available then RabbitMQ will be used for message broker otherwise just TCP connections will be used.