### PR TITLE
rename engage to campaign

### DIFF
--- a/ui/src/modules/engage/components/AutoAndManualForm.tsx
+++ b/ui/src/modules/engage/components/AutoAndManualForm.tsx
@@ -180,7 +180,7 @@ class AutoAndManualForm extends React.Component<Props, State> {
     const { isActionLoading, kind } = this.props;
 
     const cancelButton = (
-      <Link to="/engage">
+      <Link to="/campaigns">
         <Button btnStyle="simple" uppercase={false} icon="times-circle">
           Cancel
         </Button>

--- a/ui/src/modules/engage/components/AutoAndManualForm.tsx
+++ b/ui/src/modules/engage/components/AutoAndManualForm.tsx
@@ -277,7 +277,7 @@ class AutoAndManualForm extends React.Component<Props, State> {
     return (
       <Step
         img={imagePath}
-        title="Compose your message"
+        title="Compose your campaign"
         message={message}
         noButton={method !== METHODS.EMAIL && true}
       >
@@ -367,7 +367,7 @@ class AutoAndManualForm extends React.Component<Props, State> {
 
           <Step
             img="/images/icons/erxes-06.svg"
-            title="Who is this message for?"
+            title="Who is this campaign for?"
           >
             <MessageTypeStep
               onChange={this.changeState}

--- a/ui/src/modules/engage/components/EngageStats.tsx
+++ b/ui/src/modules/engage/components/EngageStats.tsx
@@ -276,7 +276,7 @@ class EmailStatistics extends React.Component<Props> {
           <Wrapper.Header
             title={__('Show statistics')}
             breadcrumb={[
-              { title: __('Engage'), link: '/engage' },
+              { title: __('Campaigns'), link: '/campaigns' },
               { title: __('Show statistics') }
             ]}
           />

--- a/ui/src/modules/engage/components/FormBase.tsx
+++ b/ui/src/modules/engage/components/FormBase.tsx
@@ -111,7 +111,7 @@ class FormBase extends React.Component<Props> {
 
   render() {
     const breadcrumbs = [
-      { title: __('Campaigns'), link: '/engage' },
+      { title: __('Campaigns'), link: '/campaigns' },
       { title: this.renderTitle() }
     ];
 

--- a/ui/src/modules/engage/components/FormBase.tsx
+++ b/ui/src/modules/engage/components/FormBase.tsx
@@ -96,14 +96,14 @@ class FormBase extends React.Component<Props> {
   renderTitle() {
     const { kind } = this.props;
 
-    let title = __('Auto message');
+    let title = __('Auto campaign');
 
     if (kind === 'manual') {
-      title = __('Manual message');
+      title = __('Manual campaign');
     }
 
     if (kind === 'visitorAuto') {
-      title = __('Visitor auto message');
+      title = __('Visitor auto campaign');
     }
 
     return title;
@@ -111,7 +111,7 @@ class FormBase extends React.Component<Props> {
 
   render() {
     const breadcrumbs = [
-      { title: __('Engage'), link: '/engage' },
+      { title: __('Campaigns'), link: '/engage' },
       { title: this.renderTitle() }
     ];
 

--- a/ui/src/modules/engage/components/MessageList.tsx
+++ b/ui/src/modules/engage/components/MessageList.tsx
@@ -167,24 +167,24 @@ class List extends React.Component<Props> {
   renderRightActionBar = () => {
     const trigger = (
       <Button btnStyle="success" size="small" icon="plus-circle">
-        {__('New message')}
+        {__('New campaign')}
       </Button>
     );
 
     const content = () => (
       <FlexContainer direction="column">
         {this.renderBox(
-          'Auto message',
+          'Auto campaign',
           'Auto message description',
           '/engage/messages/create?kind=auto'
         )}
         {this.renderBox(
-          'Manual message',
+          'Manual campaign',
           'Manual message description',
           '/engage/messages/create?kind=manual'
         )}
         {this.renderBox(
-          'Visitor auto message',
+          'Visitor auto campaign',
           'Visitor auto message description',
           '/engage/messages/create?kind=visitorAuto'
         )}
@@ -195,7 +195,7 @@ class List extends React.Component<Props> {
       <>
         {this.renderPercentage()}
         <ModalTrigger
-          title="New message"
+          title="New campaign"
           trigger={trigger}
           content={content}
           hideHeader={true}
@@ -236,7 +236,7 @@ class List extends React.Component<Props> {
               />
             </th>
             <th>{__('Title')}</th>
-            <th>{__('Created')}</th>
+            <th>{__('Created by')}</th>
             <th>{__('From')}</th>
             <th>{__('Status')}</th>
             <th>{__('Total')}</th>
@@ -266,8 +266,8 @@ class List extends React.Component<Props> {
       <Wrapper
         header={
           <Wrapper.Header
-            title={__('Engage')}
-            breadcrumb={[{ title: __('Engage') }]}
+            title={__('Campaigns')}
+            breadcrumb={[{ title: __('Campaigns') }]}
             queryParams={queryParams}
           />
         }

--- a/ui/src/modules/engage/components/MessageList.tsx
+++ b/ui/src/modules/engage/components/MessageList.tsx
@@ -176,17 +176,17 @@ class List extends React.Component<Props> {
         {this.renderBox(
           'Auto campaign',
           'Auto message description',
-          '/engage/messages/create?kind=auto'
+          '/campaigns/create?kind=auto'
         )}
         {this.renderBox(
           'Manual campaign',
           'Manual message description',
-          '/engage/messages/create?kind=manual'
+          '/campaigns/create?kind=manual'
         )}
         {this.renderBox(
           'Visitor auto campaign',
           'Visitor auto message description',
-          '/engage/messages/create?kind=visitorAuto'
+          '/campaigns/create?kind=visitorAuto'
         )}
       </FlexContainer>
     );

--- a/ui/src/modules/engage/components/Sidebar.tsx
+++ b/ui/src/modules/engage/components/Sidebar.tsx
@@ -27,7 +27,7 @@ class Sidebar extends React.Component<Props> {
 
         <SidebarList>
           <li>
-            <Link to="/engage">
+            <Link to="/campaigns">
               <FieldStyle>{__('All')}</FieldStyle>
               <SidebarCounter>{kindCounts.all}</SidebarCounter>
             </Link>
@@ -40,7 +40,7 @@ class Sidebar extends React.Component<Props> {
                 className={
                   router.getParam(history, 'kind') === kind.name ? 'active' : ''
                 }
-                to={`/engage?kind=${kind.name}`}
+                to={`/campaigns?kind=${kind.name}`}
               >
                 <FieldStyle>{__(kind.text)}</FieldStyle>
                 <SidebarCounter>{kindCounts[kind.name]}</SidebarCounter>
@@ -69,7 +69,7 @@ class Sidebar extends React.Component<Props> {
                     ? 'active'
                     : ''
                 }
-                to={`/engage?status=${status.key}`}
+                to={`/campaigns?status=${status.key}`}
               >
                 <FieldStyle>{__(status.value)}</FieldStyle>
                 <SidebarCounter>{statusCounts[status.key]}</SidebarCounter>

--- a/ui/src/modules/engage/components/VisitorForm.tsx
+++ b/ui/src/modules/engage/components/VisitorForm.tsx
@@ -105,7 +105,7 @@ class VisitorForm extends React.Component<Props, State> {
     const { isActionLoading, kind } = this.props;
 
     const cancelButton = (
-      <Link to="/engage">
+      <Link to="/campaigns">
         <Button btnStyle="simple" uppercase={false} icon="times-circle">
           Cancel
         </Button>

--- a/ui/src/modules/engage/components/VisitorForm.tsx
+++ b/ui/src/modules/engage/components/VisitorForm.tsx
@@ -181,7 +181,7 @@ class VisitorForm extends React.Component<Props, State> {
         <Steps maxStep={maxStep} active={activeStep}>
           <Step
             img="/images/icons/erxes-02.svg"
-            title="Who is this message for?"
+            title="Who is this campaign for?"
           >
             <ConditionsRule
               rules={this.state.rules}
@@ -191,7 +191,7 @@ class VisitorForm extends React.Component<Props, State> {
 
           <Step
             img="/images/icons/erxes-08.svg"
-            title="Compose your message"
+            title="Compose your campaign"
             noButton={true}
           >
             <MessengerForm

--- a/ui/src/modules/engage/containers/MessageListRow.tsx
+++ b/ui/src/modules/engage/containers/MessageListRow.tsx
@@ -55,18 +55,18 @@ const MessageRowContainer = (props: FinalProps) => {
       });
 
   const edit = () => {
-    history.push(`/engage/messages/edit/${message._id}`);
+    history.push(`/campaigns/edit/${message._id}`);
   };
 
   const show = () => {
-    history.push(`/engage/messages/show/${message._id}`);
+    history.push(`/campaigns/show/${message._id}`);
   };
 
   const remove = () => {
     confirm().then(() => {
-      doMutation(removeMutation, `You just deleted an engagement message.`)
+      doMutation(removeMutation, `You just deleted a campaign.`)
         .then(() => {
-          history.push('/engage');
+          history.push('/campaigns');
         })
         .catch(e => {
           Alert.error(e.message);
@@ -75,14 +75,11 @@ const MessageRowContainer = (props: FinalProps) => {
   };
 
   const setLiveManual = () =>
-    doMutation(
-      setLiveManualMutation,
-      'Yay! Your engagement message is now live.'
-    );
+    doMutation(setLiveManualMutation, 'Yay! Your campaign is now live.');
   const setLive = () =>
-    doMutation(setLiveMutation, 'Yay! Your engagement message is now live.');
+    doMutation(setLiveMutation, 'Yay! Your campaign is now live.');
   const setPause = () =>
-    doMutation(setPauseMutation, 'Your engagement message is paused for now.');
+    doMutation(setPauseMutation, 'Your campaign is paused for now.');
 
   const updatedProps = {
     ...props,

--- a/ui/src/modules/engage/containers/withFormMutations.tsx
+++ b/ui/src/modules/engage/containers/withFormMutations.tsx
@@ -63,7 +63,7 @@ function withSaveAndEdit<IComponentProps>(Component) {
             Alert.success(msg);
 
             history.push({
-              pathname: '/engage',
+              pathname: '/campaigns',
               search: '?engageRefetchList=true'
             });
           })

--- a/ui/src/modules/engage/routes.tsx
+++ b/ui/src/modules/engage/routes.tsx
@@ -42,30 +42,30 @@ const routes = () => {
   return (
     <React.Fragment>
       <Route
-        key="/engage/home"
+        key="/campaigns"
         exact={true}
-        path="/engage"
+        path="/campaigns"
         component={engageList}
       />
 
       <Route
-        key="/engage/messages/create"
+        key="/campaigns/create"
         exact={true}
-        path="/engage/messages/create"
+        path="/campaigns/create"
         component={createForm}
       />
 
       <Route
-        key="/engage/messages/edit"
+        key="/campaigns/edit"
         exact={true}
-        path="/engage/messages/edit/:_id"
+        path="/campaigns/edit/:_id"
         component={editForm}
       />
 
       <Route
-        key="/engage/messages/show"
+        key="/campaigns/show"
         exact={true}
-        path="/engage/messages/show/:_id"
+        path="/campaigns/show/:_id"
         component={statistic}
       />
     </React.Fragment>

--- a/ui/src/modules/layout/components/Navigation.tsx
+++ b/ui/src/modules/layout/components/Navigation.tsx
@@ -212,7 +212,7 @@ class Navigation extends React.Component<{
           {this.renderNavItem(
             'showEngagesMessages',
             __('Campaigns'),
-            '/engage',
+            '/campaigns',
             'icon-megaphone'
           )}
           {this.renderNavItem(

--- a/ui/src/modules/layout/components/Navigation.tsx
+++ b/ui/src/modules/layout/components/Navigation.tsx
@@ -211,7 +211,7 @@ class Navigation extends React.Component<{
           )}
           {this.renderNavItem(
             'showEngagesMessages',
-            __('Engage'),
+            __('Campaigns'),
             '/engage',
             'icon-megaphone'
           )}

--- a/ui/src/modules/settings/general/components/EngageConfigs.tsx
+++ b/ui/src/modules/settings/general/components/EngageConfigs.tsx
@@ -9,17 +9,17 @@ import Sidebar from './Sidebar';
 function EngageConfigs() {
   const breadcrumb = [
     { title: __('Settings'), link: '/settings' },
-    { title: __('Engage config') }
+    { title: __('Campaign config') }
   ];
 
   return (
     <Wrapper
       header={
-        <Wrapper.Header title={__('Engage config')} breadcrumb={breadcrumb} />
+        <Wrapper.Header title={__('Campaign config')} breadcrumb={breadcrumb} />
       }
       mainHead={<Header />}
       actionBar={
-        <Wrapper.ActionBar left={<Title>{__('Engage config')}</Title>} />
+        <Wrapper.ActionBar left={<Title>{__('Campaign config')}</Title>} />
       }
       leftSidebar={<Sidebar />}
       content={<EngageSettingsContent />}

--- a/ui/src/modules/settings/general/components/Sidebar.tsx
+++ b/ui/src/modules/settings/general/components/Sidebar.tsx
@@ -46,7 +46,7 @@ class Sidebar extends React.Component {
             '/settings/integration-configs',
             'Integrations config'
           )}
-          {this.renderListItem('/settings/engage-configs', 'Engage config')}
+          {this.renderListItem('/settings/campaign-configs', 'Campaign config')}
         </List>
       </LeftSidebar>
     );

--- a/ui/src/modules/settings/general/routes.tsx
+++ b/ui/src/modules/settings/general/routes.tsx
@@ -28,7 +28,7 @@ const routes = () => {
         path="/settings/integration-configs/"
         component={IntegrationConfigs}
       />
-      <Route path="/settings/engage-configs/" component={EngageConfigs} />
+      <Route path="/settings/campaign-configs/" component={EngageConfigs} />
     </React.Fragment>
   );
 };


### PR DESCRIPTION
"Engage message" seemed confusing to some customers. Therefore, with this PR, the UI part of engage message is gonna be renamed to "campaign"s.