### PR TITLE
clientportal user moveUser mutation add

### DIFF
--- a/packages/plugin-clientportal-api/src/graphql/resolvers/mutations/clientPortalUser.ts
+++ b/packages/plugin-clientportal-api/src/graphql/resolvers/mutations/clientPortalUser.ts
@@ -1461,12 +1461,15 @@ const clientPortalUserMutations = {
 
   async clientPortalUsersMove(
     _root,
-    { userIds, clientPortalId }: { userIds: string[]; clientPortalId: string },
+    {
+      oldClientPortalId,
+      newClientPortalId,
+    }: { oldClientPortalId: string; newClientPortalId: string },
     { models }: IContext
   ) {
     const updated = await models.ClientPortalUsers.moveUser(
-      userIds,
-      clientPortalId
+      oldClientPortalId,
+      newClientPortalId
     );
 
     return updated;

--- a/packages/plugin-clientportal-api/src/graphql/resolvers/mutations/clientPortalUser.ts
+++ b/packages/plugin-clientportal-api/src/graphql/resolvers/mutations/clientPortalUser.ts
@@ -189,7 +189,7 @@ const clientPortalUserMutations = {
             fields:
               'id,name,email,gender,education,work,picture,last_name,first_name',
           })
-      ).then(r => r.json());
+      ).then((r) => r.json());
 
       if (!response || !response.id) {
         throw new Error('Facebook authentication failed');
@@ -197,7 +197,7 @@ const clientPortalUserMutations = {
 
       const { id, name, email, picture, first_name, last_name } =
         response || {};
-        
+
       let qry: any = {};
       let user: any = {};
 
@@ -301,7 +301,7 @@ const clientPortalUserMutations = {
           {
             method: 'POST',
           }
-        ).then(r => r.json());
+        ).then((r) => r.json());
 
         if (authResponse.error) {
           throw new Error(authResponse.error.message);
@@ -332,7 +332,7 @@ const clientPortalUserMutations = {
               Authorization: `Bearer ${id_token}`,
             },
           }
-        ).then(r => r.json());
+        ).then((r) => r.json());
 
         if (userResponse.error) {
           throw new Error(userResponse.error.message);
@@ -1457,6 +1457,19 @@ const clientPortalUserMutations = {
       newPassword,
       oldPassword
     );
+  },
+
+  async clientPortalUsersMove(
+    _root,
+    { userIds, clientPortalId }: { userIds: string[]; clientPortalId: string },
+    { models }: IContext
+  ) {
+    const updated = await models.ClientPortalUsers.moveUser(
+      userIds,
+      clientPortalId
+    );
+
+    return updated;
   },
 };
 

--- a/packages/plugin-clientportal-api/src/graphql/schema/clientPortalUser.ts
+++ b/packages/plugin-clientportal-api/src/graphql/schema/clientPortalUser.ts
@@ -195,7 +195,7 @@ export const mutations = () => `
   
   clientPortalUsersReplacePhone(clientPortalId: String!, phone: String!): String!
   clientPortalUsersVerifyPhone(code: String!): String!
-  clientPortalUsersMove(userIds: [String!], clientPortalId: String!): JSON
+  clientPortalUsersMove(oldClientPortalId: String!, newClientPortalId: String!): JSON
 
   clientPortalUserAssignCompany(userId: String!, erxesCompanyId: String!, erxesCustomerId: String!):  JSON
 

--- a/packages/plugin-clientportal-api/src/graphql/schema/clientPortalUser.ts
+++ b/packages/plugin-clientportal-api/src/graphql/schema/clientPortalUser.ts
@@ -195,6 +195,7 @@ export const mutations = () => `
   
   clientPortalUsersReplacePhone(clientPortalId: String!, phone: String!): String!
   clientPortalUsersVerifyPhone(code: String!): String!
+  clientPortalUsersMove(userIds: [String!], clientPortalId: String!): JSON
 
   clientPortalUserAssignCompany(userId: String!, erxesCompanyId: String!, erxesCustomerId: String!):  JSON
 

--- a/packages/plugin-clientportal-api/src/models/ClientPortalUser.ts
+++ b/packages/plugin-clientportal-api/src/models/ClientPortalUser.ts
@@ -168,8 +168,8 @@ export interface IUserModel extends Model<IUserDocument> {
     secondary?: boolean
   ): boolean;
   moveUser(
-    userIds: string[],
-    clientPortalId: string
+    oldClientPortalId: string,
+    newClientPortalId: string
   ): Promise<{ userIds: string[]; clientPortalId: string }>;
 }
 
@@ -1280,18 +1280,20 @@ export const loadClientPortalUserClass = (models: IModels) => {
       return this.comparePassword(password, user.password || '');
     }
 
-    public static async moveUser(userIds, clientPortalId) {
+    public static async moveUser(oldClientPortalId, newClientPortalId) {
       const users = await models.ClientPortalUsers.find({
-        _id: { $in: userIds },
+        clientPortalId: oldClientPortalId,
       });
 
       if (!users || !users.length) {
         throw new Error('Users not found');
       }
 
+      const userIds = users.map((user) => user._id);
+
       const updatedUsers = await models.ClientPortalUsers.updateMany(
         { _id: { $in: userIds } },
-        { $set: { clientPortalId, modifiedAt: new Date() } }
+        { $set: { clientPortalId: newClientPortalId, modifiedAt: new Date() } }
       );
 
       return updatedUsers;

--- a/packages/plugin-clientportal-ui/src/components/forms/ClientPortalMoveForm.tsx
+++ b/packages/plugin-clientportal-ui/src/components/forms/ClientPortalMoveForm.tsx
@@ -1,0 +1,133 @@
+import {
+  ClientPortalConfig,
+  IClientPortalUser,
+  IClientPortalUserDoc,
+} from '../../types';
+import { ModalFooter } from '@erxes/ui/src/styles/main';
+import { IButtonMutateProps, IFormProps } from '@erxes/ui/src/types';
+import React, { useState } from 'react';
+
+import Button from '@erxes/ui/src/components/Button';
+import ControlLabel from '@erxes/ui/src/components/form/Label';
+import { Form } from '@erxes/ui/src/components/form';
+import FormControl from '@erxes/ui/src/components/form/Control';
+import FormGroup from '@erxes/ui/src/components/form/Group';
+import { IUser } from '@erxes/ui/src/auth/types';
+import { __ } from '@erxes/ui/src/utils';
+
+type Props = {
+  currentUser: IUser;
+  clientPortalUser?: IClientPortalUser;
+  closeModal: () => void;
+  renderButton: (props: IButtonMutateProps) => JSX.Element;
+  clientPortalGetConfigs: ClientPortalConfig[];
+};
+
+type State = {
+  oldClientPortalId: string;
+  newClientPortalId: string;
+};
+
+const ClientPortalMoveForm: React.FC<Props> = (props: Props) => {
+  const [state, setState] = useState<State>({
+    oldClientPortalId: '',
+    newClientPortalId: '',
+  });
+
+  const generateDoc = (
+    values: {
+      oldClientPortalId: string;
+      newClientPortalId: string;
+    } & IClientPortalUserDoc
+  ) => {
+    const finalValues = values;
+
+    const doc: any = {
+      oldClientPortalId: finalValues.oldClientPortalId,
+      newClientPortalId: finalValues.newClientPortalId,
+    };
+
+    return doc;
+  };
+
+  const onChange = (e: any) => {
+    setState((prevState) => ({
+      ...prevState,
+      oldClientPortalId: e.target.value,
+    }));
+  };
+
+  const onNewChange = (e: any) => {
+    setState((prevState) => ({
+      ...prevState,
+      newClientPortalId: e.target.value,
+    }));
+  };
+
+  const renderContent = (formProps: IFormProps) => {
+    const { values, isSubmitted, resetSubmit } = formProps;
+
+    return (
+      <>
+        <FormGroup>
+          <ControlLabel>Current Client portal</ControlLabel>
+          <FormControl
+            {...formProps}
+            name="oldClientPortalId"
+            componentclass="select"
+            defaultValue={state.oldClientPortalId}
+            required={true}
+            onChange={onChange}
+          >
+            <option />
+            {props.clientPortalGetConfigs.map((cp, index) => (
+              <option key={index} value={cp._id}>
+                {cp.name}
+              </option>
+            ))}
+          </FormControl>
+        </FormGroup>
+
+        <FormGroup>
+          <ControlLabel>Move Client portal</ControlLabel>
+          <FormControl
+            {...formProps}
+            name="newClientPortalId"
+            componentclass="select"
+            defaultValue={state.newClientPortalId}
+            required={true}
+            onChange={onNewChange}
+          >
+            <option />
+            {props.clientPortalGetConfigs.map((cp, index) => (
+              <option key={index} value={cp._id}>
+                {cp.name}
+              </option>
+            ))}
+          </FormControl>
+        </FormGroup>
+        <ModalFooter>
+          <Button
+            btnStyle="simple"
+            uppercase={false}
+            onClick={props.closeModal}
+            icon="times-circle"
+          >
+            Close
+          </Button>
+
+          {props.renderButton({
+            name: 'clientPortalUser',
+            values: generateDoc(values),
+            isSubmitted,
+            resetSubmit,
+          })}
+        </ModalFooter>
+      </>
+    );
+  };
+
+  return <Form renderContent={renderContent} />;
+};
+
+export default ClientPortalMoveForm;

--- a/packages/plugin-clientportal-ui/src/components/list/ClientPortalUserList.tsx
+++ b/packages/plugin-clientportal-ui/src/components/list/ClientPortalUserList.tsx
@@ -1,28 +1,29 @@
-import { Alert, confirm, router } from "@erxes/ui/src/utils";
-import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Alert, confirm, router } from '@erxes/ui/src/utils';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-import { BarItems } from "@erxes/ui/src/layout/styles";
-import Button from "@erxes/ui/src/components/Button";
-import ClientPortalUserForm from "../../containers/ClientPortalUserForm";
-import ClientPortalUserRow from "./ClientPortalUserRow";
-import DataWithLoader from "@erxes/ui/src/components/DataWithLoader";
-import { EMPTY_CONTENT_CONTACTS } from "@erxes/ui-settings/src/constants";
-import EmptyContent from "@erxes/ui/src/components/empty/EmptyContent";
-import FormControl from "@erxes/ui/src/components/form/Control";
-import { IClientPortalUser } from "../../types";
-import ModalTrigger from "@erxes/ui/src/components/ModalTrigger";
-import Pagination from "@erxes/ui/src/components/pagination/Pagination";
-import Sidebar from "./Sidebar";
-import Table from "@erxes/ui/src/components/table";
-import Wrapper from "@erxes/ui/src/layout/components/Wrapper";
-import { __ } from "@erxes/ui/src/utils/core";
-import { menuContacts } from "@erxes/ui/src/utils/menus";
-import withTableWrapper from "@erxes/ui/src/components/table/withTableWrapper";
+import { BarItems } from '@erxes/ui/src/layout/styles';
+import Button from '@erxes/ui/src/components/Button';
+import ClientPortalUserForm from '../../containers/ClientPortalUserForm';
+import ClientPortalUserRow from './ClientPortalUserRow';
+import DataWithLoader from '@erxes/ui/src/components/DataWithLoader';
+import { EMPTY_CONTENT_CONTACTS } from '@erxes/ui-settings/src/constants';
+import EmptyContent from '@erxes/ui/src/components/empty/EmptyContent';
+import FormControl from '@erxes/ui/src/components/form/Control';
+import { IClientPortalUser } from '../../types';
+import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
+import Pagination from '@erxes/ui/src/components/pagination/Pagination';
+import Sidebar from './Sidebar';
+import Table from '@erxes/ui/src/components/table';
+import Wrapper from '@erxes/ui/src/layout/components/Wrapper';
+import { __ } from '@erxes/ui/src/utils/core';
+import { menuContacts } from '@erxes/ui/src/utils/menus';
+import withTableWrapper from '@erxes/ui/src/components/table/withTableWrapper';
+import ClientPortalMoveForm from '../../containers/ClientPortalMoveForm';
 
 interface IProps {
   type: string;
-  kind: "client" | "vendor";
+  kind: 'client' | 'vendor';
   queryParams: any;
   clientPortalUsers: IClientPortalUser[];
   clientPortalUserCount: number;
@@ -70,7 +71,7 @@ const ClientportalUserList: React.FC<IProps> = ({
   const timerRef = React.useRef<NodeJS.Timeout | null>(null);
 
   const onChange = () => {
-    toggleAll(clientPortalUsers, "clientPortalUsers");
+    toggleAll(clientPortalUsers, 'clientPortalUsers');
   };
 
   const removeUsersHandler = (clientPortalUsersToRemove: any[]) => {
@@ -112,21 +113,21 @@ const ClientportalUserList: React.FC<IProps> = ({
                 />
               </th>
               <th>#</th>
-              <th>{__("ID Verification")}</th>
-              <th>{__("Email")}</th>
-              <th>{__("Phone")}</th>
-              <th>{__("User Name")}</th>
-              <th>{__("Code")}</th>
-              <th>{__("First Name")}</th>
-              <th>{__("Last Name")}</th>
-              <th>{__("Company name")}</th>
-              <th>{__("Type")}</th>
-              <th>{__("from")}</th>
-              <th>{__("Status")}</th>
-              <th>{__("Session count")}</th>
-              <th>{__("Last seen at")}</th>
-              <th>{__("Registered at")}</th>
-              <th>{__("Modified at")}</th>
+              <th>{__('ID Verification')}</th>
+              <th>{__('Email')}</th>
+              <th>{__('Phone')}</th>
+              <th>{__('User Name')}</th>
+              <th>{__('Code')}</th>
+              <th>{__('First Name')}</th>
+              <th>{__('Last Name')}</th>
+              <th>{__('Company name')}</th>
+              <th>{__('Type')}</th>
+              <th>{__('from')}</th>
+              <th>{__('Status')}</th>
+              <th>{__('Session count')}</th>
+              <th>{__('Last seen at')}</th>
+              <th>{__('Registered at')}</th>
+              <th>{__('Modified at')}</th>
             </tr>
           </thead>
           <tbody id="clientPortalUsers">
@@ -155,7 +156,7 @@ const ClientportalUserList: React.FC<IProps> = ({
     setState((prevState) => ({ ...prevState, searchValue }));
 
     timerRef.current = setTimeout(() => {
-      router.removeParams(navigate, location, "page");
+      router.removeParams(navigate, location, 'page');
       router.setParams(navigate, location, { searchValue });
     }, 500);
   };
@@ -163,7 +164,7 @@ const ClientportalUserList: React.FC<IProps> = ({
   const moveCursorAtTheEnd = (e) => {
     const tmpValue = e.target.value;
 
-    e.target.value = "";
+    e.target.value = '';
     e.target.value = tmpValue;
   };
 
@@ -173,19 +174,37 @@ const ClientportalUserList: React.FC<IProps> = ({
     </Button>
   );
 
+  const moveTrigger = (
+    <Button btnStyle="default" size="small" icon="plus-circle">
+      Move user
+    </Button>
+  );
+
   const customerForm = (props) => {
     return <ClientPortalUserForm {...props} size="lg" kind={kind} />;
+  };
+
+  const moveForm = (props) => {
+    return <ClientPortalMoveForm {...props} size="sm" kind={kind} />;
   };
 
   const actionBarRight = (
     <BarItems>
       <FormControl
         type="text"
-        placeholder={__("Type to search")}
+        placeholder={__('Type to search')}
         onChange={searchHandler}
         value={state.searchValue}
         autoFocus={true}
         onFocus={moveCursorAtTheEnd}
+      />
+
+      <ModalTrigger
+        title="Move user"
+        autoOpenKey="showCustomerModal"
+        trigger={moveTrigger}
+        content={moveForm}
+        backDrop="static"
       />
 
       <ModalTrigger

--- a/packages/plugin-clientportal-ui/src/containers/ClientPortalMoveForm.tsx
+++ b/packages/plugin-clientportal-ui/src/containers/ClientPortalMoveForm.tsx
@@ -1,0 +1,88 @@
+import { AppConsumer, ButtonMutate } from '@erxes/ui/src';
+import { ClientPortalConfigsQueryResponse, IClientPortalUser } from '../types';
+import { IButtonMutateProps, IQueryParams } from '@erxes/ui/src/types';
+import { IUser, UsersQueryResponse } from '@erxes/ui/src/auth/types';
+import { mutations, queries } from '../graphql';
+
+import ClientPortalMoveForm from '../components/forms/ClientPortalMoveForm';
+import React from 'react';
+import { gql } from '@apollo/client';
+import { useQuery } from '@apollo/client';
+
+type Props = {
+  clientPortalUser: IClientPortalUser;
+  closeModal: () => void;
+  queryParams: IQueryParams;
+  kind: 'client' | 'vendor';
+};
+
+type FinalProps = {
+  usersQuery: UsersQueryResponse;
+  currentUser: IUser;
+  clientPortalConfigsQuery: ClientPortalConfigsQueryResponse;
+} & Props;
+
+const ClientPortalMoveFormContainer: React.FC<FinalProps> = (
+  props: FinalProps
+) => {
+  const { closeModal, kind } = props;
+
+  const clientPortalConfigsQuery = useQuery(gql(queries.getConfigs), {
+    fetchPolicy: 'network-only',
+    variables: { kind },
+  });
+
+  if (clientPortalConfigsQuery.loading) {
+    return null;
+  }
+
+  const renderButton = ({ values, isSubmitted }: IButtonMutateProps) => {
+    const afterSave = (_data) => {
+      closeModal();
+    };
+
+    return (
+      <ButtonMutate
+        mutation={mutations.clientPortalUsersMove}
+        variables={values}
+        callback={afterSave}
+        refetchQueries={getRefetchQueries()}
+        isSubmitted={isSubmitted}
+        type="submit"
+        successMessage={'You successfully updated'}
+      ></ButtonMutate>
+    );
+  };
+
+  const clientPortalGetConfigs =
+    (clientPortalConfigsQuery.data &&
+      clientPortalConfigsQuery.data.clientPortalGetConfigs) ||
+    [];
+
+  const updatedProps = {
+    ...props,
+    clientPortalGetConfigs,
+    renderButton,
+  };
+
+  return (
+    <AppConsumer>
+      {({ currentUser }) => (
+        <ClientPortalMoveForm
+          {...updatedProps}
+          currentUser={currentUser || ({} as IUser)}
+        />
+      )}
+    </AppConsumer>
+  );
+};
+
+const getRefetchQueries = () => {
+  return [
+    'clientPortalUsers',
+    'clientPortalUserCounts',
+    'clientPortalGetConfigs',
+  ];
+};
+
+export default ClientPortalMoveFormContainer;

--- a/packages/plugin-clientportal-ui/src/graphql/mutations.ts
+++ b/packages/plugin-clientportal-ui/src/graphql/mutations.ts
@@ -145,6 +145,11 @@ mutation clientPortalParticipantEdit($id: String!, $contentType: UserCardEnum, $
     _id
   }
 }`;
+const clientPortalUsersMove = `
+  mutation clientPortalUsersMove($oldClientPortalId: String!, $newClientPortalId: String!) {
+    clientPortalUsersMove(oldClientPortalId: $oldClientPortalId, newClientPortalId: $newClientPortalId)
+  }
+`;
 export default {
   createOrUpdateConfig,
   remove,
@@ -159,4 +164,5 @@ export default {
   clientPortalUserAssignCompany,
   clientPortalParticipantRelationEdit,
   clientPortalParticipantEdit,
+  clientPortalUsersMove,
 };


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

## Summary by Sourcery

Add a new mutation 'clientPortalUsersMove' to enable moving users between client portals and refactor code to use single quotes for strings consistently.

New Features:
- Introduce a new mutation 'clientPortalUsersMove' to move users between client portals.

Enhancements:
- Refactor code to use consistent single quotes for strings instead of double quotes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `clientPortalUsersMove` mutation to move users between client portals and refactor string usage for consistency.
> 
>   - **Behavior**:
>     - Adds `clientPortalUsersMove` mutation to move users between client portals in `clientPortalUserMutations`.
>     - Implements `moveUser` function in `ClientPortalUser` class to update `clientPortalId` for specified users.
>   - **Schema**:
>     - Updates `clientPortalUser.ts` to include `clientPortalUsersMove` mutation with `userIds` and `clientPortalId` as parameters.
>   - **UI**:
>     - Adds `ClientPortalMoveForm.tsx` for user interface to move users between portals.
>     - Integrates `ClientPortalMoveForm` into `ClientPortalUserList.tsx` with a new button and modal.
>   - **Misc**:
>     - Refactors code to use consistent single quotes for strings in `ClientPortalUser.ts` and `ClientPortalUserList.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for afbb5c12dca97618a0cc2c9e864c00b12ccbda51. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->