### PR TITLE
fix: remove trailing whitespace in GraphQL query file

### DIFF
--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/graphql/queries/getCampaignsQuery.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/graphql/queries/getCampaignsQuery.ts
@@ -5,13 +5,13 @@ export const QUERY_SPIN_CAMPAIGNS = gql`
   query GetSpinCampaigns(
     $searchValue: String
     $status: String
- 
+
   ${GQL_CURSOR_PARAM_DEFS}
   ) {
     spinCampaigns(
       searchValue: $searchValue
       status: $status
-    
+
       ${GQL_CURSOR_PARAMS}
     ) {
       list {


### PR DESCRIPTION
## Summary
Removed trailing whitespace on blank lines in GraphQL query.

## Changes
- Line 8: Removed trailing space
- Line 14: Removed trailing spaces

## Type
- [x] Code style fix

**Review time: < 10 seconds**

## Summary by Sourcery

Enhancements:
- Clean up trailing whitespace in the GetSpinCampaigns GraphQL query definition.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove trailing whitespace in `getCampaignsQuery.ts` for code style consistency.
> 
>   - **Code Style Fix**:
>     - Removed trailing whitespace on line 8 and line 14 in `getCampaignsQuery.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for a058578b6974104b766e1acf08b7447ef849bd6f. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->