### PR TITLE
Fix syntax error

### DIFF
--- a/docs/docs/installation/upgrade.md
+++ b/docs/docs/installation/upgrade.md
@@ -32,7 +32,7 @@ bash -c "$(wget -O - https://github.com/erxes/erxes/blob/develop/scripts/install
 cd ~/erxes-api
 export MONGO_URL=mongodb://localhost/erxes?replicaSet=rs0
 yarn migrate
-```
+
 
 6. Lastly, update `/home/erxes/erxes/ui/build/js/env.js`, `ecosystem.json` and start pm2 by `pm2 start ecosystem.json`, and update nginx config using your backup and reload nginx by `systemctl reload nginx`.
 


### PR DESCRIPTION
Fixing a syntax error that causes an extended code block throughout the documnetation

[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context
On the [Erxes Upgrade page](https://www.erxes.org/installation/upgrade), step 6 (line 35) has an unwanted syntax tag ` ``` ` causing the rest of the document to be within a code block. This caused a great deal of confusion at first until I noticed the syntax error.

![image](https://user-images.githubusercontent.com/18176012/136668845-22262946-2b70-41c9-a002-57e032a2d51a.png)


