### PR TITLE
fix: remove await from non-Promise removeChecklists

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/utils.ts
@@ -328,7 +328,7 @@ export const removeItems = async (models: IModels, stageIds: string[]) => {
 
   const itemIds = items.map((i) => i._id);
 
-  await models.Checklists.removeChecklists(itemIds);
+  models.Checklists.removeChecklists(itemIds);
 
   //   await sendCoreMessage({
   //     subdomain,


### PR DESCRIPTION
#6422 The `models.Checklists.removeChecklists` function is not a Promise/Thenable, so using `await` on it is incorrect and triggers TypeScript S4123 warning. 

This PR removes the `await` keyword from the call to ensure correct usage and avoid unnecessary asynchronous handling.

Affected line: backend/plugins/sales_api/src/modules/sales/graphql/resolvers/utils.ts, line 331

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary await on non-Promise models.Checklists.removeChecklists to fix TS warning S4123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal asynchronous operations for improved system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->