### PR TITLE
add Dockerfile replacer, when DockerFile exists in plugin

### DIFF
--- a/builder/commands/build.ts
+++ b/builder/commands/build.ts
@@ -74,6 +74,16 @@ const main = async () => {
         }
       )
     );
+
+    await execute(() =>
+      fse.copy(
+        `./${folderName}/Dockerfile`,
+        `./${folderName}/.erxes/Dockerfile`,
+        {
+          overwrite: true
+        }
+      )
+    );
   }
 
   // Even though this global yarn.lock contains all node_modules in packages folder


### PR DESCRIPTION
Replace Dockerfile in build time when DockerFile exists in plugin-api.