### PR TITLE
added: sales close date warning

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
@@ -76,12 +76,14 @@ export const DealsBoardCard = memo(function DealsBoardCard({
     >
       <div className="flex items-center justify-between h-9 px-1.5">
         <DateSelectDeal
+          placeholder="Start Date"
           value={startDate}
           id={_id}
           type="startDate"
           variant="card"
         />
         <DateSelectDeal
+          placeholder="Close Date"
           value={closeDate}
           id={_id}
           type="closeDate"

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/DateSelectDeal.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/DateSelectDeal.tsx
@@ -9,7 +9,11 @@ import {
   Button,
   Form,
 } from 'erxes-ui';
-import { IconCalendarPlus, IconCalendarTime } from '@tabler/icons-react';
+import {
+  IconCalendarPlus,
+  IconCalendarTime,
+  IconAlertCircleFilled,
+} from '@tabler/icons-react';
 import { type ApolloError } from '@apollo/client';
 import { useDealsEdit } from '@/deals/cards/hooks/useDeals';
 
@@ -138,15 +142,33 @@ export const DateSelectDealRoot = ({
   type,
   scope,
   variant = DateSelectVariant.TABLE,
+  placeholder,
 }: {
   value?: Date | string;
   id?: string;
   type: 'startDate' | 'closeDate';
   scope?: string;
   variant?: `${DateSelectVariant}`;
+  placeholder: string;
 }) => {
   const [open, setOpen] = useState(false);
   const { editDeals, loading, error } = useDealsEdit();
+  const closeDate = type === 'closeDate';
+  const now = new Date();
+  const closeDateValue = closeDate && value && new Date(value);
+  const isEnded = closeDateValue && closeDateValue < now;
+  const formatted =
+    value &&
+    new Date(value).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+
+  const EndedDiff = closeDateValue
+    ? Math.floor(
+        (now.getTime() - closeDateValue.getTime()) / (1000 * 60 * 60 * 24),
+      )
+    : 0;
 
   const handleValueChange = (value?: Date) => {
     if (id) {
@@ -162,6 +184,31 @@ export const DateSelectDealRoot = ({
 
   const Content =
     variant === 'table' ? RecordTableInlineCell.Content : Combobox.Content;
+  if (closeDate && value && isEnded) {
+    return (
+      <>
+        <DateSelectProvider
+          value={value ? new Date(value) : undefined}
+          onValueChange={handleValueChange}
+          variant={variant as DateSelectVariant}
+          loading={loading}
+          error={error}
+        >
+          <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
+            <DateSelectTrigger>
+              <div className="text-gray-500 text-sm bg-yellow-50 text-yellow-400 px-2 py-1 rounded flex items-center gap-1">
+                <IconAlertCircleFilled className="size-4" />
+                Ended {EndedDiff} days ago {formatted && `(${formatted})`}
+              </div>
+            </DateSelectTrigger>
+            <Content className="w-fit" onClick={(e) => e.stopPropagation()}>
+              <DateSelectContent />
+            </Content>
+          </PopoverScoped>
+        </DateSelectProvider>
+      </>
+    );
+  }
 
   return (
     <DateSelectProvider
@@ -173,7 +220,7 @@ export const DateSelectDealRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder="Not specified" />
+          <DateSelectValue placeholder={placeholder} />
         </DateSelectTrigger>
         <Content className="w-fit" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />


### PR DESCRIPTION
## Summary by Sourcery

Add close date expiry warning to deal date selector and support configurable placeholders for start and close dates in deal cards.

New Features:
- Display a warning label when a deal's close date is in the past within the date selector.
- Allow the deal date selector to accept a customizable placeholder label for date fields.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning for past close dates in `DateSelectDealRoot`, displaying days since close date and formatted date, and updates `DealsBoardCard` to use this feature.
> 
>   - **Behavior**:
>     - Adds warning for past close dates in `DateSelectDealRoot` in `DateSelectDeal.tsx`.
>     - Displays warning with days since close date and formatted date.
>   - **Components**:
>     - Updates `DealsBoardCard` in `DealsBoardCard.tsx` to use updated `DateSelectDeal` with close date warning.
>   - **Icons**:
>     - Adds `IconAlertCircleFilled` for warning display in `DateSelectDeal.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for c3a3b7ff2b4fcc78139059b9a9832af786a183bd. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicator for ended deals displaying "Ended X days ago" with an alert icon when the close date has passed
  * Improved date field clarity with added placeholder text ("Start Date" and "Close Date") in deal boards

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->