### PR TITLE
Security patch against DDoS Attack to subscriptionPlugin.js closing alert #1144

### DIFF
--- a/backend/erxes-api-shared/src/utils/start-plugin.ts
+++ b/backend/erxes-api-shared/src/utils/start-plugin.ts
@@ -15,6 +15,7 @@ import express, {
 import { DocumentNode, GraphQLScalarType } from 'graphql';
 import * as http from 'http';
 import * as path from 'path';
+import rateLimit from 'express-rate-limit';
 import { startPayments } from '../common-modules/payment/worker';
 import type {
   IPropertyMeta,
@@ -147,6 +148,21 @@ export async function startPlugin(
     res.end('ok');
   });
 
+  /**
+   * Protects the public subscription bundle endpoint from request floods.
+   *
+   * The limit is intentionally generous so regular page loads, retries, and
+   * normal multi-user traffic are not blocked. It only throttles abnormal
+   * high-frequency bursts from the same IP.
+   */
+  const subscriptionFileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 1000,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Too many requests from this IP, please try again later.',
+  });
+
   if (expressRouter) {
     app.use(expressRouter);
   }
@@ -191,9 +207,13 @@ export async function startPlugin(
   }
 
   if (hasSubscriptions) {
-    app.get('/subscriptionPlugin.js', async (_req, res) => {
-      res.sendFile(path.join(subscriptionPluginPath));
-    });
+    app.get(
+      '/subscriptionPlugin.js',
+      subscriptionFileLimiter,
+      async (_req, res) => {
+        res.sendFile(path.join(subscriptionPluginPath));
+      },
+    );
   }
 
   if (trpcAppRouter) {

--- a/backend/erxes-api-shared/src/utils/start-plugin.ts
+++ b/backend/erxes-api-shared/src/utils/start-plugin.ts
@@ -148,21 +148,6 @@ export async function startPlugin(
     res.end('ok');
   });
 
-  /**
-   * Protects the public subscription bundle endpoint from request floods.
-   *
-   * The limit is intentionally generous so regular page loads, retries, and
-   * normal multi-user traffic are not blocked. It only throttles abnormal
-   * high-frequency bursts from the same IP.
-   */
-  const subscriptionFileLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 1000,
-    standardHeaders: true,
-    legacyHeaders: false,
-    message: 'Too many requests from this IP, please try again later.',
-  });
-
   if (expressRouter) {
     app.use(expressRouter);
   }
@@ -207,11 +192,32 @@ export async function startPlugin(
   }
 
   if (hasSubscriptions) {
+    if (!subscriptionPluginPath) {
+      throw new Error(
+        'subscriptionPluginPath is required when hasSubscriptions is true',
+      );
+    }
+
+    /**
+     * Protects the public subscription bundle endpoint from request floods.
+     *
+     * The limit is intentionally generous so regular page loads, retries, and
+     * normal multi-user traffic are not blocked. It only throttles abnormal
+     * high-frequency bursts from the same IP.
+     */
+    const subscriptionFileLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 1000,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: 'Too many requests from this IP, please try again later.',
+    });
+
     app.get(
       '/subscriptionPlugin.js',
       subscriptionFileLimiter,
-      async (_req, res) => {
-        res.sendFile(path.join(subscriptionPluginPath));
+      (_req, res) => {
+        res.sendFile(path.resolve(subscriptionPluginPath));
       },
     );
   }

--- a/backend/erxes-api-shared/src/utils/start-plugin.ts
+++ b/backend/erxes-api-shared/src/utils/start-plugin.ts
@@ -213,13 +213,9 @@ export async function startPlugin(
       message: 'Too many requests from this IP, please try again later.',
     });
 
-    app.get(
-      '/subscriptionPlugin.js',
-      subscriptionFileLimiter,
-      (_req, res) => {
-        res.sendFile(path.resolve(subscriptionPluginPath));
-      },
-    );
+    app.get('/subscriptionPlugin.js', subscriptionFileLimiter, (_req, res) => {
+      res.sendFile(path.resolve(subscriptionPluginPath));
+    });
   }
 
   if (trpcAppRouter) {


### PR DESCRIPTION
Added a lightweight, very generous rate limit for the public /subscriptionPlugin.js endpoint in shared plugin startup logic to reduce abuse/flood traffic without impacting normal users. Also added clear JSDoc comments to explain why the limit is intentionally high and scoped only to this endpoint.

1000 requests per IP per 15 minutes (for /subscriptionPlugin.js).

## Summary by Sourcery

Add rate limiting to the public subscription plugin endpoint to mitigate abusive traffic while preserving normal usage.

Enhancements:
- Introduce a generous IP-based rate limiter for the /subscriptionPlugin.js endpoint in the shared plugin startup logic.
- Document the rationale and scope of the rate limit with JSDoc comments to clarify its protective intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added per-IP rate limiting on the subscription plugin endpoint: 1,000 requests per IP per 15 minutes.
* **Bug Fixes**
  * Endpoint now validates presence of the subscription plugin file and returns an error if missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->