### PR TITLE
fix(calls): sometimes not saved call history

### DIFF
--- a/packages/plugin-calls-api/src/acceptCall.ts
+++ b/packages/plugin-calls-api/src/acceptCall.ts
@@ -44,13 +44,12 @@ const acceptCall = async (
 
   let history;
   try {
-    history = new models.CallHistory({
+    const historyData: any = {
       operatorPhone,
       customerPhone,
       callStartTime,
       callType,
       callStatus,
-      timeStamp,
       inboxIntegrationId,
       createdAt: new Date(),
       createdBy: user._id,
@@ -58,7 +57,13 @@ const acceptCall = async (
       callDuration: 0,
       extentionNumber,
       queueName: queue,
-    });
+    };
+
+    if (timeStamp === 0) {
+      historyData.timeStamp = Date.now().toString();
+    }
+
+    history = new models.CallHistory(historyData);
 
     try {
       await models.CallHistory.deleteMany({

--- a/packages/plugin-calls-api/src/graphql/resolvers/mutations.ts
+++ b/packages/plugin-calls-api/src/graphql/resolvers/mutations.ts
@@ -159,6 +159,9 @@ const callsMutations = {
         timeStamp: doc.timeStamp,
         callStatus: 'cancelled',
       });
+      if (doc.timeStamp === 0) {
+        doc.timeStamp = Date.now().toString();
+      }
       await models.CallHistory.updateOne(
         { _id },
         {

--- a/packages/plugin-calls-api/src/graphql/typeDefs.ts
+++ b/packages/plugin-calls-api/src/graphql/typeDefs.ts
@@ -70,7 +70,7 @@ const types = `
     callEndTime: Date
     callType: String
     callStatus: String
-    timeStamp: Int
+    timeStamp: Float
     modifiedAt: Date
     createdAt: Date
     createdBy: String
@@ -97,7 +97,7 @@ const commonHistoryFields = `
   callEndTime: Date
   callType: String
   callStatus: String
-  timeStamp: Int
+  timeStamp: Float
   inboxIntegrationId: String
   transferedCallStatus: String
   endedBy: String
@@ -141,7 +141,7 @@ const mutations = `
   callDisconnect: String
   callHistoryAdd(${commonHistoryFields}, queueName: String): CallHistory
   callHistoryEdit(_id: String,${commonHistoryFields}): String
-  callHistoryEditStatus(callStatus: String, timeStamp: Int): String
+  callHistoryEditStatus(callStatus: String, timeStamp: Float): String
   callHistoryRemove(_id: String!): JSON
   callsUpdateConfigs(configsMap: JSON!): JSON
   callsPauseAgent(status: String!, integrationId: String!): String

--- a/packages/plugin-calls-api/src/models/definitions/callHistories.ts
+++ b/packages/plugin-calls-api/src/models/definitions/callHistories.ts
@@ -9,7 +9,7 @@ export interface ICallHistory {
   callEndTime: Date;
   callType: string;
   callStatus: string;
-  timeStamp: number;
+  timeStamp: number | string;
   modifiedAt: Date;
   createdAt: Date;
   createdBy: string;

--- a/packages/plugin-calls-ui/src/graphql/mutations.ts
+++ b/packages/plugin-calls-ui/src/graphql/mutations.ts
@@ -1,5 +1,3 @@
-import { isEnabled } from '@erxes/ui/src/utils/core';
-
 const callsIntegrationUpdate: string = `
 mutation CallsIntegrationUpdate($configs: CallIntegrationConfigs) {
   callsIntegrationUpdate(configs: $configs)

--- a/packages/plugin-calls-ui/src/graphql/mutations.ts
+++ b/packages/plugin-calls-ui/src/graphql/mutations.ts
@@ -1,4 +1,4 @@
-import { isEnabled } from "@erxes/ui/src/utils/core";
+import { isEnabled } from '@erxes/ui/src/utils/core';
 
 const callsIntegrationUpdate: string = `
 mutation CallsIntegrationUpdate($configs: CallIntegrationConfigs) {
@@ -112,7 +112,7 @@ const callDisconnect = `
 `;
 
 const callHistoryAdd = `
-  mutation CallHistoryAdd($inboxIntegrationId: String,$customerPhone: String, $callStartTime: Date ,$callStatus: String, $callType: String, $timeStamp: Int, $endedBy: String, $queueName: String) {
+  mutation CallHistoryAdd($inboxIntegrationId: String,$customerPhone: String, $callStartTime: Date ,$callStatus: String, $callType: String, $timeStamp: Float, $endedBy: String, $queueName: String) {
   callHistoryAdd(inboxIntegrationId: $inboxIntegrationId,  customerPhone: $customerPhone, callStartTime: $callStartTime, callStatus: $callStatus, callType: $callType, timeStamp: $timeStamp, endedBy: $endedBy, queueName: $queueName) {
     _id
     timeStamp
@@ -122,12 +122,12 @@ const callHistoryAdd = `
 `;
 
 const callHistoryEdit = `
-  mutation CallHistoryEdit($id: String, $inboxIntegrationId: String, $customerPhone: String, $callDuration: Int, $callStartTime: Date, $callEndTime: Date, $callType: String, $callStatus: String, $timeStamp: Int, $transferedCallStatus: String, $endedBy: String) {
+  mutation CallHistoryEdit($id: String, $inboxIntegrationId: String, $customerPhone: String, $callDuration: Int, $callStartTime: Date, $callEndTime: Date, $callType: String, $callStatus: String, $timeStamp: Float, $transferedCallStatus: String, $endedBy: String) {
     callHistoryEdit(_id: $id, inboxIntegrationId: $inboxIntegrationId, customerPhone: $customerPhone, callDuration: $callDuration, callStartTime: $callStartTime, callEndTime: $callEndTime, callType: $callType, callStatus: $callStatus, timeStamp: $timeStamp, transferedCallStatus: $transferedCallStatus, endedBy: $endedBy) 
 }`;
 
 const callHistoryEditStatus = ` 
-  mutation CallHistoryEditStatus($callStatus: String, $timeStamp: Int) {
+  mutation CallHistoryEditStatus($callStatus: String, $timeStamp: Float) {
     callHistoryEditStatus(callStatus: $callStatus, timeStamp: $timeStamp)
 }`;
 
@@ -164,5 +164,5 @@ export default {
   callsUpdateConfigs,
   callHistoryEditStatus,
   callPauseAgent,
-  callTransfer
+  callTransfer,
 };


### PR DESCRIPTION
## Summary by Sourcery

Fix the call history saving issue by setting a valid timestamp when it is zero and update the 'timeStamp' field type from 'Int' to 'Float' for better precision in GraphQL schemas.

Bug Fixes:
- Fix the issue where call history was sometimes not saved by ensuring a valid timestamp is set when it is zero.

Enhancements:
- Change the data type of the 'timeStamp' field from 'Int' to 'Float' in GraphQL mutations and type definitions to accommodate more precise time values.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix call history saving by updating `timeStamp` handling and changing its type to `Float`.
> 
>   - **Behavior**:
>     - In `acceptCall.ts`, if `timeStamp` is `0`, set it to current time as string.
>     - In `mutations.ts`, handle `timeStamp` as `Float` and update if `0`.
>   - **GraphQL**:
>     - Change `timeStamp` type from `Int` to `Float` in `typeDefs.ts`.
>     - Update `callHistoryAdd`, `callHistoryEdit`, and `callHistoryEditStatus` mutations to use `Float` for `timeStamp`.
>   - **Models**:
>     - Update `ICallHistory` in `callHistories.ts` to allow `timeStamp` as `number | string`.
>   - **Misc**:
>     - Remove unused import in `mutations.ts` in UI package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 30c590a253a1eff8105a11fbbc018830531ccb6b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->