### PR TITLE
fix: correct typo 'dont' to 'don't' in migratePropertiesData.ts

### DIFF
--- a/backend/core-api/src/commands/migratePropertiesData.ts
+++ b/backend/core-api/src/commands/migratePropertiesData.ts
@@ -108,7 +108,7 @@ const toObject = (contentType, document, fields, groups) => {
 
           if (!fieldIds.length) {
             console.log(
-              `${contentType} Group is multiple and Document (${document._id}) object dont have any field ${customField.field}.`,
+              `${contentType} Group is multiple and Document (${document._id}) object don't have any field ${customField.field}.`,
             );
             continue;
           }


### PR DESCRIPTION
## Summary
Fixed typo: 'dont' → 'don't' (missing apostrophe)

## Change
- Line 111: Fixed console.log message

## Type
- [x] Typo fix

**Review time: < 30 seconds**

## Summary by Sourcery

Bug Fixes:
- Correct a grammatical typo in a console log message where "dont" is updated to "don't".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected grammar in error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->