### PR TITLE
chore: add extraInfo field to Order type

### DIFF
--- a/packages/plugin-posclient-api/src/graphql/schema/orders.ts
+++ b/packages/plugin-posclient-api/src/graphql/schema/orders.ts
@@ -51,6 +51,8 @@ export const orderTypeFields = `
   returnInfo: JSON
 
   slotCode: String
+
+  extraInfo: JSON
 `;
 
 const addEditParams = `


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Extend the Order type schema by introducing a new extraInfo field of JSON type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field to orders, allowing for additional information to be included in order details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->