### PR TITLE
fix: correct typo 'occured' to 'occurred' in Fields model

### DIFF
--- a/backend/plugins/frontline_api/src/modules/form/db/models/Fields.ts
+++ b/backend/plugins/frontline_api/src/modules/form/db/models/Fields.ts
@@ -354,7 +354,7 @@ export const loadFieldClass = (models: IModels, subdomain: string) => {
           fixedValues[_id] = await this.clean(_id, data[_id]);
         } catch (e) {
           console.log(
-            `An error occured in CLEAN while cleanMulti: ${
+            `An error occurred in CLEAN while cleanMulti: ${
               e.message
             } ::: customFieldData ::: ${JSON.stringify(data)}`,
           );


### PR DESCRIPTION
## Summary
Fixed a typo in error message: 'occured' → 'occurred'

## Change
- Line 357: Corrected spelling in console.log message

## Type
- [x] Typo fix

**Review time: < 5 seconds**

## Summary by Sourcery

Bug Fixes:
- Correct the spelling of 'occurred' in the CLEAN error log message within the Fields model.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected typo in `console.log` message from 'occured' to 'occurred' in `Fields.ts`.
> 
>   - **Typo Fix**:
>     - Corrected typo in `console.log` message from 'occured' to 'occurred' in `Fields.ts` at line 357.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for a725ce4b7d74555df2bca01790d8b75019833f1e. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->