### PR TITLE
fix(clientportal) sendNotification fix

### DIFF
--- a/packages/plugin-clientportal-api/src/utils.ts
+++ b/packages/plugin-clientportal-api/src/utils.ts
@@ -264,11 +264,11 @@ export const sendNotification = async (
     isMobile,
     eventData,
     mobileConfig,
+    type,
   } = doc;
 
   const link = doc.link;
 
-  const relType: string = doc.type ?? "ticket";
   // remove duplicated ids
   const receiverIds = [...Array.from(new Set(receivers))];
 
@@ -292,7 +292,7 @@ export const sendNotification = async (
     const notification =
       await models.ClientPortalNotifications.createNotification(
         {
-          type: relType,
+          type,
           title,
           link,
           content,
@@ -308,7 +308,7 @@ export const sendNotification = async (
     graphqlPubsub.publish(`clientPortalNotificationInserted:${recipient._id}`, {
       clientPortalNotificationInserted: {
         _id: notification._id,
-        type: relType,
+        type: type,
         userId: recipient._id,
         title: notification.title,
         content: notification.content,

--- a/packages/plugin-clientportal-api/src/utils.ts
+++ b/packages/plugin-clientportal-api/src/utils.ts
@@ -21,7 +21,6 @@ import { CLOSE_DATE_TYPES } from "./constants";
 import { IUser } from "./models/definitions/clientPortalUser";
 import { isEnabled } from "@erxes/api-utils/src/serviceDiscovery";
 import { IClientPortal } from "./models/definitions/clientPortal";
-import { string } from "zod";
 
 export const getConfig = async (
   code: string,

--- a/packages/plugin-clientportal-api/src/utils.ts
+++ b/packages/plugin-clientportal-api/src/utils.ts
@@ -21,6 +21,7 @@ import { CLOSE_DATE_TYPES } from "./constants";
 import { IUser } from "./models/definitions/clientPortalUser";
 import { isEnabled } from "@erxes/api-utils/src/serviceDiscovery";
 import { IClientPortal } from "./models/definitions/clientPortal";
+import { string } from "zod";
 
 export const getConfig = async (
   code: string,
@@ -264,11 +265,11 @@ export const sendNotification = async (
     isMobile,
     eventData,
     mobileConfig,
-    type,
   } = doc;
 
   const link = doc.link;
 
+  const relType: string = doc.type ?? "ticket";
   // remove duplicated ids
   const receiverIds = [...Array.from(new Set(receivers))];
 
@@ -292,9 +293,10 @@ export const sendNotification = async (
     const notification =
       await models.ClientPortalNotifications.createNotification(
         {
-          type,
+          type: relType,
           title,
           link,
+          content,
           receiver: recipient._id,
           notifType,
           clientPortalId: recipient.clientPortalId,
@@ -307,7 +309,7 @@ export const sendNotification = async (
     graphqlPubsub.publish(`clientPortalNotificationInserted:${recipient._id}`, {
       clientPortalNotificationInserted: {
         _id: notification._id,
-        type: notification.type,
+        type: relType,
         userId: recipient._id,
         title: notification.title,
         content: notification.content,


### PR DESCRIPTION
## Summary by Sourcery

Ensure sendNotification correctly defaults notification type to "ticket" if missing and includes content in the notification payload.

Enhancements:
- Default to "ticket" when doc.type is absent and use this relType when creating and publishing notifications
- Include the content field in the createNotification payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification handling to ensure a default notification type is always set and consistent.
  - Enhanced notifications to explicitly include content in all cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `sendNotification` in `utils.ts` to default `notifType` to "ticket" and include `content` in the payload.
> 
>   - **Behavior**:
>     - In `sendNotification` in `utils.ts`, default `notifType` to "ticket" if `doc.type` is missing.
>     - Include `content` in the `createNotification` payload in `sendNotification`.
>   - **Misc**:
>     - Ensure consistent notification type handling and content inclusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 4686fc930353639bda7841701115ce17e251e630. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->