### PR TITLE
fix: loans contract form fill by cards and contacts

### DIFF
--- a/packages/plugin-loans-api/src/graphql/resolvers/utils.ts
+++ b/packages/plugin-loans-api/src/graphql/resolvers/utils.ts
@@ -1,0 +1,90 @@
+import { sendCoreMessage, sendMessageBroker } from "../../messageBroker";
+
+const getFieldsWithCode = async (subdomain, contentType) => {
+  return await sendMessageBroker({
+    subdomain,
+    action: 'fields.find',
+    data: {
+      query: {
+        contentType,
+        code: { $exists: true, $ne: '' }
+      },
+      projection: {
+        groupId: 1,
+        code: 1,
+        _id: 1
+      }
+    },
+    isRPC: true,
+    defaultValue: []
+  }, 'forms');
+}
+
+const getCustomerInfo = async (subdomain, type, id) => {
+  if (type === 'cards:deal') {
+    const companyIds: string[] = await sendCoreMessage({
+      subdomain,
+      action: 'conformities.savedConformity',
+      data: {
+        mainType: 'deal',
+        mainTypeId: id,
+        relTypes: ['company']
+      },
+      isRPC: true,
+      defaultValue: []
+    });
+
+    if (companyIds?.length) {
+      return { customerType: 'company', customerId: companyIds[0] }
+    }
+
+    const customerIds: string[] = await sendCoreMessage({
+      subdomain,
+      action: 'conformities.savedConformity',
+      data: {
+        mainType: 'deal',
+        mainTypeId: id,
+        relTypes: ['customer']
+      },
+      isRPC: true,
+      defaultValue: []
+    });
+
+    if (customerIds?.length) {
+      return { customerType: 'customer', customerId: customerIds[0] }
+    }
+    return {};
+  }
+
+  if (type === 'contacts:customer') {
+    return { customerType: 'customer', customerId: id }
+  }
+
+  if (type === 'contacts:company') {
+    return { customerType: 'company', customerId: id }
+  }
+
+  return {};
+}
+
+export const customFieldToObject = async (
+  subdomain,
+  customFieldType,
+  object
+) => {
+  if (!object) {
+    return {}
+  }
+
+  const result: any = {};
+
+  const objFields = await getFieldsWithCode(subdomain, customFieldType);
+
+  const customFieldsData: any[] = object.customFieldsData || [];
+  for (const f of objFields) {
+    const existingData = customFieldsData.find((c) => c.field === f._id);
+    result[f.code] = existingData?.value;
+  }
+
+  return { ...result, ...(await getCustomerInfo(subdomain, customFieldType, object._id)) };
+};

--- a/packages/plugin-loans-api/src/graphql/schema/contract.ts
+++ b/packages/plugin-loans-api/src/graphql/schema/contract.ts
@@ -190,7 +190,7 @@ export const queries = `
   cpContractDetail(_id: String!): LoanContract
   closeInfo(contractId: String, date: Date): CloseInfo
   contractsAlert(date: Date): [LoanAlert]
-  dealsToContract(id: String!): JSON
+  convertToContract(id: String!, contentType: String): JSON
 `;
 
 const commonFields = `

--- a/packages/plugin-loans-api/src/messageBroker.ts
+++ b/packages/plugin-loans-api/src/messageBroker.ts
@@ -269,12 +269,12 @@ export const sendSms = async (
     try {
       await fetch(
         "https://api.messagepro.mn/send?" +
-          new URLSearchParams({
-            key: MESSAGE_PRO_API_KEY,
-            from: MESSAGE_PRO_PHONE_NUMBER,
-            to: phoneNumber,
-            text: content
-          })
+        new URLSearchParams({
+          key: MESSAGE_PRO_API_KEY,
+          from: MESSAGE_PRO_PHONE_NUMBER,
+          to: phoneNumber,
+          text: content
+        })
       );
 
       return "sent";
@@ -282,36 +282,4 @@ export const sendSms = async (
       throw new Error(e.message);
     }
   }
-};
-
-export const customFieldToObject = async (
-  subdomain,
-  customFieldType: 'cards:deal',
-  object
-) => {
-  const fields = await sendCommonMessage({
-    subdomain,
-    serviceName: 'forms',
-    action: 'fields.find',
-    data: {
-      query: {
-        contentType: customFieldType,
-        code: { $exists: true, $ne: '' }
-      },
-      projection: {
-        groupId: 1,
-        code: 1,
-        _id: 1
-      }
-    },
-    isRPC: true,
-    defaultValue: []
-  });
-  const customFieldsData: any[] = object.customFieldsData || [];
-  for (const f of fields) {
-    const existingData = customFieldsData.find((c) => c.field === f._id);
-    object[f.code] = existingData?.value;
-  }
-
-  return object;
 };

--- a/packages/plugin-loans-ui/src/contracts/components/common/ContractSection.tsx
+++ b/packages/plugin-loans-ui/src/contracts/components/common/ContractSection.tsx
@@ -1,32 +1,32 @@
+import Alert from '@erxes/ui/src/utils/Alert';
 import Box from '@erxes/ui/src/components/Box';
+import ContractChooser from '../../containers/ContractChooser';
 import EmptyState from '@erxes/ui/src/components/EmptyState';
 import Icon from '@erxes/ui/src/components/Icon';
 import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
-import { MainStyleButtonRelated as ButtonRelated } from '@erxes/ui/src/styles/eindex';
-import { SectionBodyItem } from '@erxes/ui/src/layout/styles';
-import Alert from '@erxes/ui/src/utils/Alert';
-
 import React from 'react';
-import { Link } from 'react-router-dom';
-import ContractChooser from '../../containers/ContractChooser';
-import { mutations, queries } from '../../graphql';
+import withConsumer from '../../../withConsumer';
 import { __ } from 'coreui/utils';
+import { can } from '@erxes/ui/src/utils/core';
+import { gql } from '@apollo/client';
+import { IUser } from '@erxes/ui/src/auth/types';
+import { Link } from 'react-router-dom';
+import { MainStyleButtonRelated as ButtonRelated } from '@erxes/ui/src/styles/eindex';
+import { mutations, queries } from '../../graphql';
+import { SectionBodyItem } from '@erxes/ui/src/layout/styles';
+import { useMutation, useQuery } from '@apollo/client';
 import {
   EditMutationResponse,
   IContract,
   IContractDoc,
   MainQueryResponse,
 } from '../../types';
-import { can } from '@erxes/ui/src/utils/core';
-import { gql } from '@apollo/client';
-import withConsumer from '../../../withConsumer';
-import { IUser } from '@erxes/ui/src/auth/types';
-import { useMutation, useQuery } from '@apollo/client';
 
 type Props = {
   name: string;
   mainType?: string;
   mainTypeId?: string;
+  id?: string;
   onSelect?: (contract: IContract[]) => void;
   collapseCallback?: () => void;
   title?: string;
@@ -34,11 +34,11 @@ type Props = {
 };
 
 function Component(
-  this: any,
   {
     name,
     mainType = '',
     mainTypeId = '',
+    id = '',
     collapseCallback,
     title,
     currentUser,
@@ -50,7 +50,7 @@ function Component(
       fetchPolicy: 'network-only',
       variables:
         mainType === 'customer' || mainType === 'company'
-          ? { customerId: mainTypeId }
+          ? { customerId: mainTypeId || id }
           : { dealId: mainTypeId },
     },
   );
@@ -68,7 +68,7 @@ function Component(
           name,
           contracts: contractsQuery?.data?.contractsMain?.list,
           mainType,
-          mainTypeId,
+          mainTypeId: mainTypeId || id,
         }}
         onSelect={(contracts: IContractDoc[]) => {
           contractsDealEdit({

--- a/packages/plugin-loans-ui/src/contracts/components/list/ContractForm.tsx
+++ b/packages/plugin-loans-ui/src/contracts/components/list/ContractForm.tsx
@@ -37,6 +37,7 @@ import Table from "@erxes/ui/src/components/table";
 import { __ } from "coreui/utils";
 import dayjs from "dayjs";
 import moment from "moment";
+import { RelType } from "../../containers/ContractForm";
 
 const onFieldClick = (e) => {
   e.target.select();
@@ -47,9 +48,10 @@ type Props = {
   renderButton: (
     props: IButtonMutateProps & { disabled: boolean }
   ) => JSX.Element;
-  contract: IContract;
+  contract?: IContract;
   closeModal: () => void;
   change?: boolean;
+  data?: RelType;
 };
 
 interface IConfig {
@@ -87,7 +89,7 @@ function generateDefault(props) {
     loanDestination: contract.loanDestination,
     loanSubPurpose: contract.loanSubPurpose,
     contractTypeId: contract.contractTypeId,
-    status: contract.status,
+    status: contract.status || 'normal',
     branchId: contract.branchId,
     leaseType: contract.leaseType,
     description: contract.description,

--- a/packages/plugin-loans-ui/src/contracts/containers/ContractForm.tsx
+++ b/packages/plugin-loans-ui/src/contracts/containers/ContractForm.tsx
@@ -10,7 +10,7 @@ import { IContract } from '../types';
 import { IUser } from '@erxes/ui/src/auth/types';
 import { __ } from 'coreui/utils';
 
-type RelType = {
+export type RelType = {
   _id: string,
   mainTypeId: string,
   mainType: string,
@@ -18,10 +18,10 @@ type RelType = {
 }
 
 type Props = {
-  contract: IContract;
+  contract?: IContract;
   getAssociatedContract?: (contractId: string) => void;
   closeModal: () => void;
-  data?:RelType
+  data?: RelType
 };
 
 type FinalProps = {
@@ -31,11 +31,12 @@ type FinalProps = {
 const ContractFromContainer = (props: FinalProps) => {
   const { closeModal, getAssociatedContract, data } = props;
 
-  const dealsContract = useQuery(
-    gql(queries.dealsToContract),
+  const objectOnContract = useQuery(
+    gql(queries.convertToContract),
     {
       variables: {
-        dealsToContractId:data?.mainTypeId
+        contentType: data?.mainType,
+        id: data?.mainTypeId
       },
       fetchPolicy: "network-only",
     }
@@ -59,15 +60,14 @@ const ContractFromContainer = (props: FinalProps) => {
 
     return (
       <ButtonMutate
-        mutation={object ? mutations.contractsEdit : mutations.contractsAdd}
+        mutation={object._id ? mutations.contractsEdit : mutations.contractsAdd}
         variables={values}
         callback={afterSave}
         refetchQueries={getRefetchQueries()}
         isSubmitted={isSubmitted}
         disabled={disabled}
-        successMessage={`You successfully ${
-          object ? 'updated' : 'added'
-        } a ${name}`}
+        successMessage={`You successfully ${object ? 'updated' : 'added'
+          } a ${name}`}
       >
         {__('Save')}
       </ButtonMutate>
@@ -79,10 +79,10 @@ const ContractFromContainer = (props: FinalProps) => {
     renderButton,
   };
 
-  if(data){
-    if(dealsContract.loading)
+  if (data) {
+    if (objectOnContract.loading)
       return 'Loading';
-    return <ContractForm {...updatedProps} contract={{...dealsContract.data.dealsToContract,_id:undefined}} />;
+    return <ContractForm {...updatedProps} contract={{ ...(objectOnContract.data?.convertToContract || {}), _id: undefined }} />;
   }
 
   return <ContractForm {...updatedProps} />;

--- a/packages/plugin-loans-ui/src/contracts/graphql/queries.ts
+++ b/packages/plugin-loans-ui/src/contracts/graphql/queries.ts
@@ -372,9 +372,9 @@ export const scheduleYears = `
   }
 `;
 
-export const dealsToContract = `
-  query DealsToContract($dealsToContractId: String!) {
-    dealsToContract(id: $dealsToContractId)
+export const convertToContract = `
+  query convertToContract($id: String!, $contentType: String) {
+    convertToContract(id: $id, contentType: $contentType)
   }
 `
 
@@ -433,5 +433,5 @@ export default {
   contractsAlert,
   savingContracts,
   getPolarisData,
-  dealsToContract
+  convertToContract
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 21eb3563939cf2ad3d3cf6a35073a656eea5a0b7  | 
|--------|--------|

### Summary:
This PR updates the loans contract form to support filling by cards and contacts, introducing a new `convertToContract` query and refactoring related functions and UI components.

**Key points**:
- Added `convertToContract` query in `packages/plugin-loans-api/src/graphql/resolvers/queries/contracts.ts` to handle conversion from deals, customers, and companies.
- Refactored `customFieldToObject` function and moved it to `packages/plugin-loans-api/src/graphql/resolvers/utils.ts`.
- Updated `packages/plugin-loans-api/src/graphql/schema/contract.ts` to include `convertToContract` query.
- Modified `ContractSection.tsx` and `ContractForm.tsx` in `packages/plugin-loans-ui` to use `convertToContract` query.
- Adjusted UI components to handle new data structure and fields.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->