### PR TITLE
chore: add createdAt option to dimension

### DIFF
--- a/packages/plugin-calls-api/src/reports/constants.ts
+++ b/packages/plugin-calls-api/src/reports/constants.ts
@@ -59,6 +59,7 @@ export const CALL_DIMENSION = [
     { label: 'Status', value: 'status' },
     { label: 'Queue', value: 'queue' },
     { label: 'Type', value: 'type' },
+    { label: 'Date', value: 'createdAt' },
     { label: 'Frequency (day, week, month)', value: 'frequency' },
 ]
 

--- a/packages/plugin-calls-api/src/reports/utils.ts
+++ b/packages/plugin-calls-api/src/reports/utils.ts
@@ -192,6 +192,10 @@ export const buildPipeline = (filter: any, matchFilter: any) => {
         matchStage['inboxIntegrationId'] = { $ne: null }
     }
 
+    if ((dimensions || []).includes('createdAt')) {
+        matchStage['createdAt'] = { $ne: null }
+    }
+
     if ((dimensions || []).includes('type')) {
         matchStage['callType'] = { $ne: null }
     }
@@ -247,6 +251,10 @@ export const buildPipeline = (filter: any, matchFilter: any) => {
 
     if ((dimensions || []).includes('teamMember')) {
         groupStage.$group._id['teamMember'] = "$createdBy"
+    }
+
+    if ((dimensions || []).includes('createdAt')) {
+        groupStage.$group._id['createdAt'] = "$createdAt"
     }
 
     if ((dimensions || []).includes('type')) {
@@ -377,12 +385,16 @@ export const buildPipeline = (filter: any, matchFilter: any) => {
         }
     }
 
-    measures.forEach((measure) => {
+    measures?.forEach((measure) => {
         projectStage.$project[measure] = 1;
     });
 
     if ((dimensions || []).includes('teamMember')) {
         projectStage.$project['teamMember'] = "$user"
+    }
+
+    if ((dimensions || []).includes('createdAt')) {
+        projectStage.$project['createdAt'] = "$_id.createdAt"
     }
 
     if ((dimensions || []).includes('type')) {
@@ -446,6 +458,12 @@ export const formatData = (data, frequencyType) => {
             const frequency = item['frequency']
 
             item['frequency'] = formatFrequency(frequencyType, frequency)
+        }
+
+        if (item.hasOwnProperty('createdAt')) {
+            const createdAt = item['createdAt']
+
+            item['createdAt'] = dayjs(createdAt).format('YYYY/MM/DD h:mm A')
         }
 
         ['type', 'status', 'endedBy'].map(key => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 323f7ee9c60534048bb26a84f2de70040bb9e27a  | 
|--------|--------|

### Summary:
Added `createdAt` dimension to reporting functionality, updating pipeline and data formatting to support filtering and grouping by creation date.

**Key points**:
- Added `createdAt` dimension to `CALL_DIMENSION` in `packages/plugin-calls-api/src/reports/constants.ts`.
- Updated `buildPipeline` function in `packages/plugin-calls-api/src/reports/utils.ts` to handle `createdAt` dimension in match, group, and project stages.
- Modified `formatData` function in `packages/plugin-calls-api/src/reports/utils.ts` to format `createdAt` field.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->