### PR TITLE
feat: implement bulk form deletion functionality

### DIFF
--- a/backend/plugins/frontline_api/src/modules/form/graphql/resolvers/mutations/forms.ts
+++ b/backend/plugins/frontline_api/src/modules/form/graphql/resolvers/mutations/forms.ts
@@ -28,7 +28,7 @@ export const formMutations = {
   /**
    * Update a form data
    */
-  formsEdit: async (_root, { _id, ...doc }: IForm, { models }: IContext) => {
+  formsEdit: async (_root: undefined, { _id, ...doc }: IForm, { models }: IContext) => {
     return models.Forms.updateForm(_id, doc);
   },
 
@@ -37,7 +37,7 @@ export const formMutations = {
    */
 
   formsDuplicate: async (
-    _root,
+    _root: undefined,
     { _id: id }: { _id: string },
     { models, user }: IContext,
   ) => {
@@ -62,23 +62,26 @@ export const formMutations = {
    * Remove a form
    */
   formsRemove: async (
-    _root,
-    { _id }: { _id: string },
+    _root: undefined,
+    { _ids }: { _ids: string[] },
     { models }: IContext,
   ) => {
-    const form = await models.Forms.getForm(_id);
-    if (form?.integrationId) {
-      await models.Integrations.removeIntegration(form.integrationId);
+    const integrationIds: string[] = await models.Forms.find({ _id: { $in: _ids } }).distinct('integrationId');
+    
+    if (integrationIds?.length) {
+      await models.Integrations.removeIntegrations(integrationIds);
     }
 
-    await models.Fields.deleteMany({ contentTypeId: _id });
-    await models.FormSubmissions.deleteMany({ formId: _id });
+    await models.Fields.deleteMany({ contentTypeId: { $in: _ids } });
+    await models.FormSubmissions.deleteMany({ formId: { $in: _ids } });
 
-    return await models.Forms.removeForm(_id);
+    await models.Forms.deleteMany({ _id: { $in: _ids } });
+
+    return _ids
   },
 
   formsToggleStatus: async (
-    _root,
+    _root: undefined,
     { _id }: { _id: string; status: boolean },
     { models }: IContext,
   ) => {
@@ -95,7 +98,7 @@ export const formMutations = {
    * Create a form submission data
    */
   formSubmissionsSave: async (
-    _root,
+    _root: undefined,
     {
       formId,
       contentTypeId,
@@ -137,7 +140,7 @@ export const formMutations = {
     return true;
   },
 
-  formSubmissionsEdit: async (_root, params, { models }: IContext) => {
+  formSubmissionsEdit: async (_root: undefined, params, { models }: IContext) => {
     const { contentTypeId, customerId, submissions } = params;
 
     const conversation = await models.Conversations.findOne({
@@ -165,7 +168,7 @@ export const formMutations = {
     };
   },
 
-  formSubmissionsRemove: async (_root, params, { models }: IContext) => {
+  formSubmissionsRemove: async (_root: undefined, params, { models }: IContext) => {
     const { customerId, contentTypeId } = params;
 
     await models.ConversationMessages.deleteMany({

--- a/backend/plugins/frontline_api/src/modules/form/graphql/schema/form.ts
+++ b/backend/plugins/frontline_api/src/modules/form/graphql/schema/form.ts
@@ -182,7 +182,7 @@ export const queries = `
 export const mutations = `
   formsAdd(${commonFields}): Form
   formsEdit(_id: String!, ${commonFields} ): Form
-  formsRemove(_id: String!): JSON
+  formsRemove(_ids: [String]): [String]
   formsToggleStatus(_id: String!): Form
   formsDuplicate(_id: String!): Form
   formSubmissionsSave(${commonFormSubmissionFields}): Boolean

--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
@@ -127,7 +127,8 @@ export interface IIntegrationModel extends Model<IIntegrationDocument> {
     doc: IExternalIntegrationParams,
     userId: string,
   ): Promise<IIntegrationDocument>;
-  removeIntegration(_id: string): void;
+  removeIntegration(_id: string): Promise<void>;
+  removeIntegrations(_ids: string[]): Promise<void>;
   updateBasicInfo(
     _id: string,
     doc: IIntegrationBasicInfo,
@@ -418,6 +419,10 @@ export const loadClass = (models: IModels, subdomain: string) => {
      */
     public static async removeIntegration(_id: string) {
       return models.Integrations.deleteMany({ _id });
+    }
+
+    public static async removeIntegrations(_ids: string[]) {
+      return models.Integrations.deleteMany({ _id: { $in: _ids } });
     }
 
     public static async updateBasicInfo(

--- a/frontend/plugins/frontline_ui/src/modules/forms/components/FormsList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/forms/components/FormsList.tsx
@@ -219,7 +219,7 @@ export const RemoveForm = ({
         confirm({
           message: `Are you sure you want to remove "${title}" form?`,
         }).then(() => {
-          removeForm({ variables: { id: formId } });
+          removeForm({ variables: { _ids: [formId] } });
         });
       }}
       disabled={loading}

--- a/frontend/plugins/frontline_ui/src/modules/forms/graphql/formMutations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/forms/graphql/formMutations.ts
@@ -45,8 +45,8 @@ export const FORM_BULK_ACTION = gql`
 `;
 
 export const FORM_REMOVE = gql`
-  mutation FormsRemove($id: String!) {
-    formsRemove(_id: $id)
+  mutation FormsRemove($_ids: [String]) {
+    formsRemove(_ids: $_ids)
   }
 `;
 

--- a/frontend/plugins/frontline_ui/src/modules/forms/hooks/useRemoveForm.ts
+++ b/frontend/plugins/frontline_ui/src/modules/forms/hooks/useRemoveForm.ts
@@ -6,14 +6,10 @@ export const useRemoveForm = () => {
   const [_remove, { loading }] = useMutation(FORM_REMOVE);
 
   const removeForm = async (formIds: string[]) => {
-    await Promise.all(
-      formIds.map(async (formId) => {
-        await _remove({
-          variables: { id: formId },
-          refetchQueries: [GET_FORMS_LIST],
-        });
-      }),
-    );
+    await _remove({
+      variables: { _ids: formIds },
+      refetchQueries: [GET_FORMS_LIST],
+    });
   };
 
   return {


### PR DESCRIPTION
- Enhance formsRemove mutation to accept multiple form IDs
- Add removeIntegrations method for bulk integration cleanup
- Optimize database operations using $in operator for bulk deletions
- Simplify frontend hook to use single API call instead of multiple parallel calls
- Update GraphQL schema and mutations to support bulk operations
- Improve TypeScript typing with proper undefined annotations

## Summary by Sourcery

Add support for bulk form deletion across backend and frontend, including related integrations and submissions.

New Features:
- Introduce bulk form removal mutation that accepts multiple form IDs and returns the list of removed IDs.

Enhancements:
- Cascade-delete related integrations, fields, and submissions for multiple forms in a single operation using bulk database queries.
- Unify frontend form removal to use a single bulk deletion API call instead of multiple per-form mutations.
- Tighten TypeScript typings by explicitly annotating unused GraphQL resolver root parameters as undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch deletion capability for forms, allowing users to remove multiple forms in a single operation.

* **Improvements**
  * Enhanced form removal performance with optimized bulk cleanup of related integrations and submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->