### PR TITLE
fix: Profile is appeared to be blocked in email templates section

### DIFF
--- a/ui/src/modules/settings/emailTemplates/styles.ts
+++ b/ui/src/modules/settings/emailTemplates/styles.ts
@@ -38,7 +38,7 @@ const Actions = styled.div`
   display: flex;
   position: absolute;
   opacity: 0;
-  z-index: 3;
+  z-index: 2;
   width: 100%;
   height: 100%;
   left: 0;


### PR DESCRIPTION
[Fix #2981 ](https://github.com/erxes/erxes/issues/2981)

### Context

Fixed: On Hover placed the overlapping email template behind the profile
![image](https://user-images.githubusercontent.com/47504288/146051638-eb27def2-54a1-4b82-a0d4-aa7b94a512ea.png)
