### PR TITLE
check registerNumber when settlePayment

### DIFF
--- a/pos/modules/checkout/hooks/usePrintBill.tsx
+++ b/pos/modules/checkout/hooks/usePrintBill.tsx
@@ -35,7 +35,8 @@ const usePrintBill = (onCompleted?: () => void) => {
       variables: {
         _id,
         billType: skipEbarimt ? BILL_TYPES.INNER : billType,
-        registerNumber,
+        registerNumber:
+          billType === BILL_TYPES.ENTITY ? registerNumber : undefined,
       },
       onCompleted() {
         if (mode === "mobile") {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f1009057b05a1d3d707870b8e2b293cd1617aef5  | 
|--------|--------|

fix: conditionally set registerNumber in usePrintBill

### Summary:
In `usePrintBill`, set `registerNumber` to `undefined` unless `billType` is `BILL_TYPES.ENTITY` when settling payment.

**Key points**:
- **Behavior**:
  - In `usePrintBill`, `registerNumber` is now set to `undefined` unless `billType` is `BILL_TYPES.ENTITY`.
  - This change affects the `variables` object in the `settlePayment` mutation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the logic to conditionally include the registerNumber based on the billType when settling payments.

Bug Fixes:
- Ensure that the registerNumber is only included when the billType is ENTITY during the settlePayment process.

<!-- Generated by sourcery-ai[bot]: end summary -->