### PR TITLE
Replace the promise.resolve with value as per typescript:S4335 rule

### DIFF
--- a/frontend/core-ui/src/modules/app/hooks/useCreateAppRouter.tsx
+++ b/frontend/core-ui/src/modules/app/hooks/useCreateAppRouter.tsx
@@ -38,7 +38,7 @@ export const useCreateAppRouter = () => {
 
   return createBrowserRouter(
     createRoutesFromElements(
-      <Route element={<Providers />} loader={async () => Promise.resolve(null)}>
+      <Route element={<Providers />} loader={async () => null}>
         <Route path={AppPath.CreateOwner} element={<CreateOwnerPage />} />
         <Route element={<OrganizationProvider />}>
           <Route path={AppPath.Login} element={<LoginPage />} />


### PR DESCRIPTION
Applied fix for #6425  issue

## Summary by Sourcery

Enhancements:
- Replace Promise.resolve(null) with direct null return in createBrowserRouter loader
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `Promise.resolve(null)` with `null` in `useCreateAppRouter.tsx` to comply with TypeScript rule S4335, addressing issue #6425.
> 
>   - **Behavior**:
>     - Replaces `Promise.resolve(null)` with `null` in `loader` function of `Route` in `useCreateAppRouter.tsx`.
>   - **Misc**:
>     - Addresses issue #6425 by complying with TypeScript rule S4335.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for f00e63cb189eac9786e9dbb80e80c2b779370859. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the app router loader to return null directly instead of wrapping it in a Promise, streamlining the code path.
  * Maintains identical behavior—no changes to navigation, data loading, or error handling.
  * Improves readability and maintainability of routing logic.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->