### PR TITLE
using localeCompare instead of sort

### DIFF
--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -686,7 +686,7 @@ const queries = {
       columns[otherAmount._id.type] = otherAmount._id.title;
     }
 
-    const keys = Object.keys(summary).sort();
+    const keys = Object.keys(summary).sort((a, b) => a.localeCompare(b));
 
     const amounts: any[] = [];
     for (const key of keys) {


### PR DESCRIPTION
related to issue #6411 

Using localeCompare instead to reliably sort elements alphabetically

## Summary by Sourcery

Enhancements:
- Replace default array sort with localeCompare-based comparator for reliable alphabetical ordering of summary keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented locale-aware string sorting for order summary keys, ensuring consistent and predictable ordering across languages and regions in POS order views and reports.
  * Resolves previously erratic ordering with accents and special characters, improving readability and scanning.
  * No changes to data content—only the display order is affected, providing a more reliable experience for international users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->