### PR TITLE
resolve apiUrl getting method

### DIFF
--- a/widgets/client/messenger/widget/index.ts
+++ b/widgets/client/messenger/widget/index.ts
@@ -118,9 +118,6 @@ iframe.onload = async () => {
 
   const contentWindow = iframe.contentWindow;
 
-  if (iframe && iframe.contentWindow && iframe.contentWindow.erxesEnv) {
-    baseUrl = iframe.contentWindow.erxesEnv.API_URL || "";
-  }
 
   if (!contentWindow) {
     return;
@@ -196,6 +193,11 @@ launcherIframe.onload = async () => {
 // Listen for messages from the iframe
 window.addEventListener('message', async (event: MessageEvent) => {
   const { data } = event;
+
+  if (data.fromErxes && data.message === 'connected' && data.apiUrl) {
+    baseUrl = data.apiUrl
+  }
+
   if (data.fromErxes && data.connectionInfo) {
     const { connectionInfo } = data;
     const { widgetsMessengerConnect } = connectionInfo;

--- a/widgets/client/widgetConnect.js
+++ b/widgets/client/widgetConnect.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import client from './apollo-client';
+import { getEnv } from './utils';
 
 // base connect function for all widgets
 const widgetConnect = (params) => {
@@ -33,6 +34,7 @@ const widgetConnect = (params) => {
             ...postParams,
             message: 'connected',
             connectionInfo: data,
+            apiUrl: getEnv()?.API_URL || '',
             setting: event.data.setting,
           },
           '*'


### PR DESCRIPTION
- Resolve api url getter method

[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9c1178d8479b88c978151c4a921317b7c7dfa015  | 
|--------|--------|

### Summary:
Refactored the method of obtaining and setting `apiUrl` for the messenger widget by using message events instead of direct iframe access.

**Key points**:
- Removed direct access to `iframe.contentWindow.erxesEnv.API_URL` in `widgets/client/messenger/widget/index.ts`.
- Added a listener for messages from the iframe to set `baseUrl` when `data.message` is 'connected' and `data.apiUrl` is present in `widgets/client/messenger/widget/index.ts`.
- Updated `widgetConnect` function in `widgets/client/widgetConnect.js` to include `apiUrl` in the postMessage data using `getEnv()?.API_URL`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->