### PR TITLE
fix: correct typo 'occured' to 'occurred' in useUsersInvite.tsx

### DIFF
--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useUsersInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useUsersInvite.tsx
@@ -13,7 +13,7 @@ const useUsersInvite = () => {
         ...options,
       });
     } catch (error) {
-      console.error('Error occured', error);
+      console.error('Error occurred', error);
     }
   };
 


### PR DESCRIPTION
## Summary
Fixed typo: 'occured' → 'occurred' in error message.

## Change
- Line 16: Corrected spelling in console.error

## Type
- [x] Typo fix

**Review time: < 30 seconds**

## Summary by Sourcery

Bug Fixes:
- Correct the typo in the team member invite hook error log from 'occured' to 'occurred'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a typo in an error message displayed during team member invitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->