### PR TITLE
refactor: centralize broadcast config handling

### DIFF
--- a/backend/core-api/src/modules/broadcast/db/models/Engages.ts
+++ b/backend/core-api/src/modules/broadcast/db/models/Engages.ts
@@ -21,6 +21,8 @@ import {
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
+import { ISESConfig } from '@/organization/settings/db/definitions/configs';
+import { getValueAsString } from '@/organization/settings/db/models/Configs';
 
 export interface IEngageMessageModel extends Model<IEngageMessageDocument> {
   getEngageMessage(_id: string): Promise<IEngageMessageDocument>;
@@ -62,6 +64,7 @@ export interface IEngageMessageModel extends Model<IEngageMessageDocument> {
     visitorId?: string;
     browserInfo: any;
   }): Promise<IMessageDocument[]>;
+  broadcastConfigs(): Promise<ISESConfig>;
 }
 
 export const loadEngageMessageClass = (models: IModels, subdomain: string) => {
@@ -437,6 +440,40 @@ export const loadEngageMessageClass = (models: IModels, subdomain: string) => {
           engageData,
         },
       });
+    }
+
+    public static async broadcastConfigs() {
+      const accessKeyId = await getValueAsString(
+        models,
+        'BROADCAST_AWS_SES_ACCESS_KEY_ID',
+        'BROADCAST_AWS_SES_ACCESS_KEY_ID',
+      );
+    
+      const secretAccessKey = await getValueAsString(
+        models,
+        'BROADCAST_AWS_SES_SECRET_ACCESS_KEY',
+        'BROADCAST_AWS_SES_SECRET_ACCESS_KEY',
+      );
+    
+      const region = await getValueAsString(
+        models,
+        'BROADCAST_AWS_REGION',
+        'BROADCAST_AWS_REGION',
+      );
+    
+      const unverifiedEmailsLimit = await getValueAsString(
+        models,
+        'BROADCAST_UNVERIFIED_EMAILS_LIMIT',
+        'BROADCAST_UNVERIFIED_EMAILS_LIMIT',
+        '100',
+      );
+    
+      return {
+        accessKeyId,
+        secretAccessKey,
+        region,
+        unverifiedEmailsLimit,
+      };
     }
   }
 

--- a/backend/core-api/src/modules/broadcast/trackers/engage.ts
+++ b/backend/core-api/src/modules/broadcast/trackers/engage.ts
@@ -7,37 +7,7 @@ import { generateModels, IModels } from '~/connectionResolvers';
 import { SES_DELIVERY_STATUSES } from '../constants';
 
 export const getApi = async (models: IModels, type: string): Promise<any> => {
-  const accessKeyId = await getValueAsString(
-    models,
-    'BROADCAST_AWS_SES_ACCESS_KEY_ID',
-    'BROADCAST_AWS_SES_ACCESS_KEY_ID',
-  );
-
-  const secretAccessKey = await getValueAsString(
-    models,
-    'BROADCAST_AWS_SES_SECRET_ACCESS_KEY',
-    'BROADCAST_AWS_SES_SECRET_ACCESS_KEY',
-  );
-
-  const region = await getValueAsString(
-    models,
-    'BROADCAST_AWS_REGION',
-    'BROADCAST_AWS_REGION',
-  );
-
-  const unverifiedEmailsLimit = await getValueAsString(
-    models,
-    'BROADCAST_UNVERIFIED_EMAILS_LIMIT',
-    'BROADCAST_UNVERIFIED_EMAILS_LIMIT',
-    '100',
-  );
-
-  const config = {
-    accessKeyId,
-    secretAccessKey,
-    region,
-    unverifiedEmailsLimit,
-  };
+  const config = await models.EngageMessages.broadcastConfigs();
 
   if (!config) {
     return;

--- a/backend/core-api/src/modules/broadcast/utils/transporter.ts
+++ b/backend/core-api/src/modules/broadcast/utils/transporter.ts
@@ -10,7 +10,7 @@ export const createTransporter = async (models: IModels) => {
     return broadcasTransporter;
   }
 
-  const config: ISESConfig = await models.Configs.getSESConfigs();
+  const config: ISESConfig = await models.EngageMessages.broadcastConfigs();
 
   try {
     AWS.config.update(config);


### PR DESCRIPTION
- Moved broadcast configuration logic to a single source of truth in `Engages` model
- Added `broadcastConfigs` static method to `Engages` model
- Updated `getApi` in engage tracker and `createTransporter` to use the centralized config
- Removed duplicate configuration code from multiple files

## Summary by Sourcery

Centralize broadcast AWS SES configuration retrieval in the EngageMessages model and update broadcast consumers to use this single source of truth.

Enhancements:
- Add a broadcastConfigs helper on the EngageMessages model to provide SES configuration and limits from settings.
- Refactor engage tracking and transporter utilities to consume the shared broadcast configuration instead of duplicating config lookup logic.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Centralized broadcast configuration logic in `Engages` model and updated usage in `engage.ts` and `transporter.ts`.
> 
>   - **Behavior**:
>     - Centralized broadcast configuration logic in `broadcastConfigs()` method in `Engages` model.
>     - Updated `getApi` in `engage.ts` and `createTransporter` in `transporter.ts` to use `broadcastConfigs()`.
>   - **Code Removal**:
>     - Removed duplicate configuration code from `engage.ts` and `transporter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 4eceece520fe08b6995965ed9daecfded3352059. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized broadcast configuration retrieval by consolidating credential and settings access into a unified method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->