### PR TITLE
print only new items

### DIFF
--- a/pos/app/(main)/(orders)/components/progress/ChangeOrderStatus.tsx
+++ b/pos/app/(main)/(orders)/components/progress/ChangeOrderStatus.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from "react"
-import { mutations } from "@/modules/orders/graphql"
+import useChangeOrderStatus from "@/modules/orders/hooks/useChangeOrderStatus"
 import { showRecieptAtom } from "@/store/progress.store"
-import { useMutation } from "@apollo/client"
 import { useSetAtom } from "jotai"
 import { CheckIcon } from "lucide-react"
 
@@ -20,21 +19,17 @@ const ChangeOrderStatus = ({
 }) => {
   const setShowReciept = useSetAtom(showRecieptAtom)
 
-  const [orderChangeStatus, { loading }] = useMutation(
-    mutations.orderChangeStatus,
-    {
-      onCompleted(data) {
-        const { orderChangeStatus } = data
-        orderChangeStatus.status === ORDER_STATUSES.DONE && setShowReciept(_id)
-      },
-    }
-  )
+  const { changeStatus, loading } = useChangeOrderStatus()
 
   const handleChangeStatus = (status: string) =>
-    orderChangeStatus({
+    changeStatus({
       variables: {
         _id,
         status,
+      },
+      onCompleted(data) {
+        const { orderChangeStatus } = data
+        orderChangeStatus.status === ORDER_STATUSES.DONE && setShowReciept(_id)
       },
     })
 
@@ -49,7 +44,7 @@ const ChangeOrderStatus = ({
 
     if (doneItems.length === items.length)
       handleChangeStatus(ORDER_STATUSES.DONE)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [memorisedValue])
 
   return (

--- a/pos/app/(main)/(orders)/components/progress/ChangeOrderStatus.tsx
+++ b/pos/app/(main)/(orders)/components/progress/ChangeOrderStatus.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react"
+import { useCallback, useEffect } from "react"
 import useChangeOrderStatus from "@/modules/orders/hooks/useChangeOrderStatus"
 import { showRecieptAtom } from "@/store/progress.store"
 import { useSetAtom } from "jotai"
@@ -21,19 +21,21 @@ const ChangeOrderStatus = ({
 
   const { changeStatus, loading } = useChangeOrderStatus()
 
-  const handleChangeStatus = (status: string) =>
-    changeStatus({
-      variables: {
-        _id,
-        status,
-      },
-      onCompleted(data) {
-        const { orderChangeStatus } = data
-        orderChangeStatus.status === ORDER_STATUSES.DONE && setShowReciept(_id)
-      },
-    })
-
-  const memorisedValue = useMemo<OrderItem[]>(() => items, [items])
+  const handleChangeStatus = useCallback(
+    (status: string) =>
+      changeStatus({
+        variables: {
+          _id,
+          status,
+        },
+        onCompleted(data) {
+          const { orderChangeStatus } = data
+          orderChangeStatus.status === ORDER_STATUSES.DONE &&
+            setShowReciept(_id)
+        },
+      }),
+    [_id, changeStatus, setShowReciept]
+  )
 
   useEffect(() => {
     const doneItems = items.filter(
@@ -44,8 +46,7 @@ const ChangeOrderStatus = ({
 
     if (doneItems.length === items.length)
       handleChangeStatus(ORDER_STATUSES.DONE)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [memorisedValue])
+  }, [handleChangeStatus, items, status])
 
   return (
     <>

--- a/pos/app/(main)/(orders)/components/progress/DoneOrder.tsx
+++ b/pos/app/(main)/(orders)/components/progress/DoneOrder.tsx
@@ -1,5 +1,4 @@
-import { mutations } from "@/modules/orders/graphql"
-import { useMutation } from "@apollo/client"
+import useChangeOrderStatus from "@/modules/orders/hooks/useChangeOrderStatus"
 import { ArrowDownIcon, XIcon } from "lucide-react"
 
 import { IOrder } from "@/types/order.types"
@@ -12,7 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-const DoneOrder = ({ number, status, _id }: IOrder) => {
+const DoneOrder = ({ number, _id }: IOrder) => {
   return (
     <Button
       className="mx-1 bg-green-500 hover:bg-green-500 px-0 space-x-1"
@@ -43,7 +42,7 @@ const DoneOrderAction = ({
   _id?: string
 }) => {
   const Icon = actionType === "complete" ? XIcon : ArrowDownIcon
-  const [changeStatus, { loading }] = useMutation(mutations.orderChangeStatus)
+  const { changeStatus, loading } = useChangeOrderStatus()
   return (
     <TooltipProvider>
       <Tooltip>

--- a/pos/app/(main)/(orders)/components/progress/PrintProgress.tsx
+++ b/pos/app/(main)/(orders)/components/progress/PrintProgress.tsx
@@ -1,12 +1,28 @@
+import useChangeOrderStatus from "@/modules/orders/hooks/useChangeOrderStatus"
+import { printOnlyNewItemsAtom } from "@/store"
+import { activeOrderIdAtom } from "@/store/order.store"
 import { showRecieptAtom } from "@/store/progress.store"
-import { useAtom } from "jotai"
+import { useAtom, useAtomValue } from "jotai"
 
+import { ORDER_STATUSES } from "@/lib/constants"
 import useReciept from "@/lib/useReciept"
 
 const PrintProgress = () => {
   const [showRecieptId, setShowRecieptId] = useAtom(showRecieptAtom)
+  const activeOrderId = useAtomValue(activeOrderIdAtom)
+  const printOnlyNewItems = useAtomValue(printOnlyNewItemsAtom)
+  const { changeStatus } = useChangeOrderStatus()
+
   const { iframeRef } = useReciept({
     onCompleted() {
+      printOnlyNewItems &&
+        changeStatus({
+          variables: {
+            _id: activeOrderId,
+            status: ORDER_STATUSES.DONE,
+          },
+          refetchQueries: ["orderDetail"],
+        })
       setShowRecieptId(null)
     },
   })

--- a/pos/app/(main)/settings/page.tsx
+++ b/pos/app/(main)/settings/page.tsx
@@ -3,6 +3,7 @@
 import ChooseTheme from "@/modules/settings/ChooseTheme"
 import GolomtConfig from "@/modules/settings/components/GolomtConfig"
 import Grid from "@/modules/settings/components/Grid"
+import PrintItemStatus from "@/modules/settings/components/printItemStatus"
 import ProductSimilarityConfig from "@/modules/settings/components/ProductSimilarityConfig"
 import ScrollerWidth from "@/modules/settings/components/ScrollerWidth"
 import StatusExplain from "@/modules/settings/components/StatusExplain"
@@ -35,6 +36,7 @@ const Settings = () => {
       <GolomtConfig />
       <ProductSimilarityConfig />
       <ScrollerWidth />
+      <PrintItemStatus />
       <StatusExplain />
     </>
   )

--- a/pos/app/reciept/ebarimt/page.tsx
+++ b/pos/app/reciept/ebarimt/page.tsx
@@ -81,6 +81,7 @@ const Reciept = () => {
     return () => {
       window.removeEventListener("afterprint", handleAfterPrint)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleAfterPrint])
 
   if (loading) {

--- a/pos/modules/orders/graphql/queries.ts
+++ b/pos/modules/orders/graphql/queries.ts
@@ -221,6 +221,7 @@ export const progressDetail = gql`
         productName
         unitPrice
         count
+        status
       }
       description
       type

--- a/pos/modules/orders/hooks/useChangeOrderStatus.tsx
+++ b/pos/modules/orders/hooks/useChangeOrderStatus.tsx
@@ -1,0 +1,20 @@
+import { useMutation } from "@apollo/client"
+
+import { onError } from "@/components/ui/use-toast"
+
+import { mutations } from "../graphql"
+
+const useChangeOrderStatus = () => {
+  const [changeStatus, { data, loading }] = useMutation(
+    mutations.orderChangeStatus,
+    {
+      onError(err) {
+        onError(err.message)
+      },
+    }
+  )
+  const { _id, status } = data?.orderChangeStatus || {}
+  return { changeStatus, _id, status, loading }
+}
+
+export default useChangeOrderStatus

--- a/pos/modules/settings/components/printItemStatus.tsx
+++ b/pos/modules/settings/components/printItemStatus.tsx
@@ -1,0 +1,30 @@
+import { printOnlyNewItemsAtom } from "@/store"
+import { configAtom } from "@/store/config.store"
+import { Label } from "@radix-ui/react-label"
+import { useAtom, useAtomValue } from "jotai"
+
+import { Checkbox } from "@/components/ui/checkbox"
+
+const PrintItemStatus = () => {
+  const [printOnlyNew, setPrintOnlyNew] = useAtom(printOnlyNewItemsAtom)
+  const config = useAtomValue(configAtom)
+  const { isActive, isPrint } = config?.kitchenScreen || {}
+
+  if (isActive || !isPrint) return null
+
+  return (
+    <Label
+      className="w-full pb-5 flex gap-2 items-center"
+      htmlFor="printOnlyNew"
+    >
+      <Checkbox
+        checked={printOnlyNew}
+        id="printOnlyNew"
+        onCheckedChange={(checked: boolean) => setPrintOnlyNew(checked)}
+      />
+      Зөвхөн шинэ бүтээгдэхүүнийг хэвлэх
+    </Label>
+  )
+}
+
+export default PrintItemStatus

--- a/pos/modules/settings/components/printItemStatus.tsx
+++ b/pos/modules/settings/components/printItemStatus.tsx
@@ -10,7 +10,9 @@ const PrintItemStatus = () => {
   const config = useAtomValue(configAtom)
   const { isActive, isPrint } = config?.kitchenScreen || {}
 
-  if (isActive || !isPrint) return null
+  if (isActive || !isPrint) {
+    return null
+  }
 
   return (
     <Label

--- a/pos/store/index.tsx
+++ b/pos/store/index.tsx
@@ -55,6 +55,11 @@ export const orderCollapsibleAtom = atom<boolean>(false)
 
 export const scrollWidthAtom = atomWithStorage<number>("scrollWidth", 8)
 
+export const printOnlyNewItemsAtom = atomWithStorage<boolean>(
+  "printOnlyNew",
+  false
+)
+
 export const mobileTabAtom = atomWithStorage<"products" | "checkout">(
   "mobileTab",
   "products"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ed51d97b2c9558c213868b30d9fd01681473635  | 
|--------|--------|

### Summary:
This PR adds functionality to print only new items in orders using a new hook and setting.

**Key points**:
- Added `useChangeOrderStatus` hook for order status changes.
- Replaced `useMutation` with `useChangeOrderStatus` in relevant components.
- Introduced `printOnlyNewItemsAtom` to manage printing state.
- Updated `PrintProgress` to conditionally change order status.
- Modified `Progress` to filter and print only new items.
- Added `PrintItemStatus` component to toggle print setting.
- Updated GraphQL queries to include item status.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->