### PR TITLE
refactor: replace ComponentsPath enum with ComponentsPaths map and ad…

### DIFF
--- a/frontend/core-ui/src/modules/app/components/ComponentsRoutes.tsx
+++ b/frontend/core-ui/src/modules/app/components/ComponentsRoutes.tsx
@@ -1,11 +1,17 @@
 import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 
-import { ComponentsPath } from '@/types/paths/ComponentsPath';
+import { ComponentsPaths } from '@/types/paths/ComponentsPaths';
 
 const SelectComponentsIndexPage = lazy(() =>
   import('~/pages/components/SelectComponentIndexPage').then((module) => ({
     default: module.SelectComponentIndexPage,
+  })),
+);
+
+const ReportPage = lazy(() =>
+  import('~/pages/components/Reportpage').then((module) => ({
+    default: module.ReportPage,
   })),
 );
 
@@ -17,15 +23,16 @@ export const ComponentsRoutes = () => {
           path="/"
           element={
             <Navigate
-              to={`${ComponentsPath.Index}${ComponentsPath.Select}`}
+              to={`${ComponentsPaths.Index}${ComponentsPaths.Select}`}
               replace
             />
           }
         />
         <Route
-          path={ComponentsPath.Select}
+          path={ComponentsPaths.Select}
           element={<SelectComponentsIndexPage />}
         />
+        <Route path={ComponentsPaths.Report} element={<ReportPage />} />
       </Routes>
     </Suspense>
   );

--- a/frontend/core-ui/src/modules/app/components/ComponentsRoutes.tsx
+++ b/frontend/core-ui/src/modules/app/components/ComponentsRoutes.tsx
@@ -10,7 +10,7 @@ const SelectComponentsIndexPage = lazy(() =>
 );
 
 const ReportPage = lazy(() =>
-  import('~/pages/components/Reportpage').then((module) => ({
+  import('~/pages/components/ReportPage').then((module) => ({
     default: module.ReportPage,
   })),
 );

--- a/frontend/core-ui/src/modules/types/paths/ComponentsPath.ts
+++ b/frontend/core-ui/src/modules/types/paths/ComponentsPath.ts
@@ -1,4 +1,0 @@
-export enum ComponentsPath {
-  Index = '/components',
-  Select = '/select',
-}

--- a/frontend/core-ui/src/modules/types/paths/ComponentsPaths.ts
+++ b/frontend/core-ui/src/modules/types/paths/ComponentsPaths.ts
@@ -1,0 +1,5 @@
+export enum ComponentsPaths {
+  Index = '/components',
+  Select = '/select',
+  Report = '/report',
+}

--- a/frontend/core-ui/src/pages/components/ReportPage.tsx
+++ b/frontend/core-ui/src/pages/components/ReportPage.tsx
@@ -1,0 +1,104 @@
+import { ReportTable, Separator } from 'erxes-ui';
+import { ReportPageContainer } from 'erxes-ui';
+
+export const ReportPage = () => {
+  return (
+    <ReportPageContainer>
+      <h1 className="text-[2em] leading-tight font-bold text-center py-[1em]">
+        Гүйлгээ баланс
+      </h1>
+      <div className="flex justify-between pb-[2em]">
+        <div className="flex flex-col gap-1">
+          <p className="font-bold">Нью Панда ХХК</p>
+          <Separator className="print:bg-foreground bg-border" />
+          <p>(Аж ахуй нэгж албан байгууллагын нэр)</p>
+        </div>
+        <div className="flex flex-col gap-1 text-right">
+          <p>2025/11/01 - 2025/11/30</p>
+          <p>(төгрөгөөр)</p>
+        </div>
+      </div>
+      <DemoContent />
+      <div className="py-8 flex flex-col gap-4 pl-[30%]">
+        <div>
+          Тайлан гаргасан: ................................../help_s@erkhet.biz/
+        </div>
+        <div>
+          Хянасан нягтлан бодогч: ................................../
+          Б.Эрдэнэцэцэг /
+        </div>
+      </div>
+    </ReportPageContainer>
+  );
+};
+
+export const ReportStyle = () => {
+  return (
+    <style>
+      {`
+      @page {
+        margin: 0;
+        background: white;
+        margin-top: 5mm; 
+      }
+
+      
+      table { page-break-after: auto; }
+      table tr { page-break-inside: avoid; page-break-after: auto; }
+      table td { page-break-inside: avoid; page-break-after: auto; }
+      
+    `}
+    </style>
+  );
+};
+
+const DemoContent = () => (
+  <ReportTable>
+    <ReportTable.Header>
+      <ReportTable.Row>
+        <ReportTable.Head rowSpan={2}>Код</ReportTable.Head>
+        <ReportTable.Head rowSpan={2}>Нэр</ReportTable.Head>
+        <ReportTable.Head colSpan={2}>Эхний үлдэгдэл</ReportTable.Head>
+        <ReportTable.Head colSpan={2}>Гүйлгээ</ReportTable.Head>
+        <ReportTable.Head colSpan={2}>Эцсийн үлдэгдэл</ReportTable.Head>
+      </ReportTable.Row>
+      <ReportTable.Row>
+        <ReportTable.Head>Дебет</ReportTable.Head>
+        <ReportTable.Head>Кредит</ReportTable.Head>
+        <ReportTable.Head>Дебет</ReportTable.Head>
+        <ReportTable.Head>Кредит</ReportTable.Head>
+        <ReportTable.Head>Дебет</ReportTable.Head>
+        <ReportTable.Head>Кредит</ReportTable.Head>
+      </ReportTable.Row>
+    </ReportTable.Header>
+    <ReportTable.Body>
+      {Array.from({ length: 100 }).map((_, index) => (
+        <ReportTable.Row data-value="" key={index}>
+          <ReportTable.Cell>{index + 1}</ReportTable.Cell>
+          <ReportTable.Cell className="overflow-hidden text-ellipsis">
+            Кассанд байгаа бэлэн мөнгө (төгрөг)
+          </ReportTable.Cell>
+          <ReportTable.Cell>545,451,961.59</ReportTable.Cell>
+          <ReportTable.Cell>0</ReportTable.Cell>
+          <ReportTable.Cell>0</ReportTable.Cell>
+          <ReportTable.Cell>0</ReportTable.Cell>
+          <ReportTable.Cell>545,451,961.59</ReportTable.Cell>
+          <ReportTable.Cell>0</ReportTable.Cell>
+        </ReportTable.Row>
+      ))}
+    </ReportTable.Body>
+
+    <ReportTable.Footer>
+      <ReportTable.Row>
+        <ReportTable.Cell></ReportTable.Cell>
+        <ReportTable.Cell className="text-right">НИЙТ ДҮН:</ReportTable.Cell>
+        <ReportTable.Cell>1,026,567,988.52</ReportTable.Cell>
+        <ReportTable.Cell>1,026,567,988.53</ReportTable.Cell>
+        <ReportTable.Cell>34,520,389.77</ReportTable.Cell>
+        <ReportTable.Cell>34,520,389.77</ReportTable.Cell>
+        <ReportTable.Cell>1,011,588,393.92</ReportTable.Cell>
+        <ReportTable.Cell>1,011,588,393.93</ReportTable.Cell>
+      </ReportTable.Row>
+    </ReportTable.Footer>
+  </ReportTable>
+);

--- a/frontend/libs/erxes-ui/src/modules/index.ts
+++ b/frontend/libs/erxes-ui/src/modules/index.ts
@@ -2,6 +2,7 @@ export * from './blocks';
 export * from './hotkey';
 export * from './select-tree';
 export * from './record-table';
+export * from './report';
 export * from './record-field';
 export * from './filter';
 export * from './side-menu/components/SideMenu';
@@ -15,4 +16,3 @@ export * from './navigation-menu';
 export * from './board';
 export * from './motion';
 export * from './select-operation';
-

--- a/frontend/libs/erxes-ui/src/modules/report/components/report-page-container.tsx
+++ b/frontend/libs/erxes-ui/src/modules/report/components/report-page-container.tsx
@@ -1,0 +1,179 @@
+import {
+  IconChevronDown,
+  IconFileSpreadsheet,
+  IconMinus,
+  IconPercentage,
+  IconPlus,
+  IconPrinter,
+} from '@tabler/icons-react';
+import {
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  Popover,
+  ScrollArea,
+  Separator,
+  Toggle,
+} from 'erxes-ui/components';
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { useQueryState } from 'erxes-ui/hooks/use-query-state';
+import { PageContainer } from 'erxes-ui/modules/layout';
+import { printSettingsAtom } from '../states/reportSettingsState';
+
+export const ReportPageContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [inPreview, setInPreview] = useQueryState<boolean>('inPreview');
+  const [{ printsize, showTableLayoutOnEveryPage }, setPrintSettings] =
+    useAtom(printSettingsAtom);
+  useEffect(() => {
+    if (!inPreview) {
+      setInPreview(true);
+    }
+  }, []);
+
+  const printsizeToFontSize = (size: number) => {
+    const margin = (100 - size) / 10;
+
+    return `${12 - margin}px`;
+  };
+
+  const handlePrintsizeChange = (size: number) => {
+    if (size < 60) {
+      return;
+    }
+
+    if (size > 160) {
+      return;
+    }
+
+    setPrintSettings((prev) => ({ ...prev, printsize: size }));
+  };
+
+  return (
+    <PageContainer className="h-dvh print:h-auto print:block">
+      <header className="flex items-center justify-between h-13 px-3 box-border shrink-0 bg-sidebar overflow-auto styled-scroll print:hidden">
+        <div className="flex items-center gap-2 flex-none pr-8">
+          <Button variant="ghost">Report</Button>
+          <Separator.Inline />
+          <Toggle pressed={!!inPreview} onPressedChange={setInPreview}>
+            {inPreview ? 'hide sidebar' : 'show sidebar'}
+          </Toggle>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            variant="secondary"
+            size="icon"
+            className="bg-border"
+            onClick={() => handlePrintsizeChange(printsize - 10)}
+          >
+            <IconMinus />
+          </Button>
+          <div className="relative">
+            <Input className="w-20 pr-8 text-center" value={printsize} />
+            <Button
+              variant="secondary"
+              size="icon"
+              className="absolute right-0.5 top-0.5 hover:bg-muted"
+            >
+              <IconPercentage />
+            </Button>
+          </div>
+          <Button
+            variant="secondary"
+            size="icon"
+            className="bg-border"
+            onClick={() => handlePrintsizeChange(printsize + 10)}
+          >
+            <IconPlus />
+          </Button>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button variant="outline">
+            <IconFileSpreadsheet />
+            Export to excel
+          </Button>
+          <div className="inline-flex rounded shadow-sm">
+            <Button
+              onClick={() => window.print()}
+              variant="ghost"
+              className="rounded-r-none"
+            >
+              <IconPrinter />
+              Print
+            </Button>
+            <Separator orientation="vertical" className="h-7" />
+            <Popover>
+              <Popover.Trigger asChild>
+                <Button variant="ghost" size="icon" className="rounded-l-none">
+                  <IconChevronDown />
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content>
+                <Label variant="peer" className="font-medium">
+                  Print settings
+                </Label>
+                <div className="flex flex-col gap-2 pt-4 pb-2">
+                  <Label>Table</Label>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="show-table-header-on-every-page"
+                      checked={showTableLayoutOnEveryPage}
+                      onCheckedChange={(value) =>
+                        setPrintSettings((prev) => ({
+                          ...prev,
+                          showTableLayoutOnEveryPage: !!value,
+                        }))
+                      }
+                    />
+                    <Label
+                      variant="peer"
+                      htmlFor="show-table-header-on-every-page"
+                    >
+                      Show table layout on every page
+                    </Label>
+                  </div>
+                </div>
+              </Popover.Content>
+            </Popover>
+          </div>
+        </div>
+      </header>
+      <Separator />
+      <ReportStyle />
+      <ScrollArea className="bg-sidebar flex-auto">
+        <div
+          className="m-4 bg-background shadow-sm mx-auto max-w-5xl pl-15 p-8 print:shadow-none"
+          style={{ fontSize: printsizeToFontSize(printsize) }}
+        >
+          {children}
+        </div>
+      </ScrollArea>
+    </PageContainer>
+  );
+};
+
+export const ReportStyle = () => {
+  return (
+    <style>
+      {`
+        @page {
+          margin: 0;
+          background: white;
+          margin-top: 5mm; 
+        }
+  
+        
+        table { page-break-after: auto; }
+        table tr { page-break-inside: avoid; page-break-after: auto; }
+        table td { page-break-inside: avoid; page-break-after: auto; }
+        
+      `}
+    </style>
+  );
+};

--- a/frontend/libs/erxes-ui/src/modules/report/components/report-table.tsx
+++ b/frontend/libs/erxes-ui/src/modules/report/components/report-table.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+
+import { cn } from 'erxes-ui/lib/utils';
+
+function ReportTableRoot({
+  className,
+  ...props
+}: React.ComponentProps<'table'>) {
+  return (
+    <table
+      data-slot="table"
+      className={cn(
+        'w-full overflow-hidden caption-bottom text-[1em]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ReportTableHeader({
+  className,
+  ...props
+}: React.ComponentProps<'thead'>) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn('[&_tr]:border', className)}
+      {...props}
+    />
+  );
+}
+
+function ReportTableBody({
+  className,
+  ...props
+}: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function ReportTableFooter({
+  className,
+  ...props
+}: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ReportTableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ReportTableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-[2.5em] px-[0.5em] text-left align-middle font-medium border',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ReportTableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-[0.5em] align-middle border text-[1em] whitespace-normal break-all',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ReportTableCaption({
+  className,
+  ...props
+}: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-[1em] text-[1em]', className)}
+      {...props}
+    />
+  );
+}
+
+export const ReportTable = Object.assign(ReportTableRoot, {
+  Header: ReportTableHeader,
+  Body: ReportTableBody,
+  Footer: ReportTableFooter,
+  Head: ReportTableHead,
+  Row: ReportTableRow,
+  Cell: ReportTableCell,
+  Caption: ReportTableCaption,
+});

--- a/frontend/libs/erxes-ui/src/modules/report/index.ts
+++ b/frontend/libs/erxes-ui/src/modules/report/index.ts
@@ -1,0 +1,2 @@
+export * from './components/report-table';
+export * from './components/report-page-container';

--- a/frontend/libs/erxes-ui/src/modules/report/states/reportSettingsState.ts
+++ b/frontend/libs/erxes-ui/src/modules/report/states/reportSettingsState.ts
@@ -1,0 +1,9 @@
+import { atomWithStorage } from 'jotai/utils';
+
+export const printSettingsAtom = atomWithStorage<{
+  showTableLayoutOnEveryPage: boolean;
+  printsize: number;
+}>('printSettings', {
+  printsize: 100,
+  showTableLayoutOnEveryPage: true,
+});


### PR DESCRIPTION
…d ReportPage route

## Summary by Sourcery

Introduce a new report page and routing while refactoring component path definitions to use a ComponentsPaths enum.

New Features:
- Add a report page component with a printable, exportable report layout using a reusable page container and table components.
- Expose new report UI modules (report page container and report table) through the erxes-ui library and add a /components/report route.

Enhancements:
- Replace the ComponentsPath enum with a ComponentsPaths enum that includes the new report route and update routing to use it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce a new report page with a printable layout and refactor component path definitions to use `ComponentsPaths` enum.
> 
>   - **New Features**:
>     - Add `ReportPage` component in `ReportPage.tsx` with printable and exportable report layout.
>     - Introduce `ReportTable` and `ReportPageContainer` components with print-specific styling in `report-table.tsx` and `report-page-container.tsx`.
>     - Add `/components/report` route in `ComponentsRoutes.tsx`.
>   - **Refactoring**:
>     - Replace `ComponentsPath` enum with `ComponentsPaths` in `ComponentsRoutes.tsx` and `ComponentsPaths.ts`.
>   - **Enhancements**:
>     - Add print controls and customizable settings in `report-page-container.tsx`.
>     - Export new report components in `index.ts` of `erxes-ui` module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for eec9eefebae654babd09ef88129584015010b4ce. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Reports page accessible at /report with printable layout and sample data preview.
  * Print controls: adjustable print size (60–160%), export/print actions, and preview mode.
  * Persistent print settings (including table-layout-on-every-page) across sessions.
  * New report table with print-aware styling and improved page-break behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->