### PR TITLE
fix: remove trailing whitespace in TopicDrawer.tsx

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/TopicDrawer.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/TopicDrawer.tsx
@@ -7,7 +7,7 @@ import { ADD_TOPIC, EDIT_TOPIC } from '../graphql/mutations';
 import { TOPICS } from '../graphql/queries';
 import { SelectBrand } from 'ui-modules';
 import { LANGUAGES } from '../constants';
-import { REACT_APP_WIDGETS_URL } from '@/utils'; 
+import { REACT_APP_WIDGETS_URL } from '@/utils';
 
 interface Topic {
   _id: string;


### PR DESCRIPTION
## Summary
Removed trailing whitespace at end of import statement.

## Change
- Line 10: Removed trailing space after semicolon

## Type
- [x] Code style fix

**Review time: < 5 seconds**

## Summary by Sourcery

Normalize import statement formatting in TopicDrawer to remove trailing whitespace.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove trailing whitespace in `TopicDrawer.tsx` at line 10 after semicolon.
> 
>   - **Code Style**:
>     - Remove trailing whitespace in `TopicDrawer.tsx` at line 10 after semicolon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 55eebd8b59284c4f3a9d9e4a786f27c8253fb88d. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->