### PR TITLE
feat: (ticket)initialize fields from localStorage and sync with props in componentDidUpdate

### DIFF
--- a/packages/ui-tickets/src/boards/components/portable/AddForm.tsx
+++ b/packages/ui-tickets/src/boards/components/portable/AddForm.tsx
@@ -100,12 +100,21 @@ class AddForm extends React.Component<Props, State> {
         props.mailSubject ||
         "",
       customFieldsData: [],
-      fields:
-        JSON.parse(
-          localStorage.getItem(`${props.options.type}_fields`) || "[]",
-        ) ||
-        props.fields ||
-        [],
+      fields: (() => {
+        try {
+          const stored = localStorage.getItem(`${props.options.type}_fields`);
+          if (stored) {
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed) && parsed.length > 0) {
+              return parsed;
+            }
+          }
+        } catch (e) {
+          console.warn("Failed to parse stored fields:", e);
+        }
+
+        return props.fields || [];
+      })(),
       tagIds: props.tagIds || "",
       startDate: props.startDate || null,
       closeDate: props.closeDate || null,
@@ -114,6 +123,15 @@ class AddForm extends React.Component<Props, State> {
           "false",
       ),
     };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.fields !== this.props.fields) {
+      const nextFields = this.props.fields || [];
+      if (nextFields !== this.state.fields) {
+        this.setState({ fields: nextFields });
+      }
+    }
   }
 
   onChangeField = (name: string, value: any) => {


### PR DESCRIPTION
… in componentDidUpdate

## Summary by Sourcery

Initialize AddForm component’s fields state from localStorage with error handling and sync it with incoming props.

New Features:
- Initialize form fields from localStorage on mount
- Sync fields state with updated props.fields in componentDidUpdate

Enhancements:
- Wrap localStorage parsing in try/catch and fall back to props.fields on errors or empty arrays with console warning
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Initialize `fields` state from `localStorage` and sync with `props.fields` in `AddForm` component.
> 
>   - **Behavior**:
>     - Initialize `fields` state from `localStorage` in `AddForm` constructor.
>     - Sync `fields` state with `props.fields` in `componentDidUpdate` if they differ.
>   - **Error Handling**:
>     - Add try-catch block for JSON parsing of `fields` from `localStorage` with a warning log on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for f2e86ab5bd04656c70522fb3f27d7f64978cd938. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->