### PR TITLE
unnecessary intersection (any & {...}) removed.

### DIFF
--- a/frontend/libs/ui-modules/src/modules/documents/components/DocumentsInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/documents/components/DocumentsInline.tsx
@@ -43,9 +43,6 @@ const DocumentsInlineProvider = ({
 }: DocumentsInlineProviderProps) => {
   const [_documents, _setDocuments] = useState<Document[]>(documents || []);
 
-  const handleUpdateDocuments = (docs: Document[]) => {
-    _setDocuments(docs);
-  };
 
   return (
     <DocumentsInlineContext.Provider


### PR DESCRIPTION
closes #6427 

unnecessary intersection (any & {...}), which always evaluates to any, defeating the purpose of typing.

## Summary by Sourcery

Improve type safety in DocumentsInline components by replacing `any` intersections with explicit interfaces and updating state hooks to use proper types.

Enhancements:
- Introduce Document and DocumentsInlineProviderProps interfaces for typed component props
- Replace `any` types in DocumentsInlineRoot and provider with explicit interfaces
- Update useState hook to use Document[] instead of any[]
- Add a typed handleUpdateDocuments function for state updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal typing, provider behavior, and default state handling for the Documents inline component, enhancing stability, type-safety, and reducing potential runtime issues for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->