### PR TITLE
fix: cursor null or empty double call

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
@@ -7,7 +7,7 @@ export const useRecordTableCursor = ({
   sessionKey?: string;
 }) => {
   const [cursor, setCursor] = useAtom(
-    recordTableCursorAtomFamily(sessionKey || ''),
+    recordTableCursorAtomFamily(sessionKey ?? '') ?? '',
   );
 
   useEffect(() => {

--- a/frontend/libs/erxes-ui/src/modules/record-table/states/RecordTableCursorState.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/states/RecordTableCursorState.ts
@@ -2,5 +2,5 @@ import { atom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 
 export const recordTableCursorAtomFamily = atomFamily((key: string) =>
-  atom<string | null>(null),
+  atom<string>(''),
 );


### PR DESCRIPTION
## Summary by Sourcery

Prevent null or empty cursor values from causing duplicate hook invocations by defaulting the cursor atom to an empty string and using nullish coalescing for sessionKey

Bug Fixes:
- Change recordTableCursorAtomFamily default from null to empty string to eliminate null cursor handling
- Use nullish coalescing for sessionKey fallback in useRecordTableCursor to correctly derive the atom key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved record table cursor handling to prevent undefined value issues, ensuring more stable and reliable table navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->