### PR TITLE
chore(docker): bump Alpine-based images to patched OpenSSL base

### DIFF
--- a/apps/frontline-widgets/Dockerfile
+++ b/apps/frontline-widgets/Dockerfile
@@ -1,5 +1,5 @@
 # Build jo from source
-FROM alpine:3.11 AS jo-builder
+FROM alpine:3.22 AS jo-builder
 RUN apk add --no-cache alpine-sdk && \
     cd /tmp && curl -s -LO https://github.com/jpmens/jo/releases/download/1.3/jo-1.3.tar.gz && \
     tar xzf jo-1.3.tar.gz && \
@@ -9,7 +9,7 @@ RUN apk add --no-cache alpine-sdk && \
     make install
 
 # Build the application
-FROM node:22-alpine AS build
+FROM node:22-alpine3.22 AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm install
@@ -17,7 +17,7 @@ COPY . .
 RUN pnpm nx build frontline-widgets --configuration=production --verbose
 
 # Final stage
-FROM nginx:alpine
+FROM nginx:alpine3.22
 
 # Copy jo from builder
 COPY --from=jo-builder /usr/local/bin/jo /usr/local/bin/jo

--- a/backend/core-api/Dockerfile
+++ b/backend/core-api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/accounting_api/Dockerfile
+++ b/backend/plugins/accounting_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/content_api/Dockerfile
+++ b/backend/plugins/content_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN apk add --no-cache git ca-certificates curl
 RUN npm install -g pnpm

--- a/backend/plugins/frontline_api/Dockerfile
+++ b/backend/plugins/frontline_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/operation_api/Dockerfile
+++ b/backend/plugins/operation_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/payment_api/Dockerfile
+++ b/backend/plugins/payment_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/posclient_api/Dockerfile
+++ b/backend/plugins/posclient_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm --ignore-scripts
 

--- a/backend/plugins/sales_api/Dockerfile
+++ b/backend/plugins/sales_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/backend/plugins/tourism_api/Dockerfile
+++ b/backend/plugins/tourism_api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/frontend/core-ui/Dockerfile
+++ b/frontend/core-ui/Dockerfile
@@ -1,5 +1,5 @@
 # Build jo from source
-FROM alpine:3.11 AS jo-builder
+FROM alpine:3.22 AS jo-builder
 RUN apk add --no-cache alpine-sdk && \
     cd /tmp && curl -s -LO https://github.com/jpmens/jo/releases/download/1.3/jo-1.3.tar.gz && \
     tar xzf jo-1.3.tar.gz && \
@@ -9,7 +9,7 @@ RUN apk add --no-cache alpine-sdk && \
     make install
 
 # Build the application
-FROM node:22-alpine AS build
+FROM node:22-alpine3.22 AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm install
@@ -17,7 +17,7 @@ COPY . .
 RUN pnpm nx build core-ui --configuration=production --verbose
 
 # Final stage
-FROM nginx:alpine
+FROM nginx:alpine3.22
 
 # Copy jo from builder
 COPY --from=jo-builder /usr/local/bin/jo /usr/local/bin/jo


### PR DESCRIPTION
### Summary

Bump Alpine base images.
Update Node Alpine tags.
Update Nginx Alpine tags.

### Test plan
Build changed images.
Run vulnerability scan.
Smoke test API and UI.


fix : #7197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images across services to newer Alpine and Node.js patch versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->