### PR TITLE
refactor(frontline_ui): remove nested ternary in FacebookMessageButtonsGenerator

### DIFF
--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/action/components/FacebookMessageButtonsGenerator.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/action/components/FacebookMessageButtonsGenerator.tsx
@@ -168,6 +168,41 @@ const FacebookMessageButton = ({
     handleChangeButton(updatedButton);
   };
 
+  let content: React.ReactNode;
+  if (button?.isEditing) {
+    content = (
+      <Input
+        autoFocus
+        maxLength={20}
+        placeholder="Enter button text"
+        value={button.text || button.link}
+        onBlur={onSave}
+        onChange={onChangeButtonText}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.currentTarget.blur();
+          }
+        }}
+      />
+    );
+  } else if (button.link) {
+    content = (
+      <a
+        href={button.link}
+        target="__blank"
+        className="text-blue-500 hover:text-blue-500/70 transition ease-in-out"
+      >
+        {button.link}
+      </a>
+    );
+  } else {
+    content = (
+      <span className="font-mono font-bold text-foreground text-sm">
+        {button.text || 'Type a button label'}
+      </span>
+    );
+  }
+
   return (
     <Card
       ref={setNodeRef}
@@ -197,33 +232,7 @@ const FacebookMessageButton = ({
         />
       ) : null}
       <div className="flex-1 border rounded-lg p-2 flex items-center">
-        {button?.isEditing ? (
-          <Input
-            autoFocus
-            maxLength={20}
-            placeholder="Enter button text"
-            value={button.text || button.link}
-            onBlur={onSave}
-            onChange={onChangeButtonText}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.currentTarget.blur();
-              }
-            }}
-          />
-        ) : button.link ? (
-          <a
-            href={button.link}
-            target="__blank"
-            className="text-blue-500 hover:text-blue-500/70 transition ease-in-out"
-          >
-            {button.link}
-          </a>
-        ) : (
-          <span className="font-mono font-bold text-foreground text-sm">
-            {button.text || 'Type a button label'}
-          </span>
-        )}
+        {content}
       </div>
       <Button
         size="icon"


### PR DESCRIPTION
resolved #6583 Replace nested ternary at ~226 with clear if/else assigning a content variable and Improves readability that satisfies lint rule. No behavior change.

## Summary by Sourcery

Enhancements:
- Refactor FacebookMessageButton to replace nested ternary rendering with a clear if/else content assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for button rendering logic in Facebook automation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->