### PR TITLE
fix:(cards) bug & board pipeline change

### DIFF
--- a/packages/ui-purchases/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-purchases/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
-import { __, router as routerUtils } from "@erxes/ui/src/utils";
+import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
+import { __, router as routerUtils } from '@erxes/ui/src/utils';
 
-import { ArchiveStatus } from "../../styles/item";
-import { CloseModal } from "@erxes/ui/src/styles/main";
-import Icon from "@erxes/ui/src/components/Icon";
-import React, { useState, useEffect, Fragment } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { Dialog, Transition } from "@headlessui/react";
+import { ArchiveStatus } from '../../styles/item';
+import { CloseModal } from '@erxes/ui/src/styles/main';
+import Icon from '@erxes/ui/src/components/Icon';
+import React, { useState, useEffect, Fragment } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Dialog, Transition } from '@headlessui/react';
 import {
   DialogContent,
   DialogWrapper,
   ModalOverlay,
-} from "@erxes/ui/src/styles/main";
-import styled from "styled-components";
+} from '@erxes/ui/src/styles/main';
+import styled from 'styled-components';
 
 const Relative = styled.div`
   position: relative;
@@ -48,13 +48,13 @@ function EditForm(props: Props) {
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>("");
+  const [prevStageId, setPrevStageId] = useState<string>('');
 
   useEffect(() => {
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
 
-      saveItem({ stageId }, (updatedItem) => {
+      saveItem({ stageId }, updatedItem => {
         if (onUpdate) {
           onUpdate(updatedItem, prevStageId);
         }
@@ -63,21 +63,21 @@ function EditForm(props: Props) {
   }, [stageId]);
 
   const onChangeStage = (stageId: string) => {
-    setStageId(stageId)
+    setStageId(stageId);
     const { item, saveItem, onUpdate } = props;
 
     if (item.stageId !== stageId) {
-      setPrevStageId(item.stageId)
-      saveItem({ stageId }, updatedItem => {
-        if (onUpdate) {
-          onUpdate(updatedItem, prevStageId);
-        }
-      });
+      setPrevStageId(item.stageId);
+      // saveItem({ stageId }, updatedItem => {
+      //   if (onUpdate) {
+      //     onUpdate(updatedItem, prevStageId);
+      //   }
+      // });
     }
   };
 
   const saveItemHandler = (doc: { [key: string]: any }) => {
-    saveItem(doc, (updatedItem) => {
+    saveItem(doc, updatedItem => {
       setUpdatedItem(updatedItem);
     });
   };
@@ -105,7 +105,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -121,11 +121,11 @@ function EditForm(props: Props) {
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === "archived") {
+    if (item.status === 'archived') {
       return (
         <ArchiveStatus>
-          <Icon icon="archive-alt" />
-          <span>{__("This card is archived.")}</span>
+          <Icon icon='archive-alt' />
+          <span>{__('This card is archived.')}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +137,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon="times" />
+          <Icon icon='times' />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as="h3">
-        {__("Edit")}
-        <Icon icon="times" size={24} onClick={onHideModal} />
+      <Dialog.Title as='h3'>
+        {__('Edit')}
+        <Icon icon='times' size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,7 +172,7 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className="dialog-description">
+                  <div className='dialog-description'>
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,

--- a/packages/ui-purchases/src/boards/components/editForm/Move.tsx
+++ b/packages/ui-purchases/src/boards/components/editForm/Move.tsx
@@ -1,4 +1,4 @@
-import { IItem, IOptions } from "../../types";
+import { IItem, IOptions } from '../../types';
 import {
   MoveContainer,
   MoveContainerWidth,
@@ -7,14 +7,14 @@ import {
   PipelinePopoverContent,
   StageItem,
   Stages,
-} from "../../styles/item";
+} from '../../styles/item';
 
-import BoardSelect from "../../containers/BoardSelect";
-import { IStage } from "../../types";
-import Icon from "@erxes/ui/src/components/Icon";
-import Popover from "@erxes/ui/src/components/Popover";
-import React from "react";
-import Tip from "@erxes/ui/src/components/Tip";
+import BoardSelect from '../../containers/BoardSelect';
+import { IStage } from '../../types';
+import Icon from '@erxes/ui/src/components/Icon';
+import Popover from '@erxes/ui/src/components/Popover';
+import React from 'react';
+import Tip from '@erxes/ui/src/components/Tip';
 
 type Props = {
   item?: IItem;
@@ -77,14 +77,14 @@ class Move extends React.Component<Props, State> {
 
     return (
       <Stages>
-        {stages.map((s) => {
+        {stages?.map(s => {
           const onClick = () => onChangeStage && onChangeStage(s._id);
 
           const item = (
             <StageItem key={s._id} $isPass={isPass}>
-              <Tip text={s.name} placement="top">
+              <Tip text={s.name} placement='top'>
                 <span onClick={onClick}>
-                  <Icon icon={isPass ? "check-circle" : "circle"} />
+                  <Icon icon={isPass ? 'check-circle' : 'circle'} />
                 </span>
               </Tip>
             </StageItem>
@@ -132,10 +132,10 @@ class Move extends React.Component<Props, State> {
     return (
       <MoveFormContainer ref={this.ref}>
         <Popover
-          placement="bottom-start"
+          placement='bottom-start'
           trigger={
             <PipelineName onClick={this.toggleForm}>
-              {pipeline && pipeline.name} <Icon icon="angle-down" />
+              {pipeline && pipeline.name} <Icon icon='angle-down' />
             </PipelineName>
           }
         >

--- a/packages/ui-sales/src/boards/components/editForm/Move.tsx
+++ b/packages/ui-sales/src/boards/components/editForm/Move.tsx
@@ -1,4 +1,4 @@
-import { IItem, IOptions } from "../../types";
+import { IItem, IOptions } from '../../types';
 import {
   MoveContainer,
   MoveContainerWidth,
@@ -7,14 +7,14 @@ import {
   PipelinePopoverContent,
   StageItem,
   Stages,
-} from "../../styles/item";
+} from '../../styles/item';
 
-import BoardSelect from "../../containers/BoardSelect";
-import { IStage } from "../../types";
-import Icon from "@erxes/ui/src/components/Icon";
-import Popover from "@erxes/ui/src/components/Popover";
-import React from "react";
-import Tip from "@erxes/ui/src/components/Tip";
+import BoardSelect from '../../containers/BoardSelect';
+import { IStage } from '../../types';
+import Icon from '@erxes/ui/src/components/Icon';
+import Popover from '@erxes/ui/src/components/Popover';
+import React from 'react';
+import Tip from '@erxes/ui/src/components/Tip';
 
 type Props = {
   item?: IItem;
@@ -77,14 +77,14 @@ class Move extends React.Component<Props, State> {
 
     return (
       <Stages>
-        {stages.map((s) => {
+        {stages?.map(s => {
           const onClick = () => onChangeStage && onChangeStage(s._id);
 
           const item = (
             <StageItem key={s._id} $isPass={isPass}>
-              <Tip text={s.name} placement="top">
+              <Tip text={s.name} placement='top'>
                 <span onClick={onClick}>
-                  <Icon icon={isPass ? "check-circle" : "circle"} />
+                  <Icon icon={isPass ? 'check-circle' : 'circle'} />
                 </span>
               </Tip>
             </StageItem>
@@ -132,10 +132,10 @@ class Move extends React.Component<Props, State> {
     return (
       <MoveFormContainer ref={this.ref}>
         <Popover
-          placement="bottom-start"
+          placement='bottom-start'
           trigger={
             <PipelineName onClick={this.toggleForm}>
-              {pipeline && pipeline.name} <Icon icon="angle-down" />
+              {pipeline && pipeline.name} <Icon icon='angle-down' />
             </PipelineName>
           }
         >

--- a/packages/ui-tasks/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-tasks/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
-import { __, router as routerUtils } from "@erxes/ui/src/utils";
+import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
+import { __, router as routerUtils } from '@erxes/ui/src/utils';
 
-import { ArchiveStatus } from "../../styles/item";
-import { CloseModal } from "@erxes/ui/src/styles/main";
-import Icon from "@erxes/ui/src/components/Icon";
-import React, { useState, useEffect, Fragment } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { Dialog, Transition } from "@headlessui/react";
+import { ArchiveStatus } from '../../styles/item';
+import { CloseModal } from '@erxes/ui/src/styles/main';
+import Icon from '@erxes/ui/src/components/Icon';
+import React, { useState, useEffect, Fragment } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Dialog, Transition } from '@headlessui/react';
 import {
   DialogContent,
   DialogWrapper,
-  ModalOverlay
-} from "@erxes/ui/src/styles/main";
-import styled from "styled-components";
+  ModalOverlay,
+} from '@erxes/ui/src/styles/main';
+import styled from 'styled-components';
 
 const Relative = styled.div`
   position: relative;
@@ -42,13 +42,13 @@ function EditForm(props: Props) {
     copyItem,
     options,
     beforePopupClose,
-    refresh
+    refresh,
   } = props;
   const location = useLocation();
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>("");
+  const [prevStageId, setPrevStageId] = useState<string>('');
 
   useEffect(() => {
     if (item.stageId !== stageId) {
@@ -68,11 +68,11 @@ function EditForm(props: Props) {
 
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
-      saveItem({ stageId }, updatedItem => {
-        if (onUpdate) {
-          onUpdate(updatedItem, prevStageId);
-        }
-      });
+      // saveItem({ stageId }, updatedItem => {
+      //   if (onUpdate) {
+      //     onUpdate(updatedItem, prevStageId);
+      //   }
+      // });
     }
   };
 
@@ -105,7 +105,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -121,11 +121,11 @@ function EditForm(props: Props) {
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === "archived") {
+    if (item.status === 'archived') {
       return (
         <ArchiveStatus>
-          <Icon icon="archive-alt" />
-          <span>{__("This card is archived.")}</span>
+          <Icon icon='archive-alt' />
+          <span>{__('This card is archived.')}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +137,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon="times" />
+          <Icon icon='times' />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as="h3">
-        {__("Edit")}
-        <Icon icon="times" size={24} onClick={onHideModal} />
+      <Dialog.Title as='h3'>
+        {__('Edit')}
+        <Icon icon='times' size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,13 +172,13 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className="dialog-description">
+                  <div className='dialog-description'>
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,
                       onChangeStage,
                       copy,
-                      remove
+                      remove,
                     })}
                   </div>
                 </Relative>

--- a/packages/ui-tasks/src/boards/components/editForm/Move.tsx
+++ b/packages/ui-tasks/src/boards/components/editForm/Move.tsx
@@ -1,4 +1,4 @@
-import { IItem, IOptions } from "../../types";
+import { IItem, IOptions } from '../../types';
 import {
   MoveContainer,
   MoveContainerWidth,
@@ -7,14 +7,14 @@ import {
   PipelinePopoverContent,
   StageItem,
   Stages,
-} from "../../styles/item";
+} from '../../styles/item';
 
-import BoardSelect from "../../containers/BoardSelect";
-import { IStage } from "../../types";
-import Icon from "@erxes/ui/src/components/Icon";
-import Popover from "@erxes/ui/src/components/Popover";
-import React from "react";
-import Tip from "@erxes/ui/src/components/Tip";
+import BoardSelect from '../../containers/BoardSelect';
+import { IStage } from '../../types';
+import Icon from '@erxes/ui/src/components/Icon';
+import Popover from '@erxes/ui/src/components/Popover';
+import React from 'react';
+import Tip from '@erxes/ui/src/components/Tip';
 
 type Props = {
   item?: IItem;
@@ -77,14 +77,14 @@ class Move extends React.Component<Props, State> {
 
     return (
       <Stages>
-        {stages.map((s) => {
+        {stages?.map(s => {
           const onClick = () => onChangeStage && onChangeStage(s._id);
 
           const item = (
             <StageItem key={s._id} $isPass={isPass}>
-              <Tip text={s.name} placement="top">
+              <Tip text={s.name} placement='top'>
                 <span onClick={onClick}>
-                  <Icon icon={isPass ? "check-circle" : "circle"} />
+                  <Icon icon={isPass ? 'check-circle' : 'circle'} />
                 </span>
               </Tip>
             </StageItem>
@@ -132,10 +132,10 @@ class Move extends React.Component<Props, State> {
     return (
       <MoveFormContainer ref={this.ref}>
         <Popover
-          placement="bottom-start"
+          placement='bottom-start'
           trigger={
             <PipelineName onClick={this.toggleForm}>
-              {pipeline && pipeline.name} <Icon icon="angle-down" />
+              {pipeline && pipeline.name} <Icon icon='angle-down' />
             </PipelineName>
           }
         >

--- a/packages/ui-tickets/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-tickets/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
-import { __, router as routerUtils } from "@erxes/ui/src/utils";
+import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
+import { __, router as routerUtils } from '@erxes/ui/src/utils';
 
-import { ArchiveStatus } from "../../styles/item";
-import { CloseModal } from "@erxes/ui/src/styles/main";
-import Icon from "@erxes/ui/src/components/Icon";
-import React, { useState, useEffect, Fragment } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { Dialog, Transition } from "@headlessui/react";
+import { ArchiveStatus } from '../../styles/item';
+import { CloseModal } from '@erxes/ui/src/styles/main';
+import Icon from '@erxes/ui/src/components/Icon';
+import React, { useState, useEffect, Fragment } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Dialog, Transition } from '@headlessui/react';
 import {
   DialogContent,
   DialogWrapper,
   ModalOverlay,
-} from "@erxes/ui/src/styles/main";
-import styled from "styled-components";
+} from '@erxes/ui/src/styles/main';
+import styled from 'styled-components';
 
 const Relative = styled.div`
   position: relative;
@@ -48,13 +48,13 @@ function EditForm(props: Props) {
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>("");
+  const [prevStageId, setPrevStageId] = useState<string>('');
 
   useEffect(() => {
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
 
-      saveItem({ stageId }, (updatedItem) => {
+      saveItem({ stageId }, updatedItem => {
         if (onUpdate) {
           onUpdate(updatedItem, prevStageId);
         }
@@ -63,21 +63,21 @@ function EditForm(props: Props) {
   }, [stageId]);
 
   const onChangeStage = (stageId: string) => {
-    setStageId(stageId)
+    setStageId(stageId);
     const { item, saveItem, onUpdate } = props;
 
     if (item.stageId !== stageId) {
-      setPrevStageId(item.stageId)
-      saveItem({ stageId }, updatedItem => {
-        if (onUpdate) {
-          onUpdate(updatedItem, prevStageId);
-        }
-      });
+      setPrevStageId(item.stageId);
+      // saveItem({ stageId }, updatedItem => {
+      //   if (onUpdate) {
+      //     onUpdate(updatedItem, prevStageId);
+      //   }
+      // });
     }
   };
 
   const saveItemHandler = (doc: { [key: string]: any }) => {
-    saveItem(doc, (updatedItem) => {
+    saveItem(doc, updatedItem => {
       setUpdatedItem(updatedItem);
     });
   };
@@ -105,7 +105,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -121,11 +121,11 @@ function EditForm(props: Props) {
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === "archived") {
+    if (item.status === 'archived') {
       return (
         <ArchiveStatus>
-          <Icon icon="archive-alt" />
-          <span>{__("This card is archived.")}</span>
+          <Icon icon='archive-alt' />
+          <span>{__('This card is archived.')}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +137,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon="times" />
+          <Icon icon='times' />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as="h3">
-        {__("Edit")}
-        <Icon icon="times" size={24} onClick={onHideModal} />
+      <Dialog.Title as='h3'>
+        {__('Edit')}
+        <Icon icon='times' size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,7 +172,7 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className="dialog-description">
+                  <div className='dialog-description'>
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,

--- a/packages/ui-tickets/src/boards/components/editForm/Move.tsx
+++ b/packages/ui-tickets/src/boards/components/editForm/Move.tsx
@@ -1,4 +1,4 @@
-import { IItem, IOptions } from "../../types";
+import { IItem, IOptions } from '../../types';
 import {
   MoveContainer,
   MoveContainerWidth,
@@ -7,14 +7,14 @@ import {
   PipelinePopoverContent,
   StageItem,
   Stages,
-} from "../../styles/item";
+} from '../../styles/item';
 
-import BoardSelect from "../../containers/BoardSelect";
-import { IStage } from "../../types";
-import Icon from "@erxes/ui/src/components/Icon";
-import Popover from "@erxes/ui/src/components/Popover";
-import React from "react";
-import Tip from "@erxes/ui/src/components/Tip";
+import BoardSelect from '../../containers/BoardSelect';
+import { IStage } from '../../types';
+import Icon from '@erxes/ui/src/components/Icon';
+import Popover from '@erxes/ui/src/components/Popover';
+import React from 'react';
+import Tip from '@erxes/ui/src/components/Tip';
 
 type Props = {
   item?: IItem;
@@ -77,14 +77,14 @@ class Move extends React.Component<Props, State> {
 
     return (
       <Stages>
-        {stages.map((s) => {
+        {stages?.map(s => {
           const onClick = () => onChangeStage && onChangeStage(s._id);
 
           const item = (
             <StageItem key={s._id} $isPass={isPass}>
-              <Tip text={s.name} placement="top">
+              <Tip text={s.name} placement='top'>
                 <span onClick={onClick}>
-                  <Icon icon={isPass ? "check-circle" : "circle"} />
+                  <Icon icon={isPass ? 'check-circle' : 'circle'} />
                 </span>
               </Tip>
             </StageItem>
@@ -132,10 +132,10 @@ class Move extends React.Component<Props, State> {
     return (
       <MoveFormContainer ref={this.ref}>
         <Popover
-          placement="bottom-start"
+          placement='bottom-start'
           trigger={
             <PipelineName onClick={this.toggleForm}>
-              {pipeline && pipeline.name} <Icon icon="angle-down" />
+              {pipeline && pipeline.name} <Icon icon='angle-down' />
             </PipelineName>
           }
         >


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes card handling bug and updates board pipeline logic in `EditForm` and `Move` components across multiple packages.
> 
>   - **Behavior**:
>     - Commented out `saveItem` call in `onChangeStage` in `EditForm.tsx` across `ui-purchases`, `ui-tasks`, and `ui-tickets`.
>     - Consistent use of single quotes in import statements across `EditForm.tsx` and `Move.tsx` in `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets`.
>   - **Components**:
>     - `EditForm` and `Move` components in `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets` are affected.
>   - **Misc**:
>     - Minor formatting changes in `EditForm.tsx` and `Move.tsx` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 262dd23e64336219b7a3e28ccf42f4c3fcd88801. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the bug related to stage changes in the EditForm component by commenting out problematic code and enhance code consistency by standardizing string literals to use single quotes across various components.

Bug Fixes:
- Fix the issue with the stage change functionality in the EditForm component by commenting out the saveItem function call that was causing unintended behavior.

Enhancements:
- Standardize the use of single quotes for string literals across multiple components for consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->