### PR TITLE
fix: remove debug console.log from useTags.tsx

### DIFF
--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/hooks/useTags.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/hooks/useTags.tsx
@@ -5,7 +5,7 @@ export const useGetTags = (options?: QueryHookOptions) => {
   const { data, loading, error } = useQuery(GET_TAGS, {
     ...options,
   });
-  console.log(data);
+
   const tags = data?.tags.list || [];
 
   return {


### PR DESCRIPTION
## Summary
Removed debug console.log statement from useTags hook.

## Change
- Line 8: Removed console.log(data)

## Type
- [x] Code cleanup (removed debug statement)

**Review time: < 30 seconds**
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `console.log(data)` from `useGetTags` in `useTags.tsx`.
> 
>   - **Code Cleanup**:
>     - Removed `console.log(data)` from `useGetTags` in `useTags.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 14d78b7af8c72dde1316e7668c86f6d5ff9a996c. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statement from internal code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->