### PR TITLE
fix: cp config overwrite

### DIFF
--- a/backend/core-api/src/modules/clientportal/db/models/ClientPortal.ts
+++ b/backend/core-api/src/modules/clientportal/db/models/ClientPortal.ts
@@ -10,6 +10,7 @@ import {
   removeLastTrailingSlash,
 } from 'erxes-api-shared/utils';
 import { jwtManager } from '@/clientportal/services';
+import { deepMerge } from '@/clientportal/utils/deepMerge';
 
 export interface IClientPortalModel extends Model<IClientPortalDocument> {
   getConfig(_id: string): Promise<IClientPortalDocument>;
@@ -64,9 +65,38 @@ export const loadClientPortalClass = (models: IModels) => {
         doc.url = removeExtraSpaces(removeLastTrailingSlash(doc.url));
       }
 
+      const existing = await models.ClientPortal.findOne({
+        _id,
+      }).lean<IClientPortalDocument>();
+
+      if (!existing) {
+        throw new Error('Client portal not found');
+      }
+
+      const mergedAuth =
+        doc.auth || existing.auth
+          ? deepMerge(existing.auth || {}, doc.auth || {})
+          : undefined;
+
+      const mergedSecurityAuthConfig =
+        doc.securityAuthConfig || existing.securityAuthConfig
+          ? deepMerge(
+              existing.securityAuthConfig || {},
+              doc.securityAuthConfig || {},
+            )
+          : undefined;
+
+      const updateDoc: IClientPortal = {
+        ...existing,
+        ...doc,
+        auth: mergedAuth as IClientPortal['auth'],
+        securityAuthConfig:
+          mergedSecurityAuthConfig as IClientPortal['securityAuthConfig'],
+      };
+
       await models.ClientPortal.findOneAndUpdate(
         { _id },
-        { $set: doc },
+        { $set: updateDoc },
         { new: true },
       );
     }

--- a/backend/core-api/src/modules/clientportal/utils/deepMerge.ts
+++ b/backend/core-api/src/modules/clientportal/utils/deepMerge.ts
@@ -1,0 +1,40 @@
+export function deepMerge<T extends Record<string, any>, U extends Record<string, any>>(
+  target: T | undefined,
+  source: U | undefined,
+): T & U {
+  if (!target) {
+    return (source || {}) as T & U;
+  }
+
+  if (!source) {
+    return target as T & U;
+  }
+
+  const result: Record<string, any> = { ...target };
+
+  Object.keys(source).forEach((key) => {
+    const sourceValue = (source as any)[key];
+
+    if (sourceValue === undefined) {
+      return;
+    }
+
+    const targetValue = (target as any)[key];
+
+    if (
+      sourceValue &&
+      typeof sourceValue === 'object' &&
+      !Array.isArray(sourceValue) &&
+      targetValue &&
+      typeof targetValue === 'object' &&
+      !Array.isArray(targetValue)
+    ) {
+      result[key] = deepMerge(targetValue, sourceValue);
+    } else {
+      result[key] = sourceValue;
+    }
+  });
+
+  return result as T & U;
+}
+


### PR DESCRIPTION
## Summary by Sourcery

Preserve and merge existing client portal authentication-related configuration when updating a client portal record instead of overwriting it.

Bug Fixes:
- Ensure updates to client portal records do not overwrite existing auth and securityAuthConfig fields but merge them with incoming changes.

Enhancements:
- Introduce a reusable deepMerge utility to perform recursive, non-destructive object merges for client portal configuration data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ClientPortal configuration updates now intelligently merge with existing settings rather than replacing them entirely, improving backward compatibility and preventing accidental loss of previous configurations.
  * Added validation to ensure the ClientPortal exists before processing updates, preventing errors and data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->