### PR TITLE
chore(payment): add Resolver type and skipPermission to mutation 

### DIFF
--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/transactions.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/transactions.ts
@@ -1,14 +1,31 @@
+import { Resolver } from 'erxes-api-shared/src/core-types';
 import { IContext } from '~/connectionResolvers';
 
-const mutations = {
-  async paymentTransactionsAdd(_root, args: any, { models, subdomain }: IContext) {
+const mutations: Record<string, Resolver> = {
+  async paymentTransactionsAdd(
+    _root,
+    args: any,
+    { models, subdomain }: IContext,
+  ) {
     const { input } = args;
-    const invoice = await models.Invoices.getInvoice({_id: input.invoiceId}, true);
+    const invoice = await models.Invoices.getInvoice(
+      { _id: input.invoiceId },
+      true,
+    );
 
     const description = invoice.description || invoice.invoiceNumber;
 
-    return models.Transactions.createTransaction({ ...input, subdomain, description, details: {...input.details, ...invoice.data} });
+    return models.Transactions.createTransaction({
+      ...input,
+      subdomain,
+      description,
+      details: { ...input.details, ...invoice.data },
+    });
   },
+};
+
+mutations.paymentTransactionsAdd.wrapperConfig = {
+  skipPermission: true,
 };
 
 export default mutations;


### PR DESCRIPTION
Type the mutations object with Resolver and import Resolver. Add wrapperConfig.skipPermission = true to paymentTransactionsAdd so the mutation bypasses permission checks.

## Summary by Sourcery

Type the payment transactions GraphQL mutations with the shared Resolver type and configure the paymentTransactionsAdd mutation to bypass permission checks.

Enhancements:
- Type the mutations map as a Record of shared Resolver functions for payment transactions.

Chores:
- Set wrapperConfig.skipPermission to true on the paymentTransactionsAdd mutation to allow execution without permission checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refactored payment transaction mutation handling with improved code organization and type safety.
  * Enhanced configuration for transaction operation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->