### PR TITLE
fix(hotkey): disable hotkeys on form tags by default

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/hotkey/hooks/useScopedHotkeys.tsx
+++ b/frontend/libs/erxes-ui/src/modules/hotkey/hooks/useScopedHotkeys.tsx
@@ -24,7 +24,7 @@ export const useScopedHotkeys = (
 
   const enableOnFormTags = isDefined(options?.enableOnFormTags)
     ? options.enableOnFormTags
-    : true;
+    : false;
 
   const preventDefault = isDefined(options?.preventDefault)
     ? options.preventDefault === true


### PR DESCRIPTION
Change enableOnFormTags default from true to false in useScopedHotkeys so hotkeys do not fire when the user is typing inside input fields.

## Summary by Sourcery

Bug Fixes:
- Prevent hotkeys from firing by default while users are typing in form fields by defaulting form-tag hotkeys to disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hotkeys no longer trigger by default while typing in form fields, reducing unintended shortcuts.
  * Adding tags now preserves existing tags and avoids duplicate removals, so tag assignments are merged safely across actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->