### PR TITLE
fix: tourism update

### DIFF
--- a/packages/plugin-bm-api/src/models/definitions/order.ts
+++ b/packages/plugin-bm-api/src/models/definitions/order.ts
@@ -24,12 +24,14 @@ export interface IOrderDocument extends IOrder, Document {
 
 const STATUS_TYPES = [
   { label: "paid", value: "paid" },
-  { label: "notPaid", value: "notPaid" },
-  { label: "somePaid", value: "somePaid" }
+  { label: "pending", value: "pending" },
+  { label: "prepaid", value: "prepaid" },
+  { label: "refunded", value: "refunded" },
+  { label: "cancelled", value: "cancelled" }
 ];
 
 const getEnum = (): string[] => {
-  return STATUS_TYPES.map((option) => option.value);
+  return STATUS_TYPES.map(option => option.value);
 };
 
 export const orderSchema = schemaHooksWrapper(

--- a/packages/plugin-bm-api/src/payment.ts
+++ b/packages/plugin-bm-api/src/payment.ts
@@ -17,8 +17,8 @@ export default {
     }
     const order = await models.Orders.findById(contentTypeId);
     if (!order) return;
-    const oldInvoice = order?.invoices?.find((x) => x._id === _id);
-    const restInvoices = order?.invoices?.filter((x) => x._id !== _id) || [];
+    const oldInvoice = order?.invoices?.find(x => x._id === _id);
+    const restInvoices = order?.invoices?.filter(x => x._id !== _id) || [];
     const restTotal = restInvoices?.reduce((a, b) => a + b.amount, 0) || 0;
     const total = (oldInvoice?.amount || 0) + restTotal;
     const branch = await models.BmsBranch.findById(order.branchId);
@@ -60,7 +60,7 @@ export default {
           { _id: contentTypeId },
           {
             $set: {
-              status: "halfPaid",
+              status: "prepaid",
               invoices: [...restInvoices, { _id, amount }]
             }
           }


### PR DESCRIPTION
## Summary by Sourcery

Update order status values and align payment status accordingly

Enhancements:
- Replace obsolete 'notPaid' and 'somePaid' statuses with 'pending', 'prepaid', 'refunded', and 'cancelled' in the order schema
- Update payment handler to use the new 'prepaid' status instead of 'halfPaid'

Chores:
- Simplify arrow function syntax in status enum and invoice filtering
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update order status types and adjust payment logic to reflect new statuses in `order.ts` and `payment.ts`.
> 
>   - **Order Model**:
>     - Update `STATUS_TYPES` in `order.ts` to include `pending`, `prepaid`, `refunded`, `cancelled`.
>     - Remove `notPaid` and `somePaid` statuses.
>   - **Payment Logic**:
>     - Change status from `halfPaid` to `prepaid` in `payment.ts` when updating order status.
>     - Adjust logic in `callback` function to handle new status types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for e83fb6c42e7bd3ce1871baa4bbc84f8b32a3a5dc. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->