### PR TITLE
Update ubuntu-quickstart.mdx

### DIFF
--- a/docs/docs/installation/ubuntu-quickstart.mdx
+++ b/docs/docs/installation/ubuntu-quickstart.mdx
@@ -20,14 +20,14 @@ You must have an account with your hosting provider prior to doing these steps.
 
 ### Configure your DNS Records to point at your server
 
-Your server will have an **ip address**. You will need to point your domain name to your new server.
+Your server will have an **IP address**. You will need to point your domain name to your new server.
 
 - If you are using a **subdomain**, you will need to follow the instructions of updating the `A Records' of the hosting company for your website.
 - If you are NOT using a **subdomain**, then you will need to follow the instructions of your domain name registrar.
 
 :::note Example with a domain called, example.com
 
-If your domain name is **example.com**, and the **ip address** assigned to your server is **44.123.32.12**, then you will have two `A records` that look like this:
+If your domain name is **example.com**, and the **IP address** assigned to your server is **44.123.32.12**, then you will have two `A records` that look like this:
 
 | Type | Name            | Value                  |
 | ---- | --------------- | ---------------------- |
@@ -40,7 +40,7 @@ If your domain name is **example.com**, and the **ip address** assigned to your 
 
 You first need to create a subdomain. For example, "erxes.example.com". Then you need to edit the **DNS**.
 
-If your domain name is **erxes.example.com**, and the **ip address** assigned to your server is **44.123.32.12**, then you will have a two `A records` that look like this:
+If your domain name is **erxes.example.com**, and the **IP address** assigned to your server is **44.123.32.12**, then you will have a two `A records` that look like this:
 
 | Type | Name                  | Value                  |
 | ---- | --------------------- | ---------------------- |


### PR DESCRIPTION
uniformity in "IP". There are 4 "ip"s in the documentation, and 1 was capitalized. It is clearer to have "ip" capitalized, so I changed the other 3 into all caps.

[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Changed 3/4 of the terms "ip" for IP address into all capital letters for better readability and consistency.

![Screen Shot 2021-11-27 at 11 45 55 PM](https://user-images.githubusercontent.com/70724105/143729972-f69bc9a1-2483-45b0-9afb-42598b6221d1.png)
 Additionally, any screenshots.  Delete this line.

