### PR TITLE
fix: replace eval() with safe math parser in score campaign

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
@@ -9,6 +9,7 @@ import {
   handleOnCreateCampaignScoreField,
   handleOnUpdateCampaignScoreField,
   resolvePlaceholderValue,
+  safeEvalMath,
 } from '@/score/utils';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
@@ -157,7 +158,7 @@ export const loadScoreCampaignClass = (models: IModels, subdomain: string) => {
         placeholder = resolvePlaceholderValue(target, attribute);
       }
 
-      let changeScore = (eval(placeholder) || 0) * Number(currencyRatio) || 0;
+      let changeScore = (safeEvalMath(placeholder) || 0) * Number(currencyRatio) || 0;
 
       const { score = 0, customFieldsData = [] } = owner || {};
 
@@ -263,7 +264,7 @@ export const loadScoreCampaignClass = (models: IModels, subdomain: string) => {
         );
       }
 
-      const changeScore = (eval(placeholder) || 0) * Number(currencyRatio) || 0;
+      const changeScore = (safeEvalMath(placeholder) || 0) * Number(currencyRatio) || 0;
       if (!changeScore) {
         return;
       }

--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -2,6 +2,23 @@ import dayjs from 'dayjs';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 
+/**
+ * Safely evaluate a math expression string.
+ * Only allows numbers, arithmetic operators (+, -, *, /), parentheses, and whitespace.
+ * Throws on any other input to prevent code injection.
+ */
+export const safeEvalMath = (expr: string): number => {
+  const sanitized = (expr || '').trim();
+
+  if (!sanitized) return 0;
+
+  if (!/^[\d\s+\-*/().]+$/.test(sanitized)) {
+    throw new Error(`Invalid math expression: ${sanitized.slice(0, 50)}`);
+  }
+
+  return Function(`"use strict"; return (${sanitized});`)();
+};
+
 export const resolvePlaceholderValue = (target: any, attribute: string) => {
   const [propertyName, valueToCheck, valueField] = attribute.split('-');
 


### PR DESCRIPTION
ScoreCampaign.ts uses eval() on the placeholder field at lines 160 and 266. the placeholder is meant to hold math expressions like "{{ amount }} * 2" but since there's no validation, any authenticated user can create a campaign with arbitrary javascript in the placeholder. when doCampaign() or checkScoreAviableSubtract() runs, the code executes on the server.

tested locally — confirmed full RCE: shell commands, filesystem reads, env var exfiltration, reverse shell.

the fix adds safeEvalMath() in score/utils.ts that validates the expression against a whitelist regex (digits, +, -, *, /, parentheses, dots, whitespace) before evaluating. anything else throws "Invalid math expression". both eval() call sites now use safeEvalMath() instead.

normal campaign math still works: "5000 * 2" returns 10000, "(100 + 200) * 0.5" returns 150.

closes #6968

## Summary by Sourcery

Replace unsafe score campaign math evaluation with a sanitized math expression helper to prevent code injection while preserving existing calculation behavior.

Bug Fixes:
- Prevent remote code execution in score campaigns by replacing eval-based placeholder math evaluation with a sanitized math parser.

Enhancements:
- Introduce a reusable safeEvalMath utility to validate and safely evaluate simple arithmetic expressions used in score placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in loyalty campaign score calculations by implementing a safer mathematical expression evaluator for computing score values in both add and subtract operations, while preserving existing calculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->