### PR TITLE
fix(cards): the same data between list and detail views

### DIFF
--- a/packages/plugin-purchases-api/src/graphql/utils.ts
+++ b/packages/plugin-purchases-api/src/graphql/utils.ts
@@ -29,8 +29,7 @@ export const sendNotification = (subdomain: string, data) => {
   return sendNotificationsMessage({
     subdomain,
     action: "send",
-    data,
-    isRPC: true
+    data
   });
 };
 
@@ -299,7 +298,7 @@ export const copyPipelineLabels = async (
   for (const label of oldLabels) {
     const exists =
       existingLabelsByUnique[
-      JSON.stringify({ name: label.name, colorCode: label.colorCode })
+        JSON.stringify({ name: label.name, colorCode: label.colorCode })
       ];
     if (!exists) {
       notExistingLabels.push({

--- a/packages/plugin-sales-ui/src/settings/boards/components/PaymentsStep.tsx
+++ b/packages/plugin-sales-ui/src/settings/boards/components/PaymentsStep.tsx
@@ -6,18 +6,18 @@ import {
   Icon,
   SelectWithSearch,
   Tip,
-  __,
-} from '@erxes/ui/src';
-import { LeftItem } from '@erxes/ui/src/components/step/styles';
-import { FormColumn, FormWrapper } from '@erxes/ui/src/styles/main';
-import { isEnabled, loadDynamicComponent } from '@erxes/ui/src/utils/core';
-import React, { useState } from 'react';
-import Select, { components } from 'react-select';
-import styled from 'styled-components';
+  __
+} from "@erxes/ui/src";
+import { LeftItem } from "@erxes/ui/src/components/step/styles";
+import { FormColumn, FormWrapper } from "@erxes/ui/src/styles/main";
+import { isEnabled, loadDynamicComponent } from "@erxes/ui/src/utils/core";
+import React, { useState } from "react";
+import Select, { components } from "react-select";
+import styled from "styled-components";
 // import { Block, Description, FlexColumn, FlexItem } from '../../../styles';
 
-import { PAYMENT_TYPE_ICONS } from '../../boards/constants';
-import { IPipeline } from '@erxes/ui-sales/src/boards/types';
+import { PAYMENT_TYPE_ICONS } from "../../boards/constants";
+import { IPipeline } from "@erxes/ui-sales/src/boards/types";
 export const SelectValue = styled.div`
   display: flex;
   justify-content: left;
@@ -48,7 +48,7 @@ const PaymentsStep = (props: Props) => {
   };
 
   const onChangePayments = ids => {
-    onChangeFunction('paymentIds', ids);
+    onChangeFunction("paymentIds", ids);
   };
 
   const onChangeInput = e => {
@@ -63,12 +63,11 @@ const PaymentsStep = (props: Props) => {
 
     paymentTypes_.push({
       _id: Math.random().toString(),
-      type: '',
-      title: '',
-      icon: '',
+      type: "",
+      title: "",
+      icon: ""
     });
-    console.log('paumenttypes', paymentTypes_);
-    onChange('paymentTypes', paymentTypes_);
+    onChange("paymentTypes", paymentTypes_);
   };
 
   const content = (option): React.ReactNode => (
@@ -102,7 +101,7 @@ const PaymentsStep = (props: Props) => {
       paymentTypes = (paymentTypes || []).map(p =>
         p._id === paymentType._id ? { ...p, [name]: value } : p
       );
-      onChange('paymentTypes', paymentTypes);
+      onChange("paymentTypes", paymentTypes);
     };
 
     const onChangeInput = e => {
@@ -112,28 +111,28 @@ const PaymentsStep = (props: Props) => {
     };
 
     const onChangeSelect = option => {
-      editPayment('icon', option.value);
+      editPayment("icon", option.value);
     };
 
     const removePayment = () => {
       const paymentTypes =
         (props.paymentTypes || []).filter(m => m._id !== paymentType._id) || [];
-      onChange('paymentTypes', paymentTypes);
+      onChange("paymentTypes", paymentTypes);
     };
 
     const getTipText = type => {
-      if (type === 'golomtCard') return 'continue';
-      if (type === 'TDBCard' || type === 'capitron')
+      if (type === "golomtCard") return "continue";
+      if (type === "TDBCard" || type === "capitron")
         return 'must config: "{port: 8078}"';
-      if (type === 'khaanCard')
-        return 'check localhost:27028 and contact databank';
-      return '';
+      if (type === "khaanCard")
+        return "check localhost:27028 and contact databank";
+      return "";
     };
 
     const iconOptions = PAYMENT_TYPE_ICONS.map(icon => ({
       value: icon,
       label: icon,
-      avatar: `${icon}`,
+      avatar: `${icon}`
     }));
 
     return (
@@ -144,7 +143,7 @@ const PaymentsStep = (props: Props) => {
               <FormControl
                 name="type"
                 maxLength={10}
-                defaultValue={paymentType.type || ''}
+                defaultValue={paymentType.type || ""}
                 onChange={onChangeInput}
               />
             </FormGroup>
@@ -154,7 +153,7 @@ const PaymentsStep = (props: Props) => {
               <FormControl
                 name="title"
                 type="text"
-                defaultValue={paymentType.title || ''}
+                defaultValue={paymentType.title || ""}
                 onChange={onChangeInput}
               />
             </FormGroup>
@@ -165,7 +164,7 @@ const PaymentsStep = (props: Props) => {
                 name="icon"
                 components={{ Option, SingleValue }}
                 value={iconOptions.find(
-                  (o) => o.value === (paymentType.icon || '')
+                  o => o.value === (paymentType.icon || "")
                 )}
                 onChange={onChangeSelect}
                 options={iconOptions}
@@ -179,27 +178,27 @@ const PaymentsStep = (props: Props) => {
                 <FormControl
                   name="config"
                   type="text"
-                  defaultValue={paymentType.config || ''}
+                  defaultValue={paymentType.config || ""}
                   onChange={onChangeInput}
                 />
               </Tip>
             </FormGroup>
           </FormColumn>
-          {isEnabled('loyalties') && (
+          {isEnabled("loyalties") && (
             <FormColumn>
               <FormGroup>
                 <SelectWithSearch
-                  label={'Score Campaigns'}
+                  label={"Score Campaigns"}
                   queryName="scoreCampaigns"
-                  name={'scoreCampaignId'}
+                  name={"scoreCampaignId"}
                   initialValue={paymentType?.scoreCampaignId}
-                  generateOptions={(list) =>
+                  generateOptions={list =>
                     list.map(({ _id, title }) => ({
                       value: _id,
                       label: title
                     }))
                   }
-                  onSelect={(value) => editPayment('scoreCampaignId', value)}
+                  onSelect={value => editPayment("scoreCampaignId", value)}
                   customQuery={campaignQuery}
                 />
               </FormGroup>
@@ -221,9 +220,9 @@ const PaymentsStep = (props: Props) => {
 
   return (
     <div>
-      {isEnabled('payment') && (
+      {isEnabled("payment") && (
         <>
-          {loadDynamicComponent('selectPayments', {
+          {loadDynamicComponent("selectPayments", {
             defaultValue: props.paymentIds || [],
             onChange: (ids: string[]) => onChangePayments(ids)
           })}
@@ -234,7 +233,7 @@ const PaymentsStep = (props: Props) => {
               <FormControl
                 id="erxesAppToken"
                 type="text"
-                value={props.erxesAppToken || ''}
+                value={props.erxesAppToken || ""}
                 onChange={onChangeInput}
               />
             </FormGroup>
@@ -243,7 +242,7 @@ const PaymentsStep = (props: Props) => {
       )}
 
       <div>
-        <h4>{__('Other payments')}</h4>
+        <h4>{__("Other payments")}</h4>
         <div>
           type is must latin, some default types: golomtCard, khaanCard, TDBCard
         </div>
@@ -277,7 +276,7 @@ const PaymentsStep = (props: Props) => {
                   <ControlLabel>Config</ControlLabel>
                 </FormGroup>
               </FormColumn>
-              {isEnabled('loyalties') && (
+              {isEnabled("loyalties") && (
                 <FormColumn>
                   <FormGroup>
                     <ControlLabel>Score Campaign</ControlLabel>
@@ -287,7 +286,7 @@ const PaymentsStep = (props: Props) => {
               <FormColumn></FormColumn>
             </FormWrapper>
           </div>
-          {(props.paymentTypes || []).map((item) => renderPaymentType(item))}
+          {(props.paymentTypes || []).map(item => renderPaymentType(item))}
         </FormGroup>
         <Button
           btnStyle="primary"

--- a/packages/ui-purchases/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-purchases/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
-import { __, router as routerUtils } from '@erxes/ui/src/utils';
+import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
+import { __, router as routerUtils } from "@erxes/ui/src/utils";
 
-import { ArchiveStatus } from '../../styles/item';
-import { CloseModal } from '@erxes/ui/src/styles/main';
-import Icon from '@erxes/ui/src/components/Icon';
-import React, { useState, useEffect, Fragment } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { Dialog, Transition } from '@headlessui/react';
+import { ArchiveStatus } from "../../styles/item";
+import { CloseModal } from "@erxes/ui/src/styles/main";
+import Icon from "@erxes/ui/src/components/Icon";
+import React, { useState, useEffect, Fragment } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Dialog, Transition } from "@headlessui/react";
 import {
   DialogContent,
   DialogWrapper,
-  ModalOverlay,
-} from '@erxes/ui/src/styles/main';
-import styled from 'styled-components';
+  ModalOverlay
+} from "@erxes/ui/src/styles/main";
+import styled from "styled-components";
 
 const Relative = styled.div`
   position: relative;
@@ -22,6 +22,7 @@ type Props = {
   options: IOptions;
   item: IItem;
   addItem: (doc: IItemParams, callback: () => void, msg?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   removeItem: (itemId: string, callback: () => void) => void;
   copyItem: (itemId: string, callback: () => void, msg?: string) => void;
   beforePopupClose: (afterPopupClose?: () => void) => void;
@@ -42,13 +43,13 @@ function EditForm(props: Props) {
     copyItem,
     options,
     beforePopupClose,
-    refresh,
+    refresh
   } = props;
   const location = useLocation();
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>('');
+  const [prevStageId, setPrevStageId] = useState<string>("");
 
   useEffect(() => {
     if (item.stageId !== stageId) {
@@ -68,11 +69,6 @@ function EditForm(props: Props) {
 
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
-      // saveItem({ stageId }, updatedItem => {
-      //   if (onUpdate) {
-      //     onUpdate(updatedItem, prevStageId);
-      //   }
-      // });
     }
   };
 
@@ -105,7 +101,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -113,19 +109,20 @@ function EditForm(props: Props) {
 
         localStorage.removeItem(`${updatedItem._id}Name`);
       }
+      props.synchSingleCard(updatedItem._id);
 
-      if (updatedItem && props.onUpdate) {
-        props.onUpdate(updatedItem, prevStageId);
-      }
+      // if (updatedItem && props.onUpdate) {
+      //   props.onUpdate(updatedItem, prevStageId);
+      // }
     });
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === 'archived') {
+    if (item.status === "archived") {
       return (
         <ArchiveStatus>
-          <Icon icon='archive-alt' />
-          <span>{__('This card is archived.')}</span>
+          <Icon icon="archive-alt" />
+          <span>{__("This card is archived.")}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +134,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon='times' />
+          <Icon icon="times" />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as='h3'>
-        {__('Edit')}
-        <Icon icon='times' size={24} onClick={onHideModal} />
+      <Dialog.Title as="h3">
+        {__("Edit")}
+        <Icon icon="times" size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter='ease-out duration-300'
-          enterFrom='opacity-0'
-          enterTo='opacity-100'
-          leave='ease-in duration-200'
-          leaveFrom='opacity-100'
-          leaveTo='opacity-0'
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,13 +169,13 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className='dialog-description'>
+                  <div className="dialog-description">
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,
                       onChangeStage,
                       copy,
-                      remove,
+                      remove
                     })}
                   </div>
                 </Relative>

--- a/packages/ui-purchases/src/boards/components/portable/Items.tsx
+++ b/packages/ui-purchases/src/boards/components/portable/Items.tsx
@@ -1,13 +1,13 @@
-import { ItemsWrapper } from '../../styles/item';
-import Box from '@erxes/ui/src/components/Box';
-import EmptyState from '@erxes/ui/src/components/EmptyState';
-import Icon from '@erxes/ui/src/components/Icon';
-import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
-import { ButtonRelated } from '@erxes/ui/src/styles/main';
-import { __ } from '@erxes/ui/src/utils';
-import React from 'react';
-import { ItemChooser } from '../../containers/portable/';
-import { IItem, IOptions } from '../../types';
+import { ItemsWrapper } from "../../styles/item";
+import Box from "@erxes/ui/src/components/Box";
+import EmptyState from "@erxes/ui/src/components/EmptyState";
+import Icon from "@erxes/ui/src/components/Icon";
+import ModalTrigger from "@erxes/ui/src/components/ModalTrigger";
+import { ButtonRelated } from "@erxes/ui/src/styles/main";
+import { __ } from "@erxes/ui/src/utils";
+import React from "react";
+import { ItemChooser } from "../../containers/portable/";
+import { IItem, IOptions } from "../../types";
 
 type IData = {
   options: IOptions;
@@ -29,7 +29,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     super(props);
 
     this.state = {
-      openItemId: ''
+      openItemId: ""
     };
   }
 
@@ -37,8 +37,16 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     this.setState({ openItemId: item._id });
   };
 
-  beforePopupClose = () => {
-    this.setState({ openItemId: '' });
+  beforePopupClose = (afterPopupClose: () => void) => {
+    this.setState({ openItemId: "" });
+    if (afterPopupClose) {
+      afterPopupClose();
+    }
+  };
+
+  synchSingleCard = () => {
+    const { onChangeItem } = this.props;
+    onChangeItem();
   };
 
   renderItems = () => {
@@ -64,6 +72,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
             onAdd={onChangeItem}
             onUpdate={onChangeItem}
             onRemove={onChangeItem}
+            synchSingleCard={this.synchSingleCard}
             portable={true}
           />
         ))}
@@ -91,7 +100,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
 
     const relTrigger = (
       <ButtonRelated>
-        <span>{__('See related ' + data.options.title + '..')}</span>
+        <span>{__("See related " + data.options.title + "..")}</span>
       </ButtonRelated>
     );
 

--- a/packages/ui-purchases/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-purchases/src/boards/containers/PipelineContext.tsx
@@ -76,6 +76,7 @@ interface IStore {
   onAddItem: (stageId: string, item: IItem, aboveItemId?: string) => void;
   onRemoveItem: (itemId: string, stageId: string) => void;
   onUpdateItem: (item: IItem, prevStageId?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   isShowLabel: boolean;
   toggleLabels: () => void;
 }
@@ -247,6 +248,26 @@ class PipelineProviderInner extends React.Component<Props, State> {
       }
     });
   }
+
+  synchSingleCard = (itemId: string) => {
+    setTimeout(() => {
+      client
+        .query({
+          query: gql(this.props.options.queries.detailQuery),
+          fetchPolicy: "network-only",
+          variables: {
+            _id: itemId
+          }
+        })
+        .then(({ data }) => {
+          const refetchedItem =
+            data[this.props.options.queriesName.detailQuery];
+          this.setState({
+            itemMap: updateItemInfo(this.state, refetchedItem)
+          });
+        });
+    }, 1000);
+  };
 
   findItemIndex = (stageId: string, aboveItemId: string) => {
     const { itemMap } = this.state;
@@ -681,6 +702,7 @@ class PipelineProviderInner extends React.Component<Props, State> {
             onAddItem: this.onAddItem,
             onRemoveItem: this.onRemoveItem,
             onUpdateItem: this.onUpdateItem,
+            synchSingleCard: this.synchSingleCard,
             itemMap,
             stageLoadMap,
             stageIds,

--- a/packages/ui-purchases/src/boards/containers/editForm/EditForm.tsx
+++ b/packages/ui-purchases/src/boards/containers/editForm/EditForm.tsx
@@ -33,6 +33,7 @@ type WrapperProps = {
   onUpdate?: (item: IItem, prevStageId: string) => void;
   hideHeader?: boolean;
   currentUser: IUser;
+  synchSingleCard?: (itemId: string) => void;
 };
 
 type ContainerProps = {
@@ -319,13 +320,20 @@ class WithData extends React.Component<ContainerProps> {
 export default withCurrentUser((props: WrapperProps) => {
   return (
     <PipelineConsumer>
-      {({ onAddItem, onRemoveItem, onUpdateItem, options }) => {
+      {({
+        onAddItem,
+        onRemoveItem,
+        onUpdateItem,
+        synchSingleCard,
+        options
+      }) => {
         return (
           <WithData
             {...props}
             onAdd={onAddItem || props.onAdd}
             onRemove={onRemoveItem || props.onRemove}
             onUpdate={onUpdateItem || props.onUpdate}
+            synchSingleCard={synchSingleCard || props.synchSingleCard}
             options={props.options || options}
           />
         );

--- a/packages/ui-purchases/src/boards/graphql/mutations.ts
+++ b/packages/ui-purchases/src/boards/graphql/mutations.ts
@@ -1,4 +1,4 @@
-import { isEnabled } from '@erxes/ui/src/utils/core';
+import { isEnabled } from "@erxes/ui/src/utils/core";
 
 export const commonMutationVariables = `
   $parentId: String,
@@ -105,14 +105,13 @@ export const commonFields = `
     }
   }
   boardId
-    ... @defer {
+
       companies {
         _id
         primaryName
         links
       }
-    }
-   ... @defer {
+
       customers {
         _id
         firstName
@@ -122,7 +121,7 @@ export const commonFields = `
         primaryPhone
         visitorContactInfo
       }
-    }
+    
   tags {
     _id
     name

--- a/packages/ui-sales/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-sales/src/boards/components/editForm/EditForm.tsx
@@ -22,6 +22,7 @@ type Props = {
   options: IOptions;
   item: IItem;
   addItem: (doc: IItemParams, callback: () => void, msg?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   removeItem: (itemId: string, callback: () => void) => void;
   copyItem: (itemId: string, callback: () => void, msg?: string) => void;
   beforePopupClose: (afterPopupClose?: () => void) => void;
@@ -116,9 +117,10 @@ function EditForm(props: Props) {
         localStorage.removeItem(`${updatedItem._id}Name`);
       }
 
-      if (updatedItem && props.onUpdate) {
-        props.onUpdate(updatedItem, prevStageId);
-      }
+      props.synchSingleCard(updatedItem._id);
+      // if (updatedItem && props.onUpdate) {
+      //   props.onUpdate(updatedItem, prevStageId);
+      // }
     });
   };
 

--- a/packages/ui-sales/src/boards/components/portable/Items.tsx
+++ b/packages/ui-sales/src/boards/components/portable/Items.tsx
@@ -1,13 +1,13 @@
-import { ItemsWrapper } from '../../styles/item';
-import Box from '@erxes/ui/src/components/Box';
-import EmptyState from '@erxes/ui/src/components/EmptyState';
-import Icon from '@erxes/ui/src/components/Icon';
-import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
-import { ButtonRelated } from '@erxes/ui/src/styles/main';
-import { __ } from '@erxes/ui/src/utils';
-import React from 'react';
-import { ItemChooser } from '../../containers/portable/';
-import { IItem, IOptions } from '../../types';
+import { ItemsWrapper } from "../../styles/item";
+import Box from "@erxes/ui/src/components/Box";
+import EmptyState from "@erxes/ui/src/components/EmptyState";
+import Icon from "@erxes/ui/src/components/Icon";
+import ModalTrigger from "@erxes/ui/src/components/ModalTrigger";
+import { ButtonRelated } from "@erxes/ui/src/styles/main";
+import { __ } from "@erxes/ui/src/utils";
+import React from "react";
+import { ItemChooser } from "../../containers/portable/";
+import { IItem, IOptions } from "../../types";
 
 type IData = {
   options: IOptions;
@@ -29,7 +29,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     super(props);
 
     this.state = {
-      openItemId: ''
+      openItemId: ""
     };
   }
 
@@ -37,8 +37,16 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     this.setState({ openItemId: item._id });
   };
 
-  beforePopupClose = () => {
-    this.setState({ openItemId: '' });
+  beforePopupClose = (afterPopupClose: () => void) => {
+    this.setState({ openItemId: "" });
+    if (afterPopupClose) {
+      afterPopupClose();
+    }
+  };
+
+  synchSingleCard = () => {
+    const { onChangeItem } = this.props;
+    onChangeItem();
   };
 
   renderItems = () => {
@@ -64,6 +72,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
             onAdd={onChangeItem}
             onUpdate={onChangeItem}
             onRemove={onChangeItem}
+            synchSingleCard={this.synchSingleCard}
             portable={true}
           />
         ))}
@@ -91,7 +100,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
 
     const relTrigger = (
       <ButtonRelated>
-        <span>{__('See related ' + data.options.title + '..')}</span>
+        <span>{__("See related " + data.options.title + "..")}</span>
       </ButtonRelated>
     );
 

--- a/packages/ui-sales/src/boards/containers/editForm/EditForm.tsx
+++ b/packages/ui-sales/src/boards/containers/editForm/EditForm.tsx
@@ -33,6 +33,7 @@ type WrapperProps = {
   onUpdate?: (item: IItem, prevStageId: string) => void;
   hideHeader?: boolean;
   currentUser: IUser;
+  synchSingleCard?: (itemId: string) => void;
 };
 
 type ContainerProps = {
@@ -319,13 +320,20 @@ class WithData extends React.Component<ContainerProps> {
 export default withCurrentUser((props: WrapperProps) => {
   return (
     <PipelineConsumer>
-      {({ onAddItem, onRemoveItem, onUpdateItem, options }) => {
+      {({
+        onAddItem,
+        onRemoveItem,
+        onUpdateItem,
+        synchSingleCard,
+        options
+      }) => {
         return (
           <WithData
             {...props}
             onAdd={onAddItem || props.onAdd}
             onRemove={onRemoveItem || props.onRemove}
             onUpdate={onUpdateItem || props.onUpdate}
+            synchSingleCard={synchSingleCard || props.synchSingleCard}
             options={props.options || options}
           />
         );

--- a/packages/ui-sales/src/boards/graphql/mutations.ts
+++ b/packages/ui-sales/src/boards/graphql/mutations.ts
@@ -117,14 +117,13 @@ export const commonFields = `
     }
   }
   boardId
-    ... @defer {
+
       companies {
         _id
         primaryName
         links
       }
-    }
-    ... @defer {
+    
       customers {
         _id
         firstName
@@ -134,7 +133,7 @@ export const commonFields = `
         primaryPhone
         visitorContactInfo
       }
-    }
+    
 
   tags {
     _id
@@ -329,5 +328,5 @@ export default {
   pipelineLabelsLabel,
   boardItemsSaveForGanttTimeline,
   stagesUpdateOrder,
-  conversationConvertToCard,
+  conversationConvertToCard
 };

--- a/packages/ui-tasks/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-tasks/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
-import { __, router as routerUtils } from '@erxes/ui/src/utils';
+import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
+import { __, router as routerUtils } from "@erxes/ui/src/utils";
 
-import { ArchiveStatus } from '../../styles/item';
-import { CloseModal } from '@erxes/ui/src/styles/main';
-import Icon from '@erxes/ui/src/components/Icon';
-import React, { useState, useEffect, Fragment } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { Dialog, Transition } from '@headlessui/react';
+import { ArchiveStatus } from "../../styles/item";
+import { CloseModal } from "@erxes/ui/src/styles/main";
+import Icon from "@erxes/ui/src/components/Icon";
+import React, { useState, useEffect, Fragment } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Dialog, Transition } from "@headlessui/react";
 import {
   DialogContent,
   DialogWrapper,
-  ModalOverlay,
-} from '@erxes/ui/src/styles/main';
-import styled from 'styled-components';
+  ModalOverlay
+} from "@erxes/ui/src/styles/main";
+import styled from "styled-components";
 
 const Relative = styled.div`
   position: relative;
@@ -22,6 +22,7 @@ type Props = {
   options: IOptions;
   item: IItem;
   addItem: (doc: IItemParams, callback: () => void, msg?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   removeItem: (itemId: string, callback: () => void) => void;
   copyItem: (itemId: string, callback: () => void, msg?: string) => void;
   beforePopupClose: (afterPopupClose?: () => void) => void;
@@ -42,13 +43,13 @@ function EditForm(props: Props) {
     copyItem,
     options,
     beforePopupClose,
-    refresh,
+    refresh
   } = props;
   const location = useLocation();
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>('');
+  const [prevStageId, setPrevStageId] = useState<string>("");
 
   useEffect(() => {
     if (item.stageId !== stageId) {
@@ -68,11 +69,6 @@ function EditForm(props: Props) {
 
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
-      // saveItem({ stageId }, updatedItem => {
-      //   if (onUpdate) {
-      //     onUpdate(updatedItem, prevStageId);
-      //   }
-      // });
     }
   };
 
@@ -105,7 +101,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -114,18 +110,20 @@ function EditForm(props: Props) {
         localStorage.removeItem(`${updatedItem._id}Name`);
       }
 
-      if (updatedItem && props.onUpdate) {
-        props.onUpdate(updatedItem, prevStageId);
-      }
+      props.synchSingleCard(updatedItem._id);
+
+      // if (updatedItem && props.onUpdate) {
+      //   props.onUpdate(updatedItem, prevStageId);
+      // }
     });
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === 'archived') {
+    if (item.status === "archived") {
       return (
         <ArchiveStatus>
-          <Icon icon='archive-alt' />
-          <span>{__('This card is archived.')}</span>
+          <Icon icon="archive-alt" />
+          <span>{__("This card is archived.")}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +135,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon='times' />
+          <Icon icon="times" />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as='h3'>
-        {__('Edit')}
-        <Icon icon='times' size={24} onClick={onHideModal} />
+      <Dialog.Title as="h3">
+        {__("Edit")}
+        <Icon icon="times" size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter='ease-out duration-300'
-          enterFrom='opacity-0'
-          enterTo='opacity-100'
-          leave='ease-in duration-200'
-          leaveFrom='opacity-100'
-          leaveTo='opacity-0'
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,13 +170,13 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className='dialog-description'>
+                  <div className="dialog-description">
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,
                       onChangeStage,
                       copy,
-                      remove,
+                      remove
                     })}
                   </div>
                 </Relative>

--- a/packages/ui-tasks/src/boards/components/portable/Items.tsx
+++ b/packages/ui-tasks/src/boards/components/portable/Items.tsx
@@ -1,13 +1,13 @@
-import { ItemsWrapper } from '../../styles/item';
-import Box from '@erxes/ui/src/components/Box';
-import EmptyState from '@erxes/ui/src/components/EmptyState';
-import Icon from '@erxes/ui/src/components/Icon';
-import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
-import { ButtonRelated } from '@erxes/ui/src/styles/main';
-import { __ } from '@erxes/ui/src/utils';
-import React from 'react';
-import { ItemChooser } from '../../containers/portable/';
-import { IItem, IOptions } from '../../types';
+import { ItemsWrapper } from "../../styles/item";
+import Box from "@erxes/ui/src/components/Box";
+import EmptyState from "@erxes/ui/src/components/EmptyState";
+import Icon from "@erxes/ui/src/components/Icon";
+import ModalTrigger from "@erxes/ui/src/components/ModalTrigger";
+import { ButtonRelated } from "@erxes/ui/src/styles/main";
+import { __ } from "@erxes/ui/src/utils";
+import React from "react";
+import { ItemChooser } from "../../containers/portable/";
+import { IItem, IOptions } from "../../types";
 
 type IData = {
   options: IOptions;
@@ -29,7 +29,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     super(props);
 
     this.state = {
-      openItemId: ''
+      openItemId: ""
     };
   }
 
@@ -37,8 +37,16 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     this.setState({ openItemId: item._id });
   };
 
-  beforePopupClose = () => {
-    this.setState({ openItemId: '' });
+  beforePopupClose = (afterPopupClose: () => void) => {
+    this.setState({ openItemId: "" });
+    if (afterPopupClose) {
+      afterPopupClose();
+    }
+  };
+
+  synchSingleCard = () => {
+    const { onChangeItem } = this.props;
+    onChangeItem();
   };
 
   renderItems = () => {
@@ -64,6 +72,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
             onAdd={onChangeItem}
             onUpdate={onChangeItem}
             onRemove={onChangeItem}
+            synchSingleCard={this.synchSingleCard}
             portable={true}
           />
         ))}
@@ -91,7 +100,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
 
     const relTrigger = (
       <ButtonRelated>
-        <span>{__('See related ' + data.options.title + '..')}</span>
+        <span>{__("See related " + data.options.title + "..")}</span>
       </ButtonRelated>
     );
 

--- a/packages/ui-tasks/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-tasks/src/boards/containers/PipelineContext.tsx
@@ -76,6 +76,7 @@ interface IStore {
   onAddItem: (stageId: string, item: IItem, aboveItemId?: string) => void;
   onRemoveItem: (itemId: string, stageId: string) => void;
   onUpdateItem: (item: IItem, prevStageId?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   isShowLabel: boolean;
   toggleLabels: () => void;
 }
@@ -247,6 +248,26 @@ class PipelineProviderInner extends React.Component<Props, State> {
       }
     });
   }
+
+  synchSingleCard = (itemId: string) => {
+    setTimeout(() => {
+      client
+        .query({
+          query: gql(this.props.options.queries.detailQuery),
+          fetchPolicy: "network-only",
+          variables: {
+            _id: itemId
+          }
+        })
+        .then(({ data }) => {
+          const refetchedItem =
+            data[this.props.options.queriesName.detailQuery];
+          this.setState({
+            itemMap: updateItemInfo(this.state, refetchedItem)
+          });
+        });
+    }, 1000);
+  };
 
   findItemIndex = (stageId: string, aboveItemId: string) => {
     const { itemMap } = this.state;
@@ -682,6 +703,7 @@ class PipelineProviderInner extends React.Component<Props, State> {
             onAddItem: this.onAddItem,
             onRemoveItem: this.onRemoveItem,
             onUpdateItem: this.onUpdateItem,
+            synchSingleCard: this.synchSingleCard,
             itemMap,
             stageLoadMap,
             stageIds,

--- a/packages/ui-tasks/src/boards/containers/editForm/EditForm.tsx
+++ b/packages/ui-tasks/src/boards/containers/editForm/EditForm.tsx
@@ -33,6 +33,7 @@ type WrapperProps = {
   onUpdate?: (item: IItem, prevStageId: string) => void;
   hideHeader?: boolean;
   currentUser: IUser;
+  synchSingleCard?: (itemId: string) => void;
 };
 
 type ContainerProps = {
@@ -319,13 +320,20 @@ class WithData extends React.Component<ContainerProps> {
 export default withCurrentUser((props: WrapperProps) => {
   return (
     <PipelineConsumer>
-      {({ onAddItem, onRemoveItem, onUpdateItem, options }) => {
+      {({
+        onAddItem,
+        onRemoveItem,
+        onUpdateItem,
+        synchSingleCard,
+        options
+      }) => {
         return (
           <WithData
             {...props}
             onAdd={onAddItem || props.onAdd}
             onRemove={onRemoveItem || props.onRemove}
             onUpdate={onUpdateItem || props.onUpdate}
+            synchSingleCard={synchSingleCard || props.synchSingleCard}
             options={props.options || options}
           />
         );

--- a/packages/ui-tasks/src/boards/graphql/mutations.ts
+++ b/packages/ui-tasks/src/boards/graphql/mutations.ts
@@ -1,4 +1,4 @@
-import { isEnabled } from '@erxes/ui/src/utils/core';
+import { isEnabled } from "@erxes/ui/src/utils/core";
 
 export const commonMutationVariables = `
   $parentId: String,
@@ -105,14 +105,12 @@ export const commonFields = `
     }
   }
   boardId
-    ... @defer {
       companies {
         _id
         primaryName
         links
       }
-    }
-    ... @defer {
+
       customers {
         _id
         firstName
@@ -122,7 +120,7 @@ export const commonFields = `
         primaryPhone
         visitorContactInfo
       }
-    }
+    
   tags {
     _id
     name
@@ -314,5 +312,5 @@ export default {
   pipelineLabelsLabel,
   boardItemsSaveForGanttTimeline,
   stagesUpdateOrder,
-  conversationConvertToCard,
+  conversationConvertToCard
 };

--- a/packages/ui-tickets/src/boards/components/editForm/EditForm.tsx
+++ b/packages/ui-tickets/src/boards/components/editForm/EditForm.tsx
@@ -1,18 +1,18 @@
-import { IEditFormContent, IItem, IItemParams, IOptions } from '../../types';
-import { __, router as routerUtils } from '@erxes/ui/src/utils';
+import { IEditFormContent, IItem, IItemParams, IOptions } from "../../types";
+import { __, router as routerUtils } from "@erxes/ui/src/utils";
 
-import { ArchiveStatus } from '../../styles/item';
-import { CloseModal } from '@erxes/ui/src/styles/main';
-import Icon from '@erxes/ui/src/components/Icon';
-import React, { useState, useEffect, Fragment } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { Dialog, Transition } from '@headlessui/react';
+import { ArchiveStatus } from "../../styles/item";
+import { CloseModal } from "@erxes/ui/src/styles/main";
+import Icon from "@erxes/ui/src/components/Icon";
+import React, { useState, useEffect, Fragment } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Dialog, Transition } from "@headlessui/react";
 import {
   DialogContent,
   DialogWrapper,
-  ModalOverlay,
-} from '@erxes/ui/src/styles/main';
-import styled from 'styled-components';
+  ModalOverlay
+} from "@erxes/ui/src/styles/main";
+import styled from "styled-components";
 
 const Relative = styled.div`
   position: relative;
@@ -22,6 +22,7 @@ type Props = {
   options: IOptions;
   item: IItem;
   addItem: (doc: IItemParams, callback: () => void, msg?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   removeItem: (itemId: string, callback: () => void) => void;
   copyItem: (itemId: string, callback: () => void, msg?: string) => void;
   beforePopupClose: (afterPopupClose?: () => void) => void;
@@ -42,13 +43,13 @@ function EditForm(props: Props) {
     copyItem,
     options,
     beforePopupClose,
-    refresh,
+    refresh
   } = props;
   const location = useLocation();
   const navigate = useNavigate();
   const [stageId, setStageId] = useState(item.stageId);
   const [updatedItem, setUpdatedItem] = useState(item);
-  const [prevStageId, setPrevStageId] = useState<string>('');
+  const [prevStageId, setPrevStageId] = useState<string>("");
 
   useEffect(() => {
     if (item.stageId !== stageId) {
@@ -68,11 +69,6 @@ function EditForm(props: Props) {
 
     if (item.stageId !== stageId) {
       setPrevStageId(item.stageId);
-      // saveItem({ stageId }, updatedItem => {
-      //   if (onUpdate) {
-      //     onUpdate(updatedItem, prevStageId);
-      //   }
-      // });
     }
   };
 
@@ -105,7 +101,7 @@ function EditForm(props: Props) {
 
     closeModal(() => {
       if (updatedItem) {
-        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || '';
+        const itemName = localStorage.getItem(`${updatedItem._id}Name`) || "";
 
         if (itemName && updatedItem.name !== itemName) {
           saveItemHandler({ itemName });
@@ -113,19 +109,20 @@ function EditForm(props: Props) {
 
         localStorage.removeItem(`${updatedItem._id}Name`);
       }
+      props.synchSingleCard(updatedItem._id);
 
-      if (updatedItem && props.onUpdate) {
-        props.onUpdate(updatedItem, prevStageId);
-      }
+      // if (updatedItem && props.onUpdate) {
+      //   props.onUpdate(updatedItem, prevStageId);
+      // }
     });
   };
 
   const renderArchiveStatus = () => {
-    if (item.status === 'archived') {
+    if (item.status === "archived") {
       return (
         <ArchiveStatus>
-          <Icon icon='archive-alt' />
-          <span>{__('This card is archived.')}</span>
+          <Icon icon="archive-alt" />
+          <span>{__("This card is archived.")}</span>
         </ArchiveStatus>
       );
     }
@@ -137,30 +134,30 @@ function EditForm(props: Props) {
     if (props.hideHeader) {
       return (
         <CloseModal onClick={onHideModal}>
-          <Icon icon='times' />
+          <Icon icon="times" />
         </CloseModal>
       );
     }
 
     return (
-      <Dialog.Title as='h3'>
-        {__('Edit')}
-        <Icon icon='times' size={24} onClick={onHideModal} />
+      <Dialog.Title as="h3">
+        {__("Edit")}
+        <Icon icon="times" size={24} onClick={onHideModal} />
       </Dialog.Title>
     );
   };
 
   return (
     <Transition appear show={props.isPopupVisible} as={Fragment}>
-      <Dialog as='div' onClose={onHideModal} className={` relative z-10`}>
+      <Dialog as="div" onClose={onHideModal} className={` relative z-10`}>
         <Transition.Child
           as={Fragment}
-          enter='ease-out duration-300'
-          enterFrom='opacity-0'
-          enterTo='opacity-100'
-          leave='ease-in duration-200'
-          leaveFrom='opacity-100'
-          leaveTo='opacity-0'
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
         >
           <ModalOverlay />
         </Transition.Child>
@@ -172,13 +169,13 @@ function EditForm(props: Props) {
               <Transition.Child>
                 <Relative>
                   {renderHeader()}
-                  <div className='dialog-description'>
+                  <div className="dialog-description">
                     {props.formContent({
                       state: { stageId, updatedItem, prevStageId },
                       saveItem: saveItemHandler,
                       onChangeStage,
                       copy,
-                      remove,
+                      remove
                     })}
                   </div>
                 </Relative>

--- a/packages/ui-tickets/src/boards/components/portable/Items.tsx
+++ b/packages/ui-tickets/src/boards/components/portable/Items.tsx
@@ -1,13 +1,13 @@
-import { ItemsWrapper } from '../../styles/item';
-import Box from '@erxes/ui/src/components/Box';
-import EmptyState from '@erxes/ui/src/components/EmptyState';
-import Icon from '@erxes/ui/src/components/Icon';
-import ModalTrigger from '@erxes/ui/src/components/ModalTrigger';
-import { ButtonRelated } from '@erxes/ui/src/styles/main';
-import { __ } from '@erxes/ui/src/utils';
-import React from 'react';
-import { ItemChooser } from '../../containers/portable/';
-import { IItem, IOptions } from '../../types';
+import { ItemsWrapper } from "../../styles/item";
+import Box from "@erxes/ui/src/components/Box";
+import EmptyState from "@erxes/ui/src/components/EmptyState";
+import Icon from "@erxes/ui/src/components/Icon";
+import ModalTrigger from "@erxes/ui/src/components/ModalTrigger";
+import { ButtonRelated } from "@erxes/ui/src/styles/main";
+import { __ } from "@erxes/ui/src/utils";
+import React from "react";
+import { ItemChooser } from "../../containers/portable/";
+import { IItem, IOptions } from "../../types";
 
 type IData = {
   options: IOptions;
@@ -29,7 +29,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     super(props);
 
     this.state = {
-      openItemId: ''
+      openItemId: ""
     };
   }
 
@@ -37,8 +37,16 @@ class Items extends React.Component<Props, { openItemId?: string }> {
     this.setState({ openItemId: item._id });
   };
 
-  beforePopupClose = () => {
-    this.setState({ openItemId: '' });
+  beforePopupClose = (afterPopupClose: () => void) => {
+    this.setState({ openItemId: "" });
+    if (afterPopupClose) {
+      afterPopupClose();
+    }
+  };
+
+  synchSingleCard = () => {
+    const { onChangeItem } = this.props;
+    onChangeItem();
   };
 
   renderItems = () => {
@@ -64,6 +72,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
             onAdd={onChangeItem}
             onUpdate={onChangeItem}
             onRemove={onChangeItem}
+            synchSingleCard={this.synchSingleCard}
             portable={true}
           />
         ))}
@@ -91,7 +100,7 @@ class Items extends React.Component<Props, { openItemId?: string }> {
 
     const relTrigger = (
       <ButtonRelated>
-        <span>{__('See related ' + data.options.title + '..')}</span>
+        <span>{__("See related " + data.options.title + "..")}</span>
       </ButtonRelated>
     );
 

--- a/packages/ui-tickets/src/boards/containers/PipelineContext.tsx
+++ b/packages/ui-tickets/src/boards/containers/PipelineContext.tsx
@@ -76,6 +76,7 @@ interface IStore {
   onAddItem: (stageId: string, item: IItem, aboveItemId?: string) => void;
   onRemoveItem: (itemId: string, stageId: string) => void;
   onUpdateItem: (item: IItem, prevStageId?: string) => void;
+  synchSingleCard: (itemId: string) => void;
   isShowLabel: boolean;
   toggleLabels: () => void;
 }
@@ -247,7 +248,25 @@ class PipelineProviderInner extends React.Component<Props, State> {
       }
     });
   }
-
+  synchSingleCard = (itemId: string) => {
+    setTimeout(() => {
+      client
+        .query({
+          query: gql(this.props.options.queries.detailQuery),
+          fetchPolicy: "network-only",
+          variables: {
+            _id: itemId
+          }
+        })
+        .then(({ data }) => {
+          const refetchedItem =
+            data[this.props.options.queriesName.detailQuery];
+          this.setState({
+            itemMap: updateItemInfo(this.state, refetchedItem)
+          });
+        });
+    }, 1000);
+  };
   findItemIndex = (stageId: string, aboveItemId: string) => {
     const { itemMap } = this.state;
 
@@ -682,6 +701,7 @@ class PipelineProviderInner extends React.Component<Props, State> {
             onAddItem: this.onAddItem,
             onRemoveItem: this.onRemoveItem,
             onUpdateItem: this.onUpdateItem,
+            synchSingleCard: this.synchSingleCard,
             itemMap,
             stageLoadMap,
             stageIds,

--- a/packages/ui-tickets/src/boards/containers/editForm/EditForm.tsx
+++ b/packages/ui-tickets/src/boards/containers/editForm/EditForm.tsx
@@ -33,6 +33,7 @@ type WrapperProps = {
   onUpdate?: (item: IItem, prevStageId: string) => void;
   hideHeader?: boolean;
   currentUser: IUser;
+  synchSingleCard?: (itemId: string) => void;
 };
 
 type ContainerProps = {
@@ -319,13 +320,20 @@ class WithData extends React.Component<ContainerProps> {
 export default withCurrentUser((props: WrapperProps) => {
   return (
     <PipelineConsumer>
-      {({ onAddItem, onRemoveItem, onUpdateItem, options }) => {
+      {({
+        onAddItem,
+        onRemoveItem,
+        onUpdateItem,
+        synchSingleCard,
+        options
+      }) => {
         return (
           <WithData
             {...props}
             onAdd={onAddItem || props.onAdd}
             onRemove={onRemoveItem || props.onRemove}
             onUpdate={onUpdateItem || props.onUpdate}
+            synchSingleCard={synchSingleCard || props.synchSingleCard}
             options={props.options || options}
           />
         );

--- a/packages/ui-tickets/src/boards/graphql/mutations.ts
+++ b/packages/ui-tickets/src/boards/graphql/mutations.ts
@@ -1,4 +1,4 @@
-import { isEnabled } from '@erxes/ui/src/utils/core';
+import { isEnabled } from "@erxes/ui/src/utils/core";
 
 export const commonMutationVariables = `
   $parentId: String,
@@ -105,14 +105,13 @@ export const commonFields = `
     }
   }
   boardId
-    ... @defer {
+
       companies {
         _id
         primaryName
         links
       }
-    }
-    ... @defer {
+  
       customers {
         _id
         firstName
@@ -122,7 +121,7 @@ export const commonFields = `
         primaryPhone
         visitorContactInfo
       }
-    }
+    
   tags {
     _id
     name
@@ -314,5 +313,5 @@ export default {
   pipelineLabelsLabel,
   boardItemsSaveForGanttTimeline,
   stagesUpdateOrder,
-  conversationConvertToCard,
+  conversationConvertToCard
 };


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

## Summary by Sourcery

Bug Fixes:
- Fixed data inconsistencies between the board item list view and detail view.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `synchSingleCard` function to synchronize card data between list and detail views across multiple modules.
> 
>   - **Behavior**:
>     - Add `synchSingleCard` function to synchronize card data between list and detail views.
>     - Integrate `synchSingleCard` into `EditForm` components in `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets`.
>     - Update `PipelineContext` in `ui-purchases`, `ui-sales`, `ui-tasks`, and `ui-tickets` to include `synchSingleCard`.
>   - **Components**:
>     - Modify `EditForm` components to call `synchSingleCard` after card updates.
>     - Update `Items` components to use `synchSingleCard` for data synchronization.
>   - **GraphQL**:
>     - Ensure GraphQL mutations and queries support the synchronization process.
>   - **Misc**:
>     - Standardize import statements and formatting across affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 9f94c0f1b3ce5a71d8959c37f51429091c2b5dc7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->