### PR TITLE
call: add call helper

### DIFF
--- a/backend/plugins/frontline_api/src/main.ts
+++ b/backend/plugins/frontline_api/src/main.ts
@@ -29,8 +29,8 @@ startPlugin({
   expressRouter: router,
   onServerInit: async (app) => {
     await initCallApp(app);
-    const VERSION = getEnv({ name: 'VERSION' });
-    if (!VERSION || (VERSION && VERSION !== 'saas')) {
+    const CALL_WS_SERVER = getEnv({ name: 'CALL_WS_SERVER' });
+    if (CALL_WS_SERVER) {
       await initWebsocketService();
     }
   },

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/integrations.ts
@@ -6,7 +6,7 @@ import {
   IOnboardingParamsEdit,
   IArchiveParams,
 } from '@/inbox/@types/integrations';
-import { IContext, IModels } from '~/connectionResolvers';
+import { IContext } from '~/connectionResolvers';
 import { IExternalIntegrationParams } from '@/inbox/db/models/Integrations';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { getUniqueValue } from 'erxes-api-shared/utils';

--- a/backend/plugins/frontline_api/src/modules/integrations/call/initApp.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/initApp.ts
@@ -40,14 +40,7 @@ async function validateCompanyAccess(subdomain, erxesApiId, cdrData) {
     }
 
     const { src_trunk_name, dst_trunk_name } = cdrData;
-    console.log(
-      'integration.srcTrunk::',
-      integration.srcTrunk,
-      src_trunk_name,
-      '----',
-      integration.dstTrunk,
-      dst_trunk_name,
-    );
+
     const hasTrunkAccess =
       integration.srcTrunk === src_trunk_name ||
       integration.dstTrunk === dst_trunk_name;


### PR DESCRIPTION
## Summary by Sourcery

Refactor call integration helpers to use a dedicated environment variable, streamline request payloads, remove debug logs, and conditionally initialize the websocket service

Enhancements:
- Use CALL_ENDPOINT_URL environment variable in create, update, and remove integration calls
- Remove callQueues from registration and update request bodies for call integrations
- Add domain to the removeIntegration request payload
- Remove debug console.log statements from validateCompanyAccess and error handling
- Initialize websocket service based on CALL_WS_SERVER environment variable instead of VERSION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket service now starts only when CALL_WS_SERVER is enabled, preventing unintended connections.

* **Refactor**
  * Updated call integrations to use CALL_ENDPOINT_URL.
  * Removed callQueues from registration/update payloads.
  * Added domain to remove-endpoint payloads.

* **Chores**
  * Cleaned up unused imports in integrations resolver.
  * Removed verbose debug logs from call integration validation and related helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->