### PR TITLE
fix: make Spinner component inherit color from parent

### DIFF
--- a/frontend/libs/erxes-ui/src/components/spinner.tsx
+++ b/frontend/libs/erxes-ui/src/components/spinner.tsx
@@ -54,7 +54,7 @@ export function Spinner({
         <g clipPath="url(#clip0_19_21)">
           <path
             d="M12.5 6.5V3.5"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.2"
             strokeWidth="2"
             strokeLinecap="round"
@@ -62,7 +62,7 @@ export function Spinner({
           />
           <path
             d="M16.75 8.2501L18.9 6.1001"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.05"
             strokeWidth="2"
             strokeLinecap="round"
@@ -70,14 +70,14 @@ export function Spinner({
           />
           <path
             d="M18.5 12.5H21.5"
-            stroke="#18181B"
+            stroke="currentColor"
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M16.75 16.75L18.9 18.9"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.85"
             strokeWidth="2"
             strokeLinecap="round"
@@ -85,7 +85,7 @@ export function Spinner({
           />
           <path
             d="M12.5 18.5V21.5"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.7"
             strokeWidth="2"
             strokeLinecap="round"
@@ -93,7 +93,7 @@ export function Spinner({
           />
           <path
             d="M8.2501 16.75L6.1001 18.9"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.65"
             strokeWidth="2"
             strokeLinecap="round"
@@ -101,7 +101,7 @@ export function Spinner({
           />
           <path
             d="M6.5 12.5H3.5"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.5"
             strokeWidth="2"
             strokeLinecap="round"
@@ -109,7 +109,7 @@ export function Spinner({
           />
           <path
             d="M8.2501 8.2501L6.1001 6.1001"
-            stroke="#202020"
+            stroke="currentColor"
             strokeOpacity="0.35"
             strokeWidth="2"
             strokeLinecap="round"


### PR DESCRIPTION
## What
Changed the Spinner component to inherit color from its parent element instead of using hardcoded colors.

## Why
The current spinner component uses fixed colors (#202020, #18181B), which causes styling inconsistencies when placed inside buttons, text fields, or components with different theme colors. This change ensures consistent styling across erxes 3.0.

## How
- Replaced all hardcoded `stroke` color values with `currentColor`
- Preserved `strokeOpacity` values to maintain the spinning gradient effect
- The spinner will now automatically inherit the text color from its parent component

## Testing
The change uses the standard CSS `currentColor` property, which is well-supported across all browsers.

Maintainers can verify by testing the Spinner component in various contexts:
- Inside buttons with different colors
- In text fields
- With different theme configurations (light/dark mode)

Fixes #6278