### PR TITLE
fix(sales): refetch deal detail in Main Board

### DIFF
--- a/packages/ui-sales/src/boards/components/editForm/CommonActions.tsx
+++ b/packages/ui-sales/src/boards/components/editForm/CommonActions.tsx
@@ -38,6 +38,7 @@ type Props = {
   onChangeRefresh: () => void;
   currentUser: IUser;
   isFullView?: boolean;
+  synchSingleCard?: (itemId: string) => void;
 };
 
 const CommonActions = (props: Props) => {
@@ -54,13 +55,14 @@ const CommonActions = (props: Props) => {
     onChangeRefresh,
     currentUser,
     isFullView,
+    synchSingleCard,
   } = props;
 
-  const userOnChange = (usrs) => saveItem({ assignedUserIds: usrs });
+  const userOnChange = usrs => saveItem({ assignedUserIds: usrs });
   const onChangeStructure = (values, name) => saveItem({ [name]: values });
-  const onLabelChange = (labels) => saveItem({ labels });
+  const onLabelChange = labels => saveItem({ labels });
 
-  const assignedUserIds = (item.assignedUsers || []).map((user) => user._id);
+  const assignedUserIds = (item.assignedUsers || []).map(user => user._id);
   const branchIds = currentUser.branchIds;
   const departmentIds = currentUser.departmentIds;
 
@@ -167,6 +169,9 @@ const CommonActions = (props: Props) => {
               type={TAG_TYPE}
               trigger={tagTrigger}
               refetchQueries={["dealDetail"]}
+              successCallback={() => {
+                synchSingleCard && synchSingleCard(item._id);
+              }}
               targets={[item]}
               parentTagId={pipelineTagId}
               singleSelect={false}

--- a/packages/ui-sales/src/boards/containers/editForm/EditForm.tsx
+++ b/packages/ui-sales/src/boards/containers/editForm/EditForm.tsx
@@ -134,7 +134,7 @@ class EditFormContainer extends React.Component<FinalProps> {
       .then(() => {
         callback();
       })
-      .catch((error) => {
+      .catch(error => {
         Alert.error(error.message);
       });
   }
@@ -154,7 +154,7 @@ class EditFormContainer extends React.Component<FinalProps> {
           onAdd(stageId, data[options.mutationsName.copyMutation], itemId);
         }
       })
-      .catch((error) => {
+      .catch(error => {
         Alert.error(error.message);
       });
   }
@@ -173,10 +173,10 @@ class EditFormContainer extends React.Component<FinalProps> {
         if (callback) {
           callback(data[options.mutationsName.editMutation]);
         }
-
+        this.props.synchSingleCard && this.props.synchSingleCard(itemId);
         invalidateCache();
       })
-      .catch((error) => {
+      .catch(error => {
         Alert.error(error.message);
       });
   };
@@ -200,7 +200,7 @@ class EditFormContainer extends React.Component<FinalProps> {
           }
         })
 
-        .catch((error) => {
+        .catch(error => {
           Alert.error(error.message);
         })
     );
@@ -222,7 +222,7 @@ class EditFormContainer extends React.Component<FinalProps> {
           callback();
         }
       })
-      .catch((error) => {
+      .catch(error => {
         Alert.error(error.message);
       });
   };

--- a/packages/ui-sales/src/deals/components/DealEditForm.tsx
+++ b/packages/ui-sales/src/deals/components/DealEditForm.tsx
@@ -82,7 +82,7 @@ export default class DealEditForm extends React.Component<Props, State> {
     return (
       <HeaderContentSmall>
         <ControlLabel>{__(title)}</ControlLabel>
-        {Object.keys(amount || {}).map((key) => (
+        {Object.keys(amount || {}).map(key => (
           <p key={key}>
             {amount[key].toLocaleString()} {key}
           </p>
@@ -156,7 +156,7 @@ export default class DealEditForm extends React.Component<Props, State> {
     );
   };
 
-  renderDetail = (saveItem) => {
+  renderDetail = saveItem => {
     const { item, options, updateTimeTrack } = this.props;
 
     const timeTrack = item.timeTrack || {
@@ -220,7 +220,7 @@ export default class DealEditForm extends React.Component<Props, State> {
     );
   };
 
-  renderTabContent = (props) => {
+  renderTabContent = props => {
     const { currentTab } = this.state;
 
     switch (currentTab) {
@@ -262,6 +262,7 @@ export default class DealEditForm extends React.Component<Props, State> {
           onUpdate={onUpdate}
           sendToBoard={sendToBoard}
           item={item}
+          synchSingleCard={this.props.synchSingleCard}
           addItem={addItem}
           onChangeStage={onChangeStage}
           onChangeRefresh={this.onChangeRefresh}


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

## Summary by Sourcery

Improve deal detail synchronization in the Main Board by triggering a refetch after updates and propagating the refresh callback through relevant components.

Bug Fixes:
- Ensure deal detail is refetched and updated in the Main Board after relevant actions.

Enhancements:
- Pass synchSingleCard callback to components to trigger single card refresh after updates.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `synchSingleCard` function to refetch deal details in Main Board after updates in `CommonActions.tsx`, `EditForm.tsx`, and `DealEditForm.tsx`.
> 
>   - **Behavior**:
>     - Introduces `synchSingleCard` function in `CommonActions.tsx`, `EditForm.tsx`, and `DealEditForm.tsx` to refetch deal details.
>     - `synchSingleCard` is called after tag updates in `CommonActions.tsx` and after saving items in `EditForm.tsx`.
>   - **Code Style**:
>     - Arrow function syntax updated for consistency in `CommonActions.tsx`, `EditForm.tsx`, and `DealEditForm.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 36650a0e35399fffcf1c6e587bacea29248e4293. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->