### PR TITLE
Enhancement/auto sms campaign

### DIFF
--- a/api/src/__tests__/engageMessageMutations.test.ts
+++ b/api/src/__tests__/engageMessageMutations.test.ts
@@ -487,6 +487,12 @@ describe('engage message mutation tests', () => {
       return Promise.resolve('success');
     });
 
+    const mockEngages = sinon
+      .stub(dataSources.EngagesAPI, 'engagesConfigDetail')
+      .callsFake(() => {
+        return Promise.resolve([]);
+      });
+
     process.env.AWS_SES_ACCESS_KEY_ID = '123';
     process.env.AWS_SES_SECRET_ACCESS_KEY = '123';
     process.env.AWS_SES_CONFIG_SET = 'aws-ses';
@@ -522,6 +528,7 @@ describe('engage message mutation tests', () => {
     }
 
     mock.restore();
+    mockEngages.restore();
   });
 
   test('Edit engage message', async () => {

--- a/api/src/data/dataSources/engages.ts
+++ b/api/src/data/dataSources/engages.ts
@@ -26,6 +26,10 @@ export default class EngagesAPI extends RESTDataSource {
     throw new Error(body);
   }
 
+  /**
+   * Fetches all saved configs from engages-email-sender
+   * @returns Configs documents
+   */
   public async engagesConfigDetail() {
     return this.get(`/configs/detail`);
   }

--- a/api/src/data/resolvers/mutations/engages.ts
+++ b/api/src/data/resolvers/mutations/engages.ts
@@ -55,9 +55,10 @@ const engageMutations = {
     await sendToWebhook('create', 'engageMessages', engageMessage);
 
     const configs = (await dataSources.EngagesAPI.engagesConfigDetail()) || [];
-    const smsLimit = configs.find(c => c.code === 'smsLimit');
+    const config = configs.find(c => c.code === 'smsLimit');
+    const smsLimit = config && config.value ? parseInt(config.value, 10) : 0;
 
-    await send(engageMessage, parseInt(smsLimit.value || '0', 10));
+    await send(engageMessage, smsLimit);
 
     await putCreateLog(
       {

--- a/api/src/data/resolvers/mutations/engages.ts
+++ b/api/src/data/resolvers/mutations/engages.ts
@@ -1,6 +1,5 @@
 import * as _ from 'underscore';
 import { Customers, EngageMessages, Users } from '../../../db/models';
-import { METHODS } from '../../../db/models/definitions/constants';
 import { IEngageMessage } from '../../../db/models/definitions/engages';
 import { MESSAGE_KINDS, MODULE_NAMES } from '../../constants';
 import { putCreateLog, putDeleteLog, putUpdateLog } from '../../logUtils';
@@ -40,14 +39,8 @@ const engageMutations = {
   async engageMessageAdd(
     _root,
     doc: IEngageMessage,
-    { user, docModifier }: IContext
+    { user, docModifier, dataSources }: IContext
   ) {
-    if (doc.kind !== MESSAGE_KINDS.MANUAL && doc.method === METHODS.SMS) {
-      throw new Error(
-        `SMS engage message of kind ${doc.kind} is not supported`
-      );
-    }
-
     checkCampaignDoc(doc);
 
     // fromUserId is not required in sms engage, so set it here
@@ -61,7 +54,10 @@ const engageMutations = {
 
     await sendToWebhook('create', 'engageMessages', engageMessage);
 
-    await send(engageMessage);
+    const configs = (await dataSources.EngagesAPI.engagesConfigDetail()) || [];
+    const smsLimit = configs.find(c => c.code === 'smsLimit');
+
+    await send(engageMessage, parseInt(smsLimit.value || '0', 10));
 
     await putCreateLog(
       {

--- a/ui/src/modules/settings/general/components/EngageSettingsContent.tsx
+++ b/ui/src/modules/settings/general/components/EngageSettingsContent.tsx
@@ -195,7 +195,7 @@ class EngageSettingsContent extends React.Component<Props, State> {
           <ControlLabel>Allowed email skip limit</ControlLabel>
           <p>
             The number of times that each customer can skip to open or click
-            engage emails. If this limit is exceeded, then the customer will
+            campaign emails. If this limit is exceeded, then the customer will
             automatically set to
             <strong> do not disturb </strong>mode.
           </p>
@@ -203,6 +203,21 @@ class EngageSettingsContent extends React.Component<Props, State> {
             {...formProps}
             name="allowedEmailSkipLimit"
             defaultValue={configsMap.allowedEmailSkipLimit || 10}
+          />
+        </FormGroup>
+
+        <FormGroup>
+          <ControlLabel>Customer limit per auto SMS campaign</ControlLabel>
+          <p>
+            The maximum number of customers that can receive auto SMS campaign
+            per each runtime.
+          </p>
+          <FormControl
+            {...formProps}
+            name="smsLimit"
+            defaultValue={configsMap.smsLimit || 50}
+            min={50}
+            max={100}
           />
         </FormGroup>
 


### PR DESCRIPTION
Made auto SMS campaign available with target customer count limitation. The limit can be set at **settings > campaign settings**.
If the target count is within the limit, campaign will be sent, otherwise, it won't run & proper message will be displayed in campaign detail page logs.