### PR TITLE
fix(tms): tour fields

### DIFF
--- a/packages/plugin-bm-api/src/graphql/resolvers/queries/tour.ts
+++ b/packages/plugin-bm-api/src/graphql/resolvers/queries/tour.ts
@@ -190,11 +190,12 @@ const tourQueries = {
       total
     };
   },
-  async bmToursGroupDetail(_root, { groupCode }, { models }: IContext) {
+  async bmToursGroupDetail(_root, { groupCode, status }, { models }: IContext) {
     const selector: any = {};
 
     const list = await models.Tours.find({
-      groupCode: groupCode
+      groupCode: groupCode,
+      status: status
     });
 
     return { _id: groupCode, items: list };

--- a/packages/plugin-bm-api/src/graphql/schema/tour.ts
+++ b/packages/plugin-bm-api/src/graphql/schema/tour.ts
@@ -32,7 +32,9 @@ export const types = () => `
     createdAt: Date
     modifiedAt: Date
     viewCount: Int
+    advanceCheck: Boolean
     advancePercent: Float
+    joinPercent: Float
     tagIds: [String]
     info1: String
     info2: String
@@ -99,7 +101,7 @@ export const queries = `
   bmTourDetail(_id:String!,branchId: String): Tour
   bmOrders( tourId:String, customerId:String ,branchId: String):ListBmsOrder
   bmToursGroup(branchId:String, sortField:String, sortDirection:Int, page:Int, perPage:Int, status: String, innerDate: Date,branchId: String, tags: [String],startDate1:Date,startDate2:Date,endDate1:Date,endDate2:Date): GroupTour
-  bmToursGroupDetail(groupCode:String): GroupTourItem
+  bmToursGroupDetail(groupCode:String,status: String): GroupTourItem
 
 `;
 
@@ -113,7 +115,9 @@ const params = `
   endDate: Date,
   groupSize: Int,
   duration: Int,
-  advancePercent: Float
+  advancePercent: Float,
+  joinPercent: Float,
+  advanceCheck: Boolean,
   status: String,
   cost: Float,
   location: [BMSLocationInput],

--- a/packages/plugin-bm-api/src/models/definitions/tour.ts
+++ b/packages/plugin-bm-api/src/models/definitions/tour.ts
@@ -25,6 +25,8 @@ export interface ITour {
   tags: string[];
   viewCount: number;
   advancePercent?: number;
+  joinPercent?: number;
+  advanceCheck?: boolean;
   info1?: string;
   info2?: string;
   info3?: string;
@@ -94,6 +96,16 @@ export const tourSchema = schemaHooksWrapper(
       type: Number,
       optional: true,
       label: "advancePercent"
+    }),
+    joinPercent: field({
+      type: Number,
+      optional: true,
+      label: "joinPercent"
+    }),
+    advanceCheck: field({
+      type: Boolean,
+      optional: true,
+      label: "advanceCheck"
     }),
 
     branchId: field({ type: String, optional: true, label: "branchId" }),


### PR DESCRIPTION
[ISSUE](https://github.com/erxes/erxes/issues/ISSUE)

### Context

Your context here.  Additionally, any screenshots.  Delete this line.


// Delete the below section once completed
### PR Checklist
- [ ] Description is clearly stated under Context section
- [ ] Screenshots and the additional verifications are attached

## Summary by Sourcery

Add new optional metrics to tours and enable filtering group tours by status

New Features:
- Introduce joinPercent and advanceCheck fields to the Tour model, GraphQL types, and database schema
- Add joinPercent and advanceCheck input parameters to the tour creation/update GraphQL operations

Enhancements:
- Extend the bmToursGroupDetail query and resolver to accept an optional status argument for filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two new fields, "advanceCheck" and "joinPercent", to tour details in the interface and API.
  - Enhanced the group tour detail query to allow filtering by both group code and status.
  - Updated tour-related mutations to support the new fields "advanceCheck" and "joinPercent".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->