### PR TITLE
fix: extend client-auth-token time

### DIFF
--- a/frontend/core-ui/src/modules/client-portal/components/ClientPortalDetailAuth.tsx
+++ b/frontend/core-ui/src/modules/client-portal/components/ClientPortalDetailAuth.tsx
@@ -225,7 +225,7 @@ export const ClientPortalDetailAuth = ({
                         <Input
                           type="number"
                           min={1}
-                          max={7}
+                          max={365}
                           {...field}
                           value={field.value ?? ''}
                           onChange={(e) =>
@@ -247,7 +247,7 @@ export const ClientPortalDetailAuth = ({
                         <Input
                           type="number"
                           min={1}
-                          max={7}
+                          max={365}
                           {...field}
                           value={field.value ?? ''}
                           onChange={(e) =>

--- a/frontend/core-ui/src/modules/client-portal/constants/clientPortalEditSchema.ts
+++ b/frontend/core-ui/src/modules/client-portal/constants/clientPortalEditSchema.ts
@@ -8,8 +8,8 @@ export const CLIENTPORTAL_EDIT_SCHEMA = z.object({
 
 export const CLIENTPORTAL_AUTH_SCHEMA = z.object({
   tokenPassMethod: z.enum(['cookie', 'header']),
-  tokenExpiration: z.number().min(1).max(7),
-  refreshTokenExpiration: z.number().min(1).max(7),
+  tokenExpiration: z.number().min(1).max(365),
+  refreshTokenExpiration: z.number().min(1).max(365),
 });
 
 export const CLIENTPORTAL_TEST_SCHEMA = z.object({


### PR DESCRIPTION
## Summary by Sourcery

Allow client portal auth and refresh tokens to be configured with expiration periods of up to one year instead of one week.

New Features:
- Support longer client portal token expiration configuration values up to 365 days.

Bug Fixes:
- Align frontend validation and form constraints for token expiration fields with the new extended maximum period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum token expiration duration from 7 to 365 days in client portal authentication settings
  * Increased maximum refresh token expiration duration from 7 to 365 days in client portal authentication settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->