### PR TITLE
fix(ticket): pipeline permissions

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/permissions/components/PipelinePermissionsList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/permissions/components/PipelinePermissionsList.tsx
@@ -31,8 +31,8 @@ export const PipelinePermissionsList = memo(() => {
   const { updatePipeline, loading: updating } = useUpdatePipeline();
   const { updateStatus } = useUpdateTicketStatus();
 
-  const [visibleStatusCount, setVisibleStatusCount] = useState(5);
-  const INITIAL_STATUS_COUNT = 5;
+  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
+  const INITIAL_STATUS_COUNT = 3;
 
   const form = useForm<PermissionState>({
     resolver: zodResolver(UPDATE_PIPELINE_PERMISSIONS_FORM_SCHEMA),
@@ -268,7 +268,7 @@ export const PipelinePermissionsList = memo(() => {
                             setVisibleStatusCount(INITIAL_STATUS_COUNT);
                           } else {
                             setVisibleStatusCount((prev) =>
-                              Math.min(prev + 5, statuses.length),
+                              Math.min(prev + 3, statuses.length),
                             );
                           }
                         }}
@@ -276,7 +276,7 @@ export const PipelinePermissionsList = memo(() => {
                         {visibleStatusCount >= statuses.length
                           ? 'Show Less'
                           : `Show ${Math.min(
-                              5,
+                              3,
                               statuses.length - visibleStatusCount,
                             )} More`}
                       </Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce initial and incremental visible status count from 5 to 3 in `PipelinePermissionsList`.
> 
>   - **Behavior**:
>     - Change initial `visibleStatusCount` from 5 to 3 in `PipelinePermissionsList`.
>     - Update logic to increment `visibleStatusCount` by 3 instead of 5 when showing more statuses.
>   - **UI**:
>     - Update button text to reflect the new increment value of 3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes&utm_source=github&utm_medium=referral)<sup> for 8996b46013be7ff5f2ee226e2fbf30eb815d2004. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced the initial display of status items in the pipeline permissions list from 5 to 3.
  * Updated the "Show More" button to load 3 additional items instead of 5 on each expansion.
  * Modified related UI text labels to reflect the new increment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->