### PR TITLE
fix: sanitize Facebook conversation inputs to prevent NoSQL injection

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
@@ -12,6 +12,18 @@ import {
   triggerFacebookMessageAutomation,
 } from '@/integrations/facebook/meta/automation/utils/messageUtils';
 
+/**
+ * Sanitize a value expected to be a string to prevent NoSQL injection.
+ * Coerces non-string values (e.g. numbers) to strings, which also neutralizes
+ * injection objects like {"$gt": ""} by converting them to "[object Object]".
+ */
+const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};
+
 export const receiveMessage = async (
   models: IModels,
   subdomain: string,
@@ -24,10 +36,11 @@ export const receiveMessage = async (
     );
     const { recipient, from, timestamp, channelData } = activity;
     let { message, postback } = channelData;
-    const pageId = recipient.id;
-    const userId = from.id;
+    const pageId = sanitizeString(recipient.id);
+    const userId = sanitizeString(from.id);
     const kind = INTEGRATION_KINDS.MESSENGER;
-    const mid = channelData.message?.mid || postback?.mid;
+    const rawMid = channelData.message?.mid || postback?.mid;
+    const mid = rawMid != null ? sanitizeString(rawMid) : undefined;
     const attachments = channelData.message?.attachments;
 
     let text = activity.text || message?.text;
@@ -74,8 +87,8 @@ export const receiveMessage = async (
     }
 
     let conversation = await models.FacebookConversations.findOne({
-      senderId: userId,
-      recipientId: pageId,
+      senderId: { $eq: userId },
+      recipientId: { $eq: pageId },
     });
 
     const bot = await checkIsBot(models, message, recipient.id);
@@ -154,7 +167,7 @@ export const receiveMessage = async (
     // get conversation message
     let conversationMessage = await models.FacebookConversationMessages.findOne(
       {
-        mid: mid,
+        mid: { $eq: mid },
       },
     );
 


### PR DESCRIPTION
## Summary

- Add sanitizeString helper to coerce non-string values to strings
- Apply sanitization to pageId, userId, and mid in receiveMessage
- Use explicit $eq operator in MongoDB queries to prevent injection
- Addresses code scanning issue #1175

## Changes

This fix prevents NoSQL injection attacks in the Facebook integration by:
1. Adding a sanitizeString function that converts non-string values to strings
2. Sanitizing user-controlled inputs (pageId, userId, mid) before use
3. Using explicit $eq operators in MongoDB queries instead of direct value comparison

## Testing

- Manual testing with Facebook webhook messages
- Verified that string, number, and object inputs are properly sanitized

## Summary by Sourcery

Harden Facebook message handling against NoSQL injection in conversation lookups.

Bug Fixes:
- Sanitize Facebook recipient, user, and message IDs before use to prevent NoSQL injection vectors in conversation handling.
- Use explicit $eq operators in MongoDB queries for Facebook conversations and messages to avoid unsafe query construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Fixes**
  * Strengthened input validation in Facebook message processing to prevent potential NoSQL injection vulnerabilities through untrusted event fields.
  * Improved database query safety with enhanced parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->