### PR TITLE
fix(date-filter): handle UTC to local timezone correctly

### DIFF
--- a/packages/plugin-inbox-api/src/conversationQueryBuilder.ts
+++ b/packages/plugin-inbox-api/src/conversationQueryBuilder.ts
@@ -353,9 +353,25 @@ export default class Builder {
   }
 
   public dateFilter(startDate: string, endDate: string): IOR {
-    // Ensure dates are properly parsed
-    const start = new Date(startDate);
-    const end = new Date(endDate);
+    // Enhanced date parsing to handle both "YYYY-MM-DD HH:mm" and ISO formats
+    let start: Date;
+    let end: Date;
+
+    // Handle "YYYY-MM-DD HH:mm" format
+    if (startDate.includes(" ") && !startDate.includes("T")) {
+      const [datePart, timePart] = startDate.split(" ");
+      start = new Date(`${datePart}T${timePart}:00`);
+    } else {
+      // Handle ISO format and others
+      start = new Date(startDate);
+    }
+
+    if (endDate.includes(" ") && !endDate.includes("T")) {
+      const [datePart, timePart] = endDate.split(" ");
+      end = new Date(`${datePart}T${timePart}:00`);
+    } else {
+      end = new Date(endDate);
+    }
 
     // Validate dates
     if (isNaN(start.getTime()) || isNaN(end.getTime())) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct date parsing for conversation queries by handling "YYYY-MM-DD HH:mm" inputs without implicit UTC/local timezone issues.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `dateFilter` in `conversationQueryBuilder.ts` to correctly parse 'YYYY-MM-DD HH:mm' and ISO date formats, ensuring accurate date filtering.
> 
>   - **Behavior**:
>     - Enhanced `dateFilter` in `conversationQueryBuilder.ts` to handle both 'YYYY-MM-DD HH:mm' and ISO date formats.
>     - Validates parsed dates and returns an empty `$or` array if invalid.
>   - **Date Parsing**:
>     - Splits date and time for 'YYYY-MM-DD HH:mm' format and appends ':00' for seconds.
>     - Uses `Date` constructor for ISO and other formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for e28ddcfc6693592bd95f5393a6c3943a4fabd2e4. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->