### PR TITLE
Optimize resolver: `Tag.totalObjectCount`

### DIFF
--- a/api/src/data/resolvers/tags.ts
+++ b/api/src/data/resolvers/tags.ts
@@ -1,27 +1,18 @@
-import { Tags } from '../../db/models';
 import { ITagDocument } from '../../db/models/definitions/tags';
 import { getCollection } from '../../db/models/Tags';
 
 const getCount = async (tag: ITagDocument) => {
   const { type, _id } = tag;
-
   const collection = getCollection(type);
-
   return await collection.countDocuments({ tagIds: { $in: [_id] } });
 };
 
 export default {
   async totalObjectCount(tag: ITagDocument) {
     if (tag.relatedIds && tag.relatedIds.length > 0) {
-      let objectCount = await getCount(tag);
-
-      const tags = await Tags.find({ _id: { $in: tag.relatedIds } });
-
-      for (const item of tags) {
-        objectCount += await getCount(item);
-      }
-
-      return objectCount;
+      const tagIds = tag.relatedIds.concat(tag._id);
+      const Collection = getCollection(tag.type);
+      return Collection.countDocuments({ tagIds: { $in: tagIds } });
     }
   },
 

--- a/api/src/db/models/definitions/companies.ts
+++ b/api/src/db/models/definitions/companies.ts
@@ -166,7 +166,8 @@ export const companySchema = schemaWrapper(
     tagIds: field({
       type: [String],
       optional: true,
-      label: 'Tags'
+      label: 'Tags',
+      index: true
     }),
 
     // Merged company ids

--- a/api/src/db/models/definitions/deals.ts
+++ b/api/src/db/models/definitions/deals.ts
@@ -93,7 +93,12 @@ export const productSchema = schemaWrapper(
       default: PRODUCT_TYPES.PRODUCT,
       label: 'Type'
     }),
-    tagIds: field({ type: [String], optional: true, label: 'Tags' }),
+    tagIds: field({
+      type: [String],
+      optional: true,
+      label: 'Tags',
+      index: true
+    }),
     description: field({ type: String, optional: true, label: 'Description' }),
     sku: field({ type: String, optional: true, label: 'Stock keeping unit' }),
     unitPrice: field({ type: Number, optional: true, label: 'Unit price' }),

--- a/api/src/db/models/definitions/engages.ts
+++ b/api/src/db/models/definitions/engages.ts
@@ -170,7 +170,12 @@ export const engageMessageSchema = schemaWrapper(
       label: 'Created at',
       index: true
     }),
-    tagIds: field({ type: [String], optional: true, label: 'Tags' }),
+    tagIds: field({
+      type: [String],
+      optional: true,
+      label: 'Tags',
+      index: true
+    }),
     customerTagIds: field({
       type: [String],
       optional: true,

--- a/api/src/db/models/definitions/integrations.ts
+++ b/api/src/db/models/definitions/integrations.ts
@@ -367,7 +367,7 @@ export const integrationSchema = schemaHooksWrapper(
       optional: true,
       label: 'Language code'
     }),
-    tagIds: field({ type: [String], label: 'Tags' }),
+    tagIds: field({ type: [String], label: 'Tags', index: true }),
     formId: field({ type: String, label: 'Form' }),
     leadData: field({ type: leadDataSchema, label: 'Lead data' }),
     isActive: field({


### PR DESCRIPTION
### Context
- Graphql resolver on `Tag.totalObjectCount` was running slow.
- Counting logic was also flawed. It was making duplicate counts in cases where descendant tags were assigned to the same document.