### PR TITLE
feat: core  clarify pipeline visibility logic for fields and groups

### DIFF
--- a/packages/core-ui/src/modules/forms/components/PropertyRow.tsx
+++ b/packages/core-ui/src/modules/forms/components/PropertyRow.tsx
@@ -116,7 +116,26 @@ class PropertyRow extends React.Component<Props, State> {
   };
 
   renderActionButtons = (data, remove, content, isGroup) => {
-    if (data.isDefinedByErxes || data.isDisabled) {
+    if (data.isDisabled) {
+      return null;
+    }
+
+    if (data.isDefinedByErxes) {
+      if (
+        isGroup &&
+        (data.contentType || '').split(':')[0] === 'tickets'
+      ) {
+        return (
+          <ActionButtons>
+            <ModalTrigger
+              title="Configure group"
+              trigger={<Button btnStyle="link" icon="edit-3" />}
+              content={content}
+              size="lg"
+            />
+          </ActionButtons>
+        );
+      }
       return null;
     }
 

--- a/packages/core/src/data/resolvers/queries/fields.ts
+++ b/packages/core/src/data/resolvers/queries/fields.ts
@@ -152,10 +152,12 @@ const fieldQueries = {
       groupIds.push(...inputGroupIds);
     }
 
+    let erxesDefinedGroup: any = null;
+
     if (isVisibleToCreate !== undefined) {
       query.isVisibleToCreate = isVisibleToCreate;
 
-      const erxesDefinedGroup = await models.FieldsGroups.findOne({
+      erxesDefinedGroup = await models.FieldsGroups.findOne({
         contentType,
         isDefinedByErxes: true,
         code: { $exists: false },
@@ -174,28 +176,58 @@ const fieldQueries = {
     }
 
     if (pipelineId) {
-      const otherGroupIds = await models.FieldsGroups.find({
+
+
+      const pipelineGroups = await models.FieldsGroups.find({
         'config.boardsPipelines.pipelineIds': { $in: [pipelineId] },
-      })
-        .select({ _id: 1 })
-        .sort({ order: 1 });
+      }).sort({ order: 1 });
+
+      if (pipelineGroups.length === 0) {
+        if (groupIds && groupIds.length > 0) {
+          query.groupId = { $in: groupIds };
+        }
+        return models.Fields.find(query).sort({ order: 1 });
+      }
 
       const allFields: any[] = [];
 
-      const fields = await models.Fields.find({
-        ...query,
-        groupId: { $in: groupIds },
-      }).sort({ order: 1 });
+      for (const group of pipelineGroups) {
+        const fv: Record<string, boolean> | undefined =
+          group.config?.fieldVisibility;
 
-      allFields.push(...fields);
+        if (group.isDefinedByErxes) {
 
-      for (const groupId of otherGroupIds) {
-        const groupFields = await models.Fields.find({
-          groupId,
-          ...query,
-        }).sort({ order: 1 });
+          if (fv && Object.keys(fv).length > 0) {
+            const shownFieldIds = Object.keys(fv).filter(
+              (id) => fv[id] === true,
+            );
 
-        allFields.push(...groupFields);
+            if (shownFieldIds.length > 0) {
+              const groupFields = await models.Fields.find({
+                groupId: group._id,
+                contentType: query.contentType,
+                _id: { $in: shownFieldIds },
+              }).sort({ order: 1 });
+
+              allFields.push(...groupFields);
+            }
+          } else {
+            const groupFields = await models.Fields.find({
+              groupId: group._id,
+              contentType: query.contentType,
+              isVisible: { $ne: false },
+            }).sort({ order: 1 });
+
+            allFields.push(...groupFields);
+          }
+        } else {
+          const groupFields = await models.Fields.find({
+            groupId: group._id,
+            ...query,
+          }).sort({ order: 1 });
+
+          allFields.push(...groupFields);
+        }
       }
 
       return allFields;

--- a/packages/core/src/db/models/Fields.ts
+++ b/packages/core/src/db/models/Fields.ts
@@ -651,7 +651,6 @@ export const loadGroupClass = (models: IModels) => {
     public static async checkIsDefinedByErxes(_id: string) {
       const groupObj = await models.FieldsGroups.findOne({ _id });
 
-      // Checking if the group is defined by the erxes
       if (groupObj && groupObj.isDefinedByErxes) {
         throw new Error("Cant update this group");
       }
@@ -701,8 +700,15 @@ export const loadGroupClass = (models: IModels) => {
         await this.checkCodeDuplication(doc.code);
       }
 
-      // Can not edit group that is defined by erxes
-      await this.checkIsDefinedByErxes(_id);
+      // System-defined groups only allow config (boardsPipelines / fieldVisibility) updates
+      if (group && group.isDefinedByErxes) {
+        await models.FieldsGroups.updateOne(
+          { _id },
+          { $set: { config: doc.config } },
+        );
+
+        return models.FieldsGroups.findOne({ _id });
+      }
 
       await models.FieldsGroups.updateOne({ _id }, { $set: doc });
 

--- a/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/sidebar/Sidebar.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/sidebar/Sidebar.tsx
@@ -221,6 +221,12 @@ class RightSidebar extends React.Component<IndexProps, IndexState> {
     if (currentSubTab === "details") {
       return (
         <TabContent>
+          <TaggerSection
+            data={customer}
+            type="core:customer"
+            refetchQueries={taggerRefetchQueries}
+            collapseCallback={toggleSection}
+          />
           <DetailInfo
             customer={customer}
             fieldsVisibility={customerVisibility}
@@ -244,12 +250,7 @@ class RightSidebar extends React.Component<IndexProps, IndexState> {
             />
             <ConversationCustomFieldsSection conversation={conversation} />
           </Box>
-          <TaggerSection
-            data={customer}
-            type="core:customer"
-            refetchQueries={taggerRefetchQueries}
-            collapseCallback={toggleSection}
-          />
+
 
           {this.renderTrackedData({ customer, kind, toggleSection })}
           {this.renderDeviceProperties({

--- a/packages/ui-forms/src/settings/properties/components/PropertyGroupForm.tsx
+++ b/packages/ui-forms/src/settings/properties/components/PropertyGroupForm.tsx
@@ -15,7 +15,7 @@ import { ModalFooter } from "@erxes/ui/src/styles/main";
 import PropertyLogics from "../containers/PropertyLogics";
 import React from "react";
 import { RenderDynamicComponent } from "@erxes/ui/src/utils/core";
-import { Row } from "../styles";
+import { FlexRow, Row } from "../styles";
 import Toggle from "@erxes/ui/src/components/Toggle";
 import { __ } from "@erxes/ui/src/utils";
 import ProductPropertGroupForm from "@erxes/ui-products/src/containers/form/PropertyGroupForm";
@@ -51,8 +51,22 @@ class PropertyGroupForm extends React.Component<Props, State> {
       isMultiple = props.group.isMultiple;
       isVisible = props.group.isVisible;
       isVisibleInDetail = props.group.isVisibleInDetail;
-      config = props.group.config;
+      config = props.group.config || {};
       alwaysOpen = props.group.alwaysOpen;
+
+      // Pre-populate fieldVisibility for system groups from each field's
+      // isVisibleToCreate so saving without clicking a toggle persists defaults.
+      if (
+        props.group.isDefinedByErxes &&
+        !config.fieldVisibility &&
+        props.group.fields?.length
+      ) {
+        const fieldVisibility: Record<string, boolean> = {};
+        for (const field of props.group.fields) {
+          fieldVisibility[field._id] = !!field.isVisibleToCreate;
+        }
+        config = { ...config, fieldVisibility };
+      }
     }
 
     this.state = {
@@ -81,6 +95,12 @@ class PropertyGroupForm extends React.Component<Props, State> {
 
     if (group) {
       finalValues._id = group._id;
+
+      // For system-defined groups preserve existing identity fields
+      if (group.isDefinedByErxes) {
+        finalValues.name = group.name;
+        finalValues.description = group.description || "";
+      }
     }
 
     return {
@@ -172,12 +192,73 @@ class PropertyGroupForm extends React.Component<Props, State> {
 
   onChangeItems = (boardsPipelines: any, key?: string) => {
     if (key) {
-      this.setState({ config: { [key]: boardsPipelines } });
+      this.setState(prev => ({
+        config: { ...prev.config, [key]: boardsPipelines }
+      }));
       return;
     }
 
-    this.setState({ config: { boardsPipelines } });
+    this.setState(prev => ({
+      config: { ...prev.config, boardsPipelines }
+    }));
   };
+
+  onFieldVisibilityChange = (fieldId: string, value: boolean) => {
+    this.setState(prev => ({
+      config: {
+        ...prev.config,
+        fieldVisibility: {
+          ...(prev.config?.fieldVisibility || {}),
+          [fieldId]: value
+        }
+      }
+    }));
+  };
+
+  renderFieldVisibilitySection() {
+    const { group } = this.props;
+
+    if (!group || !group.isDefinedByErxes || !group.fields?.length) {
+      return null;
+    }
+
+    const fieldVisibility: Record<string, boolean> =
+      this.state.config?.fieldVisibility || {};
+
+    return (
+      <FormGroup>
+        <ControlLabel>{__("Field Visibility to Create")}</ControlLabel>
+        <p>
+          {__(
+            "Choose which fields appear in the create form for the configured pipelines."
+          )}
+        </p>
+        {group.fields.map(field => {
+            const isChecked =
+              fieldVisibility[field._id] !== undefined
+                ? fieldVisibility[field._id]
+                : !!field.isVisibleToCreate;
+
+            return (
+              <FlexRow key={field._id} style={{ marginBottom: 8 }}>
+                <span style={{ flex: 1 }}>{field.text}</span>
+                <Toggle
+                  id={`fv_${field._id}`}
+                  checked={isChecked}
+                  icons={{
+                    checked: <span>{__("Yes")}</span>,
+                    unchecked: <span>{__("No")}</span>
+                  }}
+                  onChange={e =>
+                    this.onFieldVisibilityChange(field._id, e.target.checked)
+                  }
+                />
+              </FlexRow>
+            );
+          })}
+      </FormGroup>
+    );
+  }
 
   onChangeLogicAction = value => {
     this.setState({ logicAction: value });
@@ -226,6 +307,28 @@ class PropertyGroupForm extends React.Component<Props, State> {
     const { values, isSubmitted } = formProps;
 
     const object = group || ({} as IFieldGroup);
+
+    // For system-defined groups, only allow board & pipeline + field visibility configuration
+    if (group && group.isDefinedByErxes) {
+      return (
+        <>
+          {this.renderExtraContent()}
+          {this.renderFieldVisibilitySection()}
+          <ModalFooter>
+            <Button btnStyle="simple" onClick={closeModal} icon="times-circle">
+              Close
+            </Button>
+            {renderButton({
+              name: "property group",
+              values: this.generateDoc(values),
+              isSubmitted,
+              callback: closeModal,
+              object: group
+            })}
+          </ModalFooter>
+        </>
+      );
+    }
 
     return (
       <>


### PR DESCRIPTION
## Summary by Sourcery

Clarify and extend system-defined field group configuration and pipeline-based field visibility, while adjusting related UI controls and sidebar layout.

New Features:
- Allow configuring visibility of individual fields within system-defined groups on create forms via a new field visibility section.
- Enable editing of system-defined ticket groups through a dedicated configuration modal instead of blocking edits entirely.

Bug Fixes:
- Ensure property group config updates merge with existing settings instead of overwriting them when changing board or pipeline assignments.
- Preserve name and description of system-defined groups when saving configuration changes.
- Respect pipeline-specific field visibility for system-defined groups when fetching fields for a given pipeline, falling back to default visibility when no overrides exist.
- Show pipeline-matched fields even when no groups are configured for a pipeline by falling back to group-based queries.
- Adjust the inbox sidebar so customer tagging appears within the details tab before the customer details rather than after other sections.

Enhancements:
- Restrict updates to system-defined field groups in the backend to config-only changes while blocking structural edits.