### PR TITLE
fix: incorrect issues page links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We welcome any type of contribution, not only code. You can help with
 - **QA**: file bug reports, the more details you can give the better (e.g. screenshots with the console open)
 - **Marketing**: writing blog posts, howto's, printing stickers, ...
 - **Community**: presenting the project at meetups, organizing a dedicated meetup for the local community, ...
-- **Code**: take a look at the [open issues](issues). Even if you can't write code, commenting on them, showing that you care about a given issue matters. It helps us triage them.
+- **Code**: take a look at the [open issues](https://github.com/erxes/erxes/issues). Even if you can't write code, commenting on them, showing that you care about a given issue matters. It helps us triage them.
 - **Money**: we welcome financial contributions in full transparency on our [open collective](https://opencollective.com/erxes).
 
 ## Your First Contribution
@@ -31,7 +31,7 @@ Anyone can file an expense. If the expense makes sense for the development of th
 
 ## Questions
 
-If you have any questions, create an [issue](issue) (protip: do a quick search first to see if someone else didn't ask the same question before!).
+If you have any questions, create an [issue](https://github.com/erxes/erxes/issues/new/choose) (protip: do a quick search first to see if someone else didn't ask the same question before!).
 You can also reach us at hello@erxes.opencollective.com.
 
 ## Credits


### PR DESCRIPTION
Hey folks 👋 

### Context
The relative links to issue (one is `issues` and another is `issue`) doesn't point to the issues page of `erxes/erxes`.

Rather, I have now added absolute links for it to redirect to proper page.

The first link points to [Issues](https://github.com/erxes/erxes/issues) page
And the second link points to the [New Issue](https://github.com/erxes/erxes/issues/new/choose) page

I hope that is expected behavior :)