### PR TITLE
feat(posclient): add posCovers query and align schema with sales_api

### DIFF
--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/covers.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/covers.ts
@@ -11,8 +11,8 @@ const coverQueries = {
       selector.userId = userId;
     }
 
-    if (!config.adminIds.includes(posUser?._id || '')) {
-      selector.userId = posUser?._id;
+    if (posUser && !(config.adminIds || []).includes(posUser._id)) {
+      selector.userId = posUser._id;
     }
 
     const dateQry: any = {};
@@ -89,6 +89,34 @@ const coverQueries = {
     }
 
     return result;
+  },
+  async posCovers(_root, params, { models, config }: IContext) {
+    const selector: any = { posToken: config.token };
+
+    const { startDate, endDate, userId } = params;
+
+    if (userId) {
+      selector.userId = userId;
+    }
+
+    const dateQry: any = {};
+
+    if (startDate) {
+      dateQry.$gte = getPureDate(startDate);
+    }
+
+    if (endDate) {
+      dateQry.$lte = getPureDate(endDate);
+    }
+
+    if (Object.keys(dateQry).length) {
+      selector.endDate = dateQry;
+    }
+
+    return paginate(
+      models.Covers.find(selector).sort({ createdAt: -1 }).lean(),
+      { ...params },
+    );
   },
 };
 

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/schemas/covers.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/schemas/covers.ts
@@ -34,6 +34,34 @@ export const types = `
     createdUser: PosUser
     modifiedUser: PosUser
   }
+      type PosCover {
+    _id: String
+    posToken: String
+    status: String
+    beginDate: Date
+    endDate: Date
+    description: String
+    userId: String
+    details: [PosCoverDetail] 
+    createdAt: Date
+    createdBy: String
+    modifiedAt: Date
+    modifiedBy: String
+    note: String
+  }
+  type PosCoverDetail {
+  _id: String
+  paidType: String
+  paidSummary: [PosCoverSummary] 
+  paidDetail: JSON
+}
+  type PosCoverSummary {
+  _id: String
+  kind: String
+  kindOfVal: Float
+  value: Float
+  amount: Float
+}
 `;
 
 const coverParams = `
@@ -56,4 +84,5 @@ export const queries = `
   covers(startDate: Date, endDate: Date, userId: String, page: Int, perPage: Int): [Cover]
   coverDetail(_id: String!): Cover
   coverAmounts(_id: String, endDate: Date): JSON
+  posCovers(startDate: Date, endDate: Date, userId: String, page: Int, perPage: Int): [PosCover]
 `;


### PR DESCRIPTION
## Summary by Sourcery

Add a new paginated posCovers GraphQL query and align cover access control and schema with the sales API.

New Features:
- Introduce posCovers query to fetch POS-specific covers with pagination and date/user filters.

Bug Fixes:
- Correct admin user check when applying userId filtering to covers queries.

Enhancements:
- Extend GraphQL schema with PosCover, PosCoverDetail, and PosCoverSummary types to mirror sales API cover structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new covers query with comprehensive filtering options including date range filters, user-based filtering, and paginated results for better performance when retrieving large datasets.

* **Bug Fixes**
  * Enhanced authorization validation logic to properly guard against missing user data, preventing errors and improving application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->