### PR TITLE
fix: specify target origin for postMessage

### DIFF
--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -117,12 +117,14 @@ const InvoiceDetail = () => {
   };
 
   const postMessage = (message: any) => {
+    const targetOrigin = window.location.origin;
+
     if (window.opener) {
-      window.opener.postMessage(message, '*');
+      window.opener.postMessage(message, targetOrigin);
     }
 
     if (window.parent) {
-      window.parent.postMessage(message, '*');
+      window.parent.postMessage(message, targetOrigin);
     }
   };
 


### PR DESCRIPTION
This PR updates the postMessage calls in InvoiceDetail.tsx to use a specific target origin instead of "*". This ensures that messages are only sent to the current trusted origin, improving security.

GitHub issue: #6406

SonarCloud rule: [S2819](https://sonarcloud.io/organizations/erxes/rules?open=typescript%3AS2819&rule_key=typescript%3AS2819)

## Summary by Sourcery

Bug Fixes:
- Restrict postMessage calls in InvoiceDetail.tsx to use window.location.origin instead of '*' to prevent sending messages to untrusted origins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cross-window messaging implementation to use specific origin instead of wildcard parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->