### PR TITLE
Revert "feat(pos): added isCleanTaxPrice to interface"

### DIFF
--- a/packages/plugin-ebarimt-api/src/models/definitions/configs.ts
+++ b/packages/plugin-ebarimt-api/src/models/definitions/configs.ts
@@ -19,5 +19,4 @@ export interface IEbarimtConfig {
 
   reverseVatRules?: string[];
   reverseCtaxRules?: string[];
-  isCleanTaxPrice?: boolean;
 }

--- a/packages/plugin-pos-ui/src/pos/components/step/ConfigStep.tsx
+++ b/packages/plugin-pos-ui/src/pos/components/step/ConfigStep.tsx
@@ -359,7 +359,7 @@ const ConfigStep = (props: Props) => {
                 type="number"
                 min={0}
                 max={100}
-                value={pos.serviceCharge ?? ""}
+                value={pos.serviceCharge || ""}
                 onChange={onChangeInput}
               />
             </FormGroup>

--- a/packages/plugin-pos-ui/src/pos/components/step/EbarimtConfig.tsx
+++ b/packages/plugin-pos-ui/src/pos/components/step/EbarimtConfig.tsx
@@ -54,7 +54,6 @@ const EbarimtConfig = (props: Props) => {
         footerText: '',
         hasCopy: false,
         hasSumQty: false,
-        isCleanTaxPrice: false,
       }
   );
 
@@ -211,7 +210,6 @@ const EbarimtConfig = (props: Props) => {
               {renderInput('footerText', 'Footer text', '', 'text', true)}
               {renderCheckbox('hasCopy', 'Has copy', '')}
               {renderCheckbox('hasSumQty', 'Has summary qty', '')}
-              {renderCheckbox('isCleanTaxPrice', 'Is clean tax price', '')}
             </BlockRow>
           </Block>
         </LeftItem>

--- a/packages/plugin-posclient-api/src/graphql/resolvers/poscProduct.ts
+++ b/packages/plugin-posclient-api/src/graphql/resolvers/poscProduct.ts
@@ -13,36 +13,7 @@ export default {
   },
 
   unitPrice(product: IProductDocument, _args, { config }: IContext) {
-    const mainPrice = product.prices?.[config.token] || 0;
-
-    const ebarimtConfig = config.ebarimtConfig;
-    if (!ebarimtConfig?.isCleanTaxPrice) {
-      return mainPrice;
-    }
-
-    const vatPercent =
-      (ebarimtConfig.hasVat && Number(ebarimtConfig.vatPercent)) || 0;
-    const cityTaxPercent =
-      (ebarimtConfig.hasCitytax && Number(ebarimtConfig.cityTaxPercent)) || 0;
-
-    const taxRule = product.taxRules?.[config.token] || {};
-
-    if (taxRule.taxType && ["2", "3", "5"].includes(taxRule.taxType)) {
-      return mainPrice;
-    }
-
-    let totalPercent = vatPercent + cityTaxPercent + 100;
-
-    if (
-      !ebarimtConfig.hasCitytax &&
-      ebarimtConfig.reverseCtaxRules?.length &&
-      taxRule.citytaxCode
-    ) {
-      const pCtaxPercent = Number(taxRule.citytaxPercent) || 0;
-      totalPercent = vatPercent + pCtaxPercent + 100;
-    }
-
-    return Number(((mainPrice / totalPercent) * 100).toFixed(2));
+    return product.prices?.[config.token] || 0;
   },
 
   savedRemainder(product: IProductDocument, args, { config }: IContext) {

--- a/packages/plugin-posclient-api/src/graphql/schema/configs.ts
+++ b/packages/plugin-posclient-api/src/graphql/schema/configs.ts
@@ -26,7 +26,6 @@ export const types = `
     headerText: String
     hasCopy: Boolean
     hasSumQty: Boolean
-    isCleanTaxPrice: Boolean
   }
 
   type PoscCatProd {

--- a/packages/plugin-posclient-api/src/models/definitions/configs.ts
+++ b/packages/plugin-posclient-api/src/models/definitions/configs.ts
@@ -22,7 +22,6 @@ export interface IEbarimtConfig {
   footerText?: string;
   hasCopy: boolean;
   hasSumQty: boolean;
-  isCleanTaxPrice?: boolean;
 }
 
 interface IConfigColors {
@@ -150,7 +149,6 @@ const ebarimtConfigSchema = new Schema(
     footerText: field({ type: String, optional: true, label: "Footer text" }),
     hasCopy: field({ type: Boolean, optional: true }),
     hasSumQty: field({ type: Boolean, optional: true }),
-    isCleanTaxPrice: field({ type: Boolean, optional: true }),
   },
   { _id: false },
 );

--- a/pos/modules/auth/graphql/queries.ts
+++ b/pos/modules/auth/graphql/queries.ts
@@ -56,7 +56,6 @@ const currentConfig = gql`
         footerText
         hasCopy
         hasSumQty
-        isCleanTaxPrice
       }
       saveRemainder
       serviceCharge

--- a/pos/types/config.types.ts
+++ b/pos/types/config.types.ts
@@ -55,7 +55,6 @@ export interface IEbarimtConfig {
   ebarimtUrl?: string
   companyRD?: string
   companyName?: string
-  isCleanTaxPrice?: boolean
 }
 
 export interface IPaymentType {


### PR DESCRIPTION
Reverts erxes/erxes#7317

## Summary by Sourcery

Revert support for the `isCleanTaxPrice` ebarimt configuration and restore original POS price calculation behavior.

Bug Fixes:
- Restore unit price calculation to ignore `isCleanTaxPrice` tax cleaning logic and always use the configured product price.

Enhancements:
- Remove `isCleanTaxPrice` from ebarimt configuration interfaces, schemas, GraphQL types, and POS UI to align with the reverted behavior.
- Normalize POS service charge input handling by reverting to a simple fallback when the value is falsy.