### PR TITLE
fix: change brand on pos

### DIFF
--- a/packages/plugin-multierkhet-ui/src/containers/CheckSyncedOrders.tsx
+++ b/packages/plugin-multierkhet-ui/src/containers/CheckSyncedOrders.tsx
@@ -96,7 +96,7 @@ const CheckSyncedOrdersContainer = (props: Props) => {
       variables: { orderIds },
     })
       .then((response) => {
-        const { skipped, error, success } = response?.data?.toMultiSyncOrders;
+        const { skipped, error, success } = response?.data?.toMultiSyncOrders as any;
         const changed = unSyncedOrderIds.filter((u) => !orderIds.includes(u));
         setUnSyncedOrderIds(changed);
         Alert.success(

--- a/packages/plugin-pos-api/src/utils.ts
+++ b/packages/plugin-pos-api/src/utils.ts
@@ -761,7 +761,7 @@ export const syncOrderFromClient = async ({
 
   await syncInventoriesRem({ subdomain, newOrder, oldBranchId, pos });
 
-  const syncedResponeIds = (
+  const syncedResponseIds = (
     (await sendEbarimtMessage({
       subdomain,
       action: 'putresponses.find',
@@ -780,7 +780,7 @@ export const syncOrderFromClient = async ({
     data: {
       status: 'ok',
       posToken,
-      responseIds: syncedResponeIds,
+      responseIds: syncedResponseIds,
       orderId: newOrder._id,
       convertDealId
     },

--- a/packages/plugin-pos-ui/src/orders/components/CustomerSidebar.tsx
+++ b/packages/plugin-pos-ui/src/orders/components/CustomerSidebar.tsx
@@ -4,7 +4,6 @@ import { __ } from '@erxes/ui/src/utils';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { SideBarFooter } from '../../styles';
-import { CenterContent, Loader } from '@erxes/ui/src/styles/main';
 
 const CustomerSidebar = ({
   customerId,

--- a/packages/plugin-pos-ui/src/pos/components/Pos.tsx
+++ b/packages/plugin-pos-ui/src/pos/components/Pos.tsx
@@ -147,7 +147,7 @@ const Pos = (props: Props) => {
       beginNumber: state.pos.beginNumber,
       maxSkipNumber: Number(state.pos.maxSkipNumber) || 0,
       orderPassword: state.pos.orderPassword,
-      scopeBrandIds: pos.scopeBrandIds || [],
+      scopeBrandIds: state.pos.scopeBrandIds || [],
       initialCategoryIds: state.pos.initialCategoryIds || [],
       kioskExcludeCategoryIds: state.pos.kioskExcludeCategoryIds || [],
       kioskExcludeProductIds: state.pos.kioskExcludeProductIds || [],
@@ -168,8 +168,6 @@ const Pos = (props: Props) => {
         allowBranchIds: [],
       };
     }
-
-    console.log({ doc });
 
     save(doc);
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c478a1031e1d39a49459db674d501ab3dc69fc6c  | 
|--------|--------|

### Summary:
Fixes brand source in POS component and corrects a typo in API utils, with minor code cleanup.

**Key points**:
- **`packages/plugin-multierkhet-ui/src/containers/CheckSyncedOrders.tsx`**: Cast `response?.data?.toMultiSyncOrders` to `any` to avoid TypeScript errors.
- **`packages/plugin-pos-api/src/utils.ts`**: Fix typo `syncedResponeIds` to `syncedResponseIds`.
- **`packages/plugin-pos-ui/src/orders/components/CustomerSidebar.tsx`**: Remove unused import `CenterContent, Loader`.
- **`packages/plugin-pos-ui/src/pos/components/Pos.tsx`**: Change `scopeBrandIds` source from `pos` to `state.pos`. Remove `console.log` statement.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->