### PR TITLE
Feat/engage test email

### DIFF
--- a/api/src/data/resolvers/mutations/engages.ts
+++ b/api/src/data/resolvers/mutations/engages.ts
@@ -1,16 +1,27 @@
 import * as _ from 'underscore';
-import { EngageMessages } from '../../../db/models';
+import { Customers, EngageMessages, Users } from '../../../db/models';
 import { METHODS } from '../../../db/models/definitions/constants';
 import { IEngageMessage } from '../../../db/models/definitions/engages';
 import { MESSAGE_KINDS, MODULE_NAMES } from '../../constants';
 import { putCreateLog, putDeleteLog, putUpdateLog } from '../../logUtils';
 import { checkPermission } from '../../permissions/wrappers';
 import { IContext } from '../../types';
-import { registerOnboardHistory, sendToWebhook } from '../../utils';
+import {
+  registerOnboardHistory,
+  replaceEditorAttributes,
+  sendToWebhook
+} from '../../utils';
 import { send } from './engageUtils';
 
 interface IEngageMessageEdit extends IEngageMessage {
   _id: string;
+}
+
+interface ITestEmailParams {
+  from: string;
+  to: string;
+  content: string;
+  title: string;
 }
 
 /**
@@ -166,12 +177,32 @@ const engageMutations = {
 
   async engageMessageSendTestEmail(
     _root,
-    args,
+    args: ITestEmailParams,
     { dataSources, user }: IContext
   ) {
     await registerOnboardHistory({ type: 'engageSendTestEmail', user });
 
-    return dataSources.EngagesAPI.engagesSendTestEmail(args);
+    const { content, from, to, title } = args;
+
+    if (!(content && from && to && title)) {
+      throw new Error(
+        'Email content, title, from address or to address is missing'
+      );
+    }
+
+    const customer = await Customers.findOne({ primaryEmail: to });
+    const targetUser = await Users.findOne({ email: to });
+
+    const { replacedContent } = await replaceEditorAttributes({
+      content,
+      customer,
+      user: targetUser
+    });
+
+    return dataSources.EngagesAPI.engagesSendTestEmail({
+      ...args,
+      content: replacedContent
+    });
   }
 };
 

--- a/api/src/data/schema/engage.ts
+++ b/api/src/data/schema/engage.ts
@@ -161,5 +161,5 @@ export const mutations = `
   engagesUpdateConfigs(configsMap: JSON!): JSON
   engageMessageVerifyEmail(email: String!): String
   engageMessageRemoveVerifiedEmail(email: String!): String
-  engageMessageSendTestEmail(from: String!, to: String!, content: String!): String
+  engageMessageSendTestEmail(from: String!, to: String!, content: String!, title: String!): String
 `;

--- a/api/src/data/utils.ts
+++ b/api/src/data/utils.ts
@@ -9,13 +9,8 @@ import * as path from 'path';
 import * as puppeteer from 'puppeteer';
 import * as strip from 'strip';
 import * as xlsxPopulate from 'xlsx-populate';
-import * as models from '../db/models'
-import {
-  Customers,
-  OnboardingHistories,
-  Users,
-  Webhooks
-} from '../db/models';
+import * as models from '../db/models';
+import { Customers, OnboardingHistories, Users, Webhooks } from '../db/models';
 import { IBrandDocument } from '../db/models/definitions/brands';
 import { WEBHOOK_STATUS } from '../db/models/definitions/constants';
 import { ICustomer } from '../db/models/definitions/customers';
@@ -479,7 +474,7 @@ export const readFile = utils.readFile;
  * Create default or ses transporter
  */
 export const createTransporter = async ({ ses }) => {
-  return utils.createTransporter(models, memoryStorage, { ses })
+  return utils.createTransporter(models, memoryStorage, { ses });
 };
 
 export type IEmailParams = IEmailParamsC;
@@ -493,8 +488,8 @@ interface IReplacer {
  */
 export const replaceEditorAttributes = async (args: {
   content: string;
-  customer?: ICustomer;
-  user?: IUser;
+  customer?: ICustomer | null;
+  user?: IUser | null;
   customerFields?: string[];
   brand?: IBrandDocument;
 }): Promise<{
@@ -695,8 +690,7 @@ export const sendMobileNotification = async ({
     body,
     customerId,
     conversationId
-
-  })
+  });
 };
 
 export const paginate = utils.paginate;

--- a/engages-email-sender/src/api/configs.ts
+++ b/engages-email-sender/src/api/configs.ts
@@ -64,7 +64,7 @@ router.post('/remove-verified-email', async (req, res, next) => {
 router.post('/send-test-email', async (req, res, next) => {
   debugRequest(debugEngages, req);
 
-  const { from, to, content } = req.body;
+  const { from, to, content, title } = req.body;
 
   const transporter = await createTransporter();
 
@@ -72,7 +72,7 @@ router.post('/send-test-email', async (req, res, next) => {
     const response = await transporter.sendMail({
       from,
       to,
-      subject: content,
+      subject: title,
       html: content
     });
 

--- a/ui/src/__tests__/engage/components/EmailForm.test.tsx
+++ b/ui/src/__tests__/engage/components/EmailForm.test.tsx
@@ -45,6 +45,10 @@ describe('EmailForm component', () => {
     dateTime: 'string'
   };
 
+  const sendTestEmail = () => {
+    console.log('test email');
+  };
+
   const defaultProps = {
     onChange: (
       name: 'email' | 'content' | 'fromUserId' | 'scheduleDate',
@@ -58,7 +62,8 @@ describe('EmailForm component', () => {
     fromUserId: 'string',
     content: 'string',
     scheduleDate: testIEngageScheduleDate,
-    verifiedEmails: []
+    verifiedEmails: [],
+    sendTestEmail
   };
 
   test('renders successfully', () => {

--- a/ui/src/modules/engage/containers/EmailForm.tsx
+++ b/ui/src/modules/engage/containers/EmailForm.tsx
@@ -2,25 +2,47 @@ import gql from 'graphql-tag';
 import * as compose from 'lodash.flowright';
 import React from 'react';
 import { graphql } from 'react-apollo';
-import { withProps } from '../../common/utils';
+import { Alert, withProps } from '../../common/utils';
 import EmailForm from '../components/EmailForm';
-import { queries } from '../graphql';
+import { mutations, queries } from '../graphql';
 import { EngageVerifiedEmailsQueryResponse, IEmailFormProps } from '../types';
 
 type FinalProps = {
   engageVerifiedEmailsQuery: EngageVerifiedEmailsQueryResponse;
+  engageSendTestEmail: any;
 } & IEmailFormProps;
 
 const EmailFormContainer = (props: FinalProps) => {
-  const { engageVerifiedEmailsQuery } = props;
+  const { engageSendTestEmail, engageVerifiedEmailsQuery } = props;
 
   const verifiedEmails = engageVerifiedEmailsQuery.engageVerifiedEmails || [];
   const error = engageVerifiedEmailsQuery.error;
 
+  const sendTestEmail = ({ content, from, to, title }) => {
+    if (!content) {
+      return Alert.warning('Please fill email content');
+    }
+    if (!from) {
+      return Alert.warning('Please choose from user');
+    }
+    if (!to) {
+      return Alert.warning('Please fill destination email address');
+    }
+
+    engageSendTestEmail({ variables: { content, from, to, title } })
+      .then(() => {
+        Alert.success('Email has been sent');
+      })
+      .catch(e => {
+        Alert.error(e.message);
+      });
+  };
+
   const updatedProps = {
     ...props,
     error: error && error.message,
-    verifiedEmails
+    verifiedEmails,
+    sendTestEmail
   };
 
   return <EmailForm {...updatedProps} />;
@@ -31,6 +53,9 @@ export default withProps<IEmailFormProps>(
     graphql<IEmailFormProps, EngageVerifiedEmailsQueryResponse>(
       gql(queries.verifiedEmails),
       { name: 'engageVerifiedEmailsQuery' }
-    )
+    ),
+    graphql(gql(mutations.sendTestEmail), {
+      name: 'engageSendTestEmail'
+    })
   )(EmailFormContainer)
 );

--- a/ui/src/modules/engage/graphql/mutations.ts
+++ b/ui/src/modules/engage/graphql/mutations.ts
@@ -31,8 +31,8 @@ const engagesUpdateConfigs = `
 `;
 
 const sendTestEmail = `
-  mutation engageMessageSendTestEmail($from: String!, $to: String!, $content: String!) {
-    engageMessageSendTestEmail(from: $from, to: $to, content: $content)
+  mutation engageMessageSendTestEmail($from: String!, $to: String!, $content: String!, $title: String!) {
+    engageMessageSendTestEmail(from: $from, to: $to, content: $content, title: $title)
   }
 `;
 

--- a/ui/src/modules/engage/styles.tsx
+++ b/ui/src/modules/engage/styles.tsx
@@ -475,6 +475,16 @@ const MobilePreviewContent = styledTS<{ templateId?: string }>(styled.div)`
   overflow-x: hidden;
 `;
 
+const TestEmailWrapper = styled.div`
+  margin: 20px 0;
+  padding: 20px 0;
+  border-top: 1px dashed #ddd;
+
+  button {
+    margin-top: 10px;
+  }
+`;
+
 export {
   RowTitle,
   HelperText,
@@ -511,5 +521,6 @@ export {
   RightSection,
   DesktopPreviewContent,
   MobilePreviewContent,
-  Shell
+  Shell,
+  TestEmailWrapper
 };

--- a/ui/src/modules/settings/general/containers/EngageSettingsContent.tsx
+++ b/ui/src/modules/settings/general/containers/EngageSettingsContent.tsx
@@ -101,7 +101,8 @@ class SettingsContainer extends React.Component<Props> {
         variables: {
           from,
           to,
-          content
+          content,
+          title: 'This is a test'
         }
       })
         .then(() => {


### PR DESCRIPTION
### Context

Enable engage messages of type email to be sent to testing purpose email address. The purpose is to check the email content before sending to multiple customers.

<img width="1349" alt="Screen Shot 2021-01-13 at 16 39 32" src="https://user-images.githubusercontent.com/5917302/104427388-218d7d00-55be-11eb-9450-fdd77963d6f1.png">
