### PR TITLE
chore: property field trpc

### DIFF
--- a/backend/core-api/src/init-trpc.ts
+++ b/backend/core-api/src/init-trpc.ts
@@ -21,6 +21,7 @@ import { notificationTrpcRouter } from '~/modules/notifications/trpc';
 import { importExportTrpcRouter } from '~/modules/import-export/trpc';
 import { logsTrpcRouter } from './modules/logs/trpc';
 import { clientPortalNotificationTrpcRouter } from '@/clientportal/trpc';
+import { propertiesTrpcRouter } from '@/properties/trpc';
 
 export type CoreTRPCContext = ITRPCContext<{
   models: IModels;
@@ -48,6 +49,7 @@ export const appRouter = t.mergeRouters(
   importExportTrpcRouter,
   logsTrpcRouter,
   clientPortalNotificationTrpcRouter,
+  propertiesTrpcRouter
 );
 
 export type AppRouter = typeof appRouter;

--- a/backend/core-api/src/modules/properties/trpc/field.ts
+++ b/backend/core-api/src/modules/properties/trpc/field.ts
@@ -1,8 +1,23 @@
 import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const fieldTrpcRouter = t.router({
-  fields: t.router({}),
+  fields: t.router({
+    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+      const { models } = ctx;
+      const { query, projection, sort } = input;
+
+      return models.Fields.find(query, projection).sort(sort).lean();
+    }),
+    validateFieldValues: t.procedure
+      .input(z.any())
+      .mutation(async ({ ctx, input }) => {
+        const { models } = ctx;
+
+        return models.Fields.validateFieldValues(input);
+      }),
+  }),
 });


### PR DESCRIPTION
## Summary by Sourcery

Add TRPC endpoints and router wiring for property fields to the core API.

New Features:
- Expose a TRPC query for finding property fields with query, projection, and sort options.
- Expose a TRPC mutation for validating property field values via the Fields model.
- Register the properties TRPC router in the main application TRPC router.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `propertiesTrpcRouter` with `fieldTrpcRouter` for field operations including `find` and `validateFieldValues`.
> 
>   - **TRPC Routers**:
>     - Add `propertiesTrpcRouter` to `init-trpc.ts` and integrate into `appRouter`.
>   - **Field Operations**:
>     - Add `fieldTrpcRouter` in `field.ts` with `find` and `validateFieldValues` procedures.
>     - `find` procedure: Queries fields with `query`, `projection`, and `sort` inputs.
>     - `validateFieldValues` procedure: Validates field values using `models.Fields.validateFieldValues`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 2b4bf7693594faf76841f1ca312bed00ada8737b. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field search capability through a new API endpoint.
  * Added field validation functionality through a new API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->