### PR TITLE
chore: customer merge functionality with custom fields support

### DIFF
--- a/packages/core-ui/src/modules/contacts/customers/components/list/CustomersList.tsx
+++ b/packages/core-ui/src/modules/contacts/customers/components/list/CustomersList.tsx
@@ -4,7 +4,7 @@ import { gql } from "@apollo/client";
 import { Menu } from "@headlessui/react";
 import { Link } from "react-router-dom";
 
-import CustomersMerge from "@erxes/ui-contacts/src/customers/components/detail/CustomersMerge";
+import CustomersMerge from "@erxes/ui-contacts/src/customers/containers/CustomersMerge";
 import CustomerForm from "@erxes/ui-contacts/src/customers/containers/CustomerForm";
 import { queries } from "@erxes/ui-contacts/src/customers/graphql";
 import Widget from "@erxes/ui-engage/src/containers/Widget";
@@ -275,8 +275,8 @@ const CustomersList: React.FC<IProps> = props => {
     changeVerificationStatus("phone", value, bulk);
   };
 
-  const onStateClick = e => {
-    changeState(e.target.id);
+  const onStateClick = value => {
+    changeState(value);
   };
 
   const emailVerificationStatusList = [] as any;
@@ -320,7 +320,7 @@ const CustomersList: React.FC<IProps> = props => {
   for (const option of CUSTOMER_STATE_OPTIONS) {
     customerStateOptions.push(
       <Menu.Item key={option.value}>
-        <a id={option.value} href="#changeState" onClick={onStateClick}>
+        <a id={option.value} href="#changeState" onClick={() => onStateClick(option.value)}>
           {option.label}
         </a>
       </Menu.Item>

--- a/packages/core/src/db/models/Customers.ts
+++ b/packages/core/src/db/models/Customers.ts
@@ -601,6 +601,18 @@ export const loadCustomerClass = (models: IModels, subdomain: string) => {
             ...(customerObj.customFieldsData || []),
           ];
 
+          if (customerFields?.customFieldsData?.length) {
+            for (const customFieldData of (customerFields.customFieldsData || [])) {
+              customFieldsData = customFieldsData.filter(item => {
+                if (item.field !== customFieldData.field) {
+                  return true;
+                }
+
+                return item.value === customFieldData.value;
+              });
+            }
+          }
+
           // Merging scopeBrandIds
           scopeBrandIds = [
             ...scopeBrandIds,

--- a/packages/plugin-loyalties-api/src/utils.ts
+++ b/packages/plugin-loyalties-api/src/utils.ts
@@ -748,7 +748,6 @@ export const handleLoyaltyOwnerChange = async (
     isRPC: true,
     defaultValue: {},
   });
-  
 
   const scoreCampaigns = await models.ScoreCampaigns.find({ status: SCORE_CAMPAIGN_STATUSES.PUBLISHED }).distinct("fieldId");
 
@@ -795,5 +794,4 @@ export const handleLoyaltyOwnerChange = async (
     ownerType: "customer",
     updatedCustomFieldsData: preparedCustomFieldsData,
   });
-
 };

--- a/packages/plugin-loyalties-ui/src/loyalties/scorelogs/components/FilterCampaign.tsx
+++ b/packages/plugin-loyalties-ui/src/loyalties/scorelogs/components/FilterCampaign.tsx
@@ -76,17 +76,6 @@ const FilterCampaign = (props: Props) => {
       return clearCategoryFilter(["orderType", "order"]);
     }
 
-    if (field === "boardId") {
-      router.setParams(navigate, location, {
-        pipelineId: undefined,
-        stageId: undefined,
-      });
-    }
-
-    if (field === "pipelineId") {
-      router.setParams(navigate, location, { stageId: undefined });
-    }
-
     if (!value) {
       return clearCategoryFilter([field]);
     }

--- a/packages/ui-contacts/src/customers/containers/CustomersMerge.tsx
+++ b/packages/ui-contacts/src/customers/containers/CustomersMerge.tsx
@@ -1,0 +1,60 @@
+import * as compose from "lodash.flowright";
+
+import { ICustomer, ICustomerDoc } from "../types";
+
+import { gql } from "@apollo/client";
+import { graphql } from "@apollo/client/react/hoc";
+import { queries as fieldQueries } from "@erxes/ui-forms/src/settings/properties/graphql";
+import { FieldsGroupsQueryResponse } from "@erxes/ui-forms/src/settings/properties/types";
+import { withProps } from "@erxes/ui/src/utils";
+import React from "react";
+import CustomersMerge from "../components/detail/CustomersMerge";
+
+type Props = {
+  objects: ICustomer[];
+  mergeCustomerLoading: boolean;
+  save: (doc: {
+    ids: string[];
+    data: ICustomerDoc;
+    callback: () => void;
+  }) => void;
+  closeModal: () => void;
+};
+
+type FinalProps = {
+  fieldsGroupsQuery: FieldsGroupsQueryResponse;
+} & Props;
+
+class CustomersMergeContianer extends React.Component<FinalProps> {
+  constructor(props: FinalProps) {
+    super(props);
+  }
+
+  render() {
+    const { fieldsGroupsQuery } = this.props;
+
+    const updatedProps = {
+      ...this.props,
+      fieldsGroups: fieldsGroupsQuery ? fieldsGroupsQuery.fieldsGroups : [],
+    };
+
+    return <CustomersMerge {...updatedProps} />;
+  }
+}
+
+export default withProps<Props>(
+  compose(
+    graphql<Props, FieldsGroupsQueryResponse, { contentType: string }>(
+      gql(fieldQueries.fieldsGroups),
+      {
+        name: "fieldsGroupsQuery",
+        options: () => ({
+          variables: {
+            contentType: "core:customer",
+            isDefinedByErxes: false,
+          },
+        }),
+      },
+    ),
+  )(CustomersMergeContianer),
+);


### PR DESCRIPTION
- Add custom fields support to customer merge interface
- Create new CustomersMerge container to fetch field groups
- Update merge logic to handle custom fields data properly
- Fix event handler issues in customer list state changes
- Remove unused code in loyalty plugin filter
- Clean up formatting and remove trailing whitespace

## Summary by Sourcery

Add support for merging customer custom fields and wire the merge UI to fetch and display configurable field groups while cleaning up related UI and loyalty plugin code.

New Features:
- Enable customer merge UI to display and select values from custom fields based on visible field groups.
- Introduce a CustomersMerge container that queries customer field groups and passes them into the merge component.

Bug Fixes:
- Correct customer state change handler in the customers list so the selected state value is passed explicitly.

Enhancements:
- Refine customer merge logic on the backend to de-duplicate and correctly merge customFieldsData entries.
- Simplify loyalty scorelogs campaign filter behavior by removing unused board/pipeline-specific routing.
- Minor cleanup in loyalty owner change utility to remove redundant whitespace.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add custom fields support to customer merge functionality and update merge logic to handle these fields.
> 
>   - **Behavior**:
>     - Add custom fields support to customer merge interface in `CustomersMerge.tsx`.
>     - Update merge logic in `Customers.ts` to handle custom fields data properly.
>     - Fix event handler issues in `CustomersList.tsx` for state changes.
>   - **Containers**:
>     - Create new `CustomersMerge` container in `CustomersMerge.tsx` to fetch field groups.
>   - **Misc**:
>     - Remove unused code in `FilterCampaign.tsx`.
>     - Clean up formatting and remove trailing whitespace in `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 7a991ccf4c1e49c56fac9974683dd6c2bb4e333f. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->