### PR TITLE
show external integration data in appstore list

### DIFF
--- a/ui/src/modules/settings/integrations/components/common/IntegrationList.tsx
+++ b/ui/src/modules/settings/integrations/components/common/IntegrationList.tsx
@@ -51,7 +51,7 @@ class IntegrationList extends React.Component<Props> {
     const { integrations, kind, integrationsCount } = this.props;
 
     if (!integrations || integrations.length < 1) {
-      if(kind === INTEGRATION_KINDS.MESSENGER) {
+      if (kind === INTEGRATION_KINDS.MESSENGER) {
         return <EmptyContent content={EMPTY_CONTENT_MESSENGER} />;
       }
 
@@ -75,6 +75,7 @@ class IntegrationList extends React.Component<Props> {
               <th>{__('Kind')}</th>
               <th>{__('Brand')}</th>
               <th>{__('Status')}</th>
+              <th>{__('External info')}</th>
               <th style={{ width: 130 }}>{__('Actions')}</th>
             </tr>
           </thead>

--- a/ui/src/modules/settings/integrations/components/common/IntegrationListItem.tsx
+++ b/ui/src/modules/settings/integrations/components/common/IntegrationListItem.tsx
@@ -205,6 +205,43 @@ class IntegrationListItem extends React.Component<Props> {
     );
   }
 
+  renderExternalData(integration) {
+    const { externalData, kind } = integration;
+    let value = '';
+
+    if (!externalData) {
+      return <td />;
+    }
+
+    switch (kind) {
+      case INTEGRATION_KINDS.CALLPRO:
+        value = externalData.phoneNumber;
+        break;
+      case INTEGRATION_KINDS.CHATFUEL:
+        value = (externalData.chatfuelConfigs || {}).toString();
+        break;
+      case INTEGRATION_KINDS.WHATSAPP:
+        value = externalData.whatsappToken;
+        break;
+      case INTEGRATION_KINDS.SMOOCH_TELEGRAM:
+        value = externalData.telegramBotToken;
+        break;
+      case INTEGRATION_KINDS.SMOOCH_VIBER:
+        value = externalData.viberBotToken;
+        break;
+      case INTEGRATION_KINDS.SMOOCH_LINE:
+        value = externalData.lineChannelId;
+        break;
+      case INTEGRATION_KINDS.TELNYX:
+        value = externalData.telnyxPhoneNumber;
+        break;
+      default:
+        break;
+    }
+
+    return <td>{value}</td>;
+  }
+
   render() {
     const { integration } = this.props;
     const integrationKind = cleanIntegrationKind(integration.kind);
@@ -223,6 +260,7 @@ class IntegrationListItem extends React.Component<Props> {
         <td>
           <Label lblStyle={labelStyle}>{status}</Label>
         </td>
+        {this.renderExternalData(integration)}
         <td>
           <ActionButtons>
             {this.renderMessengerActions(integration)}

--- a/ui/src/modules/settings/integrations/graphql/queries.ts
+++ b/ui/src/modules/settings/integrations/graphql/queries.ts
@@ -105,6 +105,7 @@ const integrations = `
         title
         code
       }
+      externalData
     }
   }
 `;


### PR DESCRIPTION
### Context

When creating integrations, the third-party service configurations like API token, webhook url etc are only filled in create forms. After the integration is created, such data above is not visible in the list. With this PR, callpro, chatfuel, smooch, whatsapp & telnyx configurations will show up in the list.

<img width="1439" alt="Screen Shot 2020-10-10 at 13 33 42" src="https://user-images.githubusercontent.com/5917302/95646655-6efcd880-0afd-11eb-8cd6-c5e7ec2da37d.png">


// Delete the below section once completed
### PR Checklist
- [x] Description is clearly stated under Context section
- [x] Screenshots and the additional verifications are attached
