### PR TITLE
fix(cards): activityLog refetch in stages moving

### DIFF
--- a/packages/ui-log/src/activityLogs/containers/ActivityLogs.tsx
+++ b/packages/ui-log/src/activityLogs/containers/ActivityLogs.tsx
@@ -37,7 +37,7 @@ class Container extends React.Component<FinalProps, {}> {
       document: gql(subscriptions.activityLogsChanged),
       updateQuery: () => {
         this.props.activityLogQuery.refetch();
-      },
+      }
     });
   }
 
@@ -57,7 +57,7 @@ class Container extends React.Component<FinalProps, {}> {
       activityLogQuery,
       extraTabs,
       onChangeActivityTab,
-      activityRenderItem,
+      activityRenderItem
     } = this.props;
 
     const props = {
@@ -67,7 +67,7 @@ class Container extends React.Component<FinalProps, {}> {
       activityLogs: activityLogQuery.activityLogs || [],
       onTabClick: onChangeActivityTab,
       extraTabs,
-      activityRenderItem,
+      activityRenderItem
     };
 
     return (
@@ -95,10 +95,11 @@ const WithData = withProps<WithDataProps>(
             variables: {
               contentId,
               contentType,
-              activityType,
+              activityType
             },
+            fetchPolicy: "cache-and-network"
           };
-        },
+        }
       }
     )
   )(withCurrentUser(Container))
@@ -112,7 +113,7 @@ export default class Wrapper extends React.Component<
     super(props);
 
     this.state = {
-      activityType: "",
+      activityType: ""
     };
   }
 

--- a/packages/ui-purchases/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-purchases/src/boards/containers/PipelineContext.tsx
@@ -20,6 +20,7 @@ import {
   updateItemInfo
 } from "../utils";
 import { mutations, queries, subscriptions } from "../graphql";
+import { queries as queriesLogs } from "@erxes/ui-log/src/activityLogs/graphql";
 
 import InvisibleItemInUrl from "./InvisibleItemInUrl";
 import React from "react";
@@ -376,6 +377,16 @@ class PipelineProviderInner extends React.Component<Props, State> {
     };
   };
 
+  refetchQueryLogs = (itemId: string) => {
+    return {
+      query: gql(queriesLogs.activityLogs),
+      variables: {
+        contentId: itemId,
+        contentType: "purchases:purchase"
+      }
+    };
+  };
+
   refetchStagesQueryBuild = (pipelineId: string) => {
     return {
       query: gql(queries.stages),
@@ -395,7 +406,10 @@ class PipelineProviderInner extends React.Component<Props, State> {
     const { itemId, aboveItemId, destinationStageId, sourceStageId } = args;
 
     const { options } = this.props;
-    const refetchQueries = [this.refetchQueryBuild(destinationStageId)];
+    const refetchQueries = [
+      this.refetchQueryBuild(destinationStageId),
+      this.refetchQueryLogs(itemId)
+    ];
 
     if (sourceStageId) {
       refetchQueries.unshift(this.refetchQueryBuild(sourceStageId));

--- a/packages/ui-sales/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-sales/src/boards/containers/PipelineContext.tsx
@@ -20,7 +20,7 @@ import {
   updateItemInfo
 } from "../utils";
 import { mutations, queries, subscriptions } from "../graphql";
-
+import { queries as queriesLogs } from "@erxes/ui-log/src/activityLogs/graphql";
 import InvisibleItemInUrl from "./InvisibleItemInUrl";
 import React from "react";
 import { UserDetailQueryResponse } from "@erxes/ui/src/auth/types";
@@ -376,6 +376,16 @@ class PipelineProviderInner extends React.Component<Props, State> {
     };
   };
 
+  refetchQueryLogs = (itemId: string) => {
+    return {
+      query: gql(queriesLogs.activityLogs),
+      variables: {
+        contentId: itemId,
+        contentType: "sales:deal"
+      }
+    };
+  };
+
   refetchStagesQueryBuild = (pipelineId: string) => {
     return {
       query: gql(queries.stages),
@@ -395,7 +405,10 @@ class PipelineProviderInner extends React.Component<Props, State> {
     const { itemId, aboveItemId, destinationStageId, sourceStageId } = args;
 
     const { options } = this.props;
-    const refetchQueries = [this.refetchQueryBuild(destinationStageId)];
+    const refetchQueries = [
+      this.refetchQueryBuild(destinationStageId),
+      this.refetchQueryLogs(itemId)
+    ];
 
     if (sourceStageId) {
       refetchQueries.unshift(this.refetchQueryBuild(sourceStageId));

--- a/packages/ui-tasks/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-tasks/src/boards/containers/PipelineContext.tsx
@@ -20,6 +20,7 @@ import {
   updateItemInfo
 } from "../utils";
 import { mutations, queries, subscriptions } from "../graphql";
+import { queries as queriesLogs } from "@erxes/ui-log/src/activityLogs/graphql";
 
 import InvisibleItemInUrl from "./InvisibleItemInUrl";
 import React from "react";
@@ -376,6 +377,16 @@ class PipelineProviderInner extends React.Component<Props, State> {
     };
   };
 
+  refetchQueryLogs = (itemId: string) => {
+    return {
+      query: gql(queriesLogs.activityLogs),
+      variables: {
+        contentId: itemId,
+        contentType: "tasks:task"
+      }
+    };
+  };
+
   refetchStagesQueryBuild = (pipelineId: string) => {
     return {
       query: gql(queries.stages),
@@ -395,7 +406,10 @@ class PipelineProviderInner extends React.Component<Props, State> {
     const { itemId, aboveItemId, destinationStageId, sourceStageId } = args;
 
     const { options } = this.props;
-    const refetchQueries = [this.refetchQueryBuild(destinationStageId)];
+    const refetchQueries = [
+      this.refetchQueryBuild(destinationStageId),
+      this.refetchQueryLogs(itemId)
+    ];
 
     if (sourceStageId) {
       refetchQueries.unshift(this.refetchQueryBuild(sourceStageId));

--- a/packages/ui-tickets/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-tickets/src/boards/containers/PipelineContext.tsx
@@ -20,6 +20,7 @@ import {
   updateItemInfo
 } from "../utils";
 import { mutations, queries, subscriptions } from "../graphql";
+import { queries as queriesLogs } from "@erxes/ui-log/src/activityLogs/graphql";
 
 import InvisibleItemInUrl from "./InvisibleItemInUrl";
 import React from "react";
@@ -376,6 +377,16 @@ class PipelineProviderInner extends React.Component<Props, State> {
     };
   };
 
+  refetchQueryLogs = (itemId: string) => {
+    return {
+      query: gql(queriesLogs.activityLogs),
+      variables: {
+        contentId: itemId,
+        contentType: "tickets:ticket"
+      }
+    };
+  };
+
   refetchStagesQueryBuild = (pipelineId: string) => {
     return {
       query: gql(queries.stages),
@@ -395,7 +406,10 @@ class PipelineProviderInner extends React.Component<Props, State> {
     const { itemId, aboveItemId, destinationStageId, sourceStageId } = args;
 
     const { options } = this.props;
-    const refetchQueries = [this.refetchQueryBuild(destinationStageId)];
+    const refetchQueries = [
+      this.refetchQueryBuild(destinationStageId),
+      this.refetchQueryLogs(itemId)
+    ];
 
     if (sourceStageId) {
       refetchQueries.unshift(this.refetchQueryBuild(sourceStageId));


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the activity log was not refreshed after moving a card between stages.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes activity log refetching when moving stages in pipeline contexts by adding a refetch query for activity logs.
> 
>   - **Behavior**:
>     - Fixes activity log refetching when moving stages in `PipelineProviderInner` in `PipelineContext.tsx` for `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets`.
>     - Adds `refetchQueryLogs` function to refetch activity logs based on `itemId` and `contentType`.
>   - **GraphQL**:
>     - Adds `activityLogs` query import from `activityLogs/graphql` in `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets`.
>     - Updates `itemChange` function to include `refetchQueryLogs` in refetch queries list.
>   - **Misc**:
>     - Minor formatting changes in `ActivityLogs.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 0037bc3b2c78bb91d2286675e57d63e985453868. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->