### PR TITLE
Apm

### DIFF
--- a/api/src/__tests__/userDb.test.ts
+++ b/api/src/__tests__/userDb.test.ts
@@ -709,4 +709,34 @@ describe('User db utils', () => {
       );
     }
   });
+
+  test('Logout user & check token exist', async () => {
+    expect.assertions(6);
+
+    // invalid token ==============
+    const loggedout = await Users.logout(_user, '');
+    expect(loggedout).toBe('token not found');
+    
+
+    // valid login
+    const response = await Users.login({
+      email: _user.email.toUpperCase(),
+      password: 'pass'
+    });
+
+    expect(response.token).toBeDefined();
+    expect(response.refreshToken).toBeDefined();
+
+    // wrong token
+    const result = await Users.logout(_user, response.refreshToken);
+    expect(result).toBe('token not found');
+
+    // valid Logout
+    const message = await Users.logout(_user, response.token);
+    expect(message).toBe('loggedout');
+
+    // check token exist.
+    const userFull = await Users.getUser(_user._id);
+    expect(userFull.validatedTokens).not.toContain(response.token);
+  });
 });

--- a/api/src/__tests__/userMutations.test.ts
+++ b/api/src/__tests__/userMutations.test.ts
@@ -621,7 +621,7 @@ describe('User mutations', () => {
 
     const response = await graphqlRequest(mutation, 'logout', {}, { res });
 
-    expect(response).toBe('loggedout');
+    expect(response).toBe('token not found');
   });
 
   test('Reset member password', async () => {

--- a/api/src/data/resolvers/mutations/users.ts
+++ b/api/src/data/resolvers/mutations/users.ts
@@ -146,9 +146,10 @@ const userMutations = {
     return login(args, res, requestInfo.secure);
   },
 
-  async logout(_root, _args, { res }) {
+  async logout(_root, _args, { res, user, requestInfo }: IContext ) {
+    const loggedout = await Users.logout(user, requestInfo.cookies['auth-token']);
     res.clearCookie('auth-token');
-    return 'loggedout';
+    return loggedout;
   },
 
   /*

--- a/api/src/db/factories.ts
+++ b/api/src/db/factories.ts
@@ -178,6 +178,7 @@ interface IUserFactoryInput {
   registrationTokenExpires?: Date;
   isSubscribed?: string;
   isShowNotification?: boolean;
+  validatedTokens?: string;
 }
 
 export const userFactory = async (
@@ -212,6 +213,7 @@ export const userFactory = async (
     deviceTokens: params.deviceTokens,
     isSubscribed: params.isSubscribed,
     isShowNotification: params.isShowNotification,
+    validatedTokens: params.validatedTokens,
     ...(params.code ? { code: params.code } : {})
   };
 

--- a/api/src/db/models/definitions/users.ts
+++ b/api/src/db/models/definitions/users.ts
@@ -50,6 +50,7 @@ export interface IUser {
   isShowNotification?: boolean;
   score?: number;
   customFieldsData?: ICustomField[];
+  validatedTokens?: string[];
 }
 
 export interface IUserDocument extends IUser, Document {
@@ -136,6 +137,11 @@ export const userSchema = schemaHooksWrapper(
       type: [String],
       default: [],
       label: 'Device tokens'
+    }),
+    validatedTokens: field({
+      type: [String],
+      default: [],
+      label: 'Validated access tokens'
     }),
     code: field({ type: String }),
     doNotDisturb: field({

--- a/api/src/middlewares/userMiddleware.ts
+++ b/api/src/middlewares/userMiddleware.ts
@@ -62,6 +62,12 @@ const userMiddleware = async (req, _res, next) => {
       // verify user token and retrieve stored user information
       const { user } = jwt.verify(token, Users.getSecret());
 
+      // invalid token access.
+      const currentUser = await Users.getUser(user._id);
+      if(!currentUser.validatedTokens?.includes(token)){
+        return next();
+      }
+
       // save user in request
       req.user = user;
       req.user.loginToken = token;


### PR DESCRIPTION
[ISSUE] Invalidating access token after logout due to cookie vulnerability.

### PR Checklist
- [x] added a new field named `validatedTokens` in user collection.
- [x] implemented logout util method in User service.
- [x] put invalidate token logic in UserMiddleware to prevent permission access.