### PR TITLE
feat(notifications): add userId variable to notifications query

### DIFF
--- a/packages/plugin-notifications-api/src/graphql/notificationTypeDefs.ts
+++ b/packages/plugin-notifications-api/src/graphql/notificationTypeDefs.ts
@@ -25,6 +25,7 @@ export const types = `
 `;
 
 const params = `
+  userId:String,
   limit: Int,
   page: Int,
   perPage: Int,

--- a/packages/plugin-notifications-api/src/graphql/resolvers/notificationQueries.ts
+++ b/packages/plugin-notifications-api/src/graphql/resolvers/notificationQueries.ts
@@ -35,7 +35,6 @@ const notificationQueries = {
   ) {
     const sort: any = { date: -1 };
     const selector: any = { receiver: userId || user._id };
-    console.log(selector, 'asdkopkdspa')
     if (requireRead) {
       selector.isRead = false;
     }

--- a/packages/plugin-notifications-api/src/graphql/resolvers/notificationQueries.ts
+++ b/packages/plugin-notifications-api/src/graphql/resolvers/notificationQueries.ts
@@ -10,6 +10,7 @@ const notificationQueries = {
   async notifications(
     _root,
     {
+      userId,
       requireRead,
       title,
       limit,
@@ -19,6 +20,7 @@ const notificationQueries = {
       endDate,
       ...params
     }: {
+      userId: string
       requireRead: boolean;
       title: string;
       limit: number;
@@ -32,9 +34,8 @@ const notificationQueries = {
     { models, user }: IContext,
   ) {
     const sort: any = { date: -1 };
-
-    const selector: any = { receiver: user._id };
-
+    const selector: any = { receiver: userId || user._id };
+    console.log(selector, 'asdkopkdspa')
     if (requireRead) {
       selector.isRead = false;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `userId` parameter to notifications query for user-specific filtering in `notificationTypeDefs.ts` and `notificationQueries.ts`.
> 
>   - **Behavior**:
>     - Adds `userId` parameter to `notifications` query in `notificationTypeDefs.ts` and `notificationQueries.ts`.
>     - Allows querying notifications for a specific user or defaults to the current user if `userId` is not provided.
>   - **Resolvers**:
>     - Updates `notifications()` in `notificationQueries.ts` to use `userId` for filtering notifications.
>     - Modifies selector logic to prioritize `userId` over current user ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 1fff213d288dd844dfcc4224c6909a1aa885045d. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching notifications for a specified user by providing an optional user ID parameter in notification queries. If no user ID is provided, notifications for the current user are returned as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->