### PR TITLE
fix:  add organization handling when IMAP SAAS mode is detected

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/imap/initApp.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/initApp.ts
@@ -201,7 +201,7 @@ const onServerInitImap = async (app) => {
     console.log(
       'SAAS mode detected, but organization handling not implemented',
     );
-    startDistributingJobs('os');
+    // startDistributingJobs('os');
   } else {
     console.log('Starting IMAP job distributor for default subdomain');
     startDistributingJobs('os');


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent IMAP jobs from being distributed in SAAS mode until proper organization handling is implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted IMAP integration job distribution configuration in SAAS mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->