### PR TITLE
chore: fix routes for erxes messenger preview in channel

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/channels/components/settings/Settings.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/components/settings/Settings.tsx
@@ -40,6 +40,10 @@ const ChannelsSettings = () => {
       <ChannelSettingsPageEffect />
       <Routes>
         <Route
+          path={FrontlinePaths.ErxesMessengerPreview}
+          element={<ErxesMessengerPreview />}
+        />
+        <Route
           element={
             <PageContainer>
               <SettingsHeader breadcrumbs={<ChannelSettingsBreadcrumb />} />
@@ -59,10 +63,6 @@ const ChannelsSettings = () => {
           <Route
             path={FrontlinePaths.ChannelIntegrations}
             element={<IntegrationDetailPage />}
-          />
-          <Route
-            path={FrontlinePaths.ErxesMessengerPreview}
-            element={<ErxesMessengerPreview />}
           />
           <Route
             path={FrontlinePaths.ChannelPipelines}

--- a/frontend/plugins/frontline_ui/src/pages/ErxesMessengerPreview.tsx
+++ b/frontend/plugins/frontline_ui/src/pages/ErxesMessengerPreview.tsx
@@ -21,7 +21,7 @@ export const ErxesMessengerPreview = () => {
   }, [appearance]);
 
   return (
-    <div className="bg-sidebar h-dvh flex items-end justify-end p-5">
+    <div className="bg-accent h-dvh flex items-end justify-end p-5">
       <div>
         <Popover defaultOpen>
           <Popover.Trigger asChild>


### PR DESCRIPTION
## Summary by Sourcery

Fix the routing setup for the ErxesMessengerPreview component within ChannelsSettings and update its styling

Bug Fixes:
- Move ErxesMessengerPreview route into the primary Routes block and remove its duplicate entry

Enhancements:
- Change ErxesMessengerPreview page background class from bg-sidebar to bg-accent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Enhancements**
  * Updated the presentation and styling of the Erxes Messenger Preview page with improved background coloring and layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->