### PR TITLE
feat: add create route for automation and refactor plugin state check

### DIFF
--- a/frontend/core-ui/src/modules/app/components/AutomationRoutes.tsx
+++ b/frontend/core-ui/src/modules/app/components/AutomationRoutes.tsx
@@ -26,6 +26,10 @@ export const AutomationRoutes = () => {
           path={AutomationsPath.Detail}
           element={<AutomationDetailPage />}
         />
+        <Route
+          path={AutomationsPath.Create}
+          element={<AutomationDetailPage />}
+        />
       </Routes>
       <AutomationsPageEffect />
     </Suspense>

--- a/frontend/core-ui/src/modules/automations/utils/RenderPluginsComponentWrapper.tsx
+++ b/frontend/core-ui/src/modules/automations/utils/RenderPluginsComponentWrapper.tsx
@@ -1,6 +1,7 @@
 import { ErrorState } from '@/automations/utils/ErrorState';
+import { useAutomationsRemoteModules } from '@/automations/utils/useAutomationsModules';
 import { IconInfoTriangle } from '@tabler/icons-react';
-import { isEnabled, Spinner } from 'erxes-ui';
+import { Spinner } from 'erxes-ui';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { AutomationRemoteEntryProps } from 'ui-modules';
@@ -20,8 +21,9 @@ export const RenderPluginsComponentWrapper = ({
   if (!pluginName || !moduleName) {
     return null;
   }
+  const { isEnabled } = useAutomationsRemoteModules(pluginName);
 
-  if (!isEnabled(pluginName)) {
+  if (!isEnabled) {
     return (
       <p className="flex flex-row gap-2 items-center ml-4">
         {`Plugin ${pluginName} disabled`}

--- a/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
+++ b/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
@@ -1,0 +1,22 @@
+import { pluginsConfigState } from 'ui-modules';
+import { useAtom } from 'jotai';
+
+export const useAutomationsRemoteModules = (pluginName: string) => {
+  const [pluginsMetaData] = useAtom(pluginsConfigState);
+  if (!pluginsMetaData) {
+    return { isEnabled: false };
+  }
+
+  const plugins = Object.values(pluginsMetaData);
+
+  const result = plugins
+    .filter(({ name }) => name === pluginName)
+    .flatMap((plugin) =>
+      (plugin.modules || []).map((module) => ({
+        ...module,
+        pluginName: plugin.name,
+      })),
+    );
+
+  return { isEnabled: !!result?.length };
+};

--- a/frontend/core-ui/src/modules/types/paths/AutomationPath.ts
+++ b/frontend/core-ui/src/modules/types/paths/AutomationPath.ts
@@ -1,4 +1,5 @@
 export enum AutomationsPath {
   Index = '/',
   Detail = '/edit/:id',
+  Create = '/create',
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated create automation route and refactor plugin availability checks using a new hook

New Features:
- Introduce '/create' route for automations with AutomationDetailPage
- Implement useAutomationsRemoteModules hook to derive plugin enabled state

Enhancements:
- Update RenderPluginsComponentWrapper to use the new hook for plugin enablement
- Simplify plugin state logic by removing the old isEnabled(pluginName) call
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add create route for automations and refactor plugin state check using a new hook.
> 
>   - **Routes**:
>     - Add `Create` route to `AutomationRoutes` in `AutomationRoutes.tsx` for automation creation.
>     - Update `AutomationsPath` enum in `AutomationPath.ts` to include `Create` path.
>   - **Plugin State Check**:
>     - Refactor plugin state check in `RenderPluginsComponentWrapper.tsx` to use `useAutomationsRemoteModules` hook.
>     - Introduce `useAutomationsModules.ts` to handle plugin state logic, checking if a plugin is enabled based on `pluginsConfigState`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 0c41b2dc2fe91427e0bbbbf27b3727357055d3ac. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated “Create” route for Automations, enabling users to access a new creation page.
- Refactor
  - Updated plugin enablement logic to use a centralized hook, improving consistency of plugin availability checks across the Automations UI.
- Documentation
  - Clarified internal paths for Automations to include the new Create route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->