### PR TITLE
feat: add broadcast traces logging

### DIFF
--- a/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
+++ b/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
@@ -290,8 +290,9 @@ export const engageQueries = {
     { engageMessageId }: { engageMessageId: string },
     { models }: IContext,
   ) {
-    return models.BroadcastTraces.find({ engageMessageId })
-      .sort({ createdAt: -1 })
+    return models.BroadcastTraces.find({ engageMessageId }).sort({
+      createdAt: -1,
+    });
   },
 
   async engageSmsDeliveries(

--- a/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
+++ b/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
@@ -292,7 +292,6 @@ export const engageQueries = {
   ) {
     return models.BroadcastTraces.find({ engageMessageId })
       .sort({ createdAt: -1 })
-      .lean();
   },
 
   async engageSmsDeliveries(

--- a/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
+++ b/backend/core-api/src/modules/broadcast/graphql/resolvers/queries/engage.ts
@@ -285,6 +285,16 @@ export const engageQueries = {
     }
   },
 
+  async engageBroadcastTraces(
+    _root: undefined,
+    { engageMessageId }: { engageMessageId: string },
+    { models }: IContext,
+  ) {
+    return models.BroadcastTraces.find({ engageMessageId })
+      .sort({ createdAt: -1 })
+      .lean();
+  },
+
   async engageSmsDeliveries(
     _root: undefined,
     params: ISmsDeliveryQueryParams,

--- a/backend/core-api/src/modules/broadcast/graphql/schemas/engage.ts
+++ b/backend/core-api/src/modules/broadcast/graphql/schemas/engage.ts
@@ -177,6 +177,14 @@ export const types = `
     pageInfo: PageInfo
     totalCount: Int
   }
+
+  type BroadcastTrace {
+    _id: String!
+    engageMessageId: String!
+    type: String!
+    message: String!
+    createdAt: Date
+  }
 `;
 
 const queryParams = `
@@ -200,6 +208,7 @@ export const queries = `
   engageReportsList(page: Int, perPage: Int, customerId: String, status: String, searchValue: String): EngageDeliveryReport
   engageEmailPercentages: AvgEmailStats
   engageSmsDeliveries(type: String!, to: String, page: Int, perPage: Int): DeliveryList
+  engageBroadcastTraces(engageMessageId: String!): [BroadcastTrace]
 `;
 
 const mutationParams = `

--- a/backend/core-api/src/modules/broadcast/utils/email.ts
+++ b/backend/core-api/src/modules/broadcast/utils/email.ts
@@ -29,16 +29,9 @@ const prepareContentAndSubject = (
   subject: string,
   content: string,
   customer: ICustomer,
-  subdomain: string,
 ) => {
   let replacedContent = content;
   let replacedSubject = subject;
-
-  const DOMAIN = (getEnv({ name: 'DOMAIN' }) || '').replace(
-    '<subdomain>',
-    subdomain,
-  );
-  const unsubscribeUrl = `${DOMAIN}/gateway/pl:core/unsubscribe/?cid=${customer._id}`;
 
   if (customer.replacers) {
     for (const replacer of customer.replacers) {
@@ -47,14 +40,6 @@ const prepareContentAndSubject = (
       replacedSubject = replacedSubject.replace(regex, replacer.value);
     }
   }
-
-  replacedContent += `
-    <div style="padding: 10px; color: #ccc; text-align: center; font-size:12px;">
-      You are receiving this email because you have signed up for our services.
-      <br />
-      <a style="text-decoration: underline;color: #ccc;" rel="noopener" target="_blank" href="${unsubscribeUrl}">Unsubscribe</a>
-    </div>
-  `;
 
   return { replacedContent, replacedSubject };
 };
@@ -98,7 +83,6 @@ export const prepareEmailParams = (
     subject,
     content,
     customer,
-    subdomain,
   );
 
   return {

--- a/backend/core-api/src/modules/broadcast/worker/email.ts
+++ b/backend/core-api/src/modules/broadcast/worker/email.ts
@@ -44,6 +44,7 @@ export const handleEmailProcessor = async (payload) => {
 
           continue;
         }
+
         try {
           const replacedContent = await replaceContent({
             replacer: customer,
@@ -63,17 +64,24 @@ export const handleEmailProcessor = async (payload) => {
             },
           });
 
-          const htmlContent = blocksToHtml(replacedContent, {
-            wrapper: { email: true },
-          });
+          const DOMAIN = (
+            process.env.DOMAIN || 'http://localhost:4000'
+          ).replace('<subdomain>', subdomain);
+          
+          const unsubscribeUrl = `${DOMAIN}/gateway/pl:core/unsubscribe/?cid=${customer._id}`;
 
-          engageMessage.email.content = htmlContent;
+          const htmlContent = blocksToHtml(replacedContent, {
+            wrapper: { email: true, unsubscribeUrl },
+          });
 
           await transporter.sendMail(
             prepareEmailParams(
               subdomain,
               customer,
-              engageMessage,
+              {
+                ...engageMessage,
+                email: { ...engageMessage.email, content: htmlContent },
+              },
               fromEmail,
               configSet,
             ),

--- a/backend/core-api/src/modules/broadcast/worker/email.ts
+++ b/backend/core-api/src/modules/broadcast/worker/email.ts
@@ -67,7 +67,7 @@ export const handleEmailProcessor = async (payload) => {
           const DOMAIN = (
             process.env.DOMAIN || 'http://localhost:4000'
           ).replace('<subdomain>', subdomain);
-          
+
           const unsubscribeUrl = `${DOMAIN}/gateway/pl:core/unsubscribe/?cid=${customer._id}`;
 
           const htmlContent = blocksToHtml(replacedContent, {

--- a/backend/core-api/src/modules/documents/blocksToHtml.ts
+++ b/backend/core-api/src/modules/documents/blocksToHtml.ts
@@ -251,8 +251,8 @@ const renderBlock = (block: Block | PartialBlock, config?: Config): string => {
 
       let html = `<div style="margin: 16px 0;">
         <img src="${escapeHtml(url || '')}" alt="${escapeHtml(
-        name || '',
-      )}" width="${width}" style="${imgStyle}" />`;
+          name || '',
+        )}" width="${width}" style="${imgStyle}" />`;
 
       if (caption) {
         html += `<div style="margin-top: 8px; font-size: 14px; color: #666; font-style: italic;">${escapeHtml(

--- a/backend/core-api/src/modules/documents/blocksToHtml.ts
+++ b/backend/core-api/src/modules/documents/blocksToHtml.ts
@@ -12,7 +12,6 @@ export const COLORS_DEFAULT = {
   pink: { text: '#ad1a72', background: '#f4dfeb' },
 } as const;
 
-type ColorName = keyof typeof COLORS_DEFAULT;
 type ColorConfig = Record<string, { text: string; background: string }>;
 
 interface Config {
@@ -24,6 +23,7 @@ interface Config {
   maxWidth?: number;
   wrapper?: {
     email?: boolean;
+    unsubscribeUrl?: string;
   };
 }
 
@@ -188,7 +188,7 @@ const mergeStyles = (baseStyle: string, customStyle?: string): string => {
 };
 
 const renderBlock = (block: Block | PartialBlock, config?: Config): string => {
-  const { type, props, content, children } = block as any;
+  const { type, props, content } = block as any;
   const baseStyles = getBaseStyles(config);
   const customStyle = stylesToCss(props, config);
 
@@ -379,6 +379,17 @@ export const blocksToHtml = (
 
 export const emailHtmlWrapper = (html: string, config?: Config) => {
   const maxWidth = Math.min(config?.maxWidth || DEFAULTS.maxWidth, 600);
+  const unsubscribeUrl = config?.wrapper?.unsubscribeUrl;
+
+  const unsubscribeRow = unsubscribeUrl
+    ? `<tr>
+        <td style="padding: 10px; color: #ccc; text-align: center; font-size: 12px; border-top: 1px solid #f0f0f0;">
+          You are receiving this email because you have signed up for our services.
+          <br />
+          <a style="text-decoration: underline; color: #ccc;" rel="noopener" target="_blank" href="${unsubscribeUrl}">Unsubscribe</a>
+        </td>
+      </tr>`
+    : '';
 
   return `
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -397,6 +408,7 @@ export const emailHtmlWrapper = (html: string, config?: Config) => {
                     ${html}
                   </td>
                 </tr>
+                ${unsubscribeRow}
               </table>
             </td>
           </tr>

--- a/backend/core-api/src/modules/documents/graphql/queries.ts
+++ b/backend/core-api/src/modules/documents/graphql/queries.ts
@@ -119,18 +119,23 @@ export const documentQueries = {
     { contentType }: { contentType: string },
     { models, subdomain }: IContext,
   ) => {
-    const [serviceName] = contentType.split(':');
+    const [pluginName, moduleName] = contentType.split(':');
 
-    const { editorAttributes } = documents;
+    if (pluginName === 'core') {
+      const { editorAttributes } = documents;
 
-    if (editorAttributes) {
-      return await editorAttributes(models, subdomain, contentType);
+      if (moduleName === 'broadcast') {
+        contentType = 'core:contacts.customers';
+      }
+
+      if (editorAttributes) {
+        return await editorAttributes(models, subdomain, contentType);
+      }
     }
 
     return await sendTRPCMessage({
       subdomain,
-
-      pluginName: serviceName,
+      pluginName,
       method: 'query',
       module: 'documents',
       action: 'editorAttributes',

--- a/frontend/core-ui/src/modules/broadcast/components/BroadcastDetailSidebar.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/BroadcastDetailSidebar.tsx
@@ -3,7 +3,7 @@ import { Sidebar } from 'erxes-ui';
 const BROADCAST_SIDEBAR_TABS = {
   statistic: 'Statistic',
   preview: 'Preview',
-  log: 'Log Message',
+  log: 'Traces',
 };
 
 export type BROADCAST_TAB = keyof typeof BROADCAST_SIDEBAR_TABS;
@@ -29,7 +29,7 @@ export const BroadcastDetailSidebar = ({
                   isActive={activeTab === key}
                   onClick={() => setActiveTab(key as BROADCAST_TAB)}
                   className="capitalize"
-                  disabled={key === 'log'}
+                  disabled={false}
                 >
                   {value}
                 </Sidebar.MenuButton>

--- a/frontend/core-ui/src/modules/broadcast/components/BroadcastEditor.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/BroadcastEditor.tsx
@@ -28,9 +28,14 @@ export const BroadcastEditor = ({
       className={cn('flex-1 w-full overflow-y-auto')}
     >
       {attribute && (
-        <AttributeInEditor editor={editor} contentType="core:contacts.customers" />
+        <AttributeInEditor
+          editor={editor}
+          contentType="core:contacts.customers"
+        />
       )}
-      {document && <DocumentInEditor editor={editor} contentType="core:broadcast" />}
+      {document && (
+        <DocumentInEditor editor={editor} contentType="core:broadcast" />
+      )}
     </BlockEditor>
   );
 };

--- a/frontend/core-ui/src/modules/broadcast/components/BroadcastEditor.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/BroadcastEditor.tsx
@@ -28,7 +28,7 @@ export const BroadcastEditor = ({
       className={cn('flex-1 w-full overflow-y-auto')}
     >
       {attribute && (
-        <AttributeInEditor editor={editor} contentType="core:contact.customer" />
+        <AttributeInEditor editor={editor} contentType="core:contacts.customers" />
       )}
       {document && <DocumentInEditor editor={editor} contentType="core:broadcast" />}
     </BlockEditor>

--- a/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabLogContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabLogContent.tsx
@@ -1,3 +1,103 @@
+import { useQuery } from '@apollo/client';
+import {
+  IconActivity,
+  IconCircleCheck,
+  IconCircleX,
+  IconInfoCircle,
+} from '@tabler/icons-react';
+import { cn, Empty, RelativeDateDisplay } from 'erxes-ui';
+import { BROADCAST_TRACES } from '../../graphql/queries';
+
+type TraceType = 'success' | 'failure' | 'regular';
+
+const TRACE_CONFIG: Record<
+  TraceType,
+  { icon: React.ElementType; iconClass: string; bgClass: string }
+> = {
+  success: {
+    icon: IconCircleCheck,
+    iconClass: 'text-green-600',
+    bgClass: 'bg-green-100',
+  },
+  failure: {
+    icon: IconCircleX,
+    iconClass: 'text-red-600',
+    bgClass: 'bg-red-100',
+  },
+  regular: {
+    icon: IconInfoCircle,
+    iconClass: 'text-blue-600',
+    bgClass: 'bg-blue-100',
+  },
+};
+
+const TraceRow = ({ trace, isLast }: { trace: any; isLast: boolean }) => {
+  const config = TRACE_CONFIG[trace.type as TraceType] ?? TRACE_CONFIG.regular;
+  const Icon = config.icon;
+
+  return (
+    <div className="relative flex flex-row gap-3 pb-5">
+      {!isLast && (
+        <div className="absolute left-3 -translate-x-1/2 top-7 bottom-0 w-px bg-border" />
+      )}
+
+      <div className="relative z-10 shrink-0">
+        <div className={cn('size-6 rounded-full flex items-center justify-center border border-background', config.bgClass)}>
+          <Icon className={cn('size-4', config.iconClass)} />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-start gap-3 pt-0.5">
+        <p className="min-w-0 flex-1 text-sm">{trace.message}</p>
+        <RelativeDateDisplay value={trace.createdAt} asChild>
+          <p className="shrink-0 text-xs leading-6 text-muted-foreground">
+            <RelativeDateDisplay.Value value={trace.createdAt} />
+          </p>
+        </RelativeDateDisplay>
+      </div>
+    </div>
+  );
+};
+
 export const BroadcastTabLogContent = ({ message }: { message: any }) => {
-  return <div>BroadcastTabLogContent</div>;
+  const { data, loading } = useQuery(BROADCAST_TRACES, {
+    variables: { engageMessageId: message?._id },
+    skip: !message?._id,
+  });
+
+  const traces: any[] = (data?.engageBroadcastTraces ?? []).filter(Boolean);
+
+  return (
+    <div className="flex-1 flex flex-col h-full overflow-hidden">
+      <div className="flex-1 overflow-y-auto px-8 py-5">
+        {loading && (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        )}
+
+        {!loading && traces.length === 0 && (
+          <Empty>
+            <Empty.Header>
+              <Empty.Media variant="icon">
+                <IconActivity />
+              </Empty.Media>
+              <Empty.Title>No traces yet</Empty.Title>
+              <Empty.Description>
+                Traces will appear here once the broadcast starts sending.
+              </Empty.Description>
+            </Empty.Header>
+          </Empty>
+        )}
+
+        <div className="w-full flex flex-col">
+          {traces.map((trace, index) => (
+            <TraceRow
+              key={trace?._id}
+              trace={trace}
+              isLast={index === traces.length - 1}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabLogContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabLogContent.tsx
@@ -42,7 +42,12 @@ const TraceRow = ({ trace, isLast }: { trace: any; isLast: boolean }) => {
       )}
 
       <div className="relative z-10 shrink-0">
-        <div className={cn('size-6 rounded-full flex items-center justify-center border border-background', config.bgClass)}>
+        <div
+          className={cn(
+            'size-6 rounded-full flex items-center justify-center border border-background',
+            config.bgClass,
+          )}
+        >
           <Icon className={cn('size-4', config.iconClass)} />
         </div>
       </div>
@@ -70,9 +75,7 @@ export const BroadcastTabLogContent = ({ message }: { message: any }) => {
   return (
     <div className="flex-1 flex flex-col h-full overflow-hidden">
       <div className="flex-1 overflow-y-auto px-8 py-5">
-        {loading && (
-          <p className="text-sm text-muted-foreground">Loading...</p>
-        )}
+        {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
 
         {!loading && traces.length === 0 && (
           <Empty>

--- a/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabPreviewContent.tsx
+++ b/frontend/core-ui/src/modules/broadcast/components/tab/BroadcastTabPreviewContent.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, lazy } from 'react';
+import { ComponentType, lazy, Suspense } from 'react';
 
 const BroadcastTabPreviewEmailContent = lazy(() =>
   import('../methods/BroadcastEmailTabContent').then((module) => ({
@@ -38,7 +38,9 @@ export const BroadcastTabPreviewContent = ({ message }: { message: any }) => {
 
   return (
     <div className="w-full overflow-hidden px-8 py-5 space-y-5">
-      <BroadcastMethodTabContent message={message} />
+      <Suspense fallback={null}>
+        <BroadcastMethodTabContent message={message} />
+      </Suspense>
     </div>
   );
 };

--- a/frontend/core-ui/src/modules/broadcast/graphql/queries.ts
+++ b/frontend/core-ui/src/modules/broadcast/graphql/queries.ts
@@ -158,6 +158,17 @@ export const BROADCAST_CUSTOMERS_COUNT = gql`
   }
 `;
 
+export const BROADCAST_TRACES = gql`
+  query BroadcastTraces($engageMessageId: String!) {
+    engageBroadcastTraces(engageMessageId: $engageMessageId) {
+      _id
+      type
+      message
+      createdAt
+    }
+  }
+`;
+
 export const BROADCAST_STATISTIC = gql`
   query BroadcastStatistic {
     engageEmailPercentages {


### PR DESCRIPTION
- Add engageBroadcastTraces GraphQL query to fetch message processing logs
- Implement BroadcastTrace type and timeline UI with status indicators
- Enable traces tab in broadcast sidebar (previously disabled)
- Add unsubscribe links to broadcast emails via HTML wrapper
- Fix content type references in broadcast editor and documents queries

## Summary by Sourcery

Add broadcast trace logging and viewing, improve broadcast email unsubscribe handling, and correct content type usage for broadcast-related editors and documents.

New Features:
- Expose engageBroadcastTraces GraphQL query and BroadcastTrace type to fetch and display broadcast processing traces.
- Add a broadcast traces UI tab in the broadcast detail sidebar with a timeline view and status indicators for each trace.

Bug Fixes:
- Correct broadcast-related content type identifiers for editor attributes and document integration, including mapping broadcast editor attributes to contacts customers.

Enhancements:
- Render broadcast preview content lazily within a Suspense boundary to improve loading behavior.
- Move unsubscribe footer generation into the shared email HTML wrapper and wire it via blocksToHtml configuration instead of manual string concatenation in the broadcast email utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "Traces" timeline showing broadcast message traces with type icons, timestamps, loading and empty states.
  * Broadcast emails now include an unsubscribe link when available.

* **Improvements**
  * Renamed "Log Message" tab to "Traces" and made it accessible/clickable.
  * More robust preview rendering with smoother loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->