### PR TITLE
show cancel order button except market

### DIFF
--- a/pos/modules/orders/components/DeliveryInputs/index.tsx
+++ b/pos/modules/orders/components/DeliveryInputs/index.tsx
@@ -37,7 +37,7 @@ const DeliveryInputs = () => {
           </>
         )}
         <DirectDiscount />
-        {!!orderId && mode === "main" && (
+        {!!orderId && mode !== "market" && (
           <>
             <Separator />
             <div className="col-span-3">


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the condition to display the cancel order button by excluding the 'market' mode.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `DeliveryInputs` to show cancel order button when `mode` is not `market`.
> 
>   - **Behavior**:
>     - Modify condition in `DeliveryInputs` to show cancel order button when `mode` is not `market`.
>   - **Files Affected**:
>     - `index.tsx` in `pos/modules/orders/components/DeliveryInputs/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 4956a498f0a58c3312ef6df4bec0193d979a58b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility of the cancel order functionality; it is now displayed in more scenarios within the delivery inputs.
  
- **Bug Fixes**
	- Adjusted rendering logic to ensure the cancel button is accessible when appropriate conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->