### PR TITLE
replace field name attributes of campaign title

### DIFF
--- a/engages-email-sender/src/sender.ts
+++ b/engages-email-sender/src/sender.ts
@@ -174,11 +174,13 @@ export const start = async (data: {
 
     // replace customer attributes =====
     let replacedContent = content;
+    let replacedSubject = subject;
 
     if (customer.replacers) {
       for (const replacer of customer.replacers) {
         const regex = new RegExp(replacer.key, 'gi');
         replacedContent = replacedContent.replace(regex, replacer.value);
+        replacedSubject = replacedSubject.replace(regex, replacer.value);
       }
     }
 
@@ -189,7 +191,7 @@ export const start = async (data: {
         from: `${sender || ''} <${fromEmail}>`,
         to: customer.primaryEmail,
         replyTo,
-        subject,
+        subject: replacedSubject,
         attachments: mailAttachment,
         html: replacedContent,
         headers: {


### PR DESCRIPTION
Email campaign title can now be customized with custom fields like .
Consider a campaign with the following title. "Hello {{ customer.firstName }}".
Then the email will be delivered with a title "Hello John", considering a customer with a name John exists.