### PR TITLE
Optimize query: conversationCounts

### DIFF
--- a/api/src/data/resolvers/queries/conversations.ts
+++ b/api/src/data/resolvers/queries/conversations.ts
@@ -1,4 +1,3 @@
-import { createImportSpecifier } from 'typescript';
 import { ConversationMessages, Conversations } from '../../../db/models';
 import { CONVERSATION_STATUSES } from '../../../db/models/definitions/constants';
 import { IMessageDocument } from '../../../db/models/definitions/conversationMessages';
@@ -17,13 +16,6 @@ interface ICountBy {
 interface IConversationRes {
   [index: string]: number | ICountBy;
 }
-
-// count helper
-const count = async (query: any): Promise<number> => {
-  const result = await Conversations.find(query).countDocuments();
-
-  return Number(result);
-};
 
 const conversationQueries = {
   /**

--- a/api/src/data/resolvers/queries/conversations.ts
+++ b/api/src/data/resolvers/queries/conversations.ts
@@ -169,7 +169,7 @@ const conversationQueries = {
     const aggregationPipeline = [
       {
         $facet: {
-          unnassigned: [
+          unassigned: [
             { $match: { ...mainQuery, ...qb.unassignedFilter() } },
             { $count: 'count' }
           ],
@@ -193,7 +193,7 @@ const conversationQueries = {
       },
       {
         $project: {
-          unnassigned: { $arrayElemAt: ['$unnassigned.count', 0] },
+          unassigned: { $arrayElemAt: ['$unassigned.count', 0] },
           participating: { $arrayElemAt: ['$participating.count', 0] },
           starred: { $arrayElemAt: ['$starred.count', 0] },
           resolved: { $arrayElemAt: ['$resolved.count', 0] },

--- a/api/src/db/models/definitions/conversations.ts
+++ b/api/src/db/models/definitions/conversations.ts
@@ -113,3 +113,9 @@ conversationSchema.index(
   { userRelevance: 1 },
   { partialFilterExpression: { userRelevance: { $exists: true } } }
 );
+
+conversationSchema.index({
+  status: 1,
+  integrationId: 1,
+  userRelevance: 1
+});

--- a/api/src/db/models/definitions/conversations.ts
+++ b/api/src/db/models/definitions/conversations.ts
@@ -80,8 +80,9 @@ export const conversationSchema = new Schema({
 
   status: field({
     type: String,
-    enum: CONVERSATION_STATUSES.ALL,
-    index: true
+    enum: CONVERSATION_STATUSES.ALL
+    // compound index that starts with status already exists
+    // index: true
   }),
   messageCount: field({ type: Number }),
   tagIds: field({ type: [String] }),
@@ -114,8 +115,18 @@ conversationSchema.index(
   { partialFilterExpression: { userRelevance: { $exists: true } } }
 );
 
+// Begin: For accelerating status count
 conversationSchema.index({
   status: 1,
   integrationId: 1,
-  userRelevance: 1
+  userRelevance: 1,
+  assignedUserId: 1,
+  participatedUserIds: 1
 });
+conversationSchema.index({
+  status: 1,
+  integrationId: 1,
+  userRelevance: 1,
+  isCustomerRespondedLast: 1
+});
+// End: For accelerating status count


### PR DESCRIPTION
### Context: 
Performance of `graphql query conversationCounts` was slow.

#### Before:
- To get the counts of unassigned, participating, starred, resolved, awaitingResponse conversations, it was making 5 separate database calls. 
- DB indexes on the `Conversations` collection were not optimized for the above queries.

#### After:
- To get the counts of unassigned, participating, starred, resolved, awaitingResponse conversations, now it makes only 1 database call using aggregation.
- Created compound indexes that accelerate queries for finding unassigned, participating, starred, resolved, awaitingResponse conversations.

#### Failed to do:
- Didn't optimize calls to elasticsearch from loops