### PR TITLE
fix: remove unused import from usePositionActions.tsx

### DIFF
--- a/frontend/core-ui/src/modules/settings/structure/hooks/usePositionActions.tsx
+++ b/frontend/core-ui/src/modules/settings/structure/hooks/usePositionActions.tsx
@@ -13,7 +13,6 @@ import {
   GET_POSITIONS_LIST,
   REMOVE_POSITIONS,
 } from '../graphql';
-import { data } from 'react-router';
 
 interface PositionData {
   positionsMain: {


### PR DESCRIPTION
## Summary
Removed unused import `{ data } from 'react-router'` that was not being used in the file.

## Change
- Line 16: Removed unused import

## Type
- [x] Code cleanup (removed unused import)

**Review time: < 30 seconds**

## Summary by Sourcery

Enhancements:
- Clean up the usePositionActions hook by removing an unused react-router import.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed unused import `{ data } from 'react-router'` in `usePositionActions.tsx`.
> 
>   - **Code Cleanup**:
>     - Removed unused import `{ data } from 'react-router'` in `usePositionActions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for dd94b1f059e4ebd4bf807bc66f0307b5751bb967. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and cleanup improvements to enhance codebase quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->