### PR TITLE
removed the unuseful DateSelectContextType

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/DateSelectTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/DateSelectTask.tsx
@@ -48,7 +48,7 @@ export const DateSelectProvider = ({
   ...props
 }: DateSelectContextType & {
   children: React.ReactNode;
-} & DateSelectContextType) => {
+} ) => {
   return (
     <DateSelectContext.Provider
       value={{


### PR DESCRIPTION
closes #6429 

as asked in the issue removed the extra "DateSelectContextType" from the statement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Streamlined type annotations in the date selection provider to eliminate duplication, improving code clarity and consistency. No impact on app behavior, performance, or UI. Existing workflows and tasks continue to function as before.
* Chores
  * Minor cleanup to internal typings to reduce noise in code reviews and future maintenance. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->