### PR TITLE
fix: RPC HTTP timeout after 30000ms. Remote: instagram. Procedure: createIntegration.

### DIFF
--- a/packages/plugin-instagram-api/src/controller.ts
+++ b/packages/plugin-instagram-api/src/controller.ts
@@ -4,7 +4,7 @@ import loginMiddleware from './middlewares/loginMiddleware';
 import receiveMessage from './receiveMessage';
 import { generateModels } from './connectionResolver';
 import { getPageList } from './utils';
-import { INSTAGRAM_POST_TYPES, INTEGRATION_KINDS } from './constants';
+import { INTEGRATION_KINDS } from './constants';
 import receiveComment from './receiveComment';
 
 import {
@@ -82,13 +82,26 @@ const init = async (app) => {
     for (const entry of data.entry) {
       // receive chat
       if (entry.messaging) {
-        const messageData = entry.messaging[0];
-        try {
-          await receiveMessage(models, subdomain, messageData);
+        const pageId = entry.id;
+        const integration = await models.Integrations.getIntegration({
+          $and: [
+            { facebookPageIds: { $in: pageId } },
+            { kind: INTEGRATION_KINDS.MESSENGER }
+          ]
+        });
+        if (integration) {
+          await models.Accounts.getAccount({ _id: integration.accountId });
+          const messageData = entry.messaging[0];
 
-          return res.send('success');
-        } catch (e) {
-          return res.send('success');
+          try {
+            await receiveMessage(models, subdomain, messageData);
+
+            return res.send('success');
+          } catch (e) {
+            return res.send('error' + e);
+          }
+        } else {
+          throw new Error('no integration found');
         }
       }
 

--- a/packages/plugin-instagram-api/src/receiveMessage.ts
+++ b/packages/plugin-instagram-api/src/receiveMessage.ts
@@ -12,7 +12,6 @@ const receiveMessage = async (
 ) => {
   const { recipient, sender, timestamp, message } = messageData;
   // const attachments = messageData.message.attachments;
-
   const integration = await models.Integrations.findOne({
     $and: [
       { instagramPageId: { $in: [recipient.id] } },
@@ -23,126 +22,133 @@ const receiveMessage = async (
     throw new Error('Instagram Integration not found ');
   }
   const { facebookPageTokensMap, facebookPageId } = integration;
-
-  const userId = sender.id;
-  const pageId = recipient.id;
-  const { text, attachments } = message;
-  // get or create customer
-  const customer = await getOrCreateCustomer(
-    models,
-    subdomain,
-    pageId,
-    userId,
-    facebookPageId,
-    INTEGRATION_KINDS.MESSENGER,
-    facebookPageTokensMap
-  );
-
-  // get conversation
-  let conversation = await models.Conversations.findOne({
-    senderId: userId,
-    recipientId: recipient.id
-  });
-
-  // create conversation
-  if (!conversation) {
-    // save on integrations db
-    try {
-      conversation = await models.Conversations.create({
-        timestamp,
-        senderId: userId,
-        recipientId: recipient.id,
-        content: text,
-        integrationId: integration._id
-      });
-    } catch (e) {
-      throw new Error(
-        e.message.includes('duplicate')
-          ? 'Concurrent request: conversation duplication'
-          : e
-      );
-    }
-  }
-
-  const formattedAttachments = (attachments || [])
-    .filter((att) => att.type !== 'fallback')
-    .map((att) => ({
-      type: att.type,
-      url: att.payload ? att.payload.url : ''
-    }));
-
-  // save on api
-  try {
-    const apiConversationResponse = await sendInboxMessage({
+  if (facebookPageId && facebookPageTokensMap) {
+    const userId = sender.id;
+    const pageId = recipient.id;
+    const { text, attachments } = message;
+    // get or create customer
+    const customer = await getOrCreateCustomer(
+      models,
       subdomain,
-      action: 'integrations.receive',
-      data: {
-        action: 'create-or-update-conversation',
-        payload: JSON.stringify({
-          customerId: customer.erxesApiId,
-          integrationId: integration.erxesApiId,
-          content: text || '',
-          attachments: formattedAttachments,
-          conversationId: conversation.erxesApiId,
-          updatedAt: timestamp
-        })
-      },
-      isRPC: true
+      pageId,
+      userId,
+      facebookPageId,
+      INTEGRATION_KINDS.MESSENGER,
+      facebookPageTokensMap
+    );
+
+    // get conversation
+    let conversation = await models.Conversations.findOne({
+      senderId: userId,
+      recipientId: recipient.id
     });
-    conversation.erxesApiId = apiConversationResponse._id;
 
-    await conversation.save();
-  } catch (e) {
-    await models.Conversations.deleteOne({ _id: conversation._id });
-    throw new Error(e);
-  }
-  // get conversation message
-  const conversationMessage = await models.ConversationMessages.findOne({
-    mid: message.mid
-  });
+    // create conversation
+    if (!conversation) {
+      // save on integrations db
+      try {
+        conversation = await models.Conversations.create({
+          timestamp,
+          senderId: userId,
+          recipientId: recipient.id,
+          content: text,
+          integrationId: integration._id
+        });
+      } catch (e) {
+        throw new Error(
+          e.message.includes('duplicate')
+            ? 'Concurrent request: conversation duplication'
+            : e
+        );
+      }
+    }
 
-  if (!conversationMessage) {
-    // save on integrations db
+    const formattedAttachments = (attachments || [])
+      .filter((att) => att.type !== 'fallback')
+      .map((att) => ({
+        type: att.type,
+        url: att.payload ? att.payload.url : ''
+      }));
+
+    // save on api
     try {
-      const created = await models.ConversationMessages.create({
-        mid: message.mid,
-        timestamp,
-        senderId: userId,
-        recipientId: recipient.id,
-        content: text,
-        integrationId: integration._id,
-        conversationId: conversation._id,
-        createdAt: timestamp,
-        customerId: customer.erxesApiId,
-        attachments: formattedAttachments
-      });
-
-      // // save message on api
-      await sendInboxMessage({
+      const apiConversationResponse = await sendInboxMessage({
         subdomain,
-        action: 'conversationClientMessageInserted',
+        action: 'integrations.receive',
         data: {
-          ...created.toObject(),
-          conversationId: conversation.erxesApiId
-        }
+          action: 'create-or-update-conversation',
+          payload: JSON.stringify({
+            customerId: customer.erxesApiId,
+            integrationId: integration.erxesApiId,
+            content: text || '',
+            attachments: formattedAttachments,
+            conversationId: conversation.erxesApiId,
+            updatedAt: timestamp
+          })
+        },
+        isRPC: true
       });
+      conversation.erxesApiId = apiConversationResponse._id;
 
-      graphqlPubsub.publish(
-        `conversationMessageInserted:${conversation.erxesApiId}`,
-        {
-          conversationMessageInserted: {
+      await conversation.save();
+    } catch (e) {
+      await models.Conversations.deleteOne({ _id: conversation._id });
+      throw new Error(e);
+    }
+    // get conversation message
+    const conversationMessage = await models.ConversationMessages.findOne({
+      mid: message.mid
+    });
+
+    if (!conversationMessage) {
+      // save on integrations db
+      try {
+        const created = await models.ConversationMessages.create({
+          mid: message.mid,
+          timestamp,
+          senderId: userId,
+          recipientId: recipient.id,
+          content: text,
+          integrationId: integration._id,
+          conversationId: conversation._id,
+          createdAt: timestamp,
+          customerId: customer.erxesApiId,
+          attachments: formattedAttachments
+        });
+
+        // // save message on api
+        await sendInboxMessage({
+          subdomain,
+          action: 'conversationClientMessageInserted',
+          data: {
             ...created.toObject(),
             conversationId: conversation.erxesApiId
           }
-        }
-      );
-    } catch (e) {
-      throw new Error(
-        e.message.includes('duplicate')
-          ? 'Concurrent request: conversation message duplication'
-          : e
-      );
+        });
+
+        graphqlPubsub.publish(
+          `conversationMessageInserted:${conversation.erxesApiId}`,
+          {
+            conversationMessageInserted: {
+              ...created.toObject(),
+              conversationId: conversation.erxesApiId
+            }
+          }
+        );
+      } catch (e) {
+        throw new Error(
+          e.message.includes('duplicate')
+            ? 'Concurrent request: conversation message duplication'
+            : e
+        );
+      }
     }
+  } else {
+    return {
+      message: 'Both facebookPageTokensMap and facebookPageId are required.',
+      facebookPageTokensMap: facebookPageTokensMap,
+      facebookPageId: facebookPageId
+    };
   }
 };
 

--- a/packages/plugin-instagram-api/src/utils.ts
+++ b/packages/plugin-instagram-api/src/utils.ts
@@ -32,13 +32,13 @@ export const graphRequest = {
 
   delete(...args): any {
     return this.base('del', ...args);
-  },
+  }
 };
 
 export const getPostDetails = async (
   pageId: string,
   pageTokens: { [key: string]: string },
-  postId: string,
+  postId: string
 ) => {
   let pageAccessToken;
 
@@ -52,7 +52,7 @@ export const getPostDetails = async (
   try {
     const response: any = await graphRequest.get(
       `/${postId}?fields=permalink_url,message,created_time`,
-      pageAccessToken,
+      pageAccessToken
     );
 
     return response;
@@ -65,7 +65,7 @@ export const getPostLink = async (accessToken: string, post_id: string) => {
   try {
     const response = await graphRequest.get(
       `${post_id}/?fields=permalink,caption,media_url,media_type,comments,username,comments_count,id,ig_id,timestamp`,
-      accessToken,
+      accessToken
     );
     return response;
   } catch (e) {
@@ -75,41 +75,49 @@ export const getPostLink = async (accessToken: string, post_id: string) => {
 };
 export const getFacebookPageIdsForInsta = async (
   accessToken: string,
-  instagramPageId: string,
+  instagramPageId: string
 ): Promise<string | null> => {
-  const response: any = await graphRequest.get(
-    '/me/accounts?fields=instagram_business_account, access_token,id,name',
-    accessToken,
-  );
+  try {
+    const response: any = await graphRequest.get(
+      '/me/accounts?fields=instagram_business_account,access_token,id,name',
+      accessToken
+    );
 
-  for (const page of response.data) {
-    if (page.instagram_business_account) {
-      const pageId = page.instagram_business_account.id;
-      if (pageId === instagramPageId) {
-        return page.id; // Return the found page ID as a string
+    if (!response || !response.data || response.data.length === 0) {
+      throw new Error('No data found in response');
+    }
+
+    for (const page of response.data) {
+      if (page.instagram_business_account) {
+        const pageId = page.instagram_business_account.id;
+
+        if (pageId === instagramPageId) {
+          return page.id; // Return the found page ID as a string
+        }
       }
     }
+
+    return null;
+  } catch (error) {
+    throw error;
   }
-
-  return null;
 };
-
 export const subscribePage = async (
   pageId,
-  pageToken,
+  pageToken
 ): Promise<{ success: true } | any> => {
   return graphRequest.post(`${pageId}/subscribed_apps`, pageToken, {
-    subscribed_fields: ['conversations', 'feed', 'messages'],
+    subscribed_fields: ['conversations', 'feed', 'messages']
   });
 };
 
 export const getPageAccessToken = async (
   pageId: string,
-  userAccessToken: string,
+  userAccessToken: string
 ) => {
   const response = await graphRequest.get(
     `${pageId}/?fields=access_token`,
-    userAccessToken,
+    userAccessToken
   );
 
   return response.access_token;
@@ -118,10 +126,10 @@ export const getPageAccessToken = async (
 export const refreshPageAccesToken = async (
   models: IModels,
   pageId: string,
-  integration: IIntegrationDocument,
+  integration: IIntegrationDocument
 ) => {
   const account = await models.Accounts.getAccount({
-    _id: integration.accountId,
+    _id: integration.accountId
   });
 
   const facebookPageTokensMap = integration.facebookPageTokensMap || {};
@@ -132,7 +140,7 @@ export const refreshPageAccesToken = async (
 
   await models.Integrations.updateOne(
     { _id: integration._id },
-    { $set: { facebookPageTokensMap } },
+    { $set: { facebookPageTokensMap } }
   );
 
   return facebookPageTokensMap;
@@ -140,7 +148,7 @@ export const refreshPageAccesToken = async (
 
 export const unsubscribePage = async (
   pageId,
-  pageToken,
+  pageToken
 ): Promise<{ success: true } | any> => {
   return graphRequest
     .delete(`${pageId}/subscribed_apps`, pageToken)
@@ -153,13 +161,13 @@ export const unsubscribePage = async (
 export const getPageList = async (
   models: IModels,
   accessToken?: string,
-  kind?: string,
+  kind?: string
 ) => {
   let response = {} as any;
   try {
     response = await graphRequest.get(
       '/me/accounts?fields=instagram_business_account, access_token,id,name',
-      accessToken,
+      accessToken
     );
   } catch (e) {
     throw e;
@@ -172,18 +180,18 @@ export const getPageList = async (
       const pageId = page.instagram_business_account.id;
       const accounInfo: any = await graphRequest.get(
         `${pageId}?fields=username`,
-        accessToken,
+        accessToken
       );
 
       const integration = await models.Integrations.findOne({
         instagramPageId: accounInfo.id,
-        kind,
+        kind
       });
 
       pages.push({
         id: accounInfo.id,
         name: accounInfo.username,
-        isUsed: !!integration,
+        isUsed: !!integration
       });
     }
   }
@@ -193,7 +201,7 @@ export const getPageList = async (
 
 export const getPageAccessTokenFromMap = (
   pageId: string,
-  pageTokens: { [key: string]: string },
+  pageTokens: { [key: string]: string }
 ): string => {
   return (pageTokens || {})[pageId];
 };
@@ -201,22 +209,22 @@ export const getPageAccessTokenFromMap = (
 export const getInstagramUser = async (
   userId: string,
   facebookPageId: string,
-  facebookPageTokensMap?: { [key: string]: string },
+  facebookPageTokensMap?: { [key: string]: string }
 ) => {
   if (facebookPageTokensMap !== undefined) {
     const token = await getPageAccessTokenFromMap(
       facebookPageId,
-      facebookPageTokensMap,
+      facebookPageTokensMap
     );
     const accounInfo: any = await graphRequest.get(
       `${userId}?fields=name,profile_pic`,
-      token,
+      token
     );
 
     return accounInfo;
   } else {
     throw new Error(
-      'facebookPageTokensMap is undefined. Unable to get Instagram user.',
+      'facebookPageTokensMap is undefined. Unable to get Instagram user.'
     );
   }
 };
@@ -226,12 +234,12 @@ export const sendReply = async (
   url: string,
   data: any,
   recipientId: string,
-  integrationId: string,
+  integrationId: string
 ) => {
   let integration;
   try {
     integration = await models.Integrations.getIntegration({
-      erxesApiId: integrationId,
+      erxesApiId: integrationId
     });
   } catch (error) {
     throw new Error(error);
@@ -244,39 +252,39 @@ export const sendReply = async (
   try {
     pageAccessToken = getPageAccessTokenFromMap(
       facebookPageId,
-      facebookPageTokensMap,
+      facebookPageTokensMap
     );
   } catch (e) {
     debugError(
-      `Error ocurred while trying to get page access token with ${e.message}`,
+      `Error ocurred while trying to get page access token with ${e.message}`
     );
     return e;
   }
 
   try {
     const response = await graphRequest.post(`${url}`, pageAccessToken, {
-      ...data,
+      ...data
     });
     debugInstagram(
-      `Successfully sent data to Instagram ${JSON.stringify(data)}`,
+      `Successfully sent data to Instagram ${JSON.stringify(data)}`
     );
     return response;
   } catch (e) {
     debugError(
       `Error ocurred while trying to send post request to facebook ${
         e.message
-      } data: ${JSON.stringify(data)}`,
+      } data: ${JSON.stringify(data)}`
     );
 
     if (e.message.includes('access token')) {
       await models.Integrations.updateOne(
         { _id: integration._id },
-        { $set: { healthStatus: 'page-token', error: `${e.message}` } },
+        { $set: { healthStatus: 'page-token', error: `${e.message}` } }
       );
     } else if (e.code !== 10) {
       await models.Integrations.updateOne(
         { _id: integration._id },
-        { $set: { healthStatus: 'account-token', error: `${e.message}` } },
+        { $set: { healthStatus: 'account-token', error: `${e.message}` } }
       );
     }
     if (e.message.includes('does not exist')) {
@@ -289,7 +297,7 @@ export const sendReply = async (
 
 export const generateAttachmentMessages = (
   subdomain: string,
-  attachments: IAttachment[],
+  attachments: IAttachment[]
 ) => {
   const messages: IAttachmentMessage[] = [];
   for (const attachment of attachments || []) {
@@ -303,9 +311,9 @@ export const generateAttachmentMessages = (
       attachment: {
         type,
         payload: {
-          url,
-        },
-      },
+          url
+        }
+      }
     });
   }
 


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6cbed4d022f502eca032168eb257bfedf9d1813c  | 
|--------|--------|

### Summary:
Improved error handling and integration checks in Instagram plugin to address RPC HTTP timeout issues.

**Key points**:
- Updated `packages/plugin-instagram-api/src/controller.ts` to improve error handling in `init` function for message reception and integration checks.
- Modified `packages/plugin-instagram-api/src/helpers.ts` to handle multiple Facebook page IDs and improve error logging in `removeIntegration` and `instagramCreateIntegration` functions.
- Enhanced `packages/plugin-instagram-api/src/receiveMessage.ts` to add detailed error messages and checks for `facebookPageTokensMap` and `facebookPageId` in `receiveMessage` function.
- Refined `packages/plugin-instagram-api/src/utils.ts` to improve error handling and logging in functions like `getFacebookPageIdsForInsta`, `subscribePage`, and `getPageAccessToken`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->