### PR TITLE
fix: elastic _id bug

### DIFF
--- a/packages/api-utils/src/elasticsearch.ts
+++ b/packages/api-utils/src/elasticsearch.ts
@@ -302,9 +302,14 @@ export const fetchByQuery = async ({
 };
 
 export const getRealIdFromElk = (_id: string) => {
-  const arr = _id.split('__');
+  const VERSION = getEnv({ name: 'VERSION' });
+  if (VERSION && VERSION === 'saas') {
+    const arr = _id.split('__');
 
-  return arr.length === 2 ? arr[1] : arr[0];
+    return arr.length === 2 ? arr[1] : arr[0];
+  }
+
+  return _id
 };
 
 export const generateElkIds = async (ids: string[], subdomain: string) => {


### PR DESCRIPTION
elastic _id bug fixed

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 29b695a1e8fdc3ca626e8f8d0518d794b915cad3  | 
|--------|--------|

### Summary:
Fixed `_id` handling in `getRealIdFromElk` function based on `VERSION` environment variable in `packages/api-utils/src/elasticsearch.ts`.

**Key points**:
- Fixed `_id` handling in `getRealIdFromElk` function in `packages/api-utils/src/elasticsearch.ts`.
- Added check for `VERSION` environment variable.
- If `VERSION` is 'saas', splits `_id` by '__' and returns the second part if available, otherwise the first part.
- If `VERSION` is not 'saas', returns `_id` as is.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->