### PR TITLE
Broken Links in Contributors Graph link in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Deploy to a DigitalOcean droplet with our one-click install listing from the Dig
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/erxes/contributors.svg?width=890" /></a>
+<a href="https://opencollective.com/erxes#section-contributors"><img src="https://opencollective.com/erxes/contributors.svg?width=890" /></a>
 
 
 ## Backers

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ erxes helps you attract and engage more customers while giving you high lead con
 * **Knowledge base:** Create Help Articles for Customer Self-service. Educate both your customers, and staff by creating a help center related to your brands, products and services to reach a higher level of satisfaction.
 * **Task Management:** Work More Collaboratively and Get More Done. Save time, manage your projects, monitor your team and increase your productivity in just a few clicks. Erxes helps to turn chaos into clarity and make everything perfect. 
 ## Documentation
-  * <a href="https://docs.erxes.io/installation/docker">Install erxes</a> <br>
-  * <a href="https://docs.erxes.io">erxes documentation</a> <br>
-  * <a href="https://docs.erxes.io/developer/contributing">Contributing to erxes</a> <br>
+  * <a href="https://erxes.io/install">Install erxes</a> <br>
+  * <a href="https://www.erxes.org/overview/getting-started">erxes documentation</a> <br>
+  * <a href="https://erxes.io/community">Contributing to erxes</a> <br>
   
 ## Deployment
 


### PR DESCRIPTION
### Description 
1. The image link for the contributors graph is showing the 404 Error page. It must be resolved. 
So I changed it to [https://opencollective.com/erxes#section-contributors](https://opencollective.com/erxes#section-contributors) where the contributors are clearly showing.

2. There were some broken links in Documentation section in Readme.md. I have resolved those links.
- Install erxes : 
  Currently pointing to : https://www.erxes.org/ 
  I changed it to here : https://erxes.io/install 

- Documentation: 
  Currently pointing to : https://docs.erxes.io/
  I changed it to here : https://www.erxes.org/overview/getting-started/
  
- Contributing to erxes
  Currently pointing to : https://www.erxes.org/
  I changed it to here : https://erxes.io/community

### Issues
[ISSUE #2360 ](https://github.com/erxes/erxes/issues/2360)
[ISSUE #2352 ](https://github.com/erxes/erxes/issues/2352)

### Context
![404 error page](https://user-images.githubusercontent.com/60822964/94984229-8d942a00-0567-11eb-86c0-75d222ebfce4.png)
