### PR TITLE
fix(files): robust file upload parsing, cleanup, and safe download he…

### DIFF
--- a/backend/core-api/src/routes/fileRoutes.ts
+++ b/backend/core-api/src/routes/fileRoutes.ts
@@ -19,6 +19,12 @@ import {
 } from '~/utils/file';
 import { readFileRequest } from '~/utils/file/read';
 
+// new imports
+import fs from 'fs/promises';
+import path from 'path';
+import { lookup as mimeLookup } from 'mime-types';
+import contentDisposition from 'content-disposition';
+
 const router: Router = Router();
 
 const DOMAIN = getEnv({ name: 'DOMAIN' });
@@ -57,20 +63,27 @@ router.get(
         width,
       });
 
-      if (inline && inline === 'true') {
-        const extension = sanitizedKey.split('.').pop();
+      // derive mime type safely
+      const ext = path.extname(sanitizedKey); // includes leading dot
+      const mimeType = mimeLookup(ext) || 'application/octet-stream';
+      const filename = name ? String(name) : sanitizedKey;
 
-        res.setHeader('Content-disposition', 'inline; filename="' + key + '"');
-        res.setHeader('Content-type', `application/${extension}`);
+      if (inline && inline === 'true') {
+        // safe Content-Disposition and Content-Type
+        res.setHeader('Content-Disposition', contentDisposition(filename, { type: 'inline' }));
+        res.setHeader('Content-Type', mimeType);
 
         return res.send(response);
       }
 
-      res.attachment(name || key);
+      // attachment: use sanitizedKey (encoded by contentDisposition)
+      res.setHeader('Content-Disposition', contentDisposition(filename, { type: 'attachment' }));
+      res.setHeader('Content-Type', mimeType);
 
       return res.send(response);
     } catch (e) {
-      if ((e as Error).message.includes('key does not exist')) {
+      const message = (e as Error).message || '';
+      if (message.includes('key does not exist')) {
         return res.status(404).send('Not found');
       }
 
@@ -86,30 +99,48 @@ router.post('/upload-file', async (req: Request, res: Response) => {
   const domain = DOMAIN.replace('<subdomain>', subdomain);
   const models = await generateModels(subdomain);
 
-  const maxHeight = Number(req.query.maxHeight);
-  const maxWidth = Number(req.query.maxWidth);
+  // robust parsing of query numbers
+  const maxHeight = Number(req.query.maxHeight || 0);
+  const maxWidth = Number(req.query.maxWidth || 0);
 
   const form = new formidable.IncomingForm({
     uploadDir: os.tmpdir(),
     keepExtensions: true,
   });
 
-  form.parse(req, async (error, _fields, files) => {
-    if (error) {
-      return res
-        .status(400)
-        .send(`File upload parsing error: ${error.message}`);
-    }
+  // helper to parse form as a Promise
+  const parseForm = (frm: formidable.IncomingForm, request: Request) =>
+    new Promise<{ fields: formidable.Fields; files: formidable.Files }>((resolve, reject) => {
+      frm.parse(request, (err, fields, files) => {
+        if (err) return reject(err);
+        resolve({ fields, files });
+      });
+    });
 
-    const uploaded = files.file || files.upload;
+  // We'll try to remove temp files in finally
+  let originalFilePath: string | undefined;
+  let processedFilePath: string | undefined;
+
+  try {
+    const { files } = await parseForm(form, req);
+
+    const uploaded = (files as any).file || (files as any).upload;
 
     const file = Array.isArray(uploaded) ? uploaded[0] : uploaded;
 
-    if (!file?.filepath || !isValidPath(file.filepath)) {
+    if (!file) {
+      return res.status(400).send('No file uploaded');
+    }
+
+    // support both 'filepath' (formidable v2+) and 'path' (older)
+    const filepath: string | undefined = (file as any).filepath || (file as any).path;
+    originalFilePath = filepath;
+
+    if (!filepath || !isValidPath(filepath)) {
       return res.status(400).send('Invalid or unsafe file path');
     }
 
-    const mimetype = file?.mimetype;
+    const mimetype = (file as any).mimetype || (file as any).type;
 
     if (!mimetype) {
       return res
@@ -117,13 +148,16 @@ router.post('/upload-file', async (req: Request, res: Response) => {
         .send('One or more files have unrecognized MIME type');
     }
 
-    let processedFile = file;
+    let processedFile: any = file;
 
-    if (isImage(mimetype) && maxHeight && maxWidth) {
+    if (isImage(mimetype) && maxHeight > 0 && maxWidth > 0) {
       processedFile = await resizeImage(file, maxWidth, maxHeight);
     }
 
-    const status = await checkFile(models, processedFile, req.headers.source);
+    // processedFile may have filepath or path
+    processedFilePath = (processedFile?.filepath as string) || (processedFile?.path as string);
+
+    const status = await checkFile(models, processedFile, req.headers.source as string | undefined);
 
     if (status !== 'ok') {
       return res.status(400).send(status);
@@ -133,21 +167,44 @@ router.post('/upload-file', async (req: Request, res: Response) => {
       const result = await uploadFile(
         `${domain}/gateway`,
         processedFile,
-        !!files.upload,
+        !!(files && (files as any).upload),
         models,
       );
 
       res.send(result);
     } catch (e) {
-      return res.status(500).send(filterXSS(e.message));
+      return res.status(500).send(filterXSS((e as Error).message || 'upload error'));
     }
-  });
+  } catch (error) {
+    // formidable parse error or other error
+    return res
+      .status(400)
+      .send(`File upload parsing error: ${(error as Error).message || String(error)}`);
+  } finally {
+    // best-effort cleanup of temp files created under os.tmpdir()
+    const tryUnlink = async (p?: string) => {
+      if (!p) return;
+      try {
+        // avoid deleting non-temp files
+        if (p.startsWith(os.tmpdir())) {
+          await fs.unlink(p).catch(() => null);
+        }
+      } catch {
+        // swallow cleanup errors
+      }
+    };
+
+    // delete processed file first (if different)
+    await tryUnlink(processedFilePath);
+    // then delete original
+    await tryUnlink(originalFilePath);
+  }
 });
 
 router.post('/delete-file', async (req: Request, res: Response) => {
-  // require login
+  // require login - replace with real auth middleware in future
   if (!req.headers.userid) {
-    return res.end('forbidden');
+    return res.status(403).json({ error: 'forbidden' });
   }
 
   const subdomain = getSubdomain(req);
@@ -155,10 +212,14 @@ router.post('/delete-file', async (req: Request, res: Response) => {
 
   const sanitizedFilename = sanitizeFilename(req.body.fileName);
 
+  if (!sanitizedFilename) {
+    return res.status(400).send('Invalid fileName');
+  }
+
   const status = await deleteFile(models, sanitizedFilename);
 
   if (status === 'ok') {
-    return res.send(status);
+    return res.send({ status: 'ok' });
   }
 
   return res.status(500).send(status);


### PR DESCRIPTION
1. Promisify or wrap form.parse so parsing and subsequent async work are inside a single try/catch/finally.

2. Ensure best-effort cleanup of temp files in finally (only remove files under os.tmpdir()).

3. Use mime-types to set correct Content-Type and content-disposition (or content-disposition package) to safely encode filenames.

4. Accept both file.path and file.filepath.

5. Validate maxWidth/maxHeight as numbers > 0 before resizing.

6. Replace header-presence check with proper auth middleware (JWT/session) or at minimum return 403 and document expected auth.