### PR TITLE
choose print categories

### DIFF
--- a/pos/app/(main)/settings/page.tsx
+++ b/pos/app/(main)/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import ChooseTheme from "@/modules/settings/ChooseTheme"
+import CategoriesToPrint from "@/modules/settings/components/categoriesToPrint"
 import GolomtConfig from "@/modules/settings/components/GolomtConfig"
 import Grid from "@/modules/settings/components/Grid"
 import PrintItemStatus from "@/modules/settings/components/printItemStatus"
@@ -37,6 +38,7 @@ const Settings = () => {
       <ProductSimilarityConfig />
       <ScrollerWidth />
       <PrintItemStatus />
+      <CategoriesToPrint />
       <StatusExplain />
     </>
   )

--- a/pos/components/ui/faceted-filter.tsx
+++ b/pos/components/ui/faceted-filter.tsx
@@ -29,6 +29,7 @@ interface IFacetedFilter {
   }[]
   onSelect?: (value: string[]) => void
   values?: string[]
+  className?: string
 }
 
 export function FacetedFilter({
@@ -36,6 +37,7 @@ export function FacetedFilter({
   title,
   options,
   values,
+  className,
 }: IFacetedFilter) {
   const vals = values || []
   return (
@@ -44,7 +46,7 @@ export function FacetedFilter({
         <Button
           variant="outline"
           size="sm"
-          className="h-10 w-full justify-start border-dashed"
+          className={cn("h-10 w-full justify-start border-dashed", className)}
         >
           <PlusCircleIcon className="mr-2 h-4 w-4" />
           {title}

--- a/pos/modules/orders/graphql/queries.ts
+++ b/pos/modules/orders/graphql/queries.ts
@@ -219,6 +219,7 @@ export const progressDetail = gql`
       items {
         _id
         productName
+        productId
         unitPrice
         count
         status

--- a/pos/modules/products/graphql/queries.ts
+++ b/pos/modules/products/graphql/queries.ts
@@ -18,6 +18,17 @@ const productCategories = gql`
   }
 `
 
+const getCategoryOrders = gql`
+  query categoryOrdersByProduct($ids: [String]) {
+    poscProducts(ids: $ids) {
+      _id
+      category {
+        order
+      }
+    }
+  }
+`
+
 const products = gql`
   query poscProducts(
     $searchValue: String,
@@ -27,6 +38,7 @@ const products = gql`
     $perPage: Int, 
     $isKiosk: Boolean, 
     $groupedSimilarity: String
+    $ids: [String]
     ) {
     poscProducts(
       searchValue: $searchValue, 
@@ -36,7 +48,8 @@ const products = gql`
       perPage: $perPage, 
       isKiosk: $isKiosk, 
       groupedSimilarity: $groupedSimilarity
-    )  {
+      ids: $ids
+    ) {
       ${commonFields}
       categoryId
       unitPrice
@@ -125,5 +138,6 @@ const queries = {
   getInitialCategory,
   productSimilarities,
   getKioskCategory,
+  getCategoryOrders,
 }
 export default queries

--- a/pos/modules/products/hooks/useProductCategories.tsx
+++ b/pos/modules/products/hooks/useProductCategories.tsx
@@ -5,7 +5,8 @@ import { ICategory } from "@/types/product.types"
 import { queries } from "../graphql"
 
 const useProductCategories = (
-  onCompleted?: (data: any) => void
+  onCompleted?: (data: any) => void,
+  skip?: boolean
 ): {
   loading: boolean
   categories: ICategory[]
@@ -15,6 +16,7 @@ const useProductCategories = (
     onCompleted(data) {
       !!onCompleted && onCompleted((data || {}).poscProductCategories || [])
     },
+    skip,
   })
 
   const categories = (data || {}).poscProductCategories || []

--- a/pos/modules/settings/components/categoriesToPrint.tsx
+++ b/pos/modules/settings/components/categoriesToPrint.tsx
@@ -40,9 +40,11 @@ const CategoriesToPrint = () => {
     )
   }
 
-  const getMainCategories = (rCategories: ICategory[]) => {
+  const getMainCategories: (rCategories: ICategory[]) => ICategory[] = (
+    rCategories
+  ) => {
     if (!(rCategories || []).length) {
-      return []
+      return [] as ICategory[]
     }
     if (rCategories.length === 1) {
       return getMainCategories(getDirectChildren(rCategories[0]))

--- a/pos/modules/settings/components/categoriesToPrint.tsx
+++ b/pos/modules/settings/components/categoriesToPrint.tsx
@@ -41,7 +41,9 @@ const CategoriesToPrint = () => {
   }
 
   const getMainCategories = (rCategories: ICategory[]) => {
-    if (!(rCategories || []).length) return []
+    if (!(rCategories || []).length) {
+      return []
+    }
     if (rCategories.length === 1) {
       return getMainCategories(getDirectChildren(rCategories[0]))
     }

--- a/pos/modules/settings/components/categoriesToPrint.tsx
+++ b/pos/modules/settings/components/categoriesToPrint.tsx
@@ -1,0 +1,65 @@
+import useProductCategories from "@/modules/products/hooks/useProductCategories"
+import { categoriesToPrintAtom } from "@/store"
+import { configAtom } from "@/store/config.store"
+import { useAtom, useAtomValue } from "jotai"
+
+import { ICategory } from "@/types/product.types"
+import { FacetedFilter } from "@/components/ui/faceted-filter"
+import Loader from "@/components/ui/loader"
+
+const CategoriesToPrint = () => {
+  const [categoriesToPrint, setCategoriesToPrint] = useAtom(
+    categoriesToPrintAtom
+  )
+  const config = useAtomValue(configAtom)
+  const { isActive, isPrint } = config?.kitchenScreen || {}
+  const { loading, categories } = useProductCategories(() => {},
+  isActive || !isPrint)
+
+  if (isActive || !isPrint) {
+    return null
+  }
+
+  if (loading) return <Loader />
+
+  const rootCategories = (categories || []).filter(
+    (category) =>
+      !categories.find(
+        (cat) => cat._id !== category._id && category.order.includes(cat.order)
+      )
+  )
+
+  const getGen = (order: string) => order.split("/").length
+
+  const getDirectChildren = (parentCat: ICategory) => {
+    return categories.filter(
+      (cat) =>
+        cat._id !== parentCat._id &&
+        getGen(cat.order) === getGen(parentCat.order) + 1 &&
+        cat.order.includes(parentCat.order)
+    )
+  }
+
+  const getMainCategories = (rCategories: ICategory[]) => {
+    if (!(rCategories || []).length) return []
+    if (rCategories.length === 1) {
+      return getMainCategories(getDirectChildren(rCategories[0]))
+    }
+    return rCategories
+  }
+
+  return (
+    <FacetedFilter
+      options={getMainCategories(rootCategories).map((category) => ({
+        label: category.name,
+        value: category.order,
+      }))}
+      title="Бэлтгэх ангилалууд"
+      className="mb-5"
+      values={categoriesToPrint}
+      onSelect={(value) => setCategoriesToPrint(value)}
+    />
+  )
+}
+
+export default CategoriesToPrint

--- a/pos/store/index.tsx
+++ b/pos/store/index.tsx
@@ -60,6 +60,11 @@ export const printOnlyNewItemsAtom = atomWithStorage<boolean>(
   false
 )
 
+export const categoriesToPrintAtom = atomWithStorage<string[]>(
+  "categoriesToPrint",
+  []
+)
+
 export const mobileTabAtom = atomWithStorage<"products" | "checkout">(
   "mobileTab",
   "products"

--- a/pos/types/product.types.ts
+++ b/pos/types/product.types.ts
@@ -26,6 +26,7 @@ export interface IProduct extends IProductBase {
   manufacturedDate?: string
   hasSimilarity?: boolean
   customFieldsData?: CustomField[]
+  category?: ICategory
 }
 
 export interface IUseProducts {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e51784d476f9f9c00ca61ad7e3d1ecbd5b8c744a  | 
|--------|--------|

### Summary:
This PR adds a feature to select and print specific product categories in the POS system, with new components, updated queries, and state management changes.

**Key points**:
- Added `CategoriesToPrint` component in `pos/modules/settings/components/categoriesToPrint.tsx` for selecting categories to print.
- Updated `pos/app/(main)/settings/page.tsx` to include `CategoriesToPrint` component.
- Modified `pos/app/reciept/progress/page.tsx` to handle category-based printing.
- Added `getCategoryOrders` query in `pos/modules/products/graphql/queries.ts` to fetch products by category.
- Updated `FacetedFilter` component in `pos/components/ui/faceted-filter.tsx` to accept `className` prop.
- Introduced `categoriesToPrintAtom` in `pos/store/index.tsx` for storing selected categories.
- Extended `IProduct` type in `pos/types/product.types.ts` to include `category`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->