### PR TITLE
fix IStageModel

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/db/models/Stages.ts
+++ b/backend/plugins/sales_api/src/modules/sales/db/models/Stages.ts
@@ -9,7 +9,7 @@ import { stageSchema } from '../definitions/stages';
 export interface IStageModel extends Model<IStageDocument> {
   getStage(_id: string): Promise<IStageDocument>;
   createStage(doc: IStage): Promise<IStageDocument>;
-  removeStage(_id: string): object;
+  removeStage(_id: string): Promise<object>;
   updateStage(_id: string, doc: IStage): Promise<IStageDocument>;
   updateOrder(orders: IOrderInput[]): Promise<IStageDocument[]>;
   checkCodeDuplication(code: string): string;


### PR DESCRIPTION
Fixes #6414 

"await" should only be used with promises

## Summary by Sourcery

Bug Fixes:
- Change removeStage return type from object to Promise<object> in IStageModel interface
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `removeStage` return type in `IStageModel` to `Promise<object>` to reflect asynchronous behavior.
> 
>   - **Interface Update**:
>     - Change return type of `removeStage` in `IStageModel` from `object` to `Promise<object>` in `Stages.ts`.
>   - **Behavior**:
>     - Ensures `removeStage` method in `IStageModel` accurately reflects asynchronous behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 147b34aff9e933e75cd8436df113458d242a2787. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal asynchronous handling for improved performance and reliability of backend operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->