### PR TITLE
fix: correct typos 'cant' to 'can't' in Transactions.ts

### DIFF
--- a/backend/plugins/accounting_api/src/modules/accounting/db/models/Transactions.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/db/models/Transactions.ts
@@ -257,11 +257,11 @@ export const loadTransactionClass = (models: IModels, subdomain: string) => {
       });
 
       if (transaction.originId) {
-        throw new Error('cant remove this transaction. Remove the source transaction first')
+        throw new Error("can't remove this transaction. Remove the source transaction first")
       }
 
       if ((await models.Transactions.find({ preTrId: _id }).lean()).length) {
-        throw new Error('cant remove this transaction. Remove the dependent transaction first')
+        throw new Error("can't remove this transaction. Remove the dependent transaction first")
       }
 
       await models.Transactions.deleteMany({
@@ -299,7 +299,7 @@ export const loadTransactionClass = (models: IModels, subdomain: string) => {
       const deleteTrIds = summaryTrs.map(tr => tr._id);
 
       if ((await models.Transactions.find({ preTrId: { $in: deleteTrIds }, _id: { $nin: deleteTrIds } }).lean()).length) {
-        throw new Error('cant remove this transaction. Remove the dependent transaction first')
+        throw new Error("can't remove this transaction. Remove the dependent transaction first")
       }
       if (!(await models.Transactions.find({
         _id: { $in: deleteTrIds }


### PR DESCRIPTION
## Summary
Fixed 3 typos: 'cant' → 'can't' (missing apostrophes)

## Changes
- Line 260: Fixed error message
- Line 264: Fixed error message
- Line 302: Fixed error message

## Type
- [x] Typo fix

**Review time: < 30 seconds**

## Summary by Sourcery

Bug Fixes:
- Fix grammar in transaction removal error messages by adding missing apostrophes in "can't".
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typos by changing 'cant' to 'can't' in error messages in `Transactions.ts`.
> 
>   - **Typo Fixes**:
>     - Corrected 'cant' to 'can't' in error messages on lines 260, 264, and 302 in `Transactions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for f126462738b4ff13354b278c75da43c3d1582eed. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected punctuation in transaction-related error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->