### PR TITLE
Cms custom field

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -5,10 +5,12 @@ import {
   useConfirm,
   toast,
   PageContainer,
+  PageSubHeader,
+  Kbd,
 } from 'erxes-ui';
-import { IconPlus } from '@tabler/icons-react';
+import { IconAlignJustified, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 
 import { CustomFieldsHeader } from './components/CustomFieldsHeader';
@@ -20,6 +22,7 @@ import { FieldGroupDrawer } from './components/field-group-drawer/FieldGroupDraw
 import { FieldDrawer } from './components/field-drawer/FieldDrawer';
 import { CustomFieldGroupItem } from './components/CustomFieldGroupItem';
 import { CMS_CUSTOM_POST_TYPES } from '../graphql/queries';
+import { EmptyState } from '../shared/EmptyState';
 
 export function CustomFields() {
   const { websiteId } = useParams();
@@ -43,6 +46,9 @@ export function CustomFields() {
   });
 
   const customTypes = customTypesData?.cmsCustomPostTypes || [];
+  const totalFields = groups.reduce((count, group) => {
+    return count + (group.fields?.length || 0);
+  }, 0);
 
   const handleGroupSubmit = (data: any) => {
     const input = {
@@ -174,92 +180,75 @@ export function CustomFields() {
   return (
     <PageContainer>
       <CustomFieldsHeader>
-        <Button asChild>
-          <Link to={`/content/cms/${websiteId}/posts/add`}>
-            <IconPlus className="w-4 h-4 mr-2" />
-            Create Post
-          </Link>
+        <Button
+          onClick={() => {
+            setEditingGroup(null);
+            setIsGroupDrawerOpen(true);
+          }}
+        >
+          <IconPlus />
+          Add Group
+          <Kbd>G</Kbd>
         </Button>
       </CustomFieldsHeader>
       <div className="flex overflow-hidden flex-auto">
         <CmsSidebar />
-        <div className="flex overflow-auto flex-col flex-auto w-full">
-          <div className="flex-auto">
-            <div className="p-6">
-              <div className="max-w-4xl mx-auto">
-                {/* Header */}
-                <div className="flex items-center justify-between mb-6">
-                  <div>
-                    <h1 className="text-xl font-semibold">Custom Fields</h1>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      Manage custom field groups and fields
-                    </p>
-                  </div>
-                  <Button
-                    onClick={() => {
-                      setEditingGroup(null);
-                      setIsGroupDrawerOpen(true);
-                    }}
-                  >
-                    <IconPlus className="w-4 h-4 mr-2" />
-                    Add Group
-                  </Button>
-                </div>
-
-                {/* Table Header */}
-                <Table>
-                  <Table.Header>
-                    <Table.Row>
-                      <Table.Head>Name</Table.Head>
-                      <Table.Head>Type</Table.Head>
-                      <Table.Head className="w-12"></Table.Head>
-                    </Table.Row>
-                  </Table.Header>
-                </Table>
-
-                {/* Groups List */}
-                {loading ? (
-                  <div className="py-12 text-center">
-                    <Spinner />
-                  </div>
-                ) : groups.length === 0 ? (
-                  <div className="py-12 text-center border rounded-lg mt-2">
-                    <p className="text-muted-foreground mb-4">
-                      No field groups yet
-                    </p>
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        setEditingGroup(null);
-                        setIsGroupDrawerOpen(true);
-                      }}
-                    >
-                      <IconPlus className="w-4 h-4 mr-2" />
-                      Create First Group
-                    </Button>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-2 mt-2">
-                    {groups.map((group) => (
-                      <CustomFieldGroupItem
-                        key={group._id}
-                        group={group}
-                        selectedGroupId={selectedGroup?._id || null}
-                        onSelectGroup={setSelectedGroup}
-                        onEditGroup={handleEditGroup}
-                        onDeleteGroup={handleDeleteGroup}
-                        onEditField={handleEditField}
-                        onDeleteField={handleDeleteField}
-                        onAddField={() => {
-                          setSelectedGroup(group);
-                          setEditingField(null);
-                          setIsFieldDrawerOpen(true);
-                        }}
-                      />
-                    ))}
-                  </div>
-                )}
+        <div className="flex overflow-hidden flex-col flex-auto w-full">
+          <PageSubHeader>
+            <div className="flex items-center justify-between gap-4 w-full">
+              <div className="text-sm text-muted-foreground">
+                {`Found ${groups.length} groups and ${totalFields} fields`}
               </div>
+            </div>
+          </PageSubHeader>
+          <div className="overflow-hidden flex-auto p-3">
+            <div className="h-full rounded-lg border overflow-auto bg-background">
+              <Table>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.Head className="w-1/2">Group / Field</Table.Head>
+                    {/* <Table.Head className="w-1/4">Type</Table.Head> */}
+                    <Table.Head className="w-1/4"></Table.Head>
+                  </Table.Row>
+                </Table.Header>
+              </Table>
+
+              {loading ? (
+                <div className="py-20 text-center">
+                  <Spinner />
+                </div>
+              ) : groups.length === 0 ? (
+                <EmptyState
+                  icon={IconAlignJustified}
+                  title="No custom field groups yet"
+                  description="Create your first group to define custom fields for posts and custom post types."
+                  actionLabel="Add Group"
+                  onAction={() => {
+                    setEditingGroup(null);
+                    setIsGroupDrawerOpen(true);
+                  }}
+                />
+              ) : (
+                <div className="flex flex-col">
+                  {groups.map((group) => (
+                    <CustomFieldGroupItem
+                      key={group._id}
+                      group={group}
+                      selectedGroupId={selectedGroup?._id || null}
+                      onSelectGroup={setSelectedGroup}
+                      onEditGroup={handleEditGroup}
+                      onDeleteGroup={handleDeleteGroup}
+                      onEditField={handleEditField}
+                      onDeleteField={handleDeleteField}
+                      onAddField={() => {
+                        setSelectedGroup(group);
+                        setEditingField(null);
+                        setIsFieldDrawerOpen(true);
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
@@ -23,31 +23,38 @@ export function CustomFieldGroupItem({
   onDeleteField,
   onAddField,
 }: CustomFieldGroupItemProps) {
+  const fieldCount = group.fields?.length || 0;
+
   return (
     <Collapsible
       key={group._id}
-      className="group"
+      className="group border-b last:border-b-0"
       defaultOpen={selectedGroupId === group._id}
       onOpenChange={(open) => open && onSelectGroup(group)}
     >
-      <div className="relative">
+      <div className="relative px-1 py-1">
         <Collapsible.Trigger asChild>
-          <Button variant="secondary" className="w-full justify-start">
+          <Button variant="ghost" className="w-full justify-start h-10 pr-10">
             <Collapsible.TriggerIcon />
-            <span className="flex-1 text-left">{group.label}</span>
-            {group.code && (
-              <span className="text-xs text-muted-foreground mr-2">
-                {group.code}
-              </span>
-            )}
+            <span className="min-w-0 flex-1 flex items-center gap-3 text-left">
+              <span className="font-medium truncate">{group.label}</span>
+              {group.code && (
+                <span className="text-xs text-muted-foreground truncate">
+                  {group.code}
+                </span>
+              )}
+            </span>
+            <span className="w-40 text-center text-xs text-muted-foreground">{`${fieldCount} field${
+              fieldCount === 1 ? '' : 's'
+            }`}</span>
           </Button>
         </Collapsible.Trigger>
         <DropdownMenu>
           <DropdownMenu.Trigger asChild>
             <Button
-              variant="secondary"
+              variant="ghost"
               size="icon"
-              className="absolute right-0.5 top-0.5 size-7"
+              className="absolute right-1 top-1 size-8"
             >
               <IconDots className="w-4 h-4" />
             </Button>
@@ -68,14 +75,14 @@ export function CustomFieldGroupItem({
         </DropdownMenu>
       </div>
 
-      <Collapsible.Content className="pt-2">
-        <Table className="[&_tr_td]:border-b-0 [&_tr_td:first-child]:border-l-0 [&_tr_td]:border-r-0">
+      <Collapsible.Content className="pb-2">
+        <Table className="border-0 [&_tr_td]:border-r-0 [&_tr_td:first-child]:border-l-0 [&_tr:last-child_td]:border-b-0">
           <Table.Body>
-            {(group.fields || []).length === 0 ? (
+            {fieldCount === 0 ? (
               <Table.Row className="hover:bg-background">
                 <Table.Cell
                   colSpan={3}
-                  className="h-auto py-8 text-center text-muted-foreground"
+                  className="h-auto py-8 text-center text-muted-foreground border-b-0"
                 >
                   No fields in this group
                 </Table.Cell>
@@ -114,8 +121,8 @@ export function CustomFieldGroupItem({
                       </div>
                     </div>
                   </Table.Cell>
-                  <Table.Cell className="py-3">
-                    <div className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-md">
+                  <Table.Cell className="py-3 text-center">
+                    <div className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-sm">
                       <span className="text-sm font-medium capitalize">
                         {field.type}
                       </span>
@@ -152,9 +159,9 @@ export function CustomFieldGroupItem({
             )}
           </Table.Body>
         </Table>
-        <div className="flex items-center justify-end mt-2">
-          <Button variant="secondary" onClick={onAddField}>
-            <IconPlus className="w-4 h-4" />
+        <div className="flex items-center justify-end pt-2 px-2">
+          <Button variant="secondary" size="sm" onClick={onAddField}>
+            <IconPlus />
             Add field
           </Button>
         </div>

--- a/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
@@ -16,7 +16,6 @@ export function Page() {
   const [selectedPage, setSelectedPage] = useState<IPage | undefined>(
     undefined,
   );
-
   const { pages, totalCount, loading } = usePages({
     variables: {
       clientPortalId: websiteId || '',


### PR DESCRIPTION
## Summary by Sourcery

Revamp the CMS custom fields page layout to focus on field groups and fields, improving empty, loading, and list states.

New Features:
- Display a summary count of custom field groups and fields in the custom fields page header.
- Introduce an empty-state component for when no custom field groups exist, with a guided call-to-action to add a group.

Enhancements:
- Simplify the custom fields header actions to focus on adding field groups instead of creating posts.
- Refine the table and collapsible group layout for custom field groups, including visual tweaks, field count badges, and more compact controls.
- Tighten spacing and styling for field rows and the add-field control within each group.