### PR TITLE
chore(content): add client portal (cp) GraphQL queries and refactor context

### DIFF
--- a/backend/plugins/content_api/src/connectionResolvers.ts
+++ b/backend/plugins/content_api/src/connectionResolvers.ts
@@ -92,9 +92,8 @@ export interface IContext extends IMainContext {
   models: IModels;
   portalUser: IUserDocument;
   session: any;
-  clientPortalId?: string;
   isPassed2FA?: boolean;
-  subdomain?: string;
+  subdomain: string;
 }
 
 export const loadClasses = (db: mongoose.Connection, subdomain: string): IModels => {

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/category.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/category.ts
@@ -13,12 +13,9 @@ const mutations = {
     args: any,
     context: IContext,
   ): Promise<any> => {
-    const { models, clientPortalId } = context;
+    const { models } = context;
     const { input } = args;
 
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
 
 
     const category = await models.Categories.createCategory(input);
@@ -33,12 +30,8 @@ const mutations = {
     args: any,
     context: IContext,
   ): Promise<any> => {
-    const { models, clientPortalId } = context;
+    const { models } = context;
     const { _id, input } = args;
-
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
 
     return models.Categories.updateCategory(_id, input);
   },

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/menu.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/menu.ts
@@ -6,21 +6,15 @@ import { IContext } from '~/connectionResolvers';
 
 const mutations = {
   cmsAddMenu(_parent: any, args: any, context: IContext) {
-    const { models, clientPortalId } = context;
+    const { models } = context;
     const { input } = args;
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
+
 
     return models.MenuItems.createMenuItem(input);
   },
   cmsEditMenu(_parent: any, args: any, context: IContext) {
-    const { models, clientPortalId } = context;
+    const { models } = context;
     const { _id, input } = args;
-
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
 
     return models.MenuItems.updateMenuItem(_id, input);
   },

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/post.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/post.ts
@@ -2,10 +2,11 @@ import {
   checkPermission,
   requireLogin,
 } from 'erxes-api-shared/core-modules';
+import { Resolver } from 'erxes-api-shared/core-types';
 
 import { IContext } from '~/connectionResolvers';
 
-const mutations = {
+const mutations: Record<string, Resolver> = {
   /**
    * Cms post add
    */
@@ -14,13 +15,9 @@ const mutations = {
     args: any,
     context: IContext,
   ): Promise<any> => {
-    const { models, user, clientPortalId } = context;
+    const { models, user } = context;
     const { input } = args;
     input.authorId = user._id;
-
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
 
     return models.Posts.createPost(input);
   },
@@ -71,7 +68,7 @@ const mutations = {
   /**
    * Cms post increment view count
    */
-  cmsPostsIncrementViewCount: async (
+  cpPostsIncrementViewCount: async (
     _parent: any,
     args: any,
     context: IContext,
@@ -153,5 +150,9 @@ checkPermission(mutations, 'cmsPostsEdit', 'manageCms', []);
 checkPermission(mutations, 'cmsPostsRemove', 'manageCms', []);
 checkPermission(mutations, 'cmsPostsChangeStatus', 'manageCms', []);
 checkPermission(mutations, 'cmsPostsToggleFeatured', 'manageCms', []);
+
+mutations.cpPostsIncrementViewCount.wrapperConfig = {
+  forClientPortal: true,
+};
 
 export default mutations;

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/tag.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/mutations/tag.ts
@@ -14,12 +14,8 @@ const mutations = {
     args: any,
     context: IContext,
   ): Promise<any> => {
-    const { models, clientPortalId } = context;
+    const { models } = context;
     const { input } = args;
-
-    if (clientPortalId) {
-      input.clientPortalId = clientPortalId;
-    }
 
     return models.PostTags.createTag(input);
   },

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/category.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/category.ts
@@ -4,6 +4,7 @@ import {
   FIELD_MAPPINGS,
 } from '@/portal/utils/base-resolvers';
 import { getQueryBuilder } from '@/portal/utils/query-builders';
+import { Resolver } from 'erxes-api-shared/core-types';
 
 class CategoryQueryResolver extends BaseQueryResolver {
   /**
@@ -14,8 +15,7 @@ class CategoryQueryResolver extends BaseQueryResolver {
     args: any,
     context: IContext,
   ): Promise<any> {
-    const { language } = args;
-    const clientPortalId = args.clientPortalId || context.clientPortalId;
+    const { language, clientPortalId } = args;
     const { models } = context;
     const queryBuilder = getQueryBuilder('category', models);
     const query = queryBuilder.buildQuery({ ...args, clientPortalId });
@@ -32,8 +32,8 @@ class CategoryQueryResolver extends BaseQueryResolver {
    * Cms category
    */
   async cmsCategory(_parent: any, args: any, context: IContext): Promise<any> {
-    const { clientPortalId, models } = context;
-    const { _id, slug, language } = args;
+    const {  models } = context;
+    const { _id, slug, language, clientPortalId } = args;
 
     if (!_id && !slug) {
       return null;
@@ -53,12 +53,36 @@ class CategoryQueryResolver extends BaseQueryResolver {
       FIELD_MAPPINGS.CATEGORY,
     );
   }
+
+  async cpCategories(_parent: any, args: any, context: IContext): Promise<any> {
+    const { models, clientPortal } = context;
+    const { language } = args;
+
+    const query: any = {
+      clientPortalId: clientPortal._id,
+      status: 'active',
+    };
+
+    const { list } = await this.getListWithTranslations(
+      models.Categories,
+      query,
+      { ...args, clientPortalId: clientPortal._id, language },
+      FIELD_MAPPINGS.CATEGORY,
+    );
+
+    return list;
+  }
 }
 
 const resolver = new CategoryQueryResolver({} as IContext);
-const queries = {
+const queries: Record<string, Resolver> = {
   cmsCategories: resolver.cmsCategories.bind(resolver),
   cmsCategory: resolver.cmsCategory.bind(resolver),
+  cpCategories: resolver.cpCategories.bind(resolver),
+};
+
+queries.cpCategories.wrapperConfig = {
+  forClientPortal: true,
 };
 
 export default queries;

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/menu.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/menu.ts
@@ -1,10 +1,10 @@
 import { IContext } from '~/connectionResolvers';
+import { Resolver } from 'erxes-api-shared/core-types';
 
-const queries = {
+const queries: Record<string, Resolver> = {
   cmsMenuList: async (_parent: any, args: any, context: IContext) => {
     const { models } = context;
-    const { kind, language } = args;
-    const clientPortalId = context.clientPortalId || args.clientPortalId;
+    const { kind, language, clientPortalId } = args;
 
     if (!clientPortalId) {
       throw new Error('clientPortalId is required');
@@ -77,6 +77,51 @@ const queries = {
       }),
     };
   },
+
+  cpMenus: async (_parent: any, args: any, context: IContext) => {
+    const { models, clientPortal } = context;
+    const { language } = args;
+
+    const query: any = {
+      clientPortalId: clientPortal._id,
+      isActive: true,
+    };
+
+    const menus = await models.MenuItems.find(query).sort({ order: 1 });
+
+    if (!language) {
+      return menus;
+    }
+
+    const menuIds = menus.map((menu) => menu._id);
+
+    const translations = await models.Translations.find({
+      postId: { $in: menuIds },
+      language,
+    }).lean();
+
+    // ✅ Build a translation map for O(1) lookup
+    const translationMap = translations.reduce((acc, t) => {
+      acc[t.postId.toString()] = t;
+      return acc;
+    }, {} as Record<string, any>);
+
+    const menusWithTranslations = menus.map((menu) => {
+      const translation = translationMap[menu._id.toString()];
+      return {
+        ...menu,
+        ...(translation && {
+          label: translation.title || menu.label,
+        }),
+      };
+    });
+
+    return menusWithTranslations;
+  },
+};
+
+queries.cpMenus.wrapperConfig = {
+  forClientPortal: true,
 };
 
 export default queries;

--- a/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/page.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/resolvers/queries/page.ts
@@ -1,11 +1,11 @@
 import { IContext } from '~/connectionResolvers';
 import { BaseQueryResolver, FIELD_MAPPINGS } from '@/portal/utils/base-resolvers';
 import { getQueryBuilder } from '@/portal/utils/query-builders';
+import { Resolver } from 'erxes-api-shared/core-types';
 
 class PageQueryResolver extends BaseQueryResolver {
   async cmsPages(_parent: any, args: any, context: IContext) {
-    const { language } = args;
-    const clientPortalId = context.clientPortalId || args.clientPortalId;
+    const { language, clientPortalId } = args;
     const { models } = context;
     if (!clientPortalId) {
       throw new Error('clientPortalId is required');
@@ -25,8 +25,7 @@ class PageQueryResolver extends BaseQueryResolver {
   }
 
   async cmsPageList(_parent: any, args: any, context: IContext) {
-    const { language } = args;
-    const clientPortalId = context.clientPortalId || args.clientPortalId;
+    const { language, clientPortalId } = args;
     const { models } = context; 
     if (!clientPortalId) {
       throw new Error('clientPortalId is required');
@@ -46,8 +45,8 @@ class PageQueryResolver extends BaseQueryResolver {
   }
 
   async cmsPage(_parent: any, args: any, context: IContext) {
-    const { clientPortalId, models } = context;
-    const { _id, slug, language } = args;
+    const {  models } = context;
+    const { _id, slug, language, clientPortalId } = args;
 
     if (!_id && !slug) {
       return null;
@@ -67,15 +66,38 @@ class PageQueryResolver extends BaseQueryResolver {
       FIELD_MAPPINGS.PAGE
     );
   }
+
+  async cpPages(_parent: any, args: any, context: IContext) {
+    const { models, clientPortal } = context;
+    const { language } = args;
+
+    const query: any = {
+      clientPortalId: clientPortal._id,
+      isActive: true,
+    };
+
+    const { list } = await this.getListWithTranslations(
+      models.Pages,
+      query,
+      { ...args, clientPortalId: clientPortal._id, language },
+      FIELD_MAPPINGS.PAGE
+    );
+
+    return list;
+  }
 }
 
-const queries = {
+const queries: Record<string, Resolver> = {
   cmsPages: (_parent: any, args: any, context: IContext) =>
     new PageQueryResolver(context).cmsPages(_parent, args, context),
   cmsPageList: (_parent: any, args: any, context: IContext) =>
     new PageQueryResolver(context).cmsPageList(_parent, args, context),
   cmsPage: (_parent: any, args: any, context: IContext) =>
     new PageQueryResolver(context).cmsPage(_parent, args, context),
+};
+
+queries.cpPages.wrapperConfig = {
+  forClientPortal: true,
 };
 
 export default queries;

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/category.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/category.ts
@@ -46,7 +46,9 @@ export const inputs = `
 
 export const queries = `
     cmsCategories(clientPortalId: String, language: String, searchValue: String, status: CategoryStatus, ${GQL_CURSOR_PARAM_DEFS}, sortField: String, sortDirection: String): PostCategoryListResponse
-    cmsCategory(_id: String, slug: String, language: String): PostCategory
+    cmsCategory(_id: String, slug: String, language: String, clientPortalId: String): PostCategory
+
+    cpCmsCategories(language: String): [PostCategory]
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/customPostType.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/customPostType.ts
@@ -75,6 +75,9 @@ export const queries = `
   cmsCustomFieldGroupList(clientPortalId: String!, searchValue: String, ${GQL_CURSOR_PARAM_DEFS}): CustomFieldGroupResponse
   cmsCustomFieldGroups(clientPortalId: String!, pageId: String, categoryId: String, postType: String, searchValue: String, ${GQL_CURSOR_PARAM_DEFS}): [CustomFieldGroup]
   cmsCustomFieldGroup(_id: String): CustomFieldGroup
+
+  cpCustomPostTypes(searchValue: String): [CustomPostType]
+  cpCustomFieldGroups(searchValue: String, pageId: String, categoryId: String, postType: String): [CustomFieldGroup]
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/menu.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/menu.ts
@@ -41,6 +41,8 @@ export const inputs = `
 export const queries = `
     cmsMenuList(clientPortalId: String, kind: String, language: String, ${GQL_CURSOR_PARAM_DEFS}): [MenuItem]
     cmsMenu(_id: String!, language: String): MenuItem
+
+    cpMenus(language: String, kind: String): [MenuItem]
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/page.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/page.ts
@@ -68,9 +68,11 @@ export const inputs = `
 `;
 
 export const queries = `
-    cmsPage(_id: String, slug: String, language: String): Page
+    cmsPage(_id: String, slug: String, language: String, clientPortalId: String): Page
     cmsPages(clientPortalId: String, searchValue: String, language: String, ${GQL_CURSOR_PARAM_DEFS}): [Page]
     cmsPageList(clientPortalId: String, searchValue: String, language: String, ${GQL_CURSOR_PARAM_DEFS}): PageList
+    
+    cpPages(language: String): [Page]
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/post.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/post.ts
@@ -117,11 +117,28 @@ export const inputs = `
     }
 `;
 
+const commonPostQuerySelector = `
+    ${GQL_CURSOR_PARAM_DEFS}
+    featured: Boolean
+    type: String
+    categoryId: String
+    searchValue: String
+    status: PostStatus
+    tagIds: [String]
+    sortField: String
+    sortDirection: String
+    language: String
+`;
+
 export const queries = `
     cmsPost(_id: String, slug: String, language: String): Post
-    cmsPosts(clientPortalId: String, featured: Boolean,type: String, categoryId: String, searchValue: String, status: PostStatus, tagIds: [String], sortField: String, sortDirection: String, language: String, language: String, ${GQL_CURSOR_PARAM_DEFS}): [Post]
-    cmsPostList(clientPortalId: String, featured: Boolean, type: String, categoryId: String, searchValue: String, status: PostStatus, tagIds: [String], sortField: String, sortDirection: String, language: String, language: String, ${GQL_CURSOR_PARAM_DEFS}): PostList
+    cmsPosts(clientPortalId: String, ${commonPostQuerySelector}): [Post]
+    cmsPostList(clientPortalId: String, ${commonPostQuerySelector}): PostList
     cmsTranslations(postId: String): [Translation]
+
+    cpPosts(language: String, ${commonPostQuerySelector}): [Post]
+    cpPostList(language: String, ${commonPostQuerySelector}): PostList
+    cpPost(_id: String, slug: String, language: String, clientPortalId: String): Post
 `;
 
 export const mutations = `
@@ -131,7 +148,7 @@ export const mutations = `
     cmsPostsChangeStatus(_id: String!, status: PostStatus!): Post
     cmsPostsToggleFeatured(_id: String!): Post
 
-    cmsPostsIncrementViewCount(_id: String!): Post
+    cpPostsIncrementViewCount(_id: String!): Post
 
     cmsAddTranslation(input: TranslationInput!): Translation
     cmsEditTranslation(input: TranslationInput!): Translation

--- a/backend/plugins/content_api/src/modules/portal/graphql/schemas/tag.ts
+++ b/backend/plugins/content_api/src/modules/portal/graphql/schemas/tag.ts
@@ -29,9 +29,20 @@ export const inputs = `
 
 `;
 
+const commonTagQuerySelector = `
+    ${GQL_CURSOR_PARAM_DEFS}
+    language: String
+    searchValue: String
+    sortField: String
+    sortDirection: String
+`;
+
 export const queries = `
-    cmsTags(clientPortalId: String, language: String, searchValue: String, sortField: String, sortDirection: String, ${GQL_CURSOR_PARAM_DEFS}): PostTagList
+    cmsTags(clientPortalId: String, ${commonTagQuerySelector}): PostTagList
     cmsTag(_id: String, slug: String, language: String): PostTag
+
+    cpCmsTags(language: String, ${commonTagQuerySelector}): PostTagList
+    
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/portal/utils/base-resolvers.ts
+++ b/backend/plugins/content_api/src/modules/portal/utils/base-resolvers.ts
@@ -169,12 +169,12 @@ export class BaseQueryResolver {
       return { list, totalCount, pageInfo };
     }
 
-    if (!args.clientPortalId && !this.context.clientPortalId) {
+    if (!args.clientPortalId && !this.context.clientPortal._id) {
       throw new Error('Client portal ID is required');
     }
 
     const shouldSkip = await this.shouldSkipTranslation(
-      args.clientPortalId || this.context.clientPortalId || '',
+      args.clientPortalId || this.context.clientPortal._id || '',
       args.language || '',
     );
 


### PR DESCRIPTION
Introduces new 'cp' (client portal) prefixed GraphQL queries for categories, custom post types, menus, pages, posts, and tags, enabling client portal-specific data retrieval. Refactors context usage to rely on 'clientPortal' object instead of 'clientPortalId' in most resolvers, removes legacy 'clientPortalId' propagation in mutations, and updates schema definitions to include new queries and arguments. Also standardizes resolver typing and improves translation handling for client portal queries.

## Summary by Sourcery

Introduce client portal-specific GraphQL endpoints and refactor context handling for content API

New Features:
- Add cp* queries for tags, categories, custom post types, menus, pages, and posts to support client portal data retrieval

Enhancements:
- Refactor resolvers to use context.clientPortal._id instead of legacy clientPortalId and remove its propagation in mutations
- Standardize resolver typing with core-types Resolver and consolidate common query argument definitions in schemas
- Improve translation merging for client portal tag and menu queries

Chores:
- Update GraphQL schemas to include new cp queries and shared argument selectors
- Remove deprecated clientPortalId from IContext and enforce clientPortal in base resolvers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new client portal GraphQL queries: `cpPages`, `cpPosts`, `cpPostList`, `cpPost`, `cpMenus`, `cpCmsTags`, `cpCategories`, `cpCustomPostTypes`, and `cpCustomFieldGroups` for portal-scoped data access.

* **API Updates**
  * Updated `cmsCategory`, `cmsPage`, and related queries to accept `clientPortalId` parameter.
  * Renamed mutation `cmsPostsIncrementViewCount` to `cpPostsIncrementViewCount`.
  * Refined context handling for subdomain resolution in portal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->