### PR TITLE
fix: correct typo 'occured' to 'occurred' in useUsersInvite.tsx

### DIFF
--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useUsersInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useUsersInvite.tsx
@@ -13,7 +13,7 @@ const useUsersInvite = () => {
         ...options,
       });
     } catch (error) {
-      console.error('Error occured', error);
+      console.error('Error occurred', error);
     }
   };
 


### PR DESCRIPTION
## Summary
Fixed a common spelling mistake where 'occured' was corrected to 'occurred' in the error logging message.

## Changes
- frontend/core-ui/src/modules/settings/team-member/hooks/useUsersInvite.tsx: Line 16

## Type of Change
- [x] Bug fix (typo correction)

## Summary by Sourcery

Bug Fixes:
- Fix a misspelled word in the console error message when inviting users in the team member settings module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the error message displayed during user invitation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->