### PR TITLE
fix: show deals total numbers

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardColumn.tsx
@@ -31,6 +31,7 @@ export function DealsBoardColumn({
   const prevTriggerRef = useRef(fetchMoreTrigger);
   const prevDealsCountRef = useRef(0);
   const isFetchingRef = useRef(false);
+  const initialLoadRef = useRef(true);
 
   const queryVariablesKey = useMemo(
     () => JSON.stringify(queryVariables),
@@ -44,6 +45,7 @@ export function DealsBoardColumn({
       prevDealsCountRef.current = 0;
       prevTriggerRef.current = 0;
       isFetchingRef.current = false;
+      initialLoadRef.current = true;
     }
   }, [queryVariablesKey]);
 
@@ -115,19 +117,16 @@ export function DealsBoardColumn({
     }
 
     if (
-      isFetchingRef.current &&
-      dealItems.length !== prevDealsCountRef.current
+      initialLoadRef.current ||
+      (isFetchingRef.current && dealItems.length !== prevDealsCountRef.current)
     ) {
-      const newlyFetched = Math.max(
-        0,
-        dealItems.length - prevDealsCountRef.current,
-      );
       onFetchComplete?.(column._id, {
-        fetchedCount: newlyFetched,
+        fetchedCount: dealItems.length,
         hasMore: pageInfo?.hasNextPage ?? false,
         cursor: pageInfo?.endCursor,
         totalCount,
       });
+      initialLoadRef.current = false;
       isFetchingRef.current = false;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix deal fetch completion handler to use the full current deal count and trigger on initial load so total numbers are accurate.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes deal count display by tracking initial load state in `DealsBoardColumn.tsx`.
> 
>   - **Behavior**:
>     - Adds `initialLoadRef` in `DealsBoardColumn.tsx` to track initial load state.
>     - Updates `onFetchComplete` to use `dealItems.length` for `fetchedCount` during initial load or when fetching is complete.
>     - Resets `initialLoadRef` to `false` after initial load is processed.
>   - **Logic**:
>     - Modifies condition in `useEffect` to trigger `onFetchComplete` when `initialLoadRef` is `true` or `isFetchingRef` is `true` and `dealItems.length` changes.
>     - Resets `initialLoadRef` and `isFetchingRef` in `useEffect` after `onFetchComplete` is called.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 3de7632678e24ed19de64f1b720efa939814997e. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deal loading behavior in the Deals Board. Fixed how the system counts and displays deals on initial load versus subsequent fetches, ensuring accurate deal counts are reflected in the board view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->