### PR TITLE
fix: handle loyalty owner when customers merge

### DIFF
--- a/packages/core/src/db/models/Customers.ts
+++ b/packages/core/src/db/models/Customers.ts
@@ -13,6 +13,7 @@ import {
   sendClientPortalMessage,
   sendEngagesMessage,
   sendInboxMessage,
+  sendLoyaltiesMessage,
 } from "../../messageBroker";
 import {
   customerSchema,
@@ -668,6 +669,11 @@ export const loadCustomerClass = (models: IModels, subdomain: string) => {
         data: { customerId: customer._id, customerIds },
       });
       await sendClientPortalMessage({
+        subdomain,
+        action: "changeCustomer",
+        data: { customerId: customer._id, customerIds },
+      });
+      await sendLoyaltiesMessage({
         subdomain,
         action: "changeCustomer",
         data: { customerId: customer._id, customerIds },

--- a/packages/core/src/messageBroker.ts
+++ b/packages/core/src/messageBroker.ts
@@ -1530,3 +1530,10 @@ export const sendPurchasesMessage = async (
     ...args,
   });
 };
+
+export const sendLoyaltiesMessage = (args: MessageArgsOmitService) => {
+  return sendMessage({
+    serviceName: 'loyalties',
+    ...args,
+  });
+};

--- a/packages/plugin-loyalties-api/src/graphql/schema/scoreLog.ts
+++ b/packages/plugin-loyalties-api/src/graphql/schema/scoreLog.ts
@@ -35,7 +35,7 @@ export const types = `
 export const queries = `
   scoreLogs(${commonFilters},campaignId:String): [ScoreLog]
   scoreLogList(${commonFilters},campaignId:String,orderType:String,order:String,fromDate:String,toDate:String,stageId:String,number:String,action:String,description:String):List
-  scoreLogStatistics(${commonFilters},campaignId:String,orderType:String,order:String,fromDate:String,toDate:String,stageId:String,number:String,action:String): JSON
+  scoreLogStatistics(${commonFilters},campaignId:String,orderType:String,order:String,fromDate:String,toDate:String,stageId:String,number:String,action:String,description:String): JSON
 `;
 export const mutation = `
   changeScore( ownerType: String, ownerId: String, changeScore: Int, description: String, createdBy: String,campaignId:String, targetId: String, serviceName: String ):JSON

--- a/packages/plugin-loyalties-api/src/messageBroker.ts
+++ b/packages/plugin-loyalties-api/src/messageBroker.ts
@@ -13,6 +13,7 @@ import {
   checkVouchersSale,
   confirmVoucherSale,
   doScoreCampaign,
+  handleLoyaltyOwnerChange,
   handleLoyaltyReward,
   handleScore,
   refundLoyaltyScore,
@@ -147,6 +148,15 @@ export const setupMessageConsumers = async () => {
       status: "success",
     };
   });
+
+  consumeQueue(
+    "loyalties:changeCustomer",
+    async ({ subdomain, data: { customerId, customerIds } }) => {
+      const models = await generateModels(subdomain);
+
+      await handleLoyaltyOwnerChange(subdomain, models, customerId, customerIds);
+    }
+  );
 };
 
 export const sendCoreMessage = async (

--- a/packages/plugin-loyalties-api/src/models/ScoreCampaigns.ts
+++ b/packages/plugin-loyalties-api/src/models/ScoreCampaigns.ts
@@ -1,4 +1,4 @@
-import { IUserDocument } from "@erxes/api-utils/src/types";
+import { ICustomField, IUserDocument } from "@erxes/api-utils/src/types";
 import { Model } from "mongoose";
 import { IModels } from "../connectionResolver";
 import { putCreateLog, putDeleteLog, putUpdateLog } from "../logUtils";
@@ -58,6 +58,16 @@ export interface IScoreCampaignModel extends Model<IScoreCampaignDocuments> {
     ownerType: string,
     ownerId: string
   ): Promise<boolean>;
+
+  updateOwnerScore({
+    ownerId,
+    ownerType,
+    updatedCustomFieldsData
+  }: {
+    ownerId: string;
+    ownerType: string;
+    updatedCustomFieldsData: ICustomField[]
+  }): Promise<void>;
 }
 
 export const loadScoreCampaignClass = (models: IModels, subdomain: string) => {

--- a/packages/plugin-loyalties-api/src/models/definitions/coupons.ts
+++ b/packages/plugin-loyalties-api/src/models/definitions/coupons.ts
@@ -82,4 +82,5 @@ export const couponSchema = new Schema(
   { timestamps: true },
 );
 
+couponSchema.index({ 'usageLogs.ownerId': 1 });
 couponSchema.index({ campaignId: 1, code: 1 }, { unique: true });

--- a/packages/plugin-loyalties-api/src/models/definitions/vouchers.ts
+++ b/packages/plugin-loyalties-api/src/models/definitions/vouchers.ts
@@ -33,3 +33,5 @@ export const voucherSchema = schemaHooksWrapper(
   }),
   'erxes_loyalty_vouchers'
 );
+
+voucherSchema.index({ ownerId: 1 });

--- a/packages/plugin-loyalties-api/src/utils.ts
+++ b/packages/plugin-loyalties-api/src/utils.ts
@@ -2,6 +2,7 @@ import { getEnv } from "@erxes/api-utils/src";
 import { debugError } from "@erxes/api-utils/src/debuggers";
 import { getOrganizations } from "@erxes/api-utils/src/saas/saas";
 import { isEnabled } from "@erxes/api-utils/src/serviceDiscovery";
+import { ICustomField } from "@erxes/api-utils/src/types";
 import { IModels } from "./connectionResolver";
 import { collections } from "./constants";
 import {
@@ -10,6 +11,7 @@ import {
   sendCoreMessage,
 } from "./messageBroker";
 import { VOUCHER_STATUS } from "./models/definitions/constants";
+import { SCORE_CAMPAIGN_STATUSES } from "./models/definitions/scoreCampaigns";
 
 interface IProductD {
   productId: string;
@@ -713,4 +715,85 @@ export const refundLoyaltyScore = async (
       }
     }
   }
+};
+
+export const handleLoyaltyOwnerChange = async (
+  subdomain: string,
+  models: IModels,
+  ownerId: string,
+  ownerIds: string[],
+) => {
+  await models.Vouchers.updateMany(
+    { ownerId: { $in: ownerIds } },
+    { $set: { ownerId } },
+  );
+
+  await models.Coupons.updateMany(
+    { "usageLogs.ownerId": { $in: ownerIds } },
+    { $set: { "usageLogs.$[elem].ownerId": ownerId } },
+    { arrayFilters: [{ "elem.ownerId": { $in: ownerIds } }] },
+  );
+
+  await models.ScoreLogs.updateMany(
+    { ownerId: { $in: ownerIds } },
+    { $set: { ownerId } },
+  );
+
+  const customer = await sendCoreMessage({
+    subdomain,
+    action: "customers.findOne",
+    data: {
+      _id: ownerId,
+    },
+    isRPC: true,
+    defaultValue: {},
+  });
+  
+
+  const scoreCampaigns = await models.ScoreCampaigns.find({ status: SCORE_CAMPAIGN_STATUSES.PUBLISHED }).distinct("fieldId");
+
+  const fieldIds = new Set(scoreCampaigns);
+
+  const customFieldsData: ICustomField[] = [];
+  const scoreFieldsData: Record<string, ICustomField> = {};
+
+  for (const customFieldData of (customer?.customFieldsData || [])) {
+    const { field, value, numberValue } = customFieldData || {};
+
+    if (!fieldIds.has(field)) {
+      customFieldsData.push(customFieldData);
+
+      continue;
+    }
+
+    const numericValue = numberValue ?? Number(value) ?? 0;
+
+    if (!scoreFieldsData[field]) {
+      scoreFieldsData[field] = {
+        field,
+        value: 0,
+        numberValue: 0,
+        stringValue: "0",
+      };
+    }
+
+    scoreFieldsData[field].value += numericValue;
+    scoreFieldsData[field].numberValue += numericValue;
+    scoreFieldsData[field].stringValue = String(scoreFieldsData[field].numberValue);
+  }
+
+  const preparedCustomFieldsData = await sendCoreMessage({
+    subdomain,
+    action: "fields.prepareCustomFieldsData",
+    data: [...customFieldsData, ...(Object.values(scoreFieldsData) || [])],
+    defaultValue: [],
+    isRPC: true,
+  });
+
+  await models.ScoreCampaigns.updateOwnerScore({
+    ownerId,
+    ownerType: "customer",
+    updatedCustomFieldsData: preparedCustomFieldsData,
+  });
+
 };

--- a/packages/plugin-loyalties-ui/src/loyalties/scorelogs/components/FilterCampaign.tsx
+++ b/packages/plugin-loyalties-ui/src/loyalties/scorelogs/components/FilterCampaign.tsx
@@ -76,6 +76,17 @@ const FilterCampaign = (props: Props) => {
       return clearCategoryFilter(["orderType", "order"]);
     }
 
+    if (field === "boardId") {
+      router.setParams(navigate, location, {
+        pipelineId: undefined,
+        stageId: undefined,
+      });
+    }
+
+    if (field === "pipelineId") {
+      router.setParams(navigate, location, { stageId: undefined });
+    }
+
     if (!value) {
       return clearCategoryFilter([field]);
     }
@@ -168,6 +179,7 @@ const FilterCampaign = (props: Props) => {
     return (
       <FilterContainer>
         <BoardSelectContainer
+          key={`${boardId}-${pipelineId}-${stageId}`}
           type="deal"
           autoSelectStage={false}
           boardId={boardId || ""}


### PR DESCRIPTION
- Add loyalty message broker integration in core
- Merge score campaign related fields in customer
- Set vouchers, coupons, and score logs to new merged customer
- Add database indexes for owner-based queries
- Clear selected options when relation changes in BoardSelectContainer

## Summary by Sourcery

Handle loyalty data updates when customers are merged and improve score log filtering behavior.

Bug Fixes:
- Reset dependent board, pipeline, and stage filters when board or pipeline selection changes in score log filters.
- Include description filter in score log statistics queries.

Enhancements:
- Reassign vouchers, coupon usage logs, and score logs to the new customer when ownership changes.
- Merge and recalculate score campaign-related custom field values for the merged customer and update associated campaign scores.
- Introduce a dedicated loyalties message channel from core and consume customer change events in the loyalties service.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance loyalty owner handling during customer merges with message broker integration, database updates, and UI adjustments.
> 
>   - **Behavior**:
>     - Add `sendLoyaltiesMessage` to `Customers.ts` for loyalty message broker integration.
>     - Update `handleLoyaltyOwnerChange` in `utils.ts` to update `Vouchers`, `Coupons`, and `ScoreLogs` with new owner ID.
>     - Add `consumeQueue` for `loyalties:changeCustomer` in `messageBroker.ts` to handle loyalty owner changes.
>   - **Database**:
>     - Add indexes for `ownerId` in `coupons.ts` and `vouchers.ts` for efficient queries.
>     - Update `ScoreCampaigns.ts` to include `updateOwnerScore` method for updating scores after merge.
>   - **GraphQL**:
>     - Add `description` filter to `scoreLogStatistics` query in `scoreLog.ts`.
>   - **UI**:
>     - Clear `pipelineId` and `stageId` in `FilterCampaign.tsx` when `boardId` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for ab29e729f0c6c55b07478c629c20e00e553c877d. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->