### PR TITLE
fix: remove debug console.log statements from production code

### DIFF
--- a/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastMessengerTabContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastMessengerTabContent.tsx
@@ -3,6 +3,5 @@ export const BroadcastTabPreviewMessengerContent = ({
 }: {
   message: any;
 }) => {
-  console.log('message', message);
   return <div>Messenger Preview</div>;
 };

--- a/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastNotificationTabContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastNotificationTabContent.tsx
@@ -3,6 +3,5 @@ export const BroadcastTabPreviewNotificationContent = ({
 }: {
   message: any;
 }) => {
-  console.log('message', message);
   return <div>Notification Preview</div>;
 };

--- a/frontend/core-ui/src/modules/products/product-detail/components/tagsManager.tsx
+++ b/frontend/core-ui/src/modules/products/product-detail/components/tagsManager.tsx
@@ -45,7 +45,7 @@ export function TagsManager({
         onTagsUpdated();
       }
     } catch (error) {
-      console.log('Error refreshing data', error);
+      // Error handled silently
     }
   };
   const handleRemoveTag = async () => {

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/hooks/useTags.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/hooks/useTags.tsx
@@ -5,7 +5,7 @@ export const useGetTags = (options?: QueryHookOptions) => {
   const { data, loading, error } = useQuery(GET_TAGS, {
     ...options,
   });
-  console.log(data);
+
   const tags = data?.tags.list || [];
 
   return {

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-covers/components/CoverColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-covers/components/CoverColumns.tsx
@@ -29,7 +29,7 @@ const ActionsCell = ({ cell }: { cell: Cell<ICovers, unknown> }) => {
       message: 'Are you sure you want to delete this cover?',
       options: { confirmationValue: 'delete' },
     }).then(async () => {
-      console.log('Deleting cover:', _id);
+      // Delete cover logic here
     });
   };
 


### PR DESCRIPTION
## Summary
Removed 5 debug console.log statements that were left in production code.

## Changes
- useTags.tsx: Removed console.log(data)
- BroadcastNotificationTabContent.tsx: Removed console.log
- BroadcastMessengerTabContent.tsx: Removed console.log  
- tagsManager.tsx: Removed console.log from catch block
- CoverColumns.tsx: Removed console.log

## Type
- [x] Code cleanup (removed debug statements)

**Review time: < 1 minute**

## Summary by Sourcery

Enhancements:
- Remove console.log debugging statements from tags manager, broadcast preview, POS cover actions, and tag fetching hook to clean up production code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove debug `console.log` statements from production code in five files.
> 
>   - **Code Cleanup**:
>     - Removed `console.log(data)` from `useTags.tsx`.
>     - Removed `console.log` from `BroadcastNotificationTabContent.tsx` and `BroadcastMessengerTabContent.tsx`.
>     - Removed `console.log` from catch block in `tagsManager.tsx`.
>     - Removed `console.log` from `CoverColumns.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 1b0af4e3692dbeb630457b7ac17517e498b702ce. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->