### PR TITLE
Add lang attribute in html tag.

### DIFF
--- a/ui/public/ckeditor/plugins/autogrow/samples/autogrow.html
+++ b/ui/public/ckeditor/plugins/autogrow/samples/autogrow.html
@@ -3,7 +3,7 @@
 Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 -->
-<html>
+<html lang="en">
 <head>
 	<meta charset="utf-8">
 	<title>AutoGrow Plugin &mdash; CKEditor Sample</title>


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

You should always include the lang attribute inside the <html> tag, to declare the language of the Web page. This is meant to assist search engines and browsers.
