### PR TITLE
fix: tourism update

### DIFF
--- a/packages/plugin-bm-api/src/cronjobs/index.ts
+++ b/packages/plugin-bm-api/src/cronjobs/index.ts
@@ -14,7 +14,7 @@ const handleBmCronjob = async ({ subdomain }) => {
     },
     { $set: { date_status: 'completed' } }
   );
-    const update2 = await models.Tours.updateMany(
+    const update2 = await models.Tours.updateMany( // fixes legacy records with the typo
     {
       date_status: 'compeleted'
     },


### PR DESCRIPTION
## Summary by Sourcery

Fix typo in cronjob date_status updates and backfill existing tour records to use the corrected status

Bug Fixes:
- Correct typo in date_status update from 'compeleted' to 'completed'

Enhancements:
- Add cronjob operation to update existing Tours entries with the incorrect status value to the corrected one
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `handleBmCronjob` to update `date_status` from 'compeleted' to 'completed' in `index.ts`.
> 
>   - **Bug Fix**:
>     - Corrects typo in `handleBmCronjob` function in `index.ts`.
>     - Updates `date_status` from 'compeleted' to 'completed' for records in `models.Tours`.
>     - Ensures all records with incorrect status are updated to 'completed'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 1e8b627f80b47c2137d81f7efec1c1fdae85037b. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->