### PR TITLE
Optimize queries with adding lean() method.

### DIFF
--- a/api/src/data/resolvers/activityLog.ts
+++ b/api/src/data/resolvers/activityLog.ts
@@ -54,10 +54,10 @@ export default {
         item = await Tickets.getTicket(contentId);
         break;
       case 'checklist':
-        item = (await Checklists.findOne({ _id: content._id })) || {};
+        item = (await Checklists.findOne({ _id: content._id }).lean()) || {};
         break;
       case 'checklistitem':
-        item = (await ChecklistItems.findOne({ _id: content._id })) || {};
+        item = (await ChecklistItems.findOne({ _id: content._id }).lean()) || {};
         break;
     }
 
@@ -89,8 +89,8 @@ export default {
 
       const destinationStage = await Stages.findOne({
         _id: destinationStageId
-      });
-      const oldStage = await Stages.findOne({ _id: oldStageId });
+      }).lean();
+      const oldStage = await Stages.findOne({ _id: oldStageId }).lean();
 
       if (destinationStage && oldStage) {
         return {
@@ -110,10 +110,10 @@ export default {
 
       switch (contentType) {
         case 'company':
-          result = await Companies.find({ _id: { $in: activityLog.content } });
+          result = await Companies.find({ _id: { $in: activityLog.content } }).lean();
           break;
         case 'customer':
-          result = await Customers.find({ _id: { $in: activityLog.content } });
+          result = await Customers.find({ _id: { $in: activityLog.content } }).lean();
           break;
       }
 

--- a/api/src/data/resolvers/boards.ts
+++ b/api/src/data/resolvers/boards.ts
@@ -9,7 +9,7 @@ export default {
     }
 
     if (user.isOwner) {
-      return Pipelines.find({ boardId: board._id });
+      return Pipelines.find({ boardId: board._id }).lean();
     }
 
     return Pipelines.find({
@@ -25,6 +25,6 @@ export default {
           ]
         }
       ]
-    });
+    }).lean();
   }
 };

--- a/api/src/data/resolvers/conversation.ts
+++ b/api/src/data/resolvers/conversation.ts
@@ -125,7 +125,7 @@ export default {
     const message = await ConversationMessages.findOne({
       conversationId: conversation._id,
       contentType: MESSAGE_TYPES.VIDEO_CALL
-    });
+    }).lean();
 
     if (!message) {
       return null;
@@ -160,7 +160,7 @@ export default {
       conversationId: conversation._id,
       customerId: { $exists: true },
       createdAt: { $gt: new Date(Date.now() - 24 * 60 * 60 * 1000) }
-    }).limit(1);
+    }).limit(1).lean();
 
     if (message.length && message.length >= 1) {
       return false;

--- a/api/src/data/resolvers/conversationMessage.ts
+++ b/api/src/data/resolvers/conversationMessage.ts
@@ -58,7 +58,7 @@ export default {
   ) {
     const conversation = await Conversations.findOne({
       _id: message.conversationId
-    });
+    }).lean();
 
     if (!conversation || message.internal) {
       return null;

--- a/api/src/data/resolvers/deals.ts
+++ b/api/src/data/resolvers/deals.ts
@@ -29,7 +29,7 @@ export const generateProducts = async productsData => {
     const customFields = [];
 
     for (const customFieldData of customFieldsData || []) {
-      const field = await Fields.findOne({ _id: customFieldData.field });
+      const field = await Fields.findOne({ _id: customFieldData.field }).lean();
 
       if (field) {
         customFields[customFieldData.field] = {

--- a/api/src/data/resolvers/queries/activityLogs.ts
+++ b/api/src/data/resolvers/queries/activityLogs.ts
@@ -74,7 +74,7 @@ const activityLogQueries = {
       collectItems(
         await Conversations.find({
           $or: [{ customerId: contentId }, { participatedUserIds: contentId }]
-        }),
+        }).lean(),
         'conversation'
       );
 
@@ -89,7 +89,7 @@ const activityLogQueries = {
             }
           );
           collectItems(
-            await Conversations.find({ _id: { $in: conversationIds } }),
+            await Conversations.find({ _id: { $in: conversationIds } }).lean(),
             'comment'
           );
         } catch (e) {
@@ -114,7 +114,7 @@ const activityLogQueries = {
       collectItems(
         await InternalNotes.find({ contentTypeId: contentId }).sort({
           createdAt: -1
-        }),
+        }).lean(),
         'note'
       );
     };
@@ -153,7 +153,7 @@ const activityLogQueries = {
             ]
           }).sort({
             closeDate: 1
-          }),
+          }).lean(),
           'taskDetail'
         );
       }
@@ -164,7 +164,7 @@ const activityLogQueries = {
 
       if (Array.isArray(contentIds)) {
         collectItems(
-          await Conversations.find({ _id: { $in: contentIds } }),
+          await Conversations.find({ _id: { $in: contentIds } }).lean(),
           'conversation'
         );
       }
@@ -172,7 +172,7 @@ const activityLogQueries = {
 
     const collectEmailDeliveries = async () => {
       await collectItems(
-        await EmailDeliveries.find({ customerId: contentId }),
+        await EmailDeliveries.find({ customerId: contentId }).lean(),
         'email'
       );
     };

--- a/api/src/data/resolvers/queries/boards.ts
+++ b/api/src/data/resolvers/queries/boards.ts
@@ -101,7 +101,7 @@ const boardQueries = {
   ) {
     const boards = await Boards.find({ ...commonQuerySelector, type }).sort({
       name: 1
-    });
+    }).lean();
 
     const counts: Array<{ _id: string; name: string; count: number }> = [];
 
@@ -134,7 +134,7 @@ const boardQueries = {
     { _id }: { _id: string },
     { commonQuerySelector }: IContext
   ) {
-    return Boards.findOne({ ...commonQuerySelector, _id });
+    return Boards.findOne({ ...commonQuerySelector, _id }).lean();
   },
 
   /**
@@ -147,7 +147,7 @@ const boardQueries = {
   ) {
     return Boards.findOne({ ...commonQuerySelector, type }).sort({
       createdAt: -1
-    });
+    }).lean();
   },
 
   /**
@@ -206,7 +206,7 @@ const boardQueries = {
       );
     }
 
-    return Pipelines.find(query).sort({ order: 1, createdAt: -1 });
+    return Pipelines.find(query).sort({ order: 1, createdAt: -1 }).lean();
   },
 
   async pipelineStateCount(
@@ -269,7 +269,7 @@ const boardQueries = {
    *  Pipeline detail
    */
   pipelineDetail(_root, { _id }: { _id: string }) {
-    return Pipelines.findOne({ _id });
+    return Pipelines.findOne({ _id }).lean();
   },
 
   /**
@@ -287,7 +287,7 @@ const boardQueries = {
       .find({ stageId: { $in: stageIds } })
       .distinct('assignedUserIds');
 
-    return Users.find({ _id: { $in: assignedUserIds } });
+    return Users.find({ _id: { $in: assignedUserIds } }).lean();
   },
 
   /**
@@ -313,14 +313,14 @@ const boardQueries = {
       filter.$or = [{ status: null }, { status: BOARD_STATUSES.ACTIVE }];
     }
 
-    return Stages.find(filter).sort({ order: 1, createdAt: -1 });
+    return Stages.find(filter).sort({ order: 1, createdAt: -1 }).lean();
   },
 
   /**
    *  Stage detail
    */
   stageDetail(_root, { _id }: { _id: string }) {
-    return Stages.findOne({ _id });
+    return Stages.findOne({ _id }).lean();
   },
 
   /**
@@ -366,7 +366,7 @@ const boardQueries = {
     let ticketUrl = '';
     let taskUrl = '';
 
-    const deal = await Deals.findOne(filter);
+    const deal = await Deals.findOne(filter).lean();
 
     if (deal) {
       const stage = await Stages.getStage(deal.stageId);
@@ -376,7 +376,7 @@ const boardQueries = {
       dealUrl = `/deal/board?_id=${board._id}&pipelineId=${pipeline._id}&itemId=${deal._id}`;
     }
 
-    const task = await Tasks.findOne(filter);
+    const task = await Tasks.findOne(filter).lean();
 
     if (task) {
       const stage = await Stages.getStage(task.stageId);
@@ -386,7 +386,7 @@ const boardQueries = {
       taskUrl = `/task/board?_id=${board._id}&pipelineId=${pipeline._id}&itemId=${task._id}`;
     }
 
-    const ticket = await Tickets.findOne(filter);
+    const ticket = await Tickets.findOne(filter).lean();
 
     if (ticket) {
       const stage = await Stages.getStage(ticket.stageId);
@@ -415,7 +415,7 @@ const boardQueries = {
       contentType: type,
       boardId,
       pipelineId
-    });
+    }).lean();
 
     const counts = {};
 

--- a/api/src/data/resolvers/queries/conversations.ts
+++ b/api/src/data/resolvers/queries/conversations.ts
@@ -242,7 +242,7 @@ const conversationQueries = {
 
     await qb.buildAllQueries();
 
-    return Conversations.findOne(qb.mainQuery()).sort({ updatedAt: -1 });
+    return Conversations.findOne(qb.mainQuery()).sort({ updatedAt: -1 }).lean();
   },
 
   /**


### PR DESCRIPTION
[ISSUE] Performing the `lean()` method to exclude unnecessary full document attributes.

```javascript
Example:
 -Stage.findOne({_id: <param> })
 +Stage.findOne({_id: <param> }).lean()
```
- [x] Conversation query
- [x] ActivityLogs query
- [x] Board query
- [x] Deal resolver 
