### PR TITLE
quick_replies

### DIFF
--- a/packages/plugin-inbox-api/src/automations/utils.ts
+++ b/packages/plugin-inbox-api/src/automations/utils.ts
@@ -75,9 +75,14 @@ export const generateBotData = (
     botData.push({
       type: "custom",
       component: "QuickReplies",
-      quick_replies: quickReplies.map(({ text }) => ({
-        title: text
-      }))
+      quick_replies: [
+        { mainTitle: quickReplies[0]?.text || "Default Title" }, // First object with "mainTitle"
+        ...quickReplies.map(({ _id, text, type }) => ({
+          title: text,
+          type: type,
+          payload: _id
+        }))
+      ]
     });
   }
 

--- a/packages/plugin-inbox-api/src/graphql/resolvers/widgetMutations.ts
+++ b/packages/plugin-inbox-api/src/graphql/resolvers/widgetMutations.ts
@@ -1024,7 +1024,7 @@ const widgetMutations = {
       conversationMessageInserted: msg
     });
 
-    if (type === BOT_MESSAGE_TYPES.SAY_SOMETHING) {
+    if (payload) {
       await handleAutomation(subdomain, {
         conversationMessage: msg, // Pass msg as conversationMessage
         payload: {

--- a/widgets/client/messenger/types.ts
+++ b/widgets/client/messenger/types.ts
@@ -3,7 +3,7 @@ import {
   IIntegrationMessengerData,
   IIntegrationUiOptions,
   IParticipator,
-  IUser,
+  IUser
 } from "../types";
 import { ICarouselItem } from "./components/bot/Carousel";
 
@@ -137,8 +137,10 @@ export interface IBotData {
   elements?: ICarouselItem[];
   quick_replies?: [
     {
+      mainTitle: string;
       title: string;
       payload: string;
+      type: string;
     }
   ];
   wrapped?: {


### PR DESCRIPTION
## Summary by Sourcery

Update quick replies to include a main title and type, and use payload for automation triggers.

New Features:
- Added a "mainTitle" to quick replies to display a prominent title.
- Added a "type" field to quick replies.
- Quick replies now include a "payload" field, which is used for automation triggers.