### PR TITLE
Add frontend and API services to docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,6 +84,48 @@ services:
     networks:
       - "erxes-net"
 
+  client-portal:
+    container_name: client-portal
+    build:
+      context: ../client-portal
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:4200:4200"
+    environment:
+      API_URL: http://core-api:3100/graphql
+      REACT_APP_DOMAIN: http://localhost:4200
+      REACT_APP_SUBSCRIPTION_URL: ws://core-api:3100/graphql
+    depends_on:
+      - core-api
+    networks:
+      - erxes-net
+
+  core-api:
+    container_name: core-api
+    build:
+      context: ../packages/core
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:3100:3100"
+    environment:
+      NODE_ENV: development
+      PORT: 3100
+      MONGO_URL: mongodb://mongo:27017/erxes?replicaSet=rs0
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      RABBITMQ_HOSTNAME: rabbitmq
+      DOMAIN: http://localhost:4200
+      MAIN_APP_DOMAIN: http://localhost:4200
+      CLIENT_PORTAL_DOMAINS: http://localhost:4200
+      JWT_TOKEN_SECRET: "some-secret-key" # Please change this in a real environment
+      ENABLED_SERVICES_JSON: '{"core": true}'
+    depends_on:
+      - mongo
+      - redis
+      - rabbitmq
+    networks:
+      - erxes-net
+
 networks:
   erxes-net:
     driver: bridge


### PR DESCRIPTION
This commit updates the docker-compose.yml file to include services for the client-portal (frontend) and core-api (API).

- The `client-portal` service is built from `client-portal/Dockerfile` and exposes port 4200.
- The `core-api` service is built from `packages/core/Dockerfile` and exposes port 3100.
- Environment variables and dependencies for these services have been configured to ensure they integrate with the existing backend infrastructure (mongo, redis, rabbitmq).
- The `client-portal` service now depends on `core-api`.

[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached
