### PR TITLE
fix getChildCategories() wrong return type

### DIFF
--- a/packages/core/src/db/models/Products.ts
+++ b/packages/core/src/db/models/Products.ts
@@ -523,10 +523,7 @@ export const loadProductCategoryClass = (models: IModels) => {
 
     public static async getChildCategories(categoryIds: string[]) {
       if (!categoryIds.length) {
-        return {
-          data: [],
-          status: "success"
-        };
+        return []
       }
 
       const categories = await models.ProductCategories.find({
@@ -534,10 +531,7 @@ export const loadProductCategoryClass = (models: IModels) => {
       }).lean();
 
       if (!categories.length) {
-        return {
-          data: [],
-          status: "success"
-        };
+        return [];
       }
 
       const orderQry: any[] = [];


### PR DESCRIPTION
Fixed getChildCategories() function that was returning wrong return type.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `getChildCategories()` in `Products.ts` to return an array instead of an object.
> 
>   - **Behavior**:
>     - Fix `getChildCategories()` in `Products.ts` to return an array instead of an object with `data` and `status` fields.
>     - Handles cases where `categoryIds` is empty or no categories are found by returning an empty array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 3ab10135ebbfb431c3adfe828cf52f934f4c5503. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->