### PR TITLE
fix: extend client-auth-token time

### DIFF
--- a/frontend/core-ui/src/modules/client-portal/components/ClientPortalDetailAuth.tsx
+++ b/frontend/core-ui/src/modules/client-portal/components/ClientPortalDetailAuth.tsx
@@ -225,7 +225,7 @@ export const ClientPortalDetailAuth = ({
                         <Input
                           type="number"
                           min={1}
-                          max={7}
+                          max={365}
                           {...field}
                           value={field.value ?? ''}
                           onChange={(e) =>
@@ -247,7 +247,7 @@ export const ClientPortalDetailAuth = ({
                         <Input
                           type="number"
                           min={1}
-                          max={7}
+                          max={365}
                           {...field}
                           value={field.value ?? ''}
                           onChange={(e) =>

--- a/frontend/core-ui/src/modules/client-portal/constants/clientPortalEditSchema.ts
+++ b/frontend/core-ui/src/modules/client-portal/constants/clientPortalEditSchema.ts
@@ -8,8 +8,8 @@ export const CLIENTPORTAL_EDIT_SCHEMA = z.object({
 
 export const CLIENTPORTAL_AUTH_SCHEMA = z.object({
   tokenPassMethod: z.enum(['cookie', 'header']),
-  tokenExpiration: z.number().min(1).max(7),
-  refreshTokenExpiration: z.number().min(1).max(7),
+  tokenExpiration: z.number().min(1).max(365),
+  refreshTokenExpiration: z.number().min(1).max(365),
 });
 
 export const CLIENTPORTAL_TEST_SCHEMA = z.object({


### PR DESCRIPTION
## Summary by Sourcery

Allow longer client portal auth and refresh token lifetimes.

New Features:
- Support token and refresh token expirations up to 365 days in the client portal settings.

Enhancements:
- Increase UI and schema validation limits for token expiration fields from 7 to 365 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended maximum token expiration duration from 7 to 365 days for Token Expiration and Refresh Token Expiration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->