### PR TITLE
Optimize graphql resolver: Product

### DIFF
--- a/api/src/apolloClient.ts
+++ b/api/src/apolloClient.ts
@@ -15,6 +15,7 @@ import {
 } from './inmemoryStorage';
 import { extendViaPlugins } from './pluginUtils';
 import { graphqlPubsub } from './pubsub';
+import { IDataLoaders, generateAllDataLoaders } from './data/dataLoaders';
 
 // load environment variables
 dotenv.config();
@@ -87,6 +88,8 @@ export const initApolloServer = async app => {
         };
       }
 
+      const dataLoaders: IDataLoaders = generateAllDataLoaders();
+
       const requestInfo = {
         secure: req.secure,
         cookies: req.cookies
@@ -101,7 +104,8 @@ export const initApolloServer = async app => {
           commonQuerySelector: {},
           user,
           res,
-          requestInfo
+          requestInfo,
+          dataLoaders
         };
       }
 
@@ -138,7 +142,8 @@ export const initApolloServer = async app => {
         userBrandIdsSelector,
         user,
         res,
-        requestInfo
+        requestInfo,
+        dataLoaders
       };
     },
     subscriptions: {

--- a/api/src/data/dataLoaders/company.ts
+++ b/api/src/data/dataLoaders/company.ts
@@ -1,0 +1,18 @@
+import * as DataLoader from 'dataloader';
+import * as _ from 'underscore';
+import { Companies } from '../../db/models';
+import { ICompanyDocument } from '../../db/models/definitions/companies';
+
+export default function generateDataLoaderCompany() {
+  return new DataLoader<string, ICompanyDocument>(
+    async (ids: readonly string[]) => {
+      const result: ICompanyDocument[] = await Companies.find({
+        _id: { $in: ids }
+      });
+      const resultById = _.indexBy(result, '_id');
+      return ids.map(
+        id => resultById[id] || new Error(`Cannot find Company with id = ${id}`)
+      );
+    }
+  );
+}

--- a/api/src/data/dataLoaders/company.ts
+++ b/api/src/data/dataLoaders/company.ts
@@ -10,9 +10,7 @@ export default function generateDataLoaderCompany() {
         _id: { $in: ids }
       });
       const resultById = _.indexBy(result, '_id');
-      return ids.map(
-        id => resultById[id] || new Error(`Cannot find Company with id = ${id}`)
-      );
+      return ids.map(id => resultById[id]);
     }
   );
 }

--- a/api/src/data/dataLoaders/index.ts
+++ b/api/src/data/dataLoaders/index.ts
@@ -1,0 +1,22 @@
+import * as DataLoader from 'dataloader';
+import * as _ from 'underscore';
+import { ICompanyDocument } from '../../db/models/definitions/companies';
+import { IProductCategoryDocument } from '../../db/models/definitions/deals';
+import { ITagDocument } from '../../db/models/definitions/tags';
+import productCategory from './productCategory';
+import tag from './tag';
+import company from './company';
+
+export interface IDataLoaders {
+  productCategory: DataLoader<string, IProductCategoryDocument>;
+  tag: DataLoader<string, ITagDocument>;
+  company: DataLoader<string, ICompanyDocument>;
+}
+
+export function generateAllDataLoaders(): IDataLoaders {
+  return {
+    productCategory: productCategory(),
+    tag: tag(),
+    company: company()
+  };
+}

--- a/api/src/data/dataLoaders/productCategory.ts
+++ b/api/src/data/dataLoaders/productCategory.ts
@@ -1,0 +1,20 @@
+import * as DataLoader from 'dataloader';
+import * as _ from 'underscore';
+import { ProductCategories } from '../../db/models';
+import { IProductCategoryDocument } from '../../db/models/definitions/deals';
+
+export default function generateDataLoaderProductCategory() {
+  return new DataLoader<string, IProductCategoryDocument>(
+    async (ids: readonly string[]) => {
+      const result: IProductCategoryDocument[] = await ProductCategories.find({
+        _id: { $in: ids }
+      });
+      const resultById = _.indexBy(result, '_id');
+      return ids.map(
+        id =>
+          resultById[id] ||
+          new Error(`Cannot find ProductCategory with id = ${id}`)
+      );
+    }
+  );
+}

--- a/api/src/data/dataLoaders/productCategory.ts
+++ b/api/src/data/dataLoaders/productCategory.ts
@@ -10,11 +10,7 @@ export default function generateDataLoaderProductCategory() {
         _id: { $in: ids }
       });
       const resultById = _.indexBy(result, '_id');
-      return ids.map(
-        id =>
-          resultById[id] ||
-          new Error(`Cannot find ProductCategory with id = ${id}`)
-      );
+      return ids.map(id => resultById[id]);
     }
   );
 }

--- a/api/src/data/dataLoaders/tag.ts
+++ b/api/src/data/dataLoaders/tag.ts
@@ -1,0 +1,16 @@
+import * as DataLoader from 'dataloader';
+import * as _ from 'underscore';
+import { Tags } from '../../db/models';
+import { ITagDocument } from '../../db/models/definitions/tags';
+
+export default function generateDataLoaderTag() {
+  return new DataLoader<string, ITagDocument>(
+    async (ids: readonly string[]) => {
+      const result: ITagDocument[] = await Tags.find({ _id: { $in: ids } });
+      const resultById = _.indexBy(result, '_id');
+      return ids.map(
+        id => resultById[id] || new Error(`Cannot find Tag with id = ${id}`)
+      );
+    }
+  );
+}

--- a/api/src/data/dataLoaders/tag.ts
+++ b/api/src/data/dataLoaders/tag.ts
@@ -8,9 +8,7 @@ export default function generateDataLoaderTag() {
     async (ids: readonly string[]) => {
       const result: ITagDocument[] = await Tags.find({ _id: { $in: ids } });
       const resultById = _.indexBy(result, '_id');
-      return ids.map(
-        id => resultById[id] || new Error(`Cannot find Tag with id = ${id}`)
-      );
+      return ids.map(id => resultById[id]);
     }
   );
 }

--- a/api/src/data/resolvers/product.ts
+++ b/api/src/data/resolvers/product.ts
@@ -1,16 +1,20 @@
-import { Companies, ProductCategories, Tags } from '../../db/models';
 import { IProductDocument } from '../../db/models/definitions/deals';
+import { IContext } from '../types';
 
 export default {
-  category(product: IProductDocument) {
-    return ProductCategories.findOne({ _id: product.categoryId });
+  category(product: IProductDocument, _, { dataLoaders }: IContext) {
+    if (product.categoryId) {
+      return dataLoaders.productCategory.load(product.categoryId);
+    }
   },
 
-  getTags(product: IProductDocument) {
-    return Tags.find({ _id: { $in: product.tagIds || [] } });
+  getTags(product: IProductDocument, _, { dataLoaders }: IContext) {
+    return dataLoaders.tag.loadMany(product.tagIds || []);
   },
 
-  vendor(product: IProductDocument) {
-    return Companies.findOne({ _id: product.vendorId || '' });
+  vendor(product: IProductDocument, _, { dataLoaders }: IContext) {
+    if (product.vendorId) {
+      return dataLoaders.company.load(product.vendorId);
+    }
   }
 };

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -1,5 +1,6 @@
 import * as express from 'express';
 import { IUserDocument } from '../db/models/definitions/users';
+import { IDataLoaders } from './dataLoaders';
 
 export interface IContext {
   res: express.Response;
@@ -16,4 +17,5 @@ export interface IContext {
     IntegrationsAPI: any;
     HelpersApi: any;
   };
+  dataLoaders: IDataLoaders;
 }

--- a/api/src/db/connection.ts
+++ b/api/src/db/connection.ts
@@ -8,6 +8,7 @@ import { mutations, queries, subscriptions, types } from '../data/schema';
 import { getEnv } from '../data/utils';
 import { debugDb } from '../debuggers';
 import { userFactory } from './factories';
+import { generateAllDataLoaders } from '../data/dataLoaders';
 
 dotenv.config();
 
@@ -106,6 +107,7 @@ export const graphqlRequest = async (
   finalContext.userBrandIdsSelector = {};
   finalContext.brandIdSelector = {};
   finalContext.docModifier = doc => doc;
+  finalContext.dataLoaders = generateAllDataLoaders();
 
   const rootValue = {};
 


### PR DESCRIPTION
### Context
Graphql resolvers were creating too many database calls. By using `dataloader` now it batches and caches database requests from resolvers.