### PR TITLE
fix: remove debug console.log statements and extra blank lines

### DIFF
--- a/frontend/libs/ui-modules/src/modules/import-export/hooks/export/useExportFieldSelection.ts
+++ b/frontend/libs/ui-modules/src/modules/import-export/hooks/export/useExportFieldSelection.ts
@@ -36,11 +36,6 @@ export const useExportFieldSelection = ({
     );
   };
 
-  console.log('[ExportFieldSelection] entityType:', entityType);
-  console.log('[ExportFieldSelection] loading:', loading);
-  console.log('[ExportFieldSelection] headers:', headers);
-
-
   const handleSelectAll = () => {
     const allKeys = headers.map((h) => h.key);
     setSelectedFields(allKeys);
@@ -56,8 +51,6 @@ export const useExportFieldSelection = ({
   };
 
   const handleConfirm = () => {
-    console.log('[ExportFieldSelection] selectedFields:', selectedFields);
-    console.log('[ExportFieldSelection] headers:', headers);
     if (selectedFields.length === 0) {
       // If nothing selected, use defaults
       const defaultFields = headers


### PR DESCRIPTION
## Summary
Removed debug console.log statements and extra blank lines from export hook.

## Changes
- Removed 5 console.log statements
- Removed extra blank lines between functions

## Type
- [x] Code cleanup (removed debug statements and formatting)

**Review time: < 30 seconds**

## Summary by Sourcery

Clean up the export field selection hook by removing debug logging and unnecessary whitespace.

Enhancements:
- Remove temporary console.log debug statements from the export field selection hook.
- Tidy export hook formatting by eliminating superfluous blank lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from the import-export module to clean up console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->