### PR TITLE
fix minus bug

### DIFF
--- a/pos/modules/checkout/components/cartItem/cartItem.main.tsx
+++ b/pos/modules/checkout/components/cartItem/cartItem.main.tsx
@@ -135,6 +135,7 @@ const CartItem = ({
                     count: banFractions
                       ? parseInt(e.target.value)
                       : Number(e.target.value),
+                    status,
                   })
                 }
                 value={count.toString()}

--- a/pos/store/cart.store.ts
+++ b/pos/store/cart.store.ts
@@ -7,7 +7,7 @@ import {
   OrderItem,
   OrderItemInput,
 } from "@/types/order.types"
-import { ORDER_STATUSES } from "@/lib/constants"
+import { ORDER_ITEM_STATUSES, ORDER_STATUSES } from "@/lib/constants"
 import { getCartTotal, getItemInputs } from "@/lib/utils"
 
 import { banFractionsAtom, orderPasswordAtom } from "./config.store"
@@ -132,15 +132,18 @@ export const addToCartAtom = atom(
 )
 export const updateCartAtom = atom(
   () => "",
-  (get, set, update: IUpdateItem) => {
+  (get, set, { status, ...update }: IUpdateItem) => {
     if (
       !!get(orderPasswordAtom) &&
       !!get(activeOrderIdAtom) &&
       !update.allowed &&
       update.count === (get(banFractionsAtom) ? 0 : -1) &&
-      update.status !== "new"
+      [ORDER_ITEM_STATUSES.DONE, ORDER_ITEM_STATUSES.CONFIRM].includes(
+        status || ""
+      )
     ) {
-      return set(requirePasswordAtom, update)
+      set(requirePasswordAtom, update)
+      return
     }
     set(cartChangedAtom, get(activeOrderIdAtom) ?? "-")
     set(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a7a9eaf486e0873d8eaeb2620eb2af5a446dc68d  | 
|--------|--------|

fix: handle cart item status when count is zero or negative

### Summary:
Fixes bug in `updateCartAtom` to handle item status when count is zero or negative, ensuring correct password requirement behavior.

**Key points**:
- **Behavior**:
  - Fixes bug in `updateCartAtom` in `cart.store.ts` to handle `status` when `count` is zero or negative.
  - Ensures `requirePasswordAtom` is set only if `status` is `DONE` or `CONFIRM`.
- **Components**:
  - Adds `status` to `changeItem` calls in `cartItem.main.tsx` to ensure correct state updates.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a bug in the cart update logic to correctly handle items with a count of -1 and specific statuses, ensuring they do not incorrectly require a password.

Bug Fixes:
- Fix a bug in the cart update logic where items with a count of -1 and specific statuses were incorrectly requiring a password.

<!-- Generated by sourcery-ai[bot]: end summary -->