### PR TITLE
fix: resolve pdf image not displaying issue

### DIFF
--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/utils.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/utils.ts
@@ -86,25 +86,25 @@ export const toBase64 = async (url: string): Promise<string> => {
 
   const promise = (async () => {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10_000);
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
+      const response = await fetch(url);
       if (!response.ok) return '';
 
       const blob = await response.blob();
-      if (!blob.type.startsWith('image/')) return '';
+      if (blob.size === 0) return '';
 
       return await new Promise<string>((resolve) => {
         const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result as string);
+        reader.onloadend = () => resolve((reader.result as string) || '');
         reader.onerror = () => resolve('');
         reader.readAsDataURL(blob);
       });
     } catch {
       return '';
     }
-  })();
+  })().then((result) => {
+    if (!result) base64Cache.delete(url);
+    return result;
+  });
 
   base64Cache.set(url, promise);
   return promise;


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness of image URL to base64 conversion for PDF itinerary generation to prevent broken or missing images.

Bug Fixes:
- Fix PDF image conversion failures by removing the fetch timeout/abort logic that could prematurely cancel image loading.
- Ensure empty or invalid image responses are detected via blob size and handled without breaking PDF generation.
- Avoid caching failed base64 conversions by clearing the cache entry when conversion returns an empty result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of image loading and validation in PDF generation for itineraries.
  * Enhanced handling of invalid or empty images to prevent PDF generation failures.
  * Optimized image caching behavior for better performance during repeated PDF exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->