### PR TITLE
fix(content-ui): avoid regex-only HTML stripping in post submission

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -167,7 +167,22 @@ const blocksToHtml = (raw: string): string => {
   }
 };
 
+/**
+ * Extracts plain text from HTML for derived fields (for example, fallback title).
+ *
+ * Uses a DOM parser instead of regex-only stripping to avoid malformed HTML edge
+ * cases where crafted input can bypass simplistic replacements.
+ */
 const extractText = (html: string): string => {
+  if (!html) {
+    return '';
+  }
+
+  if (typeof DOMParser !== 'undefined') {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return (doc.body.textContent ?? '').trim();
+  }
+
   return html.replace(/<[^>]*>/g, '').trim();
 };
 


### PR DESCRIPTION
## Summary
- replace regex-only HTML tag stripping in `extractText` with `DOMParser`-based extraction
- keep a fallback regex path when `DOMParser` is unavailable
- add JSDoc explaining the security rationale

## Why
This prevents malformed/crafted HTML edge cases from bypassing simplistic regex sanitization when deriving plain text (for example fallback post titles).

## Validation
- pnpm nx build content_ui

## Summary by Sourcery

Enhancements:
- Replace regex-only HTML tag stripping in extractText with DOMParser-based text extraction when available, falling back to regex when not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction reliability in post submission forms through enhanced parsing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->