### PR TITLE
fix(gateway): add generous global rate limit

### DIFF
--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import * as http from 'http';
+import rateLimit, { type RateLimitRequestHandler } from 'express-rate-limit';
 import { Queue } from 'bullmq';
 import { createBullBoard } from '@bull-board/api';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
@@ -84,6 +85,17 @@ const app = express();
 applyTrustProxy(app);
 
 app.use(cookieParser());
+
+const gatewayRateLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5000, // generous global cap per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) =>
+    req.path === '/health' || req.path.startsWith('/bullmq-board'),
+});
+
+app.use(gatewayRateLimiter);
 
 app.use(async (req, res, next) => {
   const appToken = req.headers['x-app-api-token'] as string;

--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -91,8 +91,7 @@ const gatewayRateLimiter: RateLimitRequestHandler = rateLimit({
   max: 5000, // generous global cap per IP
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) =>
-    req.path === '/health' || req.path.startsWith('/bullmq-board'),
+  skip: (req) => req.path === '/health' || req.path.startsWith('/bullmq-board'),
 });
 
 app.use(gatewayRateLimiter);


### PR DESCRIPTION
Adds a global rate limiter in gateway to address code scanning alert 1126.\n\n- 15-minute window\n- Max 5000 requests/IP\n- Skips /health and /bullmq-board\n- Adds explicit RateLimitRequestHandler typing

## Summary by Sourcery

Bug Fixes:
- Mitigate excessive request rates per IP in the gateway by enforcing a generous global limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented API rate limiting with a global cap of 5000 requests per IP address per 15-minute window. Health checks and monitoring endpoints are excluded from rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->