### PR TITLE
fix(core-ui): properly handle selectedOptions in SelectWithSearch

### DIFF
--- a/packages/erxes-ui/src/components/SelectWithSearch.tsx
+++ b/packages/erxes-ui/src/components/SelectWithSearch.tsx
@@ -158,12 +158,14 @@ class SelectWithSearch extends React.Component<
         datas.filter((data) => !totalOptionsValues.includes(data._id))
       );
 
-      const updatedTotalOptions = [
-        ...(this.state.selectedOptions || []),
-        ...uniqueLoadedOptions,
-        ...totalOptions,
-      ].filter(
-        (opt, idx, arr) => arr.findIndex((o) => o.value === opt.value) === idx
+      const updatedTotalOptions = Array.from(
+        new Map(
+          [
+            ...(this.state.selectedOptions || []),
+            ...uniqueLoadedOptions,
+            ...totalOptions,
+          ].map((opt) => [opt.value, opt])
+        ).values()
       );
 
       const upSelectedOptions = updatedTotalOptions.filter((option) =>
@@ -177,7 +179,9 @@ class SelectWithSearch extends React.Component<
 
       this.setState({
         totalOptions: updatedTotalOptions,
-        selectedOptions: upSelectedOptions,
+        selectedOptions: upSelectedOptions.length
+          ? upSelectedOptions
+          : this.state.selectedOptions,
       });
     }
   }

--- a/packages/erxes-ui/src/components/SelectWithSearch.tsx
+++ b/packages/erxes-ui/src/components/SelectWithSearch.tsx
@@ -179,9 +179,12 @@ class SelectWithSearch extends React.Component<
 
       this.setState({
         totalOptions: updatedTotalOptions,
-        selectedOptions: upSelectedOptions.length
-          ? upSelectedOptions
-          : this.state.selectedOptions,
+        selectedOptions:
+          exactFilter && selectedValues?.length && !upSelectedOptions.length
+            ? []
+            : upSelectedOptions.length
+              ? upSelectedOptions
+              : this.state.selectedOptions,
       });
     }
   }


### PR DESCRIPTION
## Summary by Sourcery

Use Map-based deduplication to merge options and prevent clearing selectedOptions when no matches are found

Bug Fixes:
- Replace manual array filtering with a Map to merge and dedupe selectedOptions, loadedOptions, and totalOptions
- Retain existing selectedOptions when filtering yields no updated matches instead of clearing them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Eliminated duplicate entries in the searchable select, ensuring each option appears only once.
  - Preserved existing selections after options refresh, preventing unexpected clearing when updated options don’t include previously chosen values.
  - Improved reliability when loading or updating option lists during use.
- Refactor
  - Optimized internal option handling for better consistency and responsiveness in dynamic data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `SelectWithSearch` to retain `selectedOptions` using `Map` for deduplication, preventing unexpected clearing.
> 
>   - **Behavior**:
>     - Use `Map` for deduplication in `SelectWithSearch` to merge `selectedOptions`, `loadedOptions`, and `totalOptions`.
>     - Retain `selectedOptions` when no matches are found during filtering, preventing unexpected clearing.
>   - **Refactor**:
>     - Optimized option handling for better consistency and responsiveness in dynamic data scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 39260c6ba2e575c38d834240e9986adb3444f483. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->