### PR TITLE
feat: posts media videoUrl field

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/MediaSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/MediaSection.tsx
@@ -1,4 +1,4 @@
-import { Form, Upload, Button } from 'erxes-ui';
+import { Form, Upload, Button, Input } from 'erxes-ui';
 import { readImage } from 'erxes-ui/utils/core';
 import { IconUpload, IconX } from '@tabler/icons-react';
 import { GalleryUploader } from '../../GalleryUploader';
@@ -57,6 +57,20 @@ export const MediaSection = ({ form }: { form: any }) => (
             <Form.Label>Video</Form.Label>
             <Form.Control>
               <VideoUploader value={field.value} onChange={field.onChange} />
+            </Form.Control>
+            <Form.Message />
+          </Form.Item>
+        )}
+      />
+
+      <Form.Field
+        control={form.control}
+        name="videoUrl"
+        render={({ field }) => (
+          <Form.Item>
+            <Form.Label>Video URL</Form.Label>
+            <Form.Control>
+              <Input value={field.value} onChange={field.onChange} />
             </Form.Control>
             <Form.Message />
           </Form.Item>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
@@ -23,6 +23,7 @@ interface PostFormData {
   thumbnail?: any | null;
   gallery?: string[];
   video?: string | null;
+  videoUrl?: string;
   audio?: string | null;
   documents?: string[];
   attachments?: string[];
@@ -60,6 +61,7 @@ export const usePostForm = (editingPost?: any) => {
       thumbnail: null,
       gallery: [],
       video: null,
+      videoUrl: '',
       audio: null,
       documents: [],
       attachments: [],
@@ -135,6 +137,7 @@ export const usePostForm = (editingPost?: any) => {
         thumbnail: fullPost.thumbnail || null,
         gallery: (fullPost.images || []).map((i: any) => i.url).filter(Boolean),
         video: (fullPost.video && fullPost.video.url) || fullPost.video || null,
+        videoUrl: fullPost.videoUrl || '',
         audio: (fullPost.audio && fullPost.audio.url) || fullPost.audio || null,
         documents: (fullPost.documents || [])
           .map((d: any) => d.url)

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -21,6 +21,7 @@ interface PostFormData {
   thumbnail?: any | null;
   gallery?: string[];
   video?: string | null;
+  videoUrl?: string;
   audio?: string | null;
   documents?: string[];
   attachments?: string[];
@@ -166,6 +167,7 @@ export const usePostSubmission = ({
       thumbnail: normalizeAttachment(data.thumbnail || undefined),
       images: imagesPayload.length ? imagesPayload : undefined,
       video: videoPayload,
+      videoUrl: data.videoUrl,
       audio: audioPayload,
       documents: documentsPayload.length ? documentsPayload : undefined,
       attachments: attachmentsPayload.length ? attachmentsPayload : undefined,


### PR DESCRIPTION
## Summary by Sourcery

Add support for an optional video URL field to post media data and submission payloads in the CMS add-post form.

New Features:
- Introduce a Video URL input field in the add-post media section for posts.
- Persist the videoUrl value in post form state, including initialization for new posts and population when editing existing posts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for video URLs in the post creation and editing forms. Users can now attach video content to posts through a new dedicated input field that integrates seamlessly with the existing form workflow and properly persists across save and edit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->