### PR TITLE
Fix SSRF in Facebook integration uploadMedia

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
@@ -1,0 +1,52 @@
+const ALLOWED_FACEBOOK_HOSTNAME_PATTERNS: ReadonlyArray<RegExp> = [
+  /^(.+\.)?fbcdn\.net$/,
+  /^(.+\.)?facebook\.com$/,
+  /^(.+\.)?fb\.com$/,
+  /^(.+\.)?fbsbx\.com$/,
+  /^(.+\.)?instagram\.com$/,
+  /^(.+\.)?cdninstagram\.com$/,
+];
+
+const PRIVATE_IP_PATTERNS: ReadonlyArray<RegExp> = [
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
+  /^::1$/,
+  /^fc00:/i,
+  /^fe80:/i,
+];
+
+function isPrivateIp(hostname: string): boolean {
+  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(hostname));
+}
+
+function isAllowedFacebookHost(hostname: string): boolean {
+  return ALLOWED_FACEBOOK_HOSTNAME_PATTERNS.some((pattern) =>
+    pattern.test(hostname.toLowerCase()),
+  );
+}
+
+export function validateMediaUrl(url: string): void {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: unable to parse`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Blocked non-HTTPS URL scheme: ${parsed.protocol}`);
+  }
+
+  if (isPrivateIp(parsed.hostname)) {
+    throw new Error(`Blocked private/internal IP: ${parsed.hostname}`);
+  }
+
+  if (!isAllowedFacebookHost(parsed.hostname)) {
+    throw new Error(`Blocked non-Facebook hostname: ${parsed.hostname}`);
+  }
+}

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
@@ -19,6 +19,7 @@ const PRIVATE_IP_PATTERNS: ReadonlyArray<RegExp> = [
   /^fe80:/i,
 ];
 
+/** Converts hex-normalized IPv4-mapped IPv6 (e.g. ::ffff:7f00:1) to dotted IPv4. */
 function extractIPv4FromMappedIPv6(ip: string): string | null {
   const match = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
   if (!match) return null;
@@ -28,25 +29,32 @@ function extractIPv4FromMappedIPv6(ip: string): string | null {
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
 }
 
+/** Checks whether a hostname is a private or reserved IP address. */
 function isPrivateIp(hostname: string): boolean {
   const bare = hostname.replace(/^\[|\]$/g, '');
   const target = extractIPv4FromMappedIPv6(bare) ?? bare;
   return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(target));
 }
 
+/** Checks whether a hostname belongs to a known Facebook CDN domain. */
 function isAllowedFacebookHost(hostname: string): boolean {
   return ALLOWED_FACEBOOK_HOSTNAME_PATTERNS.some((pattern) =>
     pattern.test(hostname.toLowerCase()),
   );
 }
 
+/**
+ * Validates that a URL is safe to fetch server-side.
+ * Enforces HTTPS-only, Facebook CDN hostname allowlist, and private IP blocking.
+ * @throws {Error} if the URL fails any validation check
+ */
 export function validateMediaUrl(url: string): void {
   let parsed: URL;
 
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`Invalid URL: unable to parse`);
+    throw new Error('Invalid URL: unable to parse');
   }
 
   if (parsed.protocol !== 'https:') {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
@@ -15,17 +15,25 @@ const PRIVATE_IP_PATTERNS: ReadonlyArray<RegExp> = [
   /^169\.254\./,
   /^0\./,
   /^::1$/,
-  /^fc00:/i,
+  /^f[cd]00:/i,
   /^fe80:/i,
 ];
 
-/** Converts hex-normalized IPv4-mapped IPv6 (e.g. ::ffff:7f00:1) to dotted IPv4. */
+/** Converts IPv4-mapped IPv6 to dotted IPv4.
+ *  Handles both hex form (::ffff:7f00:1) and dotted-quad form (::ffff:127.0.0.1). */
 function extractIPv4FromMappedIPv6(ip: string): string | null {
-  const match = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
-  if (!match) return null;
+  // Dotted-quad form: ::ffff:127.0.0.1
+  const dottedMatch = ip.match(
+    /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i,
+  );
+  if (dottedMatch) return dottedMatch[1];
 
-  const hi = parseInt(match[1], 16);
-  const lo = parseInt(match[2], 16);
+  // Hex form: ::ffff:7f00:1
+  const hexMatch = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (!hexMatch) return null;
+
+  const hi = parseInt(hexMatch[1], 16);
+  const lo = parseInt(hexMatch[2], 16);
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
 }
 

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
@@ -17,12 +17,21 @@ const PRIVATE_IP_PATTERNS: ReadonlyArray<RegExp> = [
   /^::1$/,
   /^fc00:/i,
   /^fe80:/i,
-  /^::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.)/i,
 ];
+
+function extractIPv4FromMappedIPv6(ip: string): string | null {
+  const match = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (!match) return null;
+
+  const hi = parseInt(match[1], 16);
+  const lo = parseInt(match[2], 16);
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
 
 function isPrivateIp(hostname: string): boolean {
   const bare = hostname.replace(/^\[|\]$/g, '');
-  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(bare));
+  const target = extractIPv4FromMappedIPv6(bare) ?? bare;
+  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(target));
 }
 
 function isAllowedFacebookHost(hostname: string): boolean {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts
@@ -17,10 +17,12 @@ const PRIVATE_IP_PATTERNS: ReadonlyArray<RegExp> = [
   /^::1$/,
   /^fc00:/i,
   /^fe80:/i,
+  /^::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.)/i,
 ];
 
 function isPrivateIp(hostname: string): boolean {
-  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(hostname));
+  const bare = hostname.replace(/^\[|\]$/g, '');
+  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(bare));
 }
 
 function isAllowedFacebookHost(hostname: string): boolean {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
@@ -10,6 +10,7 @@ import { randomAlphanumeric, sendTRPCMessage } from 'erxes-api-shared/utils';
 import * as graph from 'fbgraph';
 import { IModels } from '~/connectionResolvers';
 import { SUBSCRIBED_FIELDS } from './constants';
+import { validateMediaUrl } from './urlValidation';
 
 export const graphRequest = {
   base(method: string, path?: any, accessToken?: any, ...otherParams) {
@@ -121,6 +122,14 @@ export const uploadMedia = async (
   url: string,
   video: boolean,
 ) => {
+  try {
+    validateMediaUrl(url);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    debugError(`SSRF protection blocked media fetch: ${message}`);
+    return null;
+  }
+
   const mediaFile = `uploads/${randomAlphanumeric(16)}.${
     video ? 'mp4' : 'jpg'
   }`;


### PR DESCRIPTION
## Summary

The `uploadMedia` function in the Facebook integration fetches URLs from webhook payloads and uploads the content to S3. Those URLs come straight from the request body with zero validation, so an attacker who sends a crafted webhook can point the fetch at internal services, cloud metadata endpoints, or localhost.

Addresses CodeQL alert #1012 (CWE-918, critical severity).

## What changed

Added `validateMediaUrl()` as a gate at the top of `uploadMedia`. It checks three things before any fetch happens:

- HTTPS only (blocks http, file, ftp schemes)
- Hostname must match Facebook CDN domains (fbcdn.net, facebook.com, fbsbx.com, instagram.com, cdninstagram.com)
- No private/internal IPs (RFC 1918, loopback, link-local, IPv4-mapped IPv6)

If any check fails, `uploadMedia` returns null, which is the same thing it already returns on network errors. Callers all handle null gracefully, so posts and messages still get created without the media attachment.

**Note:** the webhook endpoint also lacks Facebook's `X-Hub-Signature` HMAC verification, which makes forging payloads trivial. That's a separate fix.

## Files

- **New:** `backend/plugins/frontline_api/src/modules/integrations/facebook/urlValidation.ts` (64 lines)
- **Modified:** `backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts` (+9 lines)

## Test plan

- [x] Verify Facebook post webhooks with photos/videos still save media to S3
- [x] Verify profile picture upload works for new Facebook customers
- [x] Verify posts with blocked/invalid URLs still get created (with empty attachments)
- [x] Verify non-AWS deployments are unaffected (uploadMedia is only called when UPLOAD_SERVICE_TYPE=AWS)

## Summary by Sourcery

Bug Fixes:
- Block media uploads from non-HTTPS URLs, private/internal IPs, and non-Facebook domains in the Facebook integration uploadMedia flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced URL validation for Facebook/Instagram media: enforces HTTPS, blocks private/reserved IP addresses, and restricts hosts to known Facebook/CDN domains.
* **Bug Fixes**
  * Validation failures now stop media fetches/uploads and return null, and log debug info to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->