### PR TITLE
feat: add template in operation

### DIFF
--- a/backend/plugins/operation_api/src/apollo/resolvers/mutations.ts
+++ b/backend/plugins/operation_api/src/apollo/resolvers/mutations.ts
@@ -6,6 +6,7 @@ import { statusMutations } from '@/status/graphql/resolvers/mutations/status';
 import { taskMutations } from '@/task/graphql/resolvers/mutations/task';
 import { teamMutations } from '@/team/graphql/resolvers/mutations/team';
 import { triageMutations } from '@/task/graphql/resolvers/mutations/triage';
+import { mutations as templateMutations } from '@/template/graphql/resolvers';
 
 export const mutations = {
   ...taskMutations,
@@ -16,4 +17,5 @@ export const mutations = {
   ...cycleMutations,
   ...milestoneMutations,
   ...triageMutations,
+  ...templateMutations,
 };

--- a/backend/plugins/operation_api/src/apollo/resolvers/queries.ts
+++ b/backend/plugins/operation_api/src/apollo/resolvers/queries.ts
@@ -7,6 +7,7 @@ import { statusQueries } from '@/status/graphql/resolvers/queries/status';
 import { taskQueries } from '@/task/graphql/resolvers/queries/task';
 import { teamQueries } from '@/team/graphql/resolvers/queries/team';
 import { triageQueries } from '@/task/graphql/resolvers/queries/triage';
+import { queries as templateQueries } from '@/template/graphql/resolvers';
 
 export const queries = {
   ...taskQueries,
@@ -18,4 +19,5 @@ export const queries = {
   ...cycleQueries,
   ...milestoneQueries,
   ...triageQueries,
+  ...templateQueries,
 };

--- a/backend/plugins/operation_api/src/apollo/schema/schema.ts
+++ b/backend/plugins/operation_api/src/apollo/schema/schema.ts
@@ -49,6 +49,12 @@ import {
   types as TriageTypes,
 } from '@/task/graphql/schemas/triage';
 
+import {
+  mutations as TemplateMutations,
+  queries as TemplateQueries,
+  types as TemplateTypes,
+} from '@/template/graphql/schema';
+
 export const types = `
   ${TaskTypes}
   ${ProjectTypes}
@@ -59,6 +65,7 @@ export const types = `
   ${CycleTypes}
   ${MilestoneTypes}
   ${TriageTypes}
+  ${TemplateTypes}
 `;
 
 export const queries = `
@@ -71,6 +78,7 @@ export const queries = `
   ${CycleQueries}
   ${MilestoneQueries}
   ${TriageQueries}
+  ${TemplateQueries}
 `;
 
 export const mutations = `
@@ -82,6 +90,7 @@ export const mutations = `
   ${CycleMutations}
   ${MilestoneMutations}
   ${TriageMutations}
+  ${TemplateMutations}
 `;
 
 export default { types, queries, mutations };

--- a/backend/plugins/operation_api/src/connectionResolvers.ts
+++ b/backend/plugins/operation_api/src/connectionResolvers.ts
@@ -32,6 +32,8 @@ import {
 import { IMilestoneDocument } from '@/milestone/types';
 import { ITriageModel, loadTriageClass } from '@/task/db/models/Triage';
 import { ITriageDocument } from './modules/task/@types/triage';
+import { IOperationTemplateDocument } from '@/template/@types/template';
+import { IOperationTemplateModel, loadTemplateClass } from '@/template/db/models/Template';
 
 export interface IModels {
   Task: ITaskModel;
@@ -44,6 +46,7 @@ export interface IModels {
   Cycle: ICycleModel;
   Milestone: IMilestoneModel;
   Triage: ITriageModel;
+  OperationTemplate: IOperationTemplateModel;
 }
 
 export interface IContext extends IMainContext {
@@ -105,6 +108,11 @@ export const loadClasses = (
   models.Triage = db.model<ITriageDocument, ITriageModel>(
     'operation_triage',
     loadTriageClass(models),
+  );
+
+  models.OperationTemplate = db.model<IOperationTemplateDocument, IOperationTemplateModel>(
+    'operation_templates',
+    loadTemplateClass(models),
   );
 
   return models;

--- a/backend/plugins/operation_api/src/modules/template/@types/template.ts
+++ b/backend/plugins/operation_api/src/modules/template/@types/template.ts
@@ -1,0 +1,28 @@
+import { Document } from 'mongoose';
+
+export interface IOperationTemplate {
+  name: string;
+  defaults?: any;
+  teamId: string;
+  createdBy?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface IOperationTemplateDocument
+  extends IOperationTemplate,
+    Document {
+  _id: string;
+}
+
+export interface IOperationTemplateAdd {
+  name: string;
+  defaults?: any;
+  teamId: string;
+}
+
+export interface IOperationTemplateEdit {
+  _id: string;
+  name?: string;
+  defaults?: any;
+}

--- a/backend/plugins/operation_api/src/modules/template/db/definitions/template.ts
+++ b/backend/plugins/operation_api/src/modules/template/db/definitions/template.ts
@@ -1,0 +1,13 @@
+import { Schema } from 'mongoose';
+
+export const operationTemplateSchema = new Schema(
+  {
+    name: { type: String, label: 'Name', required: true },
+    defaults: { type: Object, label: 'Defaults' },
+    teamId: { type: String, label: 'Team', required: true },
+    createdBy: { type: String, label: 'Created By' },
+  },
+  {
+    timestamps: true,
+  },
+);

--- a/backend/plugins/operation_api/src/modules/template/db/models/Template.ts
+++ b/backend/plugins/operation_api/src/modules/template/db/models/Template.ts
@@ -1,0 +1,62 @@
+
+import { Model } from 'mongoose';
+import { IModels } from '~/connectionResolvers';
+import { 
+  IOperationTemplateDocument, 
+  IOperationTemplateAdd, 
+  IOperationTemplateEdit 
+} from '../../@types/template';
+import { operationTemplateSchema } from '../definitions/template';
+
+export interface IOperationTemplateModel extends Model<IOperationTemplateDocument> {
+  getTemplate(_id: string): Promise<IOperationTemplateDocument>;
+  addTemplate(doc: IOperationTemplateAdd, userId: string): Promise<IOperationTemplateDocument>;
+  editTemplate(doc: IOperationTemplateEdit): Promise<IOperationTemplateDocument>;
+  removeTemplate(_id: string): Promise<void>;
+}
+
+export const loadTemplateClass = (models: IModels) => {
+  class OperationTemplate {
+    public static async getTemplate(_id: string) {
+      const template = await models.OperationTemplate.findOne({ _id });
+
+      if (!template) {
+        throw new Error('Template not found');
+      }
+
+      return template;
+    }
+
+    public static async addTemplate(doc: IOperationTemplateAdd, userId: string) {
+      return models.OperationTemplate.create({
+        ...doc,
+        createdBy: userId,
+      });
+    }
+
+    public static async editTemplate(doc: IOperationTemplateEdit) {
+      const { _id, ...updateDoc } = doc;
+      
+      const template = await models.OperationTemplate.findOne({ _id });
+      if (!template) {
+        throw new Error('Template not found');
+      }
+
+      await models.OperationTemplate.updateOne({ _id }, { $set: updateDoc });
+      return models.OperationTemplate.findOne({ _id });
+    }
+
+    public static async removeTemplate(_id: string) {
+      const template = await models.OperationTemplate.findOne({ _id });
+      if (!template) {
+        throw new Error('Template not found');
+      }
+
+      return models.OperationTemplate.deleteOne({ _id });
+    }
+  }
+
+  operationTemplateSchema.loadClass(OperationTemplate);
+
+  return operationTemplateSchema;
+};

--- a/backend/plugins/operation_api/src/modules/template/graphql/resolvers.ts
+++ b/backend/plugins/operation_api/src/modules/template/graphql/resolvers.ts
@@ -1,0 +1,45 @@
+
+import { IContext } from '~/connectionResolvers';
+
+const queries = {
+  operationTemplates: async (
+    _root,
+    { teamId }: { teamId: string },
+    { models }: IContext
+  ) => {
+    return models.OperationTemplate.find({ teamId }).sort({ createdAt: -1 });
+  },
+  operationTemplateDetail: async (
+    _root,
+    { _id }: { _id: string },
+    { models }: IContext
+  ) => {
+    return models.OperationTemplate.getTemplate(_id);
+  },
+};
+
+const mutations = {
+  operationTemplateAdd: async (
+    _root,
+    doc,
+    { models, user }: IContext
+  ) => {
+    return models.OperationTemplate.addTemplate(doc, user._id);
+  },
+  operationTemplateEdit: async (
+    _root,
+    doc,
+    { models }: IContext
+  ) => {
+    return models.OperationTemplate.editTemplate(doc);
+  },
+  operationTemplateRemove: async (
+    _root,
+    { _id }: { _id: string },
+    { models }: IContext
+  ) => {
+    return models.OperationTemplate.removeTemplate(_id);
+  },
+};
+
+export { queries, mutations };

--- a/backend/plugins/operation_api/src/modules/template/graphql/schema.ts
+++ b/backend/plugins/operation_api/src/modules/template/graphql/schema.ts
@@ -1,0 +1,23 @@
+
+export const types = `
+  type OperationTemplate {
+    _id: String
+    name: String
+    defaults: JSON
+    teamId: String
+    createdBy: String
+    createdAt: Date
+    updatedAt: Date
+  }
+`;
+
+export const queries = `
+  operationTemplates(teamId: String): [OperationTemplate]
+  operationTemplateDetail(_id: String): OperationTemplate
+`;
+
+export const mutations = `
+  operationTemplateAdd(name: String!, defaults: JSON!, teamId: String!): OperationTemplate
+  operationTemplateEdit(_id: String!, name: String, defaults: JSON): OperationTemplate
+  operationTemplateRemove(_id: String!): JSON
+`;

--- a/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
@@ -101,7 +101,7 @@ const MemberInlineEffectComponent = ({ memberId }: { memberId: string }) => {
     variables: {
       _id: memberId,
     },
-    skip: !memberId || memberId === currentUser._id,
+    skip: !memberId || memberId === currentUser?._id,
   });
 
   useEffect(() => {
@@ -113,7 +113,7 @@ const MemberInlineEffectComponent = ({ memberId }: { memberId: string }) => {
         return [...prev, { ...userDetail, _id: memberId }];
       });
     }
-    if (currentUser._id === memberId) {
+    if (currentUser && currentUser._id === memberId) {
       updateMembers((prev) => {
         if (prev.some((m) => m._id === memberId)) return prev;
         return [currentUser, ...prev];

--- a/frontend/plugins/operation_ui/src/modules/OperationSettings.tsx
+++ b/frontend/plugins/operation_ui/src/modules/OperationSettings.tsx
@@ -7,6 +7,8 @@ import { TeamDetailPage } from '~/pages/TeamDetailPage';
 import { TeamMembersPage } from '~/pages/TeamMembersPage';
 import { TeamsSettingsPage } from '~/pages/TeamSettingsIndexPage';
 import { TeamStatusPage } from '~/pages/TeamStatusPage';
+import { TeamTemplatesPage } from '~/pages/TeamTemplatesPage';
+import { TemplateFormPage } from '~/pages/TemplateFormPage';
 import { OperationPaths } from '~/types/paths';
 
 const TeamsSettings = lazy(() =>
@@ -47,6 +49,18 @@ const OperationSettings = () => {
           <Route
             path={OperationPaths.TeamStatus}
             element={<TeamStatusPage />}
+          />
+          <Route
+            path={OperationPaths.TeamTemplates}
+            element={<TeamTemplatesPage />}
+          />
+          <Route
+            path="templates/:id/template-new"
+            element={<TemplateFormPage />}
+          />
+          <Route
+            path="templates/:id/edit/:templateId"
+            element={<TemplateFormPage />}
           />
         </Route>
       </Routes>

--- a/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
@@ -33,6 +33,8 @@ import { useParams } from 'react-router-dom';
 import { currentUserState } from 'ui-modules';
 import { SelectMilestone } from '../task-selects/SelectMilestone';
 import { SelectTags } from 'ui-modules';
+import { SelectTemplate } from '@/template/components/SelectTemplate';
+import { IOperationTemplate } from '@/template/types';
 
 export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
   const { teamId, projectId, cycleId } = useParams<{
@@ -118,6 +120,28 @@ export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
     });
   };
 
+  const onTemplateSelect = async (template: IOperationTemplate) => {
+    if (template.defaults) {
+      if (template.defaults.description) {
+        try {
+          const content = JSON.parse(template.defaults.description);
+          editor.replaceBlocks(editor.document, content);
+          setDescriptionContent(content);
+        } catch (e) {
+          console.error('Failed to parse description', e);
+        }
+      }
+
+      const ALLOWED_FIELDS = ['name'];
+
+      Object.keys(template.defaults).forEach((key) => {
+        if (ALLOWED_FIELDS.includes(key)) {
+          form.setValue(key as any, template.defaults[key]);
+        }
+      });
+    }
+  };
+
   return (
     <Form {...form}>
       <form
@@ -152,6 +176,12 @@ export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
           />
           <IconChevronRight className="size-4" />
           <Sheet.Title className="">New task</Sheet.Title>
+          <div className="ml-auto">
+            <SelectTemplate
+              teamId={_teamId}
+              onSelect={onTemplateSelect}
+            />
+          </div>
         </Sheet.Header>
         <Sheet.Content className="px-7 py-4 gap-2 flex flex-col min-h-0">
           <Form.Field

--- a/frontend/plugins/operation_ui/src/modules/team/components/team-details/TeamDetails.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/team-details/TeamDetails.tsx
@@ -4,6 +4,7 @@ import { UpdateTeamForm } from '@/team/components/team-details/UpdateTeamForm';
 import { EstimateSection } from '@/team/components/team-details/EstimateSection';
 import { StatusSection } from '@/team/components/team-details/SatusSection';
 import { CycleSection } from '@/team/components/team-details/CycleSection';
+import { TemplateSection } from '@/team/components/team-details/TemplateSection';
 
 import { useParams } from 'react-router-dom';
 import { DeleteTeamForm } from '@/team/components/team-details/DeleteTeamForm';
@@ -31,6 +32,7 @@ export const TeamDetails = () => {
       <StatusSection team={team} />
       <CycleSection team={team} />
       <TriageSection team={team} />
+      <TemplateSection team={team} />
       <DeleteTeamForm />
     </div>
   );

--- a/frontend/plugins/operation_ui/src/modules/team/components/team-details/TemplateSection.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/team-details/TemplateSection.tsx
@@ -1,0 +1,24 @@
+import { IconChevronRight } from '@tabler/icons-react';
+import { ITeam } from '@/team/types';
+import { useNavigate } from 'react-router-dom';
+
+export const TemplateSection = ({ team }: { team: ITeam }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="mt-4 w-full border border-muted-foreground/15 rounded-md hover:bg-sidebar/50 cursor-pointer"
+      onClick={() => navigate(`/settings/operation/team/templates/${team._id}`)}
+    >
+      <section className="w-full p-4">
+        <div className="flex items-center justify-between">
+          <p>Templates</p>
+
+          <div className="flex items-center gap-2">
+            <IconChevronRight className="w-4 h-4" />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/template/components/SelectTemplate.tsx
+++ b/frontend/plugins/operation_ui/src/modules/template/components/SelectTemplate.tsx
@@ -1,0 +1,69 @@
+import { Button, Command, Popover } from 'erxes-ui';
+import {
+  IconCheck,
+  IconChevronDown,
+  IconTemplateFilled,
+} from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import { IOperationTemplate } from '../types';
+import { useTemplates } from '../hooks/useTemplates';
+
+interface SelectTemplateProps {
+  teamId?: string;
+  onSelect: (template: IOperationTemplate) => void;
+}
+
+export const SelectTemplate = ({ teamId, onSelect }: SelectTemplateProps) => {
+  const { templates, loading } = useTemplates({ teamId });
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<IOperationTemplate | null>(null);
+
+  if (loading) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button variant="outline" className="w-[120px] h-8 p-2 justify-between">
+          <span className="flex items-center">
+            <IconTemplateFilled className="size-4 mr-2 shrink-0" />
+            <span className="truncate">
+              {selected ? selected.name : 'Template'}
+            </span>
+          </span>
+          <IconChevronDown className="size-4 opacity-50 shrink-0" />
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content className="w-[200px] p-0" align="start">
+        <Command>
+          <Command.Input placeholder="Search template..." />
+          <Command.List>
+            <Command.Empty>No templates found.</Command.Empty>
+            <Command.Group>
+              {templates.map((template) => (
+                <Command.Item
+                  key={template._id}
+                  value={template.name}
+                  onSelect={() => {
+                    setSelected(template);
+                    onSelect(template);
+                    setOpen(false);
+                  }}
+                >
+                  <IconCheck
+                    className={`mr-2 size-4 ${
+                      selected?._id === template._id
+                        ? 'opacity-100'
+                        : 'opacity-0'
+                    }`}
+                  />
+                  {template.name}
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
+        </Command>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/template/components/TemplateForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/template/components/TemplateForm.tsx
@@ -1,0 +1,158 @@
+import {
+  Button,
+  Form,
+  Input,
+  useToast,
+  BlockEditor,
+  useBlockEditor,
+  Separator,
+  Label,
+} from 'erxes-ui';
+import { useForm } from 'react-hook-form';
+import { useMutation } from '@apollo/client';
+import {
+  templateAddMutation,
+  templateEditMutation,
+} from '../graphql/mutations';
+import { useState } from 'react';
+import { Block } from '@blocknote/core';
+
+export const TemplateForm = ({
+  teamId,
+  template,
+  onCancel,
+  afterSave,
+}: {
+  teamId?: string;
+  template?: any;
+  onCancel?: () => void;
+  afterSave?: () => void;
+}) => {
+  const { toast } = useToast();
+  
+  const [descriptionContent, setDescriptionContent] = useState<Block[] | undefined>(
+    template?.defaults?.description
+      ? JSON.parse(template.defaults.description)
+      : undefined
+  );
+
+  const editor = useBlockEditor({
+    initialContent: descriptionContent,
+  });
+
+  const form = useForm({
+    defaultValues: {
+      teamId: teamId || '',
+      name: template?.name || '',
+      taskName: template?.defaults?.name || '',
+    },
+  });
+
+  const [addMutation] = useMutation(templateAddMutation, {
+    refetchQueries: ['operationTemplates'],
+  });
+  const [editMutation] = useMutation(templateEditMutation, {
+    refetchQueries: ['operationTemplates'],
+  });
+
+  const handleDescriptionChange = async () => {
+    const content = await editor?.document;
+    if (content) {
+      setDescriptionContent(content as Block[]);
+    }
+  };
+
+  const onSubmit = (values: any) => {
+    const { name, taskName } = values;
+
+    const defaults = {
+      name: taskName,
+      description: JSON.stringify(descriptionContent),
+    };
+
+    const variables = {
+      name,
+      teamId,
+      defaults,
+    };
+
+    if (template) {
+      editMutation({ variables: { _id: template._id, ...variables } })
+        .then(() => {
+          toast({ title: 'Template updated' });
+          afterSave?.();
+        })
+        .catch((e) => {
+          toast({ title: 'Error', description: e.message, variant: 'destructive' });
+        });
+    } else {
+      addMutation({ variables })
+        .then(() => {
+          toast({ title: 'Template created' });
+          afterSave?.();
+        })
+        .catch((e) => {
+          toast({ title: 'Error', description: e.message, variant: 'destructive' });
+        });
+    }
+  };
+
+  return (
+    <div className="p-6 flex flex-col h-full">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 flex flex-col h-full">
+          <div className="space-y-4 shrink-0">
+             <Form.Field
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Template Name</Form.Label>
+                  <Form.Control>
+                    <Input {...field} placeholder="e.g., Bug Report, Feature Request" />
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+          </div>
+
+          <Separator />
+
+          <div className="flex-1 overflow-y-auto space-y-4 pr-1">
+              <h3 className="font-semibold text-sm text-foreground/80">Task Content</h3>
+              <Form.Field
+                control={form.control}
+                name="taskName"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Task Title</Form.Label>
+                    <Form.Control>
+                      <Input {...field} placeholder="Default task title" />
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+
+              <div className="space-y-2">
+                 <Label>Task Description</Label>
+                 <div className="border rounded-md min-h-[150px] p-2">
+                    <BlockEditor
+                      editor={editor}
+                      onChange={handleDescriptionChange}
+                      className="min-h-full"
+                    />
+                 </div>
+              </div>
+          </div>
+
+          <div className="flex justify-end gap-2 shrink-0 pt-2 mt-auto">
+            <Button variant="outline" onClick={onCancel} type="button">
+              Cancel
+            </Button>
+            <Button type="submit">Save Template</Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/template/components/TemplateList.tsx
+++ b/frontend/plugins/operation_ui/src/modules/template/components/TemplateList.tsx
@@ -1,0 +1,236 @@
+import { useQuery, useMutation } from '@apollo/client';
+import {
+  Button,
+  useToast,
+  AlertDialog,
+  RecordTable,
+  Popover,
+  Command,
+  Combobox,
+  RelativeDateDisplay,
+  RecordTableInlineCell,
+  Badge,
+} from 'erxes-ui';
+import { MembersInline } from 'ui-modules';
+import { useParams, useNavigate } from 'react-router-dom';
+import { templatesQuery } from '../graphql/queries';
+import { templateRemoveMutation } from '../graphql/mutations';
+import {
+  IconEdit,
+  IconTrash,
+  IconPlus,
+  IconDots,
+  IconCalendar,
+  IconUser,
+  IconAlignLeft,
+} from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { ColumnDef } from '@tanstack/react-table';
+
+const TemplateRowActions = ({
+  template,
+  onEdit,
+  onRemove,
+}: {
+  template: any;
+  onEdit: (template: any) => void;
+  onRemove: (id: string) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <RecordTable.MoreButton className="w-full h-full" />
+        </Popover.Trigger>
+        <Popover.Content className="w-[200px] p-0">
+          <Command shouldFilter={false}>
+            <Command.List>
+              <Command.Item
+                value="edit"
+                onSelect={() => {
+                  setOpen(false);
+                  onEdit(template);
+                }}
+              >
+                <IconEdit className="mr-2 h-4 w-4" /> Edit
+              </Command.Item>
+              <Command.Item
+                value="delete"
+                className="text-destructive"
+                onSelect={() => {
+                  setOpen(false);
+                  setShowDeleteDialog(true);
+                }}
+              >
+                <IconTrash className="mr-2 size-4" /> Delete
+              </Command.Item>
+            </Command.List>
+          </Command>
+        </Popover.Content>
+      </Popover>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialog.Content>
+          <AlertDialog.Header>
+            <AlertDialog.Title>Delete Template?</AlertDialog.Title>
+            <AlertDialog.Description>
+              This action cannot be undone.
+            </AlertDialog.Description>
+          </AlertDialog.Header>
+          <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+              onClick={() => onRemove(template._id)}
+              className="bg-destructive text-destructive hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialog.Action>
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog>
+    </>
+  );
+};
+
+export const TemplateList = () => {
+  const { id: teamId } = useParams();
+  const navigate = useNavigate();
+  const { data, loading } = useQuery(templatesQuery, {
+    variables: { teamId },
+    skip: !teamId,
+    fetchPolicy: 'network-only',
+  });
+
+  const [removeMutation] = useMutation(templateRemoveMutation, {
+    refetchQueries: ['operationTemplates'],
+  });
+  const { toast } = useToast();
+
+  const handleEdit = (template: any) => {
+    navigate(
+      `/settings/operation/team/templates/${teamId}/edit/${template._id}`,
+    );
+  };
+
+  const handleRemove = (id: string) => {
+    removeMutation({ variables: { _id: id } })
+      .then(() => toast({ title: 'Template removed' }))
+      .catch((e) => toast({ title: 'Error', description: e.message }));
+  };
+
+  const handleAdd = () => {
+    navigate(`/settings/operation/team/templates/${teamId}/template-new`);
+  };
+
+  const templates = data?.operationTemplates || [];
+
+  const columns = useMemo<ColumnDef<any>[]>(
+    () => [
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: () => (
+          <RecordTable.InlineHead label="Name" icon={IconAlignLeft} />
+        ),
+        cell: ({ cell }) => (
+          <Button asChild variant="ghost">
+            <Badge
+              variant="secondary"
+              onClick={(e) => {
+                handleEdit(cell.row.original);
+              }}
+            >
+              {cell.getValue() as string}
+            </Badge>
+          </Button>
+        ),
+      },
+      {
+        id: 'createdAt',
+        accessorKey: 'createdAt',
+        header: () => (
+          <RecordTable.InlineHead label="Created At" icon={IconCalendar} />
+        ),
+        cell: ({ cell }) => {
+          return (
+            <RelativeDateDisplay value={cell.getValue() as string} asChild>
+              <RecordTableInlineCell>
+                <RelativeDateDisplay.Value value={cell.getValue() as string} />
+              </RecordTableInlineCell>
+            </RelativeDateDisplay>
+          );
+        },
+      },
+      {
+        id: 'createdBy',
+        accessorKey: 'createdBy',
+        header: () => (
+          <RecordTable.InlineHead label="Created By" icon={IconUser} />
+        ),
+        cell: ({ getValue }) => {
+          const userId = getValue() as string;
+          if (!userId) return '-';
+          return (
+             <RecordTableInlineCell>
+                <MembersInline memberIds={[userId]} />
+             </RecordTableInlineCell>
+          )
+        },
+      },
+      {
+        id: 'more',
+        header: '',
+        cell: ({ row }) => (
+          <TemplateRowActions
+            template={row.original}
+            onEdit={handleEdit}
+            onRemove={handleRemove}
+          />
+        ),
+        size: 22,
+      },
+    ],
+    [teamId],
+  );
+
+  return (
+    <div className="p-6 h-full space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">Templates</h2>
+        <Button onClick={handleAdd}>
+          <IconPlus className="mr-2 size-4" />
+          New Template
+        </Button>
+      </div>
+
+      <RecordTable.Provider
+        data={templates || []}
+        stickyColumns={['more']}
+        columns={columns}
+      >
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.RowList
+              Row={(props) => (
+                <RecordTable.Row
+                  {...props}
+                  className="cursor-pointer hover:bg-muted/50"
+                />
+              )}
+            />
+            {loading && <RecordTable.RowSkeleton rows={5} />}
+            {templates.length === 0 && !loading && (
+              <div className="p-8 text-center text-muted-foreground text-sm italic">
+                No templates found
+              </div>
+            )}
+          </RecordTable.Body>
+        </RecordTable>
+      </RecordTable.Provider>
+    </div>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/template/graphql/mutations.ts
+++ b/frontend/plugins/operation_ui/src/modules/template/graphql/mutations.ts
@@ -1,0 +1,39 @@
+import gql from 'graphql-tag';
+
+export const templateAddMutation = gql`
+  mutation operationTemplateAdd(
+    $name: String!
+    $defaults: JSON!
+    $teamId: String!
+  ) {
+    operationTemplateAdd(
+      name: $name
+      defaults: $defaults
+      teamId: $teamId
+    ) {
+      _id
+    }
+  }
+`;
+
+export const templateEditMutation = gql`
+  mutation operationTemplateEdit(
+    $_id: String!
+    $name: String
+    $defaults: JSON
+  ) {
+    operationTemplateEdit(
+      _id: $_id
+      name: $name
+      defaults: $defaults
+    ) {
+      _id
+    }
+  }
+`;
+
+export const templateRemoveMutation = gql`
+  mutation operationTemplateRemove($_id: String!) {
+    operationTemplateRemove(_id: $_id)
+  }
+`;

--- a/frontend/plugins/operation_ui/src/modules/template/graphql/queries.ts
+++ b/frontend/plugins/operation_ui/src/modules/template/graphql/queries.ts
@@ -1,0 +1,28 @@
+import gql from 'graphql-tag';
+
+export const templatesQuery = gql`
+  query operationTemplates($teamId: String) {
+    operationTemplates(teamId: $teamId) {
+      _id
+      name
+      defaults
+      teamId
+      createdAt
+      updatedAt
+      createdBy
+    }
+  }
+`;
+
+export const templateDetailQuery = gql`
+  query operationTemplateDetail($_id: String!) {
+    operationTemplateDetail(_id: $_id) {
+      _id
+      name
+      defaults
+      teamId
+      createdAt
+      updatedAt
+    }
+  }
+`;

--- a/frontend/plugins/operation_ui/src/modules/template/hooks/useTemplates.tsx
+++ b/frontend/plugins/operation_ui/src/modules/template/hooks/useTemplates.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@apollo/client';
+import { templatesQuery } from '../graphql/queries';
+import { IOperationTemplate } from '../types';
+
+export const useTemplates = ({  teamId }: { teamId?: string }) => {
+  const { data, loading, error } = useQuery(templatesQuery, {
+    variables: { teamId },
+    skip: !teamId,
+  });
+
+  return {
+    templates: (data?.operationTemplates || []) as IOperationTemplate[],
+    loading,
+    error,
+  };
+};

--- a/frontend/plugins/operation_ui/src/modules/template/types.ts
+++ b/frontend/plugins/operation_ui/src/modules/template/types.ts
@@ -1,0 +1,8 @@
+export interface IOperationTemplate {
+  _id: string;
+  name: string;
+  defaults: any;
+  teamId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/frontend/plugins/operation_ui/src/modules/triage/components/add-triage/AddTriageForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/triage/components/add-triage/AddTriageForm.tsx
@@ -24,6 +24,8 @@ import { SelectPriority } from '@/operation/components/SelectPriority';
 import { SelectStatus } from '@/operation/components/SelectStatus';
 import { toast } from 'erxes-ui';
 import { STATUS_TYPES } from '@/operation/components/StatusInline';
+import { SelectTemplate } from '@/template/components/SelectTemplate';
+import { IOperationTemplate } from '@/template/types';
 
 export const AddTriageForm = ({
   onComplete,
@@ -95,6 +97,28 @@ export const AddTriageForm = ({
     });
   };
 
+  const onTemplateSelect = async (template: IOperationTemplate) => {
+    if (template.defaults) {
+      if (template.defaults.description) {
+        try {
+          const content = JSON.parse(template.defaults.description);
+          editor.replaceBlocks(editor.document, content);
+          setDescriptionContent(content);
+        } catch (e) {
+          console.error('Failed to parse description', e);
+        }
+      }
+
+      const ALLOWED_FIELDS = ['name'];
+
+      Object.keys(template.defaults).forEach((key) => {
+        if (ALLOWED_FIELDS.includes(key)) {
+          form.setValue(key as any, template.defaults[key]);
+        }
+      });
+    }
+  };
+
   return (
     <Form {...form}>
       <form
@@ -119,8 +143,12 @@ export const AddTriageForm = ({
               </Form.Item>
             )}
           />
+
           <IconChevronRight className="size-4" />
           <Sheet.Title className="">New triage</Sheet.Title>
+          <div className="ml-auto">
+            <SelectTemplate teamId={_teamId} onSelect={onTemplateSelect} />
+          </div>
         </Sheet.Header>
         <Sheet.Content className="px-7 py-4 gap-2 flex flex-col min-h-0">
           <Form.Field

--- a/frontend/plugins/operation_ui/src/pages/TeamTemplatesPage.tsx
+++ b/frontend/plugins/operation_ui/src/pages/TeamTemplatesPage.tsx
@@ -1,0 +1,37 @@
+import { TemplateList } from '@/template/components/TemplateList';
+import { PageContainer, Breadcrumb, Button } from 'erxes-ui';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export const TeamTemplatesPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  return (
+    <PageContainer>
+      <div className="h-full w-full bg-background overflow-auto">
+        <div className="px-4 h-16 flex items-center">
+          <Breadcrumb>
+            <Breadcrumb.List>
+              <Breadcrumb.Item>
+                <Breadcrumb.Link asChild className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    className="text-foreground font-semibold"
+                    onClick={() =>
+                      navigate(`/settings/operation/team/details/${id}`)
+                    }
+                  >
+                    <IconArrowLeft size={16} className="stroke-foreground" />
+                    Team settings
+                  </Button>
+                </Breadcrumb.Link>
+              </Breadcrumb.Item>
+            </Breadcrumb.List>
+          </Breadcrumb>
+        </div>
+        <TemplateList />
+      </div>
+    </PageContainer>
+  );
+};

--- a/frontend/plugins/operation_ui/src/pages/TemplateFormPage.tsx
+++ b/frontend/plugins/operation_ui/src/pages/TemplateFormPage.tsx
@@ -1,0 +1,65 @@
+import { PageContainer, Button, Breadcrumb } from 'erxes-ui';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { TemplateForm } from '@/template/components/TemplateForm';
+import { useQuery } from '@apollo/client';
+import { templateDetailQuery } from '@/template/graphql/queries';
+import { IconArrowLeft } from '@tabler/icons-react';
+
+export const TemplateFormPage = () => {
+  const { id: teamId, templateId } = useParams<{
+    id: string;
+    templateId?: string;
+  }>();
+  const navigate = useNavigate();
+
+  const { data, loading } = useQuery(templateDetailQuery, {
+    variables: { _id: templateId },
+    skip: !templateId,
+  });
+
+  const template = data?.operationTemplateDetail;
+
+  if (loading) return null;
+
+  return (
+    <PageContainer>
+      <div className="h-full w-full bg-background overflow-auto">
+        <div className="px-4 h-16 flex items-center">
+          <Breadcrumb>
+            <Breadcrumb.List>
+              <Breadcrumb.Item>
+                <Breadcrumb.Link asChild className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    className="text-foreground font-semibold"
+                    asChild
+                  >
+                    <Link to={`/settings/operation/team/templates/${teamId}`}>
+                      <IconArrowLeft
+                        size={16}
+                        className="stroke-foreground mr-2"
+                      />
+                      Template List
+                    </Link>
+                  </Button>
+                </Breadcrumb.Link>
+              </Breadcrumb.Item>
+            </Breadcrumb.List>
+          </Breadcrumb>
+        </div>
+        <div className="flex-1 overflow-auto bg-background p-6">
+          <div className="max-w-4xl mx-auto border rounded-lg bg-card text-card-foreground shadow-sm">
+            <TemplateForm
+              teamId={teamId}
+              template={template}
+              onCancel={() => navigate(-1)}
+              afterSave={() =>
+                navigate(`/settings/operation/team/templates/${teamId}`)
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </PageContainer>
+  );
+};

--- a/frontend/plugins/operation_ui/src/types/paths.ts
+++ b/frontend/plugins/operation_ui/src/types/paths.ts
@@ -4,4 +4,5 @@ export enum OperationPaths {
   TeamDetail = 'details/:id',
   TeamMembers = 'members/:id',
   TeamStatus = 'status/:id',
+  TeamTemplates = 'templates/:id',
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add operation template management feature with backend GraphQL support and frontend UI components for template selection and management.
> 
>   - **Backend**:
>     - Add `templateMutations` and `templateQueries` to `mutations.ts` and `queries.ts`.
>     - Update `schema.ts` to include `TemplateMutations`, `TemplateQueries`, and `TemplateTypes`.
>     - Add `IOperationTemplate` interfaces in `@types/template.ts`.
>     - Define `operationTemplateSchema` in `db/definitions/template.ts`.
>     - Implement `IOperationTemplateModel` in `db/models/Template.ts` with methods for CRUD operations.
>     - Add GraphQL resolvers in `graphql/resolvers.ts` and schema in `graphql/schema.ts`.
>   - **Frontend**:
>     - Add `SelectTemplate` component in `components/SelectTemplate.tsx` for template selection.
>     - Implement `TemplateForm` in `components/TemplateForm.tsx` for creating/editing templates.
>     - Create `TemplateList` in `components/TemplateList.tsx` for listing templates.
>     - Add GraphQL queries and mutations in `graphql/queries.ts` and `graphql/mutations.ts`.
>     - Update `AddTaskForm.tsx` and `AddTriageForm.tsx` to include template selection.
>     - Add `TeamTemplatesPage.tsx` and `TemplateFormPage.tsx` for template management UI.
>     - Update `OperationSettings.tsx` and `TeamDetails.tsx` to include template routes and sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 01380fd42a4dadb8b61bc6e10bf2c1194ba2d21a. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added operation templates management to team settings - create, edit, delete, and view templates for your team.
  * Added template-based prefill for task and triage creation - select a template to automatically populate form fields including description and task/triage name.
  * New Templates section accessible from team details page for easy template access and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->