### PR TITLE
always return isDefinedByErxes field groups on fieldsGroups query

### DIFF
--- a/packages/plugin-forms-api/src/graphql/resolvers/queries/fields.ts
+++ b/packages/plugin-forms-api/src/graphql/resolvers/queries/fields.ts
@@ -167,7 +167,9 @@ const fieldsGroupQueries = {
     },
     { commonQuerySelector, models, subdomain }: IContext
   ) {
-    let query: any = commonQuerySelector;
+    let query: any = {
+      $or: [{ ...commonQuerySelector }, { isDefinedByErxes: true }]
+    };
 
     // querying by content type
     query.contentType = contentType;


### PR DESCRIPTION
Fixed that fieldsGroups query doesn't return definedByErxes field groups when brand restriction is allowed.