### PR TITLE
added timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [2.0.3](https://github.com/erxes/erxes/compare/2.0.2...2.0.3) (2024-10-29)
+
 ## [2.0.2](https://github.com/erxes/erxes/compare/2.0.1...2.0.2) (2024-10-29)
 
 ## [2.0.1](https://github.com/erxes/erxes/compare/1.19.0-rc.0...2.0.1) (2024-10-29)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "erxes",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "workspaces": [
     "packages/*",
     "scripts"

--- a/packages/plugin-calls-api/package.json
+++ b/packages/plugin-calls-api/package.json
@@ -9,6 +9,7 @@
     "@erxes/api-utils": "*",
     "dayjs": "^1.11.11",
     "fast-xml-parser": "^4.4.1",
+    "moment-timezone": "^0.5.46",
     "redlock": "4.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17603,6 +17603,13 @@ moment-timezone@^0.5.28, moment-timezone@^0.5.31, moment-timezone@^0.5.40, momen
   dependencies:
     moment "^2.29.4"
 
+moment-timezone@^0.5.46:
+  version "0.5.46"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.46.tgz#a21aa6392b3c6b3ed916cd5e95858a28d893704a"
+  integrity sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==
+  dependencies:
+    moment "^2.29.4"
+
 moment@^2.18.1, moment@^2.19.3, moment@^2.24.0, moment@^2.27.0, moment@^2.29.4:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
@@ -19372,7 +19379,7 @@ prosemirror-menu@^1.2.4:
     prosemirror-history "^1.0.0"
     prosemirror-state "^1.0.0"
 
-prosemirror-model@1.22.3, prosemirror-model@^1.0.0, prosemirror-model@^1.19.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.22.2, prosemirror-model@^1.8.1:
+prosemirror-model@^1.0.0, prosemirror-model@^1.19.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.22.2, prosemirror-model@^1.8.1:
   version "1.22.3"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.22.3.tgz#52fdf5897f348b0f07f64bea89156d90afdf645a"
   integrity sha512-V4XCysitErI+i0rKFILGt/xClnFJaohe/wrrlT2NSZ+zk8ggQfDH4x2wNK7Gm0Hp4CIoWizvXFP7L9KMaCuI0Q==
@@ -19437,7 +19444,7 @@ prosemirror-transform@^1.9.0:
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@1.34.2, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.9:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.9:
   version "1.34.2"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.34.2.tgz#239a1766e46e364666e2b850855361929c4236df"
   integrity sha512-tPX/V2Xd70vrAGQ/V9CppJtPKnQyQMypJGlLylvdI94k6JaG+4P6fVmXPR1zc1eVTW0gq3c6zsfqwJKCRLaG9Q==


### PR DESCRIPTION
## Summary by Sourcery

Add timezone support for call start and end times, defaulting to 'Asia/Shanghai', and enhance error handling for missing cookies in the sendToGrandStream function. Update the changelog for version 2.0.3.

New Features:
- Introduce timezone handling for call start and end times using 'Asia/Shanghai' as the default timezone.

Enhancements:
- Add error handling for missing cookies in the sendToGrandStream function.

Documentation:
- Update CHANGELOG.md to include version 2.0.3.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add timezone handling for call times and improve error handling in `utils.ts`, update version to 2.0.3.
> 
>   - **Timezone Handling**:
>     - Use `moment-timezone` in `getRecordUrl` in `utils.ts` to format `callStartTime` and `callEndTime` with timezone `Asia/Shanghai`.
>   - **Error Handling**:
>     - Add error handling for missing cookies in `sendToGrandStream` in `utils.ts`.
>   - **Version Update**:
>     - Update version to `2.0.3` in `package.json` and `CHANGELOG.md`.
>     - Add `moment-timezone` dependency in `packages/plugin-calls-api/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for ebdfd0c386a3a8aa7699ce781b78d26be24a161e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->