### PR TITLE
fix: remove debug console.log statements from broadcast components

### DIFF
--- a/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastMessengerTabContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastMessengerTabContent.tsx
@@ -3,6 +3,5 @@ export const BroadcastTabPreviewMessengerContent = ({
 }: {
   message: any;
 }) => {
-  console.log('message', message);
   return <div>Messenger Preview</div>;
 };

--- a/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastNotificationTabContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/methods/BroadcastNotificationTabContent.tsx
@@ -3,6 +3,5 @@ export const BroadcastTabPreviewNotificationContent = ({
 }: {
   message: any;
 }) => {
-  console.log('message', message);
   return <div>Notification Preview</div>;
 };


### PR DESCRIPTION
## Summary
Removed debug console.log statements from broadcast preview components.

## Changes
- BroadcastNotificationTabContent.tsx: Removed console.log
- BroadcastMessengerTabContent.tsx: Removed console.log

## Type
- [x] Code cleanup (removed debug statements)

**Review time: < 30 seconds**

## Summary by Sourcery

Enhancements:
- Remove unnecessary console logging from broadcast messenger and notification preview components to clean up debug output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from broadcast components for cleaner production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->