### PR TITLE
overlap margin on the icon

### DIFF
--- a/widgets/client/sass/base/_base.scss
+++ b/widgets/client/sass/base/_base.scss
@@ -4,7 +4,7 @@ html,
 body,
 #root,
 .erxes-widget {
-  height: 100%;
+  height: 70%;
 }
 
 body {
@@ -20,6 +20,7 @@ body {
   -webkit-font-smoothing: antialiased;
   line-height: 1.5;
   margin: 0;
+  
 
   button,
   input,


### PR DESCRIPTION
on the icon margin area is overlap therefore button are not clickable 