### PR TITLE
save created user id in engages

### DIFF
--- a/api/src/__tests__/dashboardQueries.test.ts
+++ b/api/src/__tests__/dashboardQueries.test.ts
@@ -164,7 +164,8 @@ describe('dashboardQueries', () => {
       'modifiedBy',
       'integrationName',
       'Contacts.state',
-      'brand'
+      'brand',
+      'test'
     ];
 
     types.map(async type => {

--- a/api/src/__tests__/engageMessageDb.test.ts
+++ b/api/src/__tests__/engageMessageDb.test.ts
@@ -74,7 +74,8 @@ describe('engage messages model tests', () => {
       brandIds: [_brand._id],
       tagIds: [_tag._id],
       isLive: true,
-      isDraft: false
+      isDraft: false,
+      createdBy: _user._id
     };
 
     const message = await EngageMessages.createEngageMessage(doc);
@@ -86,6 +87,7 @@ describe('engage messages model tests', () => {
     expect(message.tagIds).toEqual(expect.arrayContaining(doc.tagIds));
     expect(message.isLive).toEqual(doc.isLive);
     expect(message.isDraft).toEqual(doc.isDraft);
+    expect(message.createdBy).toBe(doc.createdBy);
   });
 
   test('update messages', async () => {

--- a/api/src/__tests__/engageMessageQueries.test.ts
+++ b/api/src/__tests__/engageMessageQueries.test.ts
@@ -60,9 +60,11 @@ describe('engageQueries', () => {
   });
 
   test('Engage messages', async () => {
+    const user = await userFactory();
+
     await engageMessageFactory({});
     await engageMessageFactory({});
-    await engageMessageFactory({});
+    await engageMessageFactory({ createdBy: user._id });
 
     const responses = await graphqlRequest(qryEngageMessages, 'engageMessages');
 
@@ -205,7 +207,7 @@ describe('engageQueries', () => {
     expect(response.length).toBe(2);
   });
 
-  test('Enage email delivery report list', async () => {
+  test('Engage email delivery report list', async () => {
     const customer = await customerFactory();
     const dataSourceMock = sinon
       .stub(dataSources.EngagesAPI, 'engageReportsList')
@@ -255,7 +257,8 @@ describe('engageQueries', () => {
   });
 
   test('Engage message detail', async () => {
-    const engageMessage = await engageMessageFactory();
+    const user = await userFactory();
+    const engageMessage = await engageMessageFactory({ createdBy: user._id });
 
     const qry = `
       query engageMessageDetail($_id: String) {
@@ -277,6 +280,8 @@ describe('engageQueries', () => {
 
           email
           messenger
+          createdBy
+          createdUser
 
           brands { _id }
           segments { _id }
@@ -300,6 +305,7 @@ describe('engageQueries', () => {
     );
 
     expect(response._id).toBe(engageMessage._id);
+    expect(response.createdBy).toBe(user._id);
 
     const brand = await brandFactory();
     const messenger = { brandId: brand._id, content: 'Content' };

--- a/api/src/data/resolvers/engage.ts
+++ b/api/src/data/resolvers/engage.ts
@@ -82,5 +82,15 @@ export const message = {
     }
 
     return null;
+  },
+
+  async createdUser(engageMessage: IEngageMessageDocument): Promise<string> {
+    const user = await Users.findOne({ _id: engageMessage.createdBy });
+
+    if (!user) {
+      return '';
+    }
+
+    return user.username || user.email || user._id;
   }
 };

--- a/api/src/data/resolvers/mutations/engages.ts
+++ b/api/src/data/resolvers/mutations/engages.ts
@@ -54,7 +54,7 @@ const engageMutations = {
     }
 
     const engageMessage = await EngageMessages.createEngageMessage(
-      docModifier(doc)
+      docModifier({ ...doc, createdBy: user._id })
     );
 
     await sendToWebhook('create', 'engageMessages', engageMessage);

--- a/api/src/data/schema/engage.ts
+++ b/api/src/data/schema/engage.ts
@@ -29,6 +29,7 @@ export const types = `
     email: JSON
     messenger: JSON
     shortMessage: EngageMessageSms
+    createdBy: String
 
     scheduleDate: EngageScheduleDate
     segments: [Segment]
@@ -37,6 +38,7 @@ export const types = `
     fromUser: User
     getTags: [Tag]
     fromIntegration: Integration
+    createdUser: String
 
     stats: JSON
     logs: JSON

--- a/api/src/db/factories.ts
+++ b/api/src/db/factories.ts
@@ -247,6 +247,7 @@ interface IEngageMessageFactoryInput {
   fromUserId?: string;
   fromIntegrationId?: string;
   scheduleDate?: IScheduleDate;
+  createdBy?: string;
 }
 
 export const engageMessageFactory = (
@@ -258,6 +259,7 @@ export const engageMessageFactory = (
     method: params.method || 'messenger',
     title: params.title || faker.random.word(),
     fromUserId: params.userId || faker.random.uuid(),
+    createdBy: params.createdBy || faker.random.uuid(),
     segmentIds: params.segmentIds || [],
     brandIds: params.brandIds || [],
     tagIds: params.tagIds || [],

--- a/api/src/db/models/definitions/engages.ts
+++ b/api/src/db/models/definitions/engages.ts
@@ -69,6 +69,7 @@ export interface IEngageMessage {
 
 export interface IEngageMessageDocument extends IEngageMessage, Document {
   scheduleDate?: IScheduleDateDocument;
+  createdBy: string;
 
   email?: IEmailDocument;
   messenger?: IMessengerDocument;
@@ -173,6 +174,7 @@ export const engageMessageSchema = schemaWrapper(
     totalCustomersCount: field({ type: Number, optional: true }),
     validCustomersCount: field({ type: Number, optional: true }),
 
-    shortMessage: field({ type: smsSchema, label: 'Short message' })
+    shortMessage: field({ type: smsSchema, label: 'Short message' }),
+    createdBy: field({ type: String, label: 'Created user id' })
   })
 );

--- a/ui/src/modules/engage/components/MessageList.tsx
+++ b/ui/src/modules/engage/components/MessageList.tsx
@@ -171,7 +171,7 @@ class List extends React.Component<Props> {
       </Button>
     );
 
-    const content = props => (
+    const content = () => (
       <FlexContainer direction="column">
         {this.renderBox(
           'Auto message',
@@ -236,6 +236,7 @@ class List extends React.Component<Props> {
               />
             </th>
             <th>{__('Title')}</th>
+            <th>{__('Created')}</th>
             <th>{__('From')}</th>
             <th>{__('Status')}</th>
             <th>{__('Total')}</th>

--- a/ui/src/modules/engage/components/MessageListRow.tsx
+++ b/ui/src/modules/engage/components/MessageListRow.tsx
@@ -232,6 +232,7 @@ class Row extends React.Component<Props> {
           {message.isDraft ? <Label lblStyle="simple">Draft</Label> : null}
           {this.renderRules()}
         </td>
+        <td className="text-normal">{message.createdUser || '-'}</td>
         <td className="text-normal">
           <NameCard user={message.fromUser} avatarSize={30} />
         </td>

--- a/ui/src/modules/engage/graphql/queries.ts
+++ b/ui/src/modules/engage/graphql/queries.ts
@@ -37,6 +37,7 @@ const commonFields = `
   messenger
   email
   smsStats
+  createdUser
 
   totalCustomersCount
   validCustomersCount

--- a/ui/src/modules/engage/types.ts
+++ b/ui/src/modules/engage/types.ts
@@ -123,10 +123,10 @@ export interface IEngageMessage extends IEngageMessageDoc {
   logs?: Array<{ message: string }>;
   smsStats?: IEngageSmsStats;
   fromIntegration?: IIntegration;
+  createdUser: string;
 }
 
 // mutation types
-
 export type MutationVariables = {
   _id: string;
 };


### PR DESCRIPTION
- Save created user id in engages.
- Show created user's username or email in engage list
- Improve test & coverage.