### PR TITLE
Temporary segment

### DIFF
--- a/packages/erxes-ui/src/components/filter/Filter.tsx
+++ b/packages/erxes-ui/src/components/filter/Filter.tsx
@@ -126,6 +126,7 @@ function Filter({ queryParams = {}, history }: IProps) {
       {renderFilterParam('branchId', true, 'Branch')}
       {renderFilterWithData('tag', 'tag')}
       {renderFilterWithData('segment', 'segment')}
+      {renderFilterParam('segmentData', true, 'Temporary segment')}
       {renderFilterParam('kind', false)}
       {renderFilterWithData('brand', 'brand')}
       {renderFilterWithDate()}

--- a/packages/plugin-contacts-api/src/coc/utils.ts
+++ b/packages/plugin-contacts-api/src/coc/utils.ts
@@ -177,6 +177,7 @@ interface ICommonListArgs {
   conformityIsRelated?: boolean;
   conformityIsSaved?: boolean;
   source?: string;
+  segmentData?: any;
 }
 
 export class CommonBuilder<IListArgs extends ICommonListArgs> {
@@ -222,7 +223,7 @@ export class CommonBuilder<IListArgs extends ICommonListArgs> {
   }
 
   // filter by segment
-  public async segmentFilter(segment: any, source?: string) {
+  public async segmentFilter(segment: any, source?: string, segmentData?: any) {
     const selector = await fetchSegment(
       this.subdomain,
       segment._id,
@@ -234,7 +235,8 @@ export class CommonBuilder<IListArgs extends ICommonListArgs> {
             },
             returnSelector: true
           }
-        : { returnSelector: true }
+        : { returnSelector: true },
+      segmentData
     );
 
     this.positiveList = [...this.positiveList, selector];
@@ -386,6 +388,13 @@ export class CommonBuilder<IListArgs extends ICommonListArgs> {
   public async buildAllQueries(): Promise<void> {
     this.resetPositiveList();
     this.resetNegativeList();
+
+    // filter by segment data
+    if (this.params.segmentData) {
+      const segment = JSON.parse(this.params.segmentData);
+
+      await this.segmentFilter({}, '', segment);
+    }
 
     // filter by segment
     if (this.params.segment) {

--- a/packages/plugin-contacts-api/src/graphql/company.ts
+++ b/packages/plugin-contacts-api/src/graphql/company.ts
@@ -69,6 +69,7 @@ const queryParams = `
   sortDirection: Int
   brand: String
   dateFilters: String
+  segmentData: String
   ${conformityQueryFields}
 `;
 

--- a/packages/plugin-contacts-api/src/graphql/customer.ts
+++ b/packages/plugin-contacts-api/src/graphql/customer.ts
@@ -89,6 +89,7 @@ const queryParams = `
   sex:Int
   birthDate: Date
   dateFilters: String
+  segmentData: String
   ${conformityQueryFields}
 `;
 

--- a/packages/plugin-contacts-api/src/messageBroker.ts
+++ b/packages/plugin-contacts-api/src/messageBroker.ts
@@ -467,11 +467,16 @@ export const sendIntegrationsMessage = (
   });
 };
 
-export const fetchSegment = (subdomain: string, segmentId: string, options?) =>
+export const fetchSegment = (
+  subdomain: string,
+  segmentId: string,
+  options?,
+  segmentData?: any
+) =>
   sendSegmentsMessage({
     subdomain,
     action: 'fetchSegment',
-    data: { segmentId, options },
+    data: { segmentId, options, segmentData },
     isRPC: true
   });
 

--- a/packages/plugin-contacts-ui/src/companies/components/list/CompaniesList.tsx
+++ b/packages/plugin-contacts-ui/src/companies/components/list/CompaniesList.tsx
@@ -24,6 +24,7 @@ import gql from 'graphql-tag';
 import React from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { Link, withRouter } from 'react-router-dom';
+import TemporarySegment from '@erxes/ui-segments/src/components/filter/TemporarySegment';
 
 import { queries } from '../../graphql';
 import { ICompany } from '../../types';
@@ -285,6 +286,10 @@ class CompaniesList extends React.Component<IProps, State> {
 
         {renderExpandButton()}
 
+        {isEnabled('segments') && (
+          <TemporarySegment contentType={`contacts:company`} />
+        )}
+
         <Dropdown className="dropdown-btn" alignRight={true}>
           <Dropdown.Toggle as={DropdownToggle} id="dropdown-customize">
             <Button btnStyle="simple" size="small">
@@ -352,7 +357,7 @@ class CompaniesList extends React.Component<IProps, State> {
             emptyImage="/images/actions/1.svg"
           />
         }
-        hasBorder
+        hasBorder={true}
       />
     );
   }

--- a/packages/plugin-contacts-ui/src/companies/containers/CompaniesList.tsx
+++ b/packages/plugin-contacts-ui/src/companies/containers/CompaniesList.tsx
@@ -201,6 +201,7 @@ const generateParams = ({ queryParams }) => {
   return {
     ...generatePaginationParams(queryParams),
     segment: queryParams.segment,
+    segmentData: queryParams.segmentData,
     tag: queryParams.tag,
     brand: queryParams.brand,
     ids: queryParams.ids,

--- a/packages/plugin-contacts-ui/src/customers/components/list/CustomersList.tsx
+++ b/packages/plugin-contacts-ui/src/customers/components/list/CustomersList.tsx
@@ -35,6 +35,7 @@ import gql from 'graphql-tag';
 import React from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { Link, withRouter } from 'react-router-dom';
+import TemporarySegment from '@erxes/ui-segments/src/components/filter/TemporarySegment';
 
 import { ICustomer } from '../../types';
 import CustomerRow from './CustomerRow';
@@ -389,6 +390,10 @@ class CustomersList extends React.Component<IProps, State> {
         {renderExpandButton()}
 
         {dateFilter}
+
+        {isEnabled('segments') && (
+          <TemporarySegment contentType={`contacts:${type}`} />
+        )}
 
         <Dropdown className="dropdown-btn" alignRight={true}>
           <Dropdown.Toggle as={DropdownToggle} id="dropdown-customize">

--- a/packages/plugin-contacts-ui/src/customers/containers/CustomersList.tsx
+++ b/packages/plugin-contacts-ui/src/customers/containers/CustomersList.tsx
@@ -282,6 +282,7 @@ const generateParams = ({ queryParams, type }) => {
   return {
     ...generatePaginationParams(queryParams),
     segment: queryParams.segment,
+    segmentData: queryParams.segmentData,
     tag: queryParams.tag,
     ids: queryParams.ids,
     searchValue: queryParams.searchValue,

--- a/packages/plugin-segments-api/src/messageBroker.ts
+++ b/packages/plugin-segments-api/src/messageBroker.ts
@@ -33,9 +33,12 @@ export const initBroker = async cl => {
 
   consumeRPCQueue(
     'segments:fetchSegment',
-    async ({ subdomain, data: { segmentId, options } }) => {
+    async ({ subdomain, data: { segmentId, options, segmentData } }) => {
       const models = await generateModels(subdomain);
-      const segment = await models.Segments.findOne({ _id: segmentId }).lean();
+
+      const segment = segmentData
+        ? segmentData
+        : await models.Segments.findOne({ _id: segmentId }).lean();
 
       return {
         data: await fetchSegment(models, subdomain, segment, options),

--- a/packages/ui-contacts/src/companies/graphql/queries.ts
+++ b/packages/ui-contacts/src/companies/graphql/queries.ts
@@ -70,6 +70,7 @@ const listParamsDef = `
   $sortField: String
   $sortDirection: Int
   $dateFilters: String
+  $segmentData: String
   ${conformityQueryFields}
 `;
 
@@ -87,6 +88,7 @@ const listParamsValue = `
   sortField: $sortField
   sortDirection: $sortDirection
   dateFilters: $dateFilters
+  segmentData: $segmentData
   ${conformityQueryFieldDefs}
 `;
 

--- a/packages/ui-contacts/src/customers/graphql/queries.ts
+++ b/packages/ui-contacts/src/customers/graphql/queries.ts
@@ -92,6 +92,7 @@ const listParamsDef = `
   $sortField: String,
   $sortDirection: Int,
   $dateFilters: String,
+  $segmentData: String
   ${conformityQueryFields}
 `;
 
@@ -115,6 +116,7 @@ const listParamsValue = `
   sortField: $sortField,
   sortDirection: $sortDirection,
   dateFilters: $dateFilters,
+  segmentData: $segmentData
   ${conformityQueryFieldDefs}
 `;
 

--- a/packages/ui-segments/package.json
+++ b/packages/ui-segments/package.json
@@ -10,6 +10,7 @@
     "styled-components": "^3.2.6",
     "styled-components-ts": "^0.0.14",
     "lodash": "^4.17.15",
-    "react-router-dom": "^5.1.2"
+    "react-router-dom": "^5.1.2",
+    "react-transition-group": "^2.5.1"
   }
 }

--- a/packages/ui-segments/src/components/filter/TemporarySegment.tsx
+++ b/packages/ui-segments/src/components/filter/TemporarySegment.tsx
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import FormControl from '@erxes/ui/src/components/form/Control';
+import FormGroup from '@erxes/ui/src/components/form/Group';
+import ControlLabel from '@erxes/ui/src/components/form/Label';
+
+import { ModalFooter } from '@erxes/ui/src/styles/main';
+import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
+import { IRouterProps } from '@erxes/ui/src/types';
+import { withRouter } from 'react-router-dom';
+
+import Button from '@erxes/ui/src/components/Button';
+import styled from 'styled-components';
+import { colors, dimensions } from '@erxes/ui/src/styles';
+import * as routerUtils from '@erxes/ui/src/utils/router';
+import RTG from 'react-transition-group';
+
+import client from '@erxes/ui/src/apolloClient';
+import gql from 'graphql-tag';
+import { mutations, queries } from '../../graphql';
+
+import SegmentsForm from '../../containers/form/SegmentsForm';
+import { Alert } from '@erxes/ui/src/utils';
+
+export const RightMenuContainer = styled.div`
+  position: fixed;
+  z-index: 2;
+  top: 120px;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  background: ${colors.bgLight};
+  white-space: normal;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 24px -6px rgba(9, 30, 66, 0.25),
+    0 0 0 1px rgba(9, 30, 66, 0.08);
+`;
+
+export const RightDrawerContainer = styled(RightMenuContainer)`
+  background: ${colors.colorWhite};
+  width: 500px;
+  padding: ${dimensions.coreSpacing}px;
+  z-index: 10;
+`;
+
+export const ScrolledContent = styled.div`
+  flex: 1;
+  overflow: auto;
+`;
+
+type Props = {
+  contentType: string;
+  refetchQueries?: any;
+  btnSize?: string;
+} & IRouterProps;
+
+function TemporarySegment({ history, contentType, btnSize }: Props) {
+  const [showDrawer, setShowDrawer] = useState(false);
+  const [name, setName] = useState('');
+
+  const toggleDrawer = () => {
+    setShowDrawer(!showDrawer);
+  };
+
+  const save = ({ values, closeModal }: { values: any; closeModal?: any }) => {
+    client
+      .mutate({
+        mutation: gql(mutations.segmentsAdd),
+        variables: values,
+        refetchQueries: [
+          {
+            query: gql(queries.segments),
+            variables: { contentTypes: [contentType] }
+          }
+        ]
+      })
+      .then(() => {
+        Alert.success('Successfully added a segment');
+
+        toggleDrawer();
+        closeModal();
+      });
+  };
+
+  const renderSaveContent = (doc: any) => {
+    const saveTrigger = (
+      <Button btnStyle="success" icon="check-circle">
+        {'Save'}
+      </Button>
+    );
+
+    const modalContent = props => (
+      <>
+        <form>
+          <FormGroup>
+            <ControlLabel required={true}>Name</ControlLabel>
+            <FormControl
+              required={true}
+              autoFocus={true}
+              onChange={e =>
+                setName((e.currentTarget as HTMLInputElement).value)
+              }
+            />
+          </FormGroup>
+
+          <ModalFooter>
+            <Button
+              id="segment-form"
+              btnStyle="simple"
+              type="button"
+              onClick={props.closeModal}
+              icon="times-circle"
+            >
+              Cancel
+            </Button>
+
+            <Button
+              btnStyle="success"
+              type="button"
+              onClick={() => {
+                save({
+                  values: { ...doc, name },
+                  closeModal: props.closeModal
+                });
+              }}
+              icon="check-circle"
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </form>
+      </>
+    );
+
+    return (
+      <ModalTrigger
+        title="Save segment"
+        trigger={saveTrigger}
+        content={modalContent}
+      />
+    );
+  };
+
+  const filterContent = (values: any) => {
+    return (
+      <>
+        <Button
+          id="segment-filter"
+          onClick={() => {
+            const data = {
+              ...values,
+              conditions: values.conditionSegments[0].conditions
+            };
+
+            delete data.conditionSegments;
+
+            routerUtils.setParams(history, {
+              segmentData: JSON.stringify(data)
+            });
+          }}
+          icon="filter"
+        >
+          {'Filter'}
+        </Button>
+
+        {renderSaveContent(values)}
+      </>
+    );
+  };
+
+  const content = (
+    <>
+      <RTG.CSSTransition
+        in={showDrawer}
+        timeout={400}
+        classNames="slide-in-right"
+        unmountOnExit={true}
+      >
+        <RightDrawerContainer>
+          <ScrolledContent>
+            <SegmentsForm
+              contentType={contentType}
+              closeModal={toggleDrawer}
+              hideDetailForm={true}
+              usageType="filter"
+              filterContent={filterContent}
+            />
+          </ScrolledContent>
+        </RightDrawerContainer>
+      </RTG.CSSTransition>
+    </>
+  );
+
+  return (
+    <>
+      <Button
+        btnStyle="primary"
+        size={btnSize || 'small'}
+        icon="plus-circle"
+        onClick={toggleDrawer}
+      >
+        Add filter
+      </Button>
+
+      {showDrawer && content}
+    </>
+  );
+}
+
+export default withRouter<Props>(TemporarySegment);

--- a/packages/ui-segments/src/components/form/Form.tsx
+++ b/packages/ui-segments/src/components/form/Form.tsx
@@ -39,6 +39,7 @@ type Props = {
   fields: IField[];
   events: IEvent[];
   renderButton: (props: IButtonMutateProps) => JSX.Element;
+  filterContent?: (values: any) => void;
   edit?: (params: { _id: string; doc: ISegmentWithConditionDoc }) => void;
   segment?: ISegment;
   headSegments: ISegment[];
@@ -656,7 +657,8 @@ class SegmentFormAutomations extends React.Component<Props, State> {
       closeModal,
       previewCount,
       isModal,
-      usageType
+      usageType,
+      filterContent
     } = this.props;
 
     const onPreviewCount = () => {
@@ -684,6 +686,22 @@ class SegmentFormAutomations extends React.Component<Props, State> {
       segments[0].conditions.length > 0 &&
       state === 'list'
     ) {
+      if (filterContent) {
+        return (
+          <>
+            <Button
+              id="segment-show-count"
+              onClick={onPreviewCount}
+              icon="refresh-1"
+            >
+              {__('Count')}
+            </Button>
+
+            {filterContent(this.generateDoc(values))}
+          </>
+        );
+      }
+
       if (usageType && usageType === 'export') {
         return (
           <>

--- a/packages/ui-segments/src/components/form/SegmentsForm.tsx
+++ b/packages/ui-segments/src/components/form/SegmentsForm.tsx
@@ -14,6 +14,7 @@ type Props = {
   fields: any[];
   events: IEvent[];
   renderButton: (props: IButtonMutateProps) => JSX.Element;
+  filterContent?: (values: any) => void;
   segment: ISegment;
   headSegments: ISegment[];
   segments: ISegment[];
@@ -51,7 +52,8 @@ const SegmentsForm = (props: Props) => {
     segments,
     previewCount,
     count,
-    usageType
+    usageType,
+    filterContent
   } = props;
 
   const renderSidebar = () => {
@@ -100,6 +102,7 @@ const SegmentsForm = (props: Props) => {
       previewCount={previewCount}
       count={count}
       usageType={usageType}
+      filterContent={filterContent}
     />
   );
 

--- a/packages/ui-segments/src/containers/form/SegmentsForm.tsx
+++ b/packages/ui-segments/src/containers/form/SegmentsForm.tsx
@@ -27,6 +27,7 @@ type Props = {
   activeTrigger?: ITrigger;
   addConfig?: (trigger: ITrigger, id?: string, config?: any) => void;
   addFilter?: (segmentId: string) => void;
+  filterContent?: (values: any) => void;
   afterSave?: () => void;
   hideDetailForm?: boolean;
   usageType?: string;
@@ -109,7 +110,7 @@ class SegmentsFormContainer extends React.Component<
         type="submit"
         successMessage={`Success`}
       >
-        {text || 'save'}
+        {text || 'Save'}
       </ButtonMutate>
     );
   };
@@ -156,7 +157,8 @@ class SegmentsFormContainer extends React.Component<
       headSegmentsQuery,
       eventsQuery,
       segmentsQuery,
-      history
+      history,
+      filterContent
     } = this.props;
 
     if (segmentDetailQuery.loading) {
@@ -183,7 +185,8 @@ class SegmentsFormContainer extends React.Component<
       fields: this.state.fields,
       count: this.state.count,
       counterLoading: this.state.loading,
-      isModal
+      isModal,
+      filterContent
     };
 
     return <SegmentsForm {...updatedProps} />;


### PR DESCRIPTION
### Temporary Segment

**Description**

This PR adds a temporary segment component that filters plugin data and saves it as segments.

**Type of PR**

This PR is an `enhancement`.

**Checklists:**
- [x] Develop the segment's filter component
- [x] Temporary segment using segmentData field
- [x] Save filter as segment
- [x] Use the segment's filter component on other plugins
- [x] Test on local computer
- [x] Test on a test server
- [x] Publish

**How to use temporary segment component on new plugins:**
1. Add `a temporary segment component` in the plugin component that you want to use it.
2. Pass parameter named `segmentData` through query which you want to filter.
3. Use `segmentData` parameter in query builder function in API development.

**Screenshots:** 📸 📸 📸 

![temporary segment on customer](https://user-images.githubusercontent.com/56122037/193802098-a56f1304-a944-4dee-be3b-735a54185557.gif)
![temporary 2](https://user-images.githubusercontent.com/56122037/193805929-260cb49c-1b99-4861-9eba-b28eb057f625.gif)

