### PR TITLE
chore: add publishedAt

### DIFF
--- a/client-portal/modules/common/Avatar.tsx
+++ b/client-portal/modules/common/Avatar.tsx
@@ -26,20 +26,30 @@ export default function Avatar({ user = {} as IUser & { status?: string }, date,
       <img
         className="round-img"
         alt={fullName}
-        src={avatar ? readFile(avatar) : "/static/avatar-colored.svg"}
+        src={avatar ? readFile(avatar) : '/static/avatar-colored.svg'}
       />
       <div className="detail avatar-info d-flex flex-wrap">
         <div>
-          {__(`${status || 'Written'} by`)}
-          <span>{fullName}</span>
+          <div>
+            {__(`${status || 'Written'} by`)}
+            <span>{fullName}</span>
+          </div>
+          <div className="d-flex align-items-center">
+            <Icon icon="eye" size={14} />
+            <span>{viewCount}</span>
+          </div>
         </div>
-        <div>
-          {__("Modified at")}
-          <span>{dayjs(date).format("MMM D YYYY")}</span>
-        </div>
-        <div className="d-flex align-items-center">
-          <Icon icon="eye" size={14} />
-          <span>{viewCount}</span>
+        <div className="d-flex flex-wrap gap-2">
+          <div>
+            {__('Modified at')}
+            <span>{dayjs(date).format('MMM D YYYY')}</span>
+          </div>
+          {status === 'Published' && (
+            <div>
+              {__('Published at')}
+              <span>{dayjs(date).format('MMM D YYYY')}</span>
+            </div>
+          )}
         </div>
       </div>
     </Avatars>

--- a/client-portal/modules/knowledgeBase/components/styles.ts
+++ b/client-portal/modules/knowledgeBase/components/styles.ts
@@ -124,10 +124,17 @@ const Avatars = styled.div`
     margin-left: 10px;
     font-size: 13px;
     flex: 1;
-    
+
     > div {
-      width: 250px;
       margin-right: ${dimensions.unitSpacing}px;
+
+      > div {
+        margin-right: ${dimensions.unitSpacing + 5}px;
+      }
+
+      :first-child {
+        width: 250px;
+      }
     }
 
     .darker {

--- a/packages/plugin-knowledgebase-api/src/graphql/knowledgeBaseTypeDefs.ts
+++ b/packages/plugin-knowledgebase-api/src/graphql/knowledgeBaseTypeDefs.ts
@@ -1,8 +1,8 @@
 import {
   attachmentInput,
   attachmentType,
+  pdfAttachmentInput,
   pdfAttachmentType,
-  pdfAttachmentInput
 } from '@erxes/api-utils/src/commonTypeDefs';
 
 export const types = `
@@ -52,6 +52,7 @@ export const types = `
     pdfAttachment: PdfAttachment
     publishedUserId:String
     publishedUser:User
+    publishedAt: Date
     scheduledDate: Date
 
     forms: [FormCode]

--- a/packages/plugin-knowledgebase-api/src/models/KnowledgeBase.ts
+++ b/packages/plugin-knowledgebase-api/src/models/KnowledgeBase.ts
@@ -67,6 +67,7 @@ export const loadArticleClass = (models: IModels) => {
 
       if (docFields.status === PUBLISH_STATUSES.PUBLISH) {
         doc.publishedUserId = userId;
+        doc.publishedAt = new Date();
       }
 
       return  await models.KnowledgeBaseArticles.create(doc);
@@ -98,6 +99,7 @@ export const loadArticleClass = (models: IModels) => {
       if (article.status === PUBLISH_STATUSES.DRAFT && doc.status === PUBLISH_STATUSES.PUBLISH) {
 
         doc.publishedUserId = userId;
+        doc.publishedAt = new Date();
       }
 
       return await models.KnowledgeBaseArticles.findOneAndUpdate(

--- a/packages/plugin-knowledgebase-api/src/models/definitions/knowledgebase.ts
+++ b/packages/plugin-knowledgebase-api/src/models/definitions/knowledgebase.ts
@@ -30,6 +30,7 @@ export interface IArticle {
   categoryId?: string;
   topicId?: string;
   publishedUserId?: string;
+  publishedAt?: Date;
   scheduledDate?: Date;
 
   forms?: IFormCodes[];
@@ -127,7 +128,7 @@ export const articleSchema = new Schema({
   topicId: field({ type: String, optional: true, label: 'Topic' }),
   categoryId: field({ type: String, optional: true, label: 'Category' }),
   publishedUserId:field({ type: String, optional: true, label: 'Published user'}),
-
+  publishedAt: field({ type: Date, label: 'Published at' }),
   forms: field({ type: [formcodesSchema], label: 'Forms' }),
 
   pdfAttachment: field({ type: Object, optional: true, label: 'PDF attachment' }),

--- a/packages/plugin-knowledgebase-api/src/models/definitions/knowledgebase.ts
+++ b/packages/plugin-knowledgebase-api/src/models/definitions/knowledgebase.ts
@@ -128,7 +128,7 @@ export const articleSchema = new Schema({
   topicId: field({ type: String, optional: true, label: 'Topic' }),
   categoryId: field({ type: String, optional: true, label: 'Category' }),
   publishedUserId:field({ type: String, optional: true, label: 'Published user'}),
-  publishedAt: field({ type: Date, label: 'Published at' }),
+  publishedAt: field({ type: Date, optional: true, label: 'Published at' }),
   forms: field({ type: [formcodesSchema], label: 'Forms' }),
 
   pdfAttachment: field({ type: Object, optional: true, label: 'PDF attachment' }),


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Display the published date for published knowledge base articles.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `publishedAt` field to knowledge base articles and updates `Avatar` component to display it when status is 'Published'.
> 
>   - **Behavior**:
>     - `Avatar.tsx`: Displays `Published at` date if `status` is 'Published'.
>   - **GraphQL**:
>     - `knowledgeBaseTypeDefs.ts`: Adds `publishedAt` field to `KnowledgeBaseArticle` type.
>   - **Models**:
>     - `KnowledgeBase.ts`: Sets `publishedAt` to current date when article status changes to 'Published'.
>     - `knowledgebase.ts`: Adds `publishedAt` field to `IArticle` interface and `articleSchema`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for eb6b199d49242aef568243bc6ec47f05d6dff43d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->