### PR TITLE
fix: resolve TypeScript await issue in pipeline archive mutation

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/db/models/Pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/db/models/Pipelines.ts
@@ -22,7 +22,7 @@ export interface IPipelineModel extends Model<IPipelineDocument> {
   updateOrder(orders: IOrderInput[]): Promise<IPipelineDocument[]>;
   watchPipeline(_id: string, isAdd: boolean, userId: string): void;
   removePipeline(_id: string, checked?: boolean): object;
-  archivePipeline(_id: string, status?: string): object;
+  archivePipeline(_id: string, status?: string): Promise<object>;
 }
 
 export const loadPipelineClass = (models: IModels) => {
@@ -114,14 +114,15 @@ export const loadPipelineClass = (models: IModels) => {
     /**
      * Archive a pipeline
      */
-    public static async archivePipeline(_id: string) {
+    public static async archivePipeline(_id: string, status?: string) {
       const pipeline = await models.Pipelines.getPipeline(_id);
-      const status =
+      const newStatus = status || (
         pipeline.status === SALES_STATUSES.ACTIVE
           ? SALES_STATUSES.ARCHIVED
-          : SALES_STATUSES.ACTIVE;
+          : SALES_STATUSES.ACTIVE
+      );
 
-      await models.Pipelines.updateOne({ _id }, { $set: { status } });
+      await models.Pipelines.updateOne({ _id }, { $set: { status: newStatus } });
     }
 
     public static watchPipeline(_id: string, isAdd: boolean, userId: string) {

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
@@ -107,6 +107,6 @@ export const mutations = `
   salesPipelinesUpdateOrder(orders: [SalesOrderItem]): [SalesPipeline]
   salesPipelinesWatch(_id: String!, isAdd: Boolean): SalesPipeline
   salesPipelinesRemove(_id: String!): JSON
-  salesPipelinesArchive(_id: String!): JSON
+  salesPipelinesArchive(_id: String!, status: String): JSON
   salesPipelinesCopied(_id: String!): JSON
 `;


### PR DESCRIPTION
- Fix interface definition for archivePipeline to return Promise<object>
- Update implementation to accept optional status parameter
- Update GraphQL schema to include status parameter
- Resolves #6419 - unexpected await of non-Promise value
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `archivePipeline` to return a `Promise` and update GraphQL schema to accept optional `status` parameter, resolving issue #6419.
> 
>   - **Behavior**:
>     - Fix `archivePipeline` in `Pipelines.ts` to return `Promise<object>`.
>     - Update `archivePipeline` to accept optional `status` parameter, defaulting to toggle between `SALES_STATUSES.ACTIVE` and `SALES_STATUSES.ARCHIVED`.
>     - Update GraphQL schema in `pipeline.ts` to include `status` parameter in `salesPipelinesArchive` mutation.
>   - **Issue Resolution**:
>     - Resolves #6419 - unexpected await of non-Promise value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for b331e813a7f62c5d3e0b8cbaf7400dd00422b724. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline archive action now supports an optional status parameter, letting you explicitly archive or re-activate a pipeline; if omitted, it toggles based on current state.
  * GraphQL mutation salesPipelinesArchive updated to accept an optional status argument while continuing to return JSON.
  * Provides more precise control and predictability when managing pipeline status through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->