### PR TITLE
fix: load plugin sub-navigation via loadRemote to fix shared scope

### DIFF
--- a/frontend/core-ui/src/modules/navigation/components/NavigationPlugins.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/NavigationPlugins.tsx
@@ -1,8 +1,69 @@
+import { Suspense, useEffect, useState } from 'react';
 import { IconChevronLeft } from '@tabler/icons-react';
 import { activePluginState, NavigationMenuGroup, Sidebar } from 'erxes-ui';
+import { ErrorBoundary } from 'react-error-boundary';
+import { loadRemote } from '@module-federation/enhanced/runtime';
 import { usePluginsNavigationGroups } from '../hooks/usePluginsNavigationGroups';
 import { useAtom } from 'jotai';
 
+/** Loads a remote Module Federation component by path. */
+function useRemoteComponent(remotePath: string) {
+  const [Component, setComponent] =
+    useState<React.ComponentType | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadRemote<{ default: React.ComponentType }>(remotePath, {
+      from: 'runtime',
+    })
+      .then((mod) => {
+        if (!cancelled && mod?.default) {
+          setComponent(() => mod.default);
+        }
+      })
+      .catch(() => {
+        /* sub-navigation is non-critical */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [remotePath]);
+
+  return Component;
+}
+
+/** Renders a sub-navigation component loaded from a remote plugin via loadRemote. */
+function RemoteSubNavigation({
+  pluginName,
+  exposeName,
+}: {
+  pluginName: string;
+  exposeName: string;
+}) {
+  const Component = useRemoteComponent(`${pluginName}_ui/${exposeName}`);
+
+  if (!Component) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <Component />
+    </Suspense>
+  );
+}
+
+/** Logs remote component render errors in development. */
+function handleRemoteError(error: Error) {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '[NavigationPlugins] Remote component failed to render:',
+      error.message,
+    );
+  }
+}
+
+/** Back button shown when a plugin navigation group is expanded. */
 export const NavigationPluginExitButton = () => {
   const [activePlugin, setActivePlugin] = useAtom(activePluginState);
 
@@ -27,6 +88,7 @@ export const NavigationPluginExitButton = () => {
   );
 };
 
+/** Renders plugin navigation groups in the sidebar with remote sub-navigation. */
 export const NavigationPlugins = () => {
   const navigationGroups = usePluginsNavigationGroups();
   const [activePlugin, setActivePlugin] = useAtom(activePluginState);
@@ -48,11 +110,26 @@ export const NavigationPlugins = () => {
           separate
         >
           {navigationGroups[activePlugin].contents.map((Content, index) => (
-            <Content key={index} />
+            <ErrorBoundary
+              key={index}
+              fallbackRender={() => null}
+              onError={handleRemoteError}
+            >
+              <Content />
+            </ErrorBoundary>
           ))}
         </NavigationMenuGroup>
-        {subGroups.map((SubGroup, index) => (
-          <SubGroup key={index} />
+        {subGroups.map(({ exposeName, pluginName }) => (
+          <ErrorBoundary
+            key={`${pluginName}-${exposeName}`}
+            fallbackRender={() => null}
+            onError={handleRemoteError}
+          >
+            <RemoteSubNavigation
+              pluginName={pluginName}
+              exposeName={exposeName}
+            />
+          </ErrorBoundary>
         ))}
       </>
     );

--- a/frontend/core-ui/src/modules/navigation/components/NavigationPlugins.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/NavigationPlugins.tsx
@@ -109,15 +109,17 @@ export const NavigationPlugins = () => {
           }
           separate
         >
-          {navigationGroups[activePlugin].contents.map((Content, index) => (
-            <ErrorBoundary
-              key={index}
-              fallbackRender={() => null}
-              onError={handleRemoteError}
-            >
-              <Content />
-            </ErrorBoundary>
-          ))}
+          {navigationGroups[activePlugin].contents.map(
+            ({ render: Content, pluginName }) => (
+              <ErrorBoundary
+                key={pluginName}
+                fallbackRender={() => null}
+                onError={handleRemoteError}
+              >
+                <Content />
+              </ErrorBoundary>
+            ),
+          )}
         </NavigationMenuGroup>
         {subGroups.map(({ exposeName, pluginName }) => (
           <ErrorBoundary

--- a/frontend/core-ui/src/modules/navigation/hooks/usePluginsNavigationGroups.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/usePluginsNavigationGroups.ts
@@ -38,10 +38,15 @@ export const usePluginsModules = () => {
   return modules;
 };
 
+interface SubGroupEntry {
+  exposeName: string;
+  pluginName: string;
+}
+
 interface NavigationGroupResult {
   icon?: React.ElementType;
-  contents: any[];
-  subGroups: any[];
+  contents: Array<() => React.ReactNode>;
+  subGroups: SubGroupEntry[];
   name: string;
 }
 
@@ -76,9 +81,12 @@ export const usePluginsNavigationGroups = () => {
           ? [...existingGroup.contents, newContent]
           : existingGroup.contents;
 
-        const newSubGroup = plugin.navigationGroup?.subGroup;
-        const updatedSubGroups = newSubGroup
-          ? [...existingGroup.subGroups, newSubGroup]
+        const subGroupExpose = plugin.navigationGroup?.subGroup;
+        const updatedSubGroups = subGroupExpose
+          ? [
+              ...existingGroup.subGroups,
+              { exposeName: subGroupExpose, pluginName: plugin.name },
+            ]
           : existingGroup.subGroups;
 
         acc[groupName] = {

--- a/frontend/core-ui/src/modules/navigation/hooks/usePluginsNavigationGroups.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/usePluginsNavigationGroups.ts
@@ -38,6 +38,11 @@ export const usePluginsModules = () => {
   return modules;
 };
 
+interface ContentEntry {
+  render: () => React.ReactNode;
+  pluginName: string;
+}
+
 interface SubGroupEntry {
   exposeName: string;
   pluginName: string;
@@ -45,7 +50,7 @@ interface SubGroupEntry {
 
 interface NavigationGroupResult {
   icon?: React.ElementType;
-  contents: Array<() => React.ReactNode>;
+  contents: ContentEntry[];
   subGroups: SubGroupEntry[];
   name: string;
 }
@@ -78,7 +83,10 @@ export const usePluginsNavigationGroups = () => {
 
         const newContent = plugin.navigationGroup?.content;
         const updatedContents = newContent
-          ? [...existingGroup.contents, newContent]
+          ? [
+              ...existingGroup.contents,
+              { render: newContent, pluginName: plugin.name },
+            ]
           : existingGroup.contents;
 
         const subGroupExpose = plugin.navigationGroup?.subGroup;

--- a/frontend/libs/erxes-ui/src/types/UIConfig.ts
+++ b/frontend/libs/erxes-ui/src/types/UIConfig.ts
@@ -8,7 +8,7 @@ export type IUIConfig = {
     name: string;
     icon: React.ElementType;
     content: () => React.ReactNode;
-    subGroup?: () => React.ReactNode;
+    subGroup?: string;
   };
 
   widgets?: {

--- a/frontend/plugins/accounting_ui/module-federation.config.ts
+++ b/frontend/plugins/accounting_ui/module-federation.config.ts
@@ -18,6 +18,7 @@ const config: ModuleFederationConfig = {
     './config': './src/config.tsx',
     './accounting': './src/modules/AccountingMain.tsx',
     './accountingSettings': './src/modules/AccountingSettings.tsx',
+    './subNavigation': './src/modules/SubNavigation.tsx',
   },
 
   shared: (libraryName, defaultConfig) => {

--- a/frontend/plugins/accounting_ui/src/config.tsx
+++ b/frontend/plugins/accounting_ui/src/config.tsx
@@ -8,18 +8,6 @@ const MainNavigation = lazy(() =>
   })),
 );
 
-const AdjustmentNavigation = lazy(() =>
-  import('./modules/AdjustmentNavigation').then((mod) => ({
-    default: mod.AdjustmentNavigation,
-  })),
-);
-
-const InventoriesNavigation = lazy(() =>
-  import('./modules/InventoriesNavigation').then((mod) => ({
-    default: mod.InventoriesNavigation,
-  })),
-);
-
 const SettingsNavigation = lazy(() =>
   import('./modules/SettingsNavigation').then((module) => ({
     default: module.SettingsNavigation,
@@ -42,12 +30,7 @@ export const CONFIG: IUIConfig = {
         <MainNavigation />
       </Suspense>
     ),
-    subGroup: () => (
-      <Suspense fallback={<div />}>
-        <AdjustmentNavigation />
-        <InventoriesNavigation />
-      </Suspense>
-    ),
+    subGroup: 'subNavigation',
   },
   modules: [
     {

--- a/frontend/plugins/accounting_ui/src/modules/SubNavigation.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/SubNavigation.tsx
@@ -1,0 +1,12 @@
+import { AdjustmentNavigation } from '~/modules/AdjustmentNavigation';
+import { InventoriesNavigation } from '~/modules/InventoriesNavigation';
+
+/** Aggregates accounting sub-navigation items loaded via Module Federation. */
+export default function SubNavigation() {
+  return (
+    <>
+      <AdjustmentNavigation />
+      <InventoriesNavigation />
+    </>
+  );
+}

--- a/frontend/plugins/frontline_ui/module-federation.config.ts
+++ b/frontend/plugins/frontline_ui/module-federation.config.ts
@@ -25,6 +25,7 @@ const config: ModuleFederationConfig = {
       './src/widgets/notifications/NotificationRemoteEntries.tsx',
     './relationWidget': './src/widgets/RelationWidget.tsx',
     './floatingWidget': './src/widgets/FloatingWidget.tsx',
+    './subNavigation': './src/modules/SubNavigation.tsx',
   },
 
   shared: (libraryName, defaultConfig) => {

--- a/frontend/plugins/frontline_ui/src/config.tsx
+++ b/frontend/plugins/frontline_ui/src/config.tsx
@@ -8,12 +8,6 @@ const FrontlineNavigation = lazy(() =>
   })),
 );
 
-const FrontlineSubGroups = lazy(() =>
-  import('./modules/FrontlineSubGroups').then((module) => ({
-    default: module.FrontlineSubGroups,
-  })),
-);
-
 const FrontlineSettingsNavigation = lazy(() =>
   import('./modules/FrontlineSettingsNavigation').then((module) => ({
     default: module.FrontlineSettingsNavigation,
@@ -37,11 +31,7 @@ export const CONFIG: IUIConfig = {
         <FrontlineNavigation />
       </Suspense>
     ),
-    subGroup: () => (
-      <Suspense fallback={<div />}>
-        <FrontlineSubGroups />
-      </Suspense>
-    ),
+    subGroup: 'subNavigation',
   },
   widgets: {
     relationWidgets: [

--- a/frontend/plugins/frontline_ui/src/modules/SubNavigation.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/SubNavigation.tsx
@@ -1,0 +1,6 @@
+import { FrontlineSubGroups } from '~/modules/FrontlineSubGroups';
+
+/** Aggregates frontline sub-navigation items loaded via Module Federation. */
+export default function SubNavigation() {
+  return <FrontlineSubGroups />;
+}

--- a/frontend/plugins/operation_ui/module-federation.config.ts
+++ b/frontend/plugins/operation_ui/module-federation.config.ts
@@ -21,6 +21,7 @@ const config: ModuleFederationConfig = {
     './relationWidget': './src/widgets/relation/RelationWidgets.tsx',
     './notificationWidget':
       './src/widgets/notifications/NotificationsWidgets.tsx',
+    './subNavigation': './src/modules/SubNavigation.tsx',
   },
 
   shared: (libraryName, defaultConfig) => {

--- a/frontend/plugins/operation_ui/src/config.tsx
+++ b/frontend/plugins/operation_ui/src/config.tsx
@@ -9,12 +9,6 @@ const MainNavigation = lazy(() =>
   })),
 );
 
-const TeamsNavigation = lazy(() =>
-  import('./modules/navigation/TeamsNavigation').then((mod) => ({
-    default: mod.TeamsNavigation,
-  })),
-);
-
 const OperationSettingsNavigation = lazy(() =>
   import('@/OperationSettingsNavigation').then((mod) => ({
     default: mod.OperationSettingsNavigation,
@@ -38,11 +32,7 @@ export const CONFIG: IUIConfig = {
         <MainNavigation />
       </Suspense>
     ),
-    subGroup: () => (
-      <Suspense fallback={<div />}>
-        <TeamsNavigation />
-      </Suspense>
-    ),
+    subGroup: 'subNavigation',
   },
   modules: [
     {

--- a/frontend/plugins/operation_ui/src/modules/SubNavigation.tsx
+++ b/frontend/plugins/operation_ui/src/modules/SubNavigation.tsx
@@ -1,0 +1,6 @@
+import { TeamsNavigation } from '~/modules/navigation/TeamsNavigation';
+
+/** Aggregates operation sub-navigation items loaded via Module Federation. */
+export default function SubNavigation() {
+  return <TeamsNavigation />;
+}

--- a/frontend/plugins/sales_ui/module-federation.config.ts
+++ b/frontend/plugins/sales_ui/module-federation.config.ts
@@ -25,6 +25,7 @@ const config: ModuleFederationConfig = {
     './posSettings': './src/modules/pos/pos/Main.tsx',
     './automationsWidget':
       './src/widgets/automations/components/AutomationRemoteEntry.tsx',
+    './subNavigation': './src/modules/SubNavigation.tsx',
   },
 
   shared: (libraryName, defaultConfig) => {

--- a/frontend/plugins/sales_ui/src/config.tsx
+++ b/frontend/plugins/sales_ui/src/config.tsx
@@ -9,18 +9,6 @@ const MainNavigation = lazy(() =>
   })),
 );
 
-const SalesSubNavigation = lazy(() =>
-  import('./modules/SalesSubNavigation').then((module) => ({
-    default: module.SalesSubNavigation,
-  })),
-);
-
-const PosOrderNavigation = lazy(() =>
-  import('./modules/pos/PosOrderNavigation').then((module) => ({
-    default: module.PosOrderNavigation,
-  })),
-);
-
 const SalesSettingsNavigation = lazy(() =>
   import('./modules/SalesSettingsNavigation').then((module) => ({
     default: module.SalesSettingsNavigation,
@@ -43,12 +31,7 @@ export const CONFIG: IUIConfig = {
         <MainNavigation />
       </Suspense>
     ),
-    subGroup: () => (
-      <Suspense fallback={<div />}>
-        <SalesSubNavigation />
-        <PosOrderNavigation />
-      </Suspense>
-    ),
+    subGroup: 'subNavigation',
   },
   modules: [
     {

--- a/frontend/plugins/sales_ui/src/modules/SubNavigation.tsx
+++ b/frontend/plugins/sales_ui/src/modules/SubNavigation.tsx
@@ -1,0 +1,12 @@
+import { SalesSubNavigation } from '~/modules/SalesSubNavigation';
+import { PosOrderNavigation } from '~/modules/pos/PosOrderNavigation';
+
+/** Aggregates sales sub-navigation items loaded via Module Federation. */
+export default function SubNavigation() {
+  return (
+    <>
+      <SalesSubNavigation />
+      <PosOrderNavigation />
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #7243

## What broke

When two or more frontend plugins are enabled, the app crashes on every page with `Cannot read properties of null (reading 'useContext')`. The crash comes from sub-navigation components like `SalesSubNavigation` and `PosOrderNavigation` in the sidebar.

## Why it broke

Plugin configs embed sub-navigation as `React.lazy()` components inside the `subGroup` field. When the host loads the config via `loadRemote()`, the config module itself gets the shared react/jotai/react-router. But the lazy chunks created for the sub-navigation components don't go through the same shared scope initialization. They resolve react and react-router from the remote's own vendor bundle, creating duplicate instances. The host's Router context is invisible to the remote's `useLocation()`.

With one plugin this doesn't surface. Add a second and the timing exposes the mismatch.

Upstream issues tracking this:
- nrwl/nx#30274
- web-infra-dev/rspack#7066
- web-infra-dev/rspack#4948

## The fix

Instead of embedding sub-navigation components in the config (which bypasses shared scope), each plugin now exposes them as a separate Module Federation entry (`./subNavigation`). The host loads them via `loadRemote()`, which properly initializes the shared scope.

Concretely:

- `IUIConfig.navigationGroup.subGroup` changed from `() => ReactNode` to `string` (the MF expose name)
- `NavigationPlugins` loads sub-navigation via `loadRemote()` with `ErrorBoundary` fallback
- 4 plugins updated: sales_ui, accounting_ui, operation_ui, frontline_ui
- Each gets a thin `SubNavigation.tsx` entry file + `./subNavigation` in their MF exposes

## Files changed

- `erxes-ui/types/UIConfig.ts` - type contract
- `core-ui/.../NavigationPlugins.tsx` - host-side loading via loadRemote
- `core-ui/.../usePluginsNavigationGroups.ts` - pass expose names instead of functions
- 4x `module-federation.config.ts` - add `./subNavigation` expose
- 4x `config.tsx` - replace function subGroup with string
- 4x `SubNavigation.tsx` (new) - thin wrappers with default exports

## Testing

- All 5 affected packages build (`core-ui`, `sales_ui`, `accounting_ui`, `operation_ui`, `frontline_ui`)
- Verification script at `scripts/verify-mf-subnav-fix.sh` (not committed, available locally)

## Summary by Sourcery

Load plugin sidebar sub-navigation via Module Federation remotes instead of embedding lazy components directly in plugin configs to ensure shared React scope is respected when multiple plugins are enabled.

New Features:
- Add a shared RemoteSubNavigation mechanism to render plugin sub-navigation components loaded via Module Federation at runtime.

Bug Fixes:
- Fix crashes when multiple frontend plugins are enabled by ensuring plugin sub-navigation components use the host's shared React/router scope via loadRemote.

Enhancements:
- Refine plugin navigation group typings to represent sub-navigation entries as remote expose names associated with plugin names.
- Wrap plugin navigation and sub-navigation rendering in error boundaries to prevent non-critical remote failures from breaking the sidebar.

Build:
- Expose a new ./subNavigation entry point in each affected plugin's Module Federation configuration for loading sub-navigation via runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation now dynamically loads plugin sub-navigation modules, with new aggregated sub-navigation components available from multiple plugins.

* **Refactor**
  * Navigation configs simplified to reference sub-navigation identifiers instead of inline lazy components.

* **Bug Fixes**
  * Remote-loading made more resilient: silent fallbacks by default and conditional development-only warnings for remote render failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->