### PR TITLE
fix: display user names in customProperties and prevent undefined fie…

### DIFF
--- a/packages/plugin-tickets-api/src/graphql/resolvers/queries/utils.ts
+++ b/packages/plugin-tickets-api/src/graphql/resolvers/queries/utils.ts
@@ -1374,7 +1374,9 @@ export const getItemList = async (
           (f) => f.field === field._id
         );
 
-        if (fieldData && field.type === "users") {
+        if (!fieldData) continue;
+
+        if (field.type === "users") {
           const valueIds = Array.isArray(fieldData.value)
             ? fieldData.value
             : [fieldData.value];
@@ -1398,7 +1400,7 @@ export const getItemList = async (
           });
         } else {
           item.customProperties.push({
-            name: `${field.text} - ${fieldData.value}`,
+            name: `${field.text} - ${fieldData.stringValue || fieldData.value || ""}`,
           });
         }
       }


### PR DESCRIPTION
## Summary by Sourcery

Skip undefined custom field data to prevent errors and update customProperties display to use stringValue or fallback value

Bug Fixes:
- Skip over undefined fieldData entries to prevent runtime exceptions

Enhancements:
- Use fieldData.stringValue or fieldData.value or empty string when formatting customProperties names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom field data to prevent issues when data is missing.
  * Enhanced display of custom property values by using a fallback to ensure information is shown when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->