### PR TITLE
chore: wrap operation resolvers with apolloResolverWrapper

### DIFF
--- a/backend/core-api/src/modules/permissions/db/models/Roles.ts
+++ b/backend/core-api/src/modules/permissions/db/models/Roles.ts
@@ -32,7 +32,7 @@ import { roleSchema } from '../definitions/roles';
         }
   
         if (userRole.role === PERMISSION_ROLES.OWNER) {
-          if (role === PERMISSION_ROLES.OWNER) {
+          if (role !== PERMISSION_ROLES.OWNER) {
             throw new Error('Access denied');
           }
   

--- a/backend/plugins/operation_api/src/main.ts
+++ b/backend/plugins/operation_api/src/main.ts
@@ -1,9 +1,9 @@
-import { redis, startPlugin } from 'erxes-api-shared/utils';
+import { redis, startPlugin, wrapApolloResolvers } from 'erxes-api-shared/utils';
+import { Router } from 'express';
 import { typeDefs } from '~/apollo/typeDefs';
+import { initMQWorkers } from '~/worker';
 import resolvers from './apollo/resolvers';
 import { generateModels } from './connectionResolvers';
-import { Router } from 'express';
-import { initMQWorkers } from '~/worker';
 
 export const router: Router = Router();
 
@@ -12,7 +12,7 @@ startPlugin({
   port: 3306,
   graphql: async () => ({
     typeDefs: await typeDefs(),
-    resolvers,
+    resolvers: wrapApolloResolvers(resolvers),
   }),
   hasSubscriptions: true,
   subscriptionPluginPath: require('path').resolve(


### PR DESCRIPTION
## Summary by Sourcery

Wrap operation API resolvers with Apollo error/permission handling and correct the owner permission validation logic

Bug Fixes:
- Fix permission check logic to correctly restrict non-owner access in the Roles model

Enhancements:
- Wrap GraphQL resolvers in the operation API with a common Apollo resolver wrapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed role validation logic for owner-level permission checks to correctly enforce access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->