### PR TITLE
fix: openSSH security updates in docker images

### DIFF
--- a/apps/frontline-widgets/Dockerfile
+++ b/apps/frontline-widgets/Dockerfile
@@ -1,6 +1,6 @@
 # Build jo from source
-FROM alpine:3.11 AS jo-builder
-RUN apk add --no-cache alpine-sdk && \
+FROM alpine:3.20 AS jo-builder
+RUN apk update && apk upgrade --no-cache && apk add --no-cache alpine-sdk && \
     cd /tmp && curl -s -LO https://github.com/jpmens/jo/releases/download/1.3/jo-1.3.tar.gz && \
     tar xzf jo-1.3.tar.gz && \
     cd jo-1.3 && \
@@ -22,8 +22,8 @@ FROM nginx:alpine
 # Copy jo from builder
 COPY --from=jo-builder /usr/local/bin/jo /usr/local/bin/jo
 
-# Install bash
-RUN apk add --no-cache bash
+# Apply security updates and install bash
+RUN apk update && apk upgrade --no-cache && apk add --no-cache bash
 
 # Copy application files
 COPY --from=build /app/dist/apps/frontline-widgets /usr/share/nginx/html

--- a/backend/gateway/Dockerfile
+++ b/backend/gateway/Dockerfile
@@ -32,8 +32,9 @@ FROM --platform=linux/amd64 node:22-bookworm AS gateway
 
 WORKDIR /app
 
-# Install required packages
-RUN apt-get update && apt-get install -y curl ca-certificates
+# Install required packages and apply security updates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy built app from build stage
 COPY --chown=1000:1000 --from=build /app /app
@@ -47,6 +48,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 # Install Rover CLI for composing supergraph
 RUN apt-get update -y \
+    && apt-get upgrade -y \
     && apt-get install -y curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && pnpm add -g @apollo/rover@0.22.0 \

--- a/backend/plugins/content_api/Dockerfile
+++ b/backend/plugins/content_api/Dockerfile
@@ -1,7 +1,7 @@
 # Base image
 FROM node:22-alpine AS base
 WORKDIR /app
-RUN apk add --no-cache git ca-certificates curl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache git ca-certificates curl
 RUN npm install -g pnpm
 
 # Dependencies (production only)

--- a/frontend/core-ui/Dockerfile
+++ b/frontend/core-ui/Dockerfile
@@ -1,6 +1,6 @@
 # Build jo from source
-FROM alpine:3.11 AS jo-builder
-RUN apk add --no-cache alpine-sdk && \
+FROM alpine:3.20 AS jo-builder
+RUN apk update && apk upgrade --no-cache && apk add --no-cache alpine-sdk && \
     cd /tmp && curl -s -LO https://github.com/jpmens/jo/releases/download/1.3/jo-1.3.tar.gz && \
     tar xzf jo-1.3.tar.gz && \
     cd jo-1.3 && \
@@ -22,8 +22,8 @@ FROM nginx:alpine
 # Copy jo from builder
 COPY --from=jo-builder /usr/local/bin/jo /usr/local/bin/jo
 
-# Install bash
-RUN apk add --no-cache bash
+# Apply security updates and install bash
+RUN apk update && apk upgrade --no-cache && apk add --no-cache bash
 
 # Copy application files
 COPY --from=build /app/dist/frontend/core-ui /usr/share/nginx/html


### PR DESCRIPTION
fix : #7175

### summary

- Updated Docker OS packages for OpenSSH security fixes.
- Upgraded old Alpine bases (3.11 -> 3.20).
- Limited scope to Dockerfile hardening only.

### Changes

- backend/gateway/Dockerfile
- frontend/core-ui/Dockerfile
- apps/frontline-widgets/Dockerfile
- backend/plugins/content_api/Dockerfile

### Test plan

- Build updated images.
- Re-run vulnerability scan.
- Verify containers start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images to latest available versions across multiple services
  * Enhanced container build workflows with system-level package updates and security upgrades prior to dependency installation
  * Standardized package management practices across all service containers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->