### PR TITLE
fix: Correct the table header and row cells in the Insight table

### DIFF
--- a/packages/plugin-cards-api/src/reports/template/task.ts
+++ b/packages/plugin-cards-api/src/reports/template/task.ts
@@ -343,7 +343,7 @@ export const taskCharts = [
         templateType: "TasksTotalCount",
         serviceType: 'cards',
         name: 'Total Tasks Count',
-        chartTypes: ['bar', 'line', 'pie', 'doughnut', 'radar', 'polarArea', 'table', 'number'],
+        chartTypes: ['bar', 'line', 'pie', 'doughnut', 'radar', 'polarArea', 'table', 'number', "pivotTable"],
         getChartResult: async (
             models: IModels,
             filter: any,

--- a/packages/plugin-cards-api/src/reports/template/ticket.ts
+++ b/packages/plugin-cards-api/src/reports/template/ticket.ts
@@ -2466,7 +2466,7 @@ export const ticketCharts = [
         templateType: "TicketsTotalCount",
         serviceType: 'cards',
         name: 'Total Tickets Count',
-        chartTypes: ['bar', 'line', 'pie', 'doughnut', 'radar', 'polarArea', 'table', 'number'],
+        chartTypes: ['bar', 'line', 'pie', 'doughnut', 'radar', 'polarArea', 'table', 'number', "pivotTable"],
         getChartResult: async (
             models: IModels,
             filter: any,

--- a/packages/plugin-cards-api/src/reports/utils.ts
+++ b/packages/plugin-cards-api/src/reports/utils.ts
@@ -2252,13 +2252,14 @@ export const buildPivotTableData = (data: any, rows: string[], cols: string[], v
 
             const bodyCell = {
                 content: row,
-                rowspan: colspan === -1 ? 0 : colspan
+                rowspan: colspan === -1 ? 0 : colspan,
+                className: 'pl-0'
             };
 
             return bodyCell
         })
 
-        const bodyCol = colKeys.map((colKey: any) => {
+        const bodyCol = colKeys.map((colKey: any, colIndex: number) => {
 
             const flatColKey = colKey.join(String.fromCharCode(0))
 
@@ -2268,11 +2269,16 @@ export const buildPivotTableData = (data: any, rows: string[], cols: string[], v
                 content: aggregator?.value() || '-',
             };
 
+            if (colIndex === 0) {
+                Object.assign(bodyCell, { className: 'pl-0' })
+            }
+
             return bodyCell
         })
 
         const totalColCell = {
-            content: totalAggregator.value()
+            content: totalAggregator.value(),
+            className: "total"
         }
 
         body.push([...bodyRow, ...bodyCol, totalColCell])
@@ -2280,19 +2286,27 @@ export const buildPivotTableData = (data: any, rows: string[], cols: string[], v
 
     const totalRowCell = {
         content: "Totals",
-        colspan: rows.length
+        colspan: rows.length,
+        className: "total"
     }
 
-    const totalColCell = colKeys.map((colKey: any) => {
+    const totalColCell = colKeys.map((colKey: any, colIndex: number) => {
 
         const totalAggregator = colTotals[colKey.join(String.fromCharCode(0))]
 
-        return {
-            content: totalAggregator?.value() || '-'
+        const totalCell = {
+            content: totalAggregator?.value() || '-',
+            className: "total"
         }
+
+        if (colIndex === 0) {
+            totalCell.className += ' pl-0';
+        }
+
+        return totalCell
     })
 
-    const grandTotalCell = { content: allTotal }
+    const grandTotalCell = { content: allTotal, className: "total" }
 
     body.push([totalRowCell, ...totalColCell, grandTotalCell])
 

--- a/packages/plugin-insight-ui/src/components/chart/Form.tsx
+++ b/packages/plugin-insight-ui/src/components/chart/Form.tsx
@@ -257,7 +257,7 @@ const Form = (props: Props) => {
             <div
               key={Math.random()}
               data-grid={{ x: 0, y: 0, w: 6, h: 4.5, static: true }}
-              style={{ overflowX: 'auto' }}
+              style={{ overflow: "hidden" }}
             >
               <ChartRenderer
                 chartType={chartType}

--- a/packages/plugin-insight-ui/src/components/chart/PivotTable.tsx
+++ b/packages/plugin-insight-ui/src/components/chart/PivotTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { PivotTable } from '../../styles'
+import { PivotTable, ScrollWrapper } from '../../styles'
 
 type Props = {
     dataset: any
@@ -20,48 +20,51 @@ const PivotTableRenderer = (props: Props) => {
     }, [headers?.length, body?.length])
 
     return (
-        <PivotTable $bordered={true} $striped={true} $condensed={true}>
-            <thead>
-                {(tableHeaders || []).map((headerRow, headerRowIndex) => (
-                    <tr key={headerRowIndex}>
-                        {(headerRow || []).map((header, headerIndex) => {
-                            if (header.rowspan === 0 || header.colspan === 0) {
-                                return null
-                            }
+        <ScrollWrapper>
+            <PivotTable $bordered={true} $striped={true} $condensed={true}>
+                <thead>
+                    {(tableHeaders || []).map((headerRow, headerRowIndex) => (
+                        <tr key={headerRowIndex}>
+                            {(headerRow || []).map((header, headerIndex) => {
+                                if (header.rowspan === 0 || header.colspan === 0) {
+                                    return null
+                                }
 
-                            return (
-                                <th
-                                    rowSpan={header.rowspan || undefined}
-                                    colSpan={header.colspan || undefined}
-                                >
-                                    {header.content}
-                                </th>
-                            )
-                        })}
-                    </tr>
-                ))}
-            </thead>
-            <tbody>
-                {(tableBody || []).map((bodyRow, bodyRowIndex) => (
-                    <tr key={bodyRowIndex}>
-                        {(bodyRow || []).map((cell, cellIndex) => {
-                            if (cell.rowspan === 0 || cell.colspan === 0) {
-                                return <td style={{ display: 'none' }} />
-                            }
+                                return (
+                                    <th
+                                        rowSpan={header.rowspan || undefined}
+                                        colSpan={header.colspan || undefined}
+                                    >
+                                        {header.content}
+                                    </th>
+                                )
+                            })}
+                        </tr>
+                    ))}
+                </thead>
+                <tbody>
+                    {(tableBody || []).map((bodyRow, bodyRowIndex) => (
+                        <tr key={bodyRowIndex}>
+                            {(bodyRow || []).map((cell, cellIndex) => {
+                                if (cell.rowspan === 0 || cell.colspan === 0) {
+                                    return <td style={{ display: 'none' }} />
+                                }
 
-                            return (
-                                <td
-                                    rowSpan={cell.rowspan || undefined}
-                                    colSpan={cell.colspan || undefined}
-                                >
-                                    {cell.content}
-                                </td>
-                            )
-                        })}
-                    </tr>
-                ))}
-            </tbody>
-        </PivotTable>
+                                return (
+                                    <td
+                                        rowSpan={cell.rowspan || undefined}
+                                        colSpan={cell.colspan || undefined}
+                                        className={cell.className || ''}
+                                    >
+                                        {cell.content}
+                                    </td>
+                                )
+                            })}
+                        </tr>
+                    ))}
+                </tbody>
+            </PivotTable>
+        </ScrollWrapper>
     )
 }
 

--- a/packages/plugin-insight-ui/src/components/chart/TableRenderer.tsx
+++ b/packages/plugin-insight-ui/src/components/chart/TableRenderer.tsx
@@ -2,17 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { commarizeNumbers } from "../../utils";
 import { colors } from "@erxes/ui/src/styles";
-import { ChartTable } from "../../styles";
-
-const ScrollWrapper = styled.div`
-  height: 50vh;
-  height: 100%;
-  overflow: auto;
-  padding: 0px 10px 0 20px;
-  margin-left: -20px;
-  margin-right: -10px;
-  margin-top: -5px;
-`;
+import { ChartTable, ScrollWrapper } from "../../styles";
 
 const SortWrapper = styled.th`
   position: relative;

--- a/packages/plugin-insight-ui/src/styles.ts
+++ b/packages/plugin-insight-ui/src/styles.ts
@@ -730,6 +730,13 @@ const ControlRange = styled.div`
 `;
 
 const ChartTable = styled(Table)`
+
+  thead {
+    background-color: #fff;
+    position: sticky;
+    top: 0;
+  }
+
   th:last-child {
     display: flex;
     justify-content: end;
@@ -742,6 +749,21 @@ const ChartTable = styled(Table)`
 `;
 
 const PivotTable = styled(Table)`
+
+  .pl-0 {
+    padding-left: 0;
+  }
+
+  .total {
+    font-weight: bold;
+  }
+
+  thead {
+    background-color: #fff;
+    position: sticky;
+    top: 0;
+  }
+
   tr:first-child {
 
     th:last-child {
@@ -751,6 +773,13 @@ const PivotTable = styled(Table)`
   }
 `;
 
+const ScrollWrapper = styled.div`
+  height: 100%;
+  overflow: auto;
+  padding: 0px 10px 0 20px;
+  margin-left: -20px;
+  margin-right: -10px;
+`;
 
 export {
   DragField,
@@ -778,5 +807,6 @@ export {
   DateRangeWrapper,
   Divider,
   ChartTable,
-  PivotTable
+  PivotTable,
+  ScrollWrapper
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit db940a859cafc28eb77efabf1151892295ff80a7  | 
|--------|--------|

### Summary:
This pull request adds a new `pivotTable` chart type and improves table rendering and styling in the Insight table components.

**Key points**:
- Added `pivotTable` as a new chart type in `packages/plugin-cards-api/src/reports/template/task.ts` and `packages/plugin-cards-api/src/reports/template/ticket.ts`.
- Updated `buildPivotTableData` in `packages/plugin-cards-api/src/reports/utils.ts` to include `className` for styling table cells.
- Modified `Form.tsx` in `packages/plugin-insight-ui/src/components/chart` to change `overflowX` to `overflow` for better control.
- Enhanced `PivotTable.tsx` in `packages/plugin-insight-ui/src/components/chart` to wrap the table in `ScrollWrapper` for better scrolling.
- Removed redundant `ScrollWrapper` definition in `TableRenderer.tsx` and used the one from `styles.ts`.
- Updated `styles.ts` to include sticky headers for `ChartTable` and `PivotTable`, and added `ScrollWrapper` for consistent styling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->