### PR TITLE
fix:permission cancel button

### DIFF
--- a/packages/core-ui/src/modules/settings/permissions/containers/PermissionList.tsx
+++ b/packages/core-ui/src/modules/settings/permissions/containers/PermissionList.tsx
@@ -51,20 +51,20 @@ const List = (props: FinalProps) => {
   } = props;
 
   // remove action
-  const remove = (id: string) => {
-    confirm("This will permanently delete are you absolutely sure?", {
-      hasDeleteConfirm: true,
-    }).then(() => {
-      removeMutation({
-        variables: { ids: [id] },
-      })
-        .then(() => {
-          Alert.success("You successfully deleted a permission.");
-        })
-        .catch((error) => {
-          Alert.error(error.message);
-        });
-    });
+  const remove = async (id: string) => {
+  try {
+    const confirmed = await confirm(
+      "This will permanently delete. Are you absolutely sure?",
+      { hasDeleteConfirm: true }
+    );
+    // if confirm returns false, just stop
+    if (!confirmed) {
+      return;
+    }
+    await removeMutation({ variables: { ids: [id] } });
+    Alert.success("You successfully deleted a permission.");
+  } catch (error) {
+  }
   };
 
   const isLoading =


### PR DESCRIPTION
## Summary by Sourcery

Refactor the permission removal logic to async/await, properly handle cancellation of the confirmation dialog, and suppress errors

Bug Fixes:
- Stop deletion when the user cancels the confirmation dialog

Enhancements:
- Refactor the remove function to use async/await instead of promise chaining
- Suppress error handling silently in the remove function