### PR TITLE
fix(erxes-ui): include details.position when positions are empty

### DIFF
--- a/packages/erxes-ui/src/team/containers/SelectTeamMembers.tsx
+++ b/packages/erxes-ui/src/team/containers/SelectTeamMembers.tsx
@@ -55,7 +55,11 @@ const UserSelect: FC<Props> = ({
           includeCustomFieldOnSelectLabel;
 
         const positionTitles =
-          user.positions?.map((pos) => pos.title).join(", ") || "";
+          (user.positions?.length
+            ? user.positions.map((pos) => pos.title).join(", ")
+            : "") ||
+          details.position ||
+          "";
 
         const branchTitles = user.branches
           ? user.branches


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fallback to details.position for position titles when user.positions is empty
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `SelectTeamMembers.tsx` to include `details.position` when `user.positions` is empty, ensuring position titles are always included.
> 
>   - **Behavior**:
>     - In `SelectTeamMembers.tsx`, update `positionTitles` to use `details.position` when `user.positions` is empty.
>     - Ensures a position title is included if available, improving label generation for users without positions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for efcf3f4dca7ad5f888ac4d10d2c3ebc0fb915766. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented potential errors when displaying team member positions by safely handling missing or empty position data.
  - Improved label reliability by using available position titles when present and falling back to an alternative position field when not.
  - Ensures team member information renders consistently without crashes or blank fields in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->