### PR TITLE
fix: replace eval() with safe arithmetic parser in score campaign

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
@@ -9,6 +9,7 @@ import {
   handleOnCreateCampaignScoreField,
   handleOnUpdateCampaignScoreField,
   resolvePlaceholderValue,
+  safeEvalMath,
 } from '@/score/utils';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
@@ -157,7 +158,7 @@ export const loadScoreCampaignClass = (models: IModels, subdomain: string) => {
         placeholder = resolvePlaceholderValue(target, attribute);
       }
 
-      let changeScore = (eval(placeholder) || 0) * Number(currencyRatio) || 0;
+      let changeScore = (safeEvalMath(placeholder) || 0) * Number(currencyRatio) || 0;
 
       const { score = 0, customFieldsData = [] } = owner || {};
 
@@ -263,7 +264,7 @@ export const loadScoreCampaignClass = (models: IModels, subdomain: string) => {
         );
       }
 
-      const changeScore = (eval(placeholder) || 0) * Number(currencyRatio) || 0;
+      const changeScore = (safeEvalMath(placeholder) || 0) * Number(currencyRatio) || 0;
       if (!changeScore) {
         return;
       }

--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -13,13 +13,11 @@ export const safeEvalMath = (expr: string): number => {
 
   let pos = 0;
 
-  const peek = () => input[pos];
-  const advance = () => input[pos++];
-  const skipWhitespace = () => {
-    while (pos < input.length && input[pos] === ' ') pos++;
-  };
+  function peek() { return input[pos]; }
+  function advance() { return input[pos++]; }
+  function skipWhitespace() { while (pos < input.length && input[pos] === ' ') pos++; }
 
-  const parseNumber = (): number => {
+  function parseNumber(): number {
     skipWhitespace();
     let numStr = '';
 
@@ -42,41 +40,9 @@ export const safeEvalMath = (expr: string): number => {
       throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
     }
     return num;
-  };
+  }
 
-  const parsePrimary = (): number => {
-    skipWhitespace();
-
-    if (peek() === '(') {
-      advance(); // skip (
-      const val = parseAddSub();
-      skipWhitespace();
-      if (peek() !== ')') {
-        throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
-      }
-      advance(); // skip )
-      return val;
-    }
-
-    return parseNumber();
-  };
-
-  const parseMulDiv = (): number => {
-    let left = parsePrimary();
-
-    while (true) {
-      skipWhitespace();
-      const op = peek();
-      if (op !== '*' && op !== '/') break;
-      advance();
-      const right = parsePrimary();
-      left = op === '*' ? left * right : left / right;
-    }
-
-    return left;
-  };
-
-  const parseAddSub = (): number => {
+  function parseAddSub(): number {
     let left = parseMulDiv();
 
     while (true) {
@@ -89,7 +55,39 @@ export const safeEvalMath = (expr: string): number => {
     }
 
     return left;
-  };
+  }
+
+  function parseMulDiv(): number {
+    let left = parsePrimary();
+
+    while (true) {
+      skipWhitespace();
+      const op = peek();
+      if (op !== '*' && op !== '/') break;
+      advance();
+      const right = parsePrimary();
+      left = op === '*' ? left * right : left / right;
+    }
+
+    return left;
+  }
+
+  function parsePrimary(): number {
+    skipWhitespace();
+
+    if (peek() === '(') {
+      advance();
+      const val = parseAddSub();
+      skipWhitespace();
+      if (peek() !== ')') {
+        throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
+      }
+      advance();
+      return val;
+    }
+
+    return parseNumber();
+  }
 
   const result = parseAddSub();
   skipWhitespace();

--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -2,6 +2,23 @@ import dayjs from 'dayjs';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 
+/**
+ * Safely evaluate a math expression string.
+ * Only allows numbers, arithmetic operators (+, -, *, /), parentheses, and whitespace.
+ * Throws on any other input to prevent code injection.
+ */
+export const safeEvalMath = (expr: string): number => {
+  const sanitized = (expr || '').trim();
+
+  if (!sanitized) return 0;
+
+  if (!/^[\d\s+\-*/().]+$/.test(sanitized)) {
+    throw new Error(`Invalid math expression: ${sanitized.slice(0, 50)}`);
+  }
+
+  return Function(`"use strict"; return (${sanitized});`)();
+};
+
 export const resolvePlaceholderValue = (target: any, attribute: string) => {
   const [propertyName, valueToCheck, valueField] = attribute.split('-');
 

--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -13,10 +13,16 @@ export const safeEvalMath = (expr: string): number => {
 
   let pos = 0;
 
+  /** look at the current character without moving forward */
   function peek() { return input[pos]; }
+
+  /** grab the current character and step to the next one */
   function advance() { return input[pos++]; }
+
+  /** jump past any spaces */
   function skipWhitespace() { while (pos < input.length && input[pos] === ' ') pos++; }
 
+  /** read a number like 42, 3.14, or -5 from the input */
   function parseNumber(): number {
     skipWhitespace();
     let numStr = '';
@@ -42,6 +48,7 @@ export const safeEvalMath = (expr: string): number => {
     return num;
   }
 
+  /** handle + and - (runs last because they have the lowest priority) */
   function parseAddSub(): number {
     let left = parseMulDiv();
 
@@ -57,6 +64,7 @@ export const safeEvalMath = (expr: string): number => {
     return left;
   }
 
+  /** handle * and / (runs before + and - because they bind tighter) */
   function parseMulDiv(): number {
     let left = parsePrimary();
 
@@ -72,6 +80,7 @@ export const safeEvalMath = (expr: string): number => {
     return left;
   }
 
+  /** handle a number or a parenthesized group like (2 + 3) */
   function parsePrimary(): number {
     skipWhitespace();
 

--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -3,20 +3,104 @@ import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 
 /**
- * Safely evaluate a math expression string.
- * Only allows numbers, arithmetic operators (+, -, *, /), parentheses, and whitespace.
- * Throws on any other input to prevent code injection.
+ * Safely evaluate a math expression string using recursive descent parsing.
+ * Only supports: numbers (int/float), +, -, *, /, parentheses.
+ * No eval/Function — purely structural parsing, no code execution.
  */
 export const safeEvalMath = (expr: string): number => {
-  const sanitized = (expr || '').trim();
+  const input = (expr || '').trim();
+  if (!input) return 0;
 
-  if (!sanitized) return 0;
+  let pos = 0;
 
-  if (!/^[\d\s+\-*/().]+$/.test(sanitized)) {
-    throw new Error(`Invalid math expression: ${sanitized.slice(0, 50)}`);
+  const peek = () => input[pos];
+  const advance = () => input[pos++];
+  const skipWhitespace = () => {
+    while (pos < input.length && input[pos] === ' ') pos++;
+  };
+
+  const parseNumber = (): number => {
+    skipWhitespace();
+    let numStr = '';
+
+    if (peek() === '-' || peek() === '+') numStr += advance();
+
+    if (peek() !== '(' && peek() !== undefined && !/[\d.]/.test(peek())) {
+      throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
+    }
+
+    while (pos < input.length && /[\d.]/.test(peek())) {
+      numStr += advance();
+    }
+
+    if (!numStr || numStr === '-' || numStr === '+') {
+      throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
+    }
+
+    const num = Number(numStr);
+    if (!isFinite(num)) {
+      throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
+    }
+    return num;
+  };
+
+  const parsePrimary = (): number => {
+    skipWhitespace();
+
+    if (peek() === '(') {
+      advance(); // skip (
+      const val = parseAddSub();
+      skipWhitespace();
+      if (peek() !== ')') {
+        throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
+      }
+      advance(); // skip )
+      return val;
+    }
+
+    return parseNumber();
+  };
+
+  const parseMulDiv = (): number => {
+    let left = parsePrimary();
+
+    while (true) {
+      skipWhitespace();
+      const op = peek();
+      if (op !== '*' && op !== '/') break;
+      advance();
+      const right = parsePrimary();
+      left = op === '*' ? left * right : left / right;
+    }
+
+    return left;
+  };
+
+  const parseAddSub = (): number => {
+    let left = parseMulDiv();
+
+    while (true) {
+      skipWhitespace();
+      const op = peek();
+      if (op !== '+' && op !== '-') break;
+      advance();
+      const right = parseMulDiv();
+      left = op === '+' ? left + right : left - right;
+    }
+
+    return left;
+  };
+
+  const result = parseAddSub();
+  skipWhitespace();
+
+  if (pos < input.length) {
+    throw new Error(`Invalid math expression: ${input.slice(0, 50)}`);
   }
 
-  return Function(`"use strict"; return (${sanitized});`)();
+  if (!isFinite(result)) return 0;
+
+  return result;
 };
 
 export const resolvePlaceholderValue = (target: any, attribute: string) => {


### PR DESCRIPTION
ScoreCampaign.ts uses eval() on the placeholder field at lines 160 and 266. the placeholder is meant for math like "{{ amount }} * 2" but there's no validation, so any authenticated user can create a campaign with arbitrary javascript in the placeholder. when doCampaign() or checkScoreAviableSubtract() runs, the code executes on the server.

tested locally — confirmed full RCE: shell commands, filesystem reads, env var exfiltration, reverse shell.

replaced eval() with a recursive descent arithmetic parser (safeEvalMath) that only handles numbers, +, -, *, /, parentheses, and decimals. no eval, no Function(), no code execution at all. invalid expressions throw instead of executing.

normal campaign math still works. edge cases like 1//2, 1..2, Infinity are handled.

closes #6968

## Summary by Sourcery

Replace dangerous use of eval in score campaign placeholder math with a safe arithmetic expression evaluator.

Bug Fixes:
- Eliminate remote code execution risk in score campaigns by removing eval-based evaluation of placeholder math expressions.

Enhancements:
- Introduce a dedicated safe arithmetic parser for placeholder expressions and reuse it where score changes are calculated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of loyalty campaign score adjustments by replacing unsafe expression handling with a safe arithmetic evaluator. Now campaign score calculations ignore empty/invalid inputs, guard against non-finite results, and consistently scale computed values so erroneous expressions no longer break campaign flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->