### PR TITLE
Fix typo in codeblock in digitalocean.md

### DIFF
--- a/docs/docs/installation/digitalocean.md
+++ b/docs/docs/installation/digitalocean.md
@@ -52,7 +52,7 @@ ssh root@YOUR_DROPLET_PUBLIC_IP
 - You need to replace the `YOUR_DOMAIN_COM` with your actual `domain name` in the nginx config file `/etc/nginx/sites-available/default`.
 
 ```bash
-nano /etc/nginx/sites-available/default
+nano /etc/nginx/sites-available/default.conf
 ```
 
 - After replacing YOUR_DOMAIN_COM with your actual domain name. Save with ctrl + x and then y to accept the changes.

--- a/docs/docs/installation/digitalocean.md
+++ b/docs/docs/installation/digitalocean.md
@@ -49,7 +49,7 @@ ssh root@YOUR_DROPLET_PUBLIC_IP
 
 ## Configure NGINX
 
-- You need to replace the `YOUR_DOMAIN_COM` with your actual `domain name` in the nginx config file `/etc/nginx/sites-available/default`.
+- You need to replace the `YOUR_DOMAIN_COM` with your actual `domain name` in the nginx config file `/etc/nginx/sites-available/default.conf`.
 
 ```bash
 nano /etc/nginx/sites-available/default.conf


### PR DESCRIPTION
### Context
Fixed typo in codeblock in the documentation for digital ocean :
In the section about changing the NGINX configuration, there is a typo in the command:
It should be /etc/nginx/sites-available/default.conf instead of just default


// Delete the below section once completed
### PR Checklist
- [✔] Description is clearly stated under Context section