### PR TITLE
fix(tags): support add/remove action for bulk tagging

### DIFF
--- a/backend/core-api/src/modules/tags/db/models/Tags.ts
+++ b/backend/core-api/src/modules/tags/db/models/Tags.ts
@@ -16,6 +16,7 @@ export interface ITagModel extends Model<ITagDocument> {
     type: string,
     targetIds: string[],
     tagIds: string[],
+    action?: 'add' | 'remove',
   ): Promise<ITagDocument>;
   getChildTags(tagIds: string[]): Promise<string[]>;
 }
@@ -199,6 +200,7 @@ export const loadTagClass = (
       type: string,
       targetIds: string[],
       tagIds: string[],
+      action: 'add' | 'remove' = 'add',
     ) {
       const [pluginName, moduleName] = type.split(':');
 
@@ -240,7 +242,9 @@ export const loadTagClass = (
 
         const result = await model.updateMany(
           { _id: { $in: targetIds } },
-          { $set: { tagIds: tags.map((tag) => tag._id) } },
+          action === 'remove'
+            ? { $pull: { tagIds: { $in: tags.map((tag) => tag._id) } } }
+            : { $addToSet: { tagIds: { $each: tags.map((tag) => tag._id) } } },
         );
 
         if (['customer', 'user', 'company', 'product'].includes(moduleName)) {

--- a/backend/core-api/src/modules/tags/graphql/mutations.ts
+++ b/backend/core-api/src/modules/tags/graphql/mutations.ts
@@ -37,12 +37,13 @@ export const tagMutations: Record<string, Resolver> = {
       type,
       targetIds,
       tagIds,
-    }: { type: string; targetIds: string[]; tagIds: string[] },
+      action,
+    }: { type: string; targetIds: string[]; tagIds: string[]; action?: 'add' | 'remove' },
     { models, checkPermission }: IContext,
   ) {
     await checkPermission('tagsTag');
 
-    return await models.Tags.tagsTag(type, targetIds, tagIds);
+    return await models.Tags.tagsTag(type, targetIds, tagIds, action);
   },
 
   /**

--- a/backend/core-api/src/modules/tags/graphql/mutations.ts
+++ b/backend/core-api/src/modules/tags/graphql/mutations.ts
@@ -38,7 +38,12 @@ export const tagMutations: Record<string, Resolver> = {
       targetIds,
       tagIds,
       action,
-    }: { type: string; targetIds: string[]; tagIds: string[]; action?: 'add' | 'remove' },
+    }: {
+      type: string;
+      targetIds: string[];
+      tagIds: string[];
+      action?: 'add' | 'remove';
+    },
     { models, checkPermission }: IContext,
   ) {
     await checkPermission('tagsTag');

--- a/backend/core-api/src/modules/tags/graphql/schemas.ts
+++ b/backend/core-api/src/modules/tags/graphql/schemas.ts
@@ -72,8 +72,8 @@ const mutationParams = `
 export const mutations = `
   tagsAdd(name: String!, ${mutationParams}): Tag
   tagsEdit(_id: String!, name: String, ${mutationParams}): Tag
-  tagsTag(type: String!, targetIds: [String!]!, tagIds: [String!]!): JSON
-  cpTagsTag(type: String!, targetIds: [String!]!, tagIds: [String!]!): JSON
+  tagsTag(type: String!, targetIds: [String!]!, tagIds: [String!]!, action: String): JSON
+  cpTagsTag(type: String!, targetIds: [String!]!, tagIds: [String!]!, action: String): JSON
   tagsRemove(_id: String!): JSON
 
   cpTagsAdd(name: String!, ${mutationParams}): Tag

--- a/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
+++ b/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
@@ -40,7 +40,7 @@ export const CustomersCommandBar = () => {
                 ) || []
               }
               targetIds={customerIds}
-              options={(newSelectedTagIds) => ({
+              options={(newSelectedTagIds, action, changedTagId) => ({
                 update: (cache) => {
                   customerIds.forEach((customerId) => {
                     cache.modify({
@@ -49,7 +49,13 @@ export const CustomersCommandBar = () => {
                         _id: customerId,
                       }),
                       fields: {
-                        tagIds: () => newSelectedTagIds,
+                        tagIds: (existingTagIds) => {
+                          const ids = existingTagIds as string[];
+                          if (action === 'remove' && changedTagId) {
+                            return ids.filter((id) => id !== changedTagId);
+                          }
+                          return [...new Set([...ids, ...newSelectedTagIds])];
+                        },
                       },
                     });
                   });

--- a/frontend/libs/ui-modules/src/modules/tags-new/components/TagBadge.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags-new/components/TagBadge.tsx
@@ -38,7 +38,7 @@ export const TagBadge = React.forwardRef<
   }
 
   return (
-    <Badge ref={ref} {...props}>
+    <Badge ref={ref} className="max-w-40" {...props}>
       <TagInline tag={tagValue} />
     </Badge>
   );

--- a/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
@@ -98,7 +98,11 @@ const TagsSelectProvider = ({
             tagIds: [tag._id],
             action: isSelected ? 'remove' : 'add',
           },
-          ...options?.(newTags.map((t) => t._id), isSelected ? 'remove' : 'add', tag._id),
+          ...options?.(
+            newTags.map((t) => t._id),
+            isSelected ? 'remove' : 'add',
+            tag._id,
+          ),
         });
       }
 
@@ -414,7 +418,11 @@ const TagsSelectedList = ({
                     tagIds: [tag._id],
                     action: 'remove',
                   },
-                  ...options?.(newTags.map((t) => t._id), 'remove', tag._id),
+                  ...options?.(
+                    newTags.map((t) => t._id),
+                    'remove',
+                    tag._id,
+                  ),
                 });
               }
             }

--- a/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
@@ -95,9 +95,10 @@ const TagsSelectProvider = ({
           variables: {
             type,
             targetIds,
-            tagIds: newTags.map((t) => t._id),
+            tagIds: [tag._id],
+            action: isSelected ? 'remove' : 'add',
           },
-          ...options?.(newTags.map((t) => t._id)),
+          ...options?.(newTags.map((t) => t._id), isSelected ? 'remove' : 'add', tag._id),
         });
       }
 
@@ -127,6 +128,7 @@ const TagsSelectProvider = ({
         tagGroups,
         type,
         targetIds,
+        options,
       }}
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
@@ -360,6 +362,7 @@ const TagsSelectedList = ({
     mode,
     targetIds,
     type,
+    options,
   } = useTagsSelectContext();
   const { giveTags } = useGiveTags();
   if (!selectedTags || selectedTags.length === 0) return null;
@@ -408,8 +411,10 @@ const TagsSelectedList = ({
                   variables: {
                     type,
                     targetIds,
-                    tagIds: newTags.map((t) => t._id),
+                    tagIds: [tag._id],
+                    action: 'remove',
                   },
+                  ...options?.(newTags.map((t) => t._id), 'remove', tag._id),
                 });
               }
             }

--- a/frontend/libs/ui-modules/src/modules/tags-new/graphql/tagMutations.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/graphql/tagMutations.ts
@@ -38,7 +38,12 @@ export const GIVE_TAGS = gql`
     $tagIds: [String!]!
     $action: String
   ) {
-    tagsTag(type: $type, targetIds: $targetIds, tagIds: $tagIds, action: $action)
+    tagsTag(
+      type: $type
+      targetIds: $targetIds
+      tagIds: $tagIds
+      action: $action
+    )
   }
 `;
 
@@ -73,6 +78,7 @@ export const EDIT_TAG = gql`
 `;
 
 export const REMOVE_TAG = gql`
-mutation TagsRemove($id: String!) {
-  tagsRemove(_id: $id)
-}`;
+  mutation TagsRemove($id: String!) {
+    tagsRemove(_id: $id)
+  }
+`;

--- a/frontend/libs/ui-modules/src/modules/tags-new/graphql/tagMutations.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/graphql/tagMutations.ts
@@ -36,8 +36,9 @@ export const GIVE_TAGS = gql`
     $type: String!
     $targetIds: [String!]!
     $tagIds: [String!]!
+    $action: String
   ) {
-    tagsTag(type: $type, targetIds: $targetIds, tagIds: $tagIds)
+    tagsTag(type: $type, targetIds: $targetIds, tagIds: $tagIds, action: $action)
   }
 `;
 

--- a/frontend/libs/ui-modules/src/modules/tags-new/types/TagMutationTypes.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/types/TagMutationTypes.ts
@@ -3,6 +3,7 @@ export type GiveTagsMutationVariables = {
   type: string | null;
   targetIds: string[];
   tagIds: string[];
+  action?: 'add' | 'remove';
 };
 
 export type GiveTagsMutationResponse = {

--- a/frontend/libs/ui-modules/src/modules/tags-new/types/TagMutationTypes.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/types/TagMutationTypes.ts
@@ -1,4 +1,4 @@
-import { ITag } from "ui-modules/modules/tags-new/types/Tag";
+import { ITag } from 'ui-modules/modules/tags-new/types/Tag';
 export type GiveTagsMutationVariables = {
   type: string | null;
   targetIds: string[];

--- a/frontend/libs/ui-modules/src/modules/tags-new/types/TagsSelectTypes.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/types/TagsSelectTypes.ts
@@ -1,7 +1,10 @@
-import { MutationHookOptions } from "@apollo/client";
-import { GiveTagsMutationResponse, GiveTagsMutationVariables } from "ui-modules/modules/tags-new/types/TagMutationTypes";
-import { ITag } from "ui-modules/modules/tags-new/types/Tag";
-import { ReactNode } from "react"
+import { MutationHookOptions } from '@apollo/client';
+import {
+  GiveTagsMutationResponse,
+  GiveTagsMutationVariables,
+} from 'ui-modules/modules/tags-new/types/TagMutationTypes';
+import { ITag } from 'ui-modules/modules/tags-new/types/Tag';
+import { ReactNode } from 'react';
 type SingleTagsSelectProps = {
   mode: 'single';
   value?: string;

--- a/frontend/libs/ui-modules/src/modules/tags-new/types/TagsSelectTypes.ts
+++ b/frontend/libs/ui-modules/src/modules/tags-new/types/TagsSelectTypes.ts
@@ -21,6 +21,8 @@ export type TagsSelectProps = {
   targetIds?: string[];
   options?: (
     newSelectedTagIds: string[],
+    action?: 'add' | 'remove',
+    changedTagId?: string,
   ) => MutationHookOptions<GiveTagsMutationResponse, GiveTagsMutationVariables>;
 } & (SingleTagsSelectProps | MultipleTagsSelectProps);
 
@@ -40,4 +42,9 @@ export type TagsSelectContextType = {
   type: string | null;
   loading: boolean;
   targetIds?: string[];
+  options?: (
+    newSelectedTagIds: string[],
+    action?: 'add' | 'remove',
+    changedTagId?: string,
+  ) => MutationHookOptions<GiveTagsMutationResponse, GiveTagsMutationVariables>;
 };


### PR DESCRIPTION
- Use $addToSet/$pull instead of $set to preserve unique tags per target
- Add action parameter to tagsTag mutation (add | remove)
- Fix Apollo cache update to immediately reflect tag changes
- Limit tag badge width to prevent hiding the remove button

## Summary by Sourcery

Support add/remove actions for bulk tagging and ensure tag changes are reflected consistently in the backend, GraphQL API, Apollo cache, and UI.

New Features:
- Introduce an optional add/remove action parameter to the tagsTag / cpTagsTag mutations and their client-side usage to control bulk tag assignment direction.

Bug Fixes:
- Fix bulk tagging behavior to avoid overwriting tag sets by using additive and subtractive updates instead of replacing tag IDs.
- Update Apollo cache modification logic for customers so tag additions and removals are reflected immediately and without duplicate IDs.
- Constrain tag badge width in the UI to prevent the remove button from being hidden on long tag names.

Enhancements:
- Extend tags selection components and context types to pass tagging action metadata through to mutation options for more granular cache handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tags can now be individually added or removed without replacing the entire tag set, enabling more efficient tag management.

* **Style**
  * Improved tag badge width constraint for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->