### PR TITLE
Conversation hook + Board filter number fix

### DIFF
--- a/api/src/__tests__/boardQueries.test.ts
+++ b/api/src/__tests__/boardQueries.test.ts
@@ -461,16 +461,27 @@ describe('boardQueries', () => {
 
   test('Stage detail itemsTotalCount by type', async () => {
     const qry = `
-      query stageDetail($_id: String!) {
-        stageDetail(_id: $_id) {
+      query stageDetail($_id: String!, $extraParams: JSON) {
+        stageDetail(_id: $_id, extraParams: $extraParams) {
           ${commonStageTypes}
         }
       }
     `;
 
+    const user = await userFactory({});
+
+    const extraParams = {
+      source: ['messenger'],
+      priority: [PRIORITIES.CRITICAL],
+      endDate: new Date().setDate(new Date().getDate() + 7),
+      userIds: [user._id]
+    } as any;
+
     const dealStage = await stageFactory({ type: BOARD_TYPES.DEAL });
+
     let response = await graphqlRequest(qry, 'stageDetail', {
-      _id: dealStage._id
+      _id: dealStage._id,
+      extraParams
     });
 
     expect(response._id).toBe(dealStage._id);
@@ -481,8 +492,12 @@ describe('boardQueries', () => {
     expect(response._id).toBe(taskStage._id);
 
     const ticketStage = await stageFactory({ type: BOARD_TYPES.TICKET });
+
+    extraParams.startDate = new Date();
+
     response = await graphqlRequest(qry, 'stageDetail', {
-      _id: ticketStage._id
+      _id: ticketStage._id,
+      extraParams
     });
 
     expect(response._id).toBe(ticketStage._id);
@@ -490,8 +505,10 @@ describe('boardQueries', () => {
     const growthHackStage = await stageFactory({
       type: BOARD_TYPES.GROWTH_HACK
     });
+
     response = await graphqlRequest(qry, 'stageDetail', {
-      _id: growthHackStage._id
+      _id: growthHackStage._id,
+      extraParams
     });
 
     expect(response._id).toBe(growthHackStage._id);

--- a/api/src/__tests__/boardQueries.test.ts
+++ b/api/src/__tests__/boardQueries.test.ts
@@ -487,7 +487,11 @@ describe('boardQueries', () => {
     expect(response._id).toBe(dealStage._id);
 
     const taskStage = await stageFactory({ type: BOARD_TYPES.TASK });
-    response = await graphqlRequest(qry, 'stageDetail', { _id: taskStage._id });
+
+    response = await graphqlRequest(qry, 'stageDetail', {
+      _id: taskStage._id,
+      extraParams
+    });
 
     expect(response._id).toBe(taskStage._id);
 

--- a/api/src/data/resolvers/queries/boardUtils.ts
+++ b/api/src/data/resolvers/queries/boardUtils.ts
@@ -86,6 +86,46 @@ export const getCloseDateByType = (closeDateType: string) => {
   }
 };
 
+export const generateExtraFilters = async (filter, extraParams) => {
+  const { source, userIds, priority, startDate, endDate } = extraParams;
+
+  const isListEmpty = value => {
+    return value.length === 1 && value[0].length === 0;
+  };
+
+  if (source) {
+    filter.source = contains(source);
+  }
+
+  if (userIds) {
+    const isEmpty = isListEmpty(userIds);
+
+    filter.userId = isEmpty ? { $in: [null, []] } : { $in: userIds };
+  }
+
+  if (priority) {
+    filter.priority = contains(priority);
+  }
+
+  if (startDate) {
+    filter.closeDate = {
+      $gte: new Date(startDate)
+    };
+  }
+
+  if (endDate) {
+    if (filter.closeDate) {
+      filter.closeDate.$lte = new Date(endDate);
+    } else {
+      filter.closeDate = {
+        $lte: new Date(endDate)
+      };
+    }
+  }
+
+  return filter;
+};
+
 export const generateCommonFilters = async (
   currentUserId: string,
   args: any
@@ -272,13 +312,17 @@ export const calendarFilters = async (filter, args) => {
 
 export const generateDealCommonFilters = async (
   currentUserId: string,
-  args,
-  extraParams?
+  args: any,
+  extraParams?: any
 ) => {
   args.type = 'deal';
-
-  const filter = await generateCommonFilters(currentUserId, args);
   const { productIds } = extraParams || args;
+
+  let filter = await generateCommonFilters(currentUserId, args);
+
+  if (extraParams) {
+    filter = await generateExtraFilters(filter, extraParams);
+  }
 
   if (productIds) {
     filter['productsData.productId'] = contains(productIds);
@@ -297,11 +341,10 @@ export const generateTicketCommonFilters = async (
 ) => {
   args.type = 'ticket';
 
-  const filter = await generateCommonFilters(currentUserId, args);
-  const { source } = extraParams || args;
+  let filter = await generateCommonFilters(currentUserId, args);
 
-  if (source) {
-    filter.source = contains(source);
+  if (extraParams) {
+    filter = await generateExtraFilters(filter, extraParams);
   }
 
   // Calendar monthly date
@@ -312,11 +355,16 @@ export const generateTicketCommonFilters = async (
 
 export const generateTaskCommonFilters = async (
   currentUserId: string,
-  args: any
+  args: any,
+  extraParams?: any
 ) => {
   args.type = 'task';
 
-  const filter = await generateCommonFilters(currentUserId, args);
+  let filter = await generateCommonFilters(currentUserId, args);
+
+  if (extraParams) {
+    filter = await generateExtraFilters(filter, extraParams);
+  }
 
   // Calendar monthly date
   await calendarFilters(filter, args);
@@ -345,7 +393,11 @@ export const generateGrowthHackCommonFilters = async (
 
   const { hackStage, pipelineId, stageId } = extraParams || args;
 
-  const filter = await generateCommonFilters(currentUserId, args);
+  let filter = await generateCommonFilters(currentUserId, args);
+
+  if (extraParams) {
+    filter = await generateExtraFilters(filter, extraParams);
+  }
 
   if (hackStage) {
     filter.hackStages = contains(hackStage);

--- a/api/src/data/resolvers/stages.ts
+++ b/api/src/data/resolvers/stages.ts
@@ -89,11 +89,15 @@ export default {
         return Tickets.find(filter).countDocuments();
       }
       case BOARD_TYPES.TASK: {
-        const filter = await generateTaskCommonFilters(user._id, {
-          ...args,
-          stageId: stage._id,
-          pipelineId: stage.pipelineId
-        });
+        const filter = await generateTaskCommonFilters(
+          user._id,
+          {
+            ...args,
+            stageId: stage._id,
+            pipelineId: stage.pipelineId
+          },
+          args.extraParams
+        );
 
         return Tasks.find(filter).countDocuments();
       }

--- a/ui/src/modules/deals/options.ts
+++ b/ui/src/modules/deals/options.ts
@@ -51,11 +51,23 @@ const options = {
   },
   isMove: true,
   getExtraParams: (queryParams: any) => {
-    const { priority, productIds } = queryParams;
+    const { priority, productIds, userIds, startDate, endDate } = queryParams;
     const extraParams: any = {};
 
     if (priority) {
       extraParams.priority = toArray(priority);
+    }
+
+    if (userIds) {
+      extraParams.userIds = toArray(userIds);
+    }
+
+    if (startDate) {
+      extraParams.startDate = startDate;
+    }
+
+    if (endDate) {
+      extraParams.endDate = endDate;
     }
 
     if (productIds) {

--- a/ui/src/modules/growthHacks/options.ts
+++ b/ui/src/modules/growthHacks/options.ts
@@ -48,11 +48,23 @@ const options = {
   },
   isMove: false,
   getExtraParams: (queryParams: any) => {
-    const { priority, hackStage } = queryParams;
+    const { priority, hackStage, userIds, startDate, endDate } = queryParams;
     const extraParams: any = {};
 
     if (priority) {
       extraParams.priority = priority;
+    }
+
+    if (userIds) {
+      extraParams.userIds = userIds;
+    }
+
+    if (startDate) {
+      extraParams.startDate = startDate;
+    }
+
+    if (endDate) {
+      extraParams.endDate = endDate;
     }
 
     if (hackStage) {

--- a/ui/src/modules/inbox/components/conversationDetail/workarea/WorkArea.tsx
+++ b/ui/src/modules/inbox/components/conversationDetail/workarea/WorkArea.tsx
@@ -171,7 +171,10 @@ export default class WorkArea extends React.Component<Props, State> {
     const { kind } = currentConversation.integration;
 
     const showInternal =
-      this.isMailConversation(kind) || kind === 'lead' || kind === 'booking';
+      this.isMailConversation(kind) ||
+      kind === 'lead' ||
+      kind === 'booking' ||
+      kind === 'webhook';
 
     const tagTrigger = (
       <PopoverButton id="conversationTags">

--- a/ui/src/modules/tasks/options.ts
+++ b/ui/src/modules/tasks/options.ts
@@ -50,11 +50,23 @@ const options = {
   },
   isMove: true,
   getExtraParams: (queryParams: any) => {
-    const { priority } = queryParams;
+    const { priority, userIds, startDate, endDate } = queryParams;
     const extraParams: any = {};
 
     if (priority) {
       extraParams.priority = toArray(priority);
+    }
+
+    if (userIds) {
+      extraParams.userIds = toArray(userIds);
+    }
+
+    if (startDate) {
+      extraParams.startDate = startDate;
+    }
+
+    if (endDate) {
+      extraParams.endDate = endDate;
     }
 
     return extraParams;

--- a/ui/src/modules/tickets/options.ts
+++ b/ui/src/modules/tickets/options.ts
@@ -49,7 +49,7 @@ const options = {
   },
   isMove: true,
   getExtraParams: (queryParams: any) => {
-    const { priority, source } = queryParams;
+    const { priority, source, userIds, startDate, endDate } = queryParams;
     const extraParams: any = {};
 
     if (priority) {
@@ -58,6 +58,18 @@ const options = {
 
     if (source) {
       extraParams.source = toArray(source);
+    }
+
+    if (userIds) {
+      extraParams.userIds = toArray(userIds);
+    }
+
+    if (startDate) {
+      extraParams.startDate = startDate;
+    }
+
+    if (endDate) {
+      extraParams.endDate = endDate;
     }
 
     return extraParams;


### PR DESCRIPTION
[ISSUE]

1. Team Inbox Web hook section. When click web hook conversation, it will show Internal Note default.
![Screenshot from 2021-11-30 16-47-31](https://user-images.githubusercontent.com/48400228/144015803-95556e2e-ecb8-4901-8741-f1dafd08e823.png)

2. Deals, Growth hacking, Tasks, Tickets. Filter section. When click Filter by created member, Filter by priority, Date range, itemsTotalCount shows wrong number. Fixed
![Screenshot from 2021-11-30 17-13-04](https://user-images.githubusercontent.com/48400228/144018603-e7861c98-9e2d-43cb-86ca-7ee9b18f45e8.png)

