### PR TITLE
fix(widgets messenger): fix iframe load call

### DIFF
--- a/widgets/client/messenger/widget/index.ts
+++ b/widgets/client/messenger/widget/index.ts
@@ -199,6 +199,12 @@ window.addEventListener('message', async (event: MessageEvent) => {
     const { widgetsMessengerConnect } = connectionInfo || {};
     const { uiOptions } = widgetsMessengerConnect || {};
 
+    try {
+      await handleLauncherIframeLoad()
+    } catch (error) {
+      console.error(error);
+    }
+
     if (!uiOptions) {
       return console.error('Messenger: uiOptions is not defined');
     }


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 624b71da8a7e6294b5e116b6c685709054f1cddd  | 
|--------|--------|

fix(widgets messenger): add error handling for iframe load

### Summary:
Adds error handling for `handleLauncherIframeLoad()` in `index.ts` to catch and log errors during iframe load.

**Key points**:
- **Behavior**:
  - Adds error handling for `handleLauncherIframeLoad()` in `index.ts` within the message event listener to catch and log errors.
- **Logging**:
  - Logs errors to the console if `handleLauncherIframeLoad()` fails.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the iframe load call in the widgets messenger by adding error handling to prevent unhandled exceptions.

Bug Fixes:
- Add error handling for the iframe load call in the widgets messenger to prevent unhandled exceptions.

<!-- Generated by sourcery-ai[bot]: end summary -->