### PR TITLE
Add tour query

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/@types/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/@types/cms.ts
@@ -4,6 +4,10 @@ import {
   ICustomField,
 } from 'erxes-api-shared/core-types';
 
+export const CMS_POST_URL_FIELDS = ['_id', 'count', 'slug'] as const;
+export type CMSPostUrlField = (typeof CMS_POST_URL_FIELDS)[number];
+export const CMS_DEFAULT_POST_URL_FIELD: CMSPostUrlField = '_id';
+
 export interface IContentCMS {
   name: string;
   description: string;
@@ -11,6 +15,7 @@ export interface IContentCMS {
   content: string;
   language?: string;
   languages?: string[];
+  postUrlField?: CMSPostUrlField;
 }
 
 export interface IContentCMSDocument extends IContentCMS, Document {
@@ -26,6 +31,7 @@ export interface IContentCMSInput {
   content: string;
   language?: string;
   languages?: string[];
+  postUrlField?: CMSPostUrlField;
 }
 
 export interface ICMSMenu {

--- a/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
@@ -18,6 +18,7 @@ export const cmsSchema = new mongoose.Schema<IContentCMSDocument>(
     content: { type: String, required: true },
     language: { type: String, optional: true },
     languages: { type: [String], optional: true },
+    postUrlField: { type: String, optional: true, default: '_id' },
   },
   { timestamps: true },
 );

--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -1,6 +1,12 @@
 import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
-import { IContentCMSDocument, IContentCMSInput } from '@/cms/@types/cms';
+import {
+  CMS_DEFAULT_POST_URL_FIELD,
+  CMS_POST_URL_FIELDS,
+  CMSPostUrlField,
+  IContentCMSDocument,
+  IContentCMSInput,
+} from '@/cms/@types/cms';
 import { cmsSchema } from '@/cms/db/definitions/cms';
 
 export interface ICMSModel extends Model<IContentCMSDocument> {
@@ -16,6 +22,19 @@ export interface ICMSModel extends Model<IContentCMSDocument> {
 
 export const loadCmsClass = (models: IModels) => {
   class CMS {
+    private static normalizePostUrlField(
+      postUrlField?: string,
+    ): CMSPostUrlField {
+      if (
+        postUrlField &&
+        CMS_POST_URL_FIELDS.includes(postUrlField as CMSPostUrlField)
+      ) {
+        return postUrlField as CMSPostUrlField;
+      }
+
+      return CMS_DEFAULT_POST_URL_FIELD;
+    }
+
     public static async getContentCMS(_id: string) {
       return models.CMS.findOne({ _id });
     }
@@ -24,10 +43,20 @@ export const loadCmsClass = (models: IModels) => {
       return data;
     }
     public static async createContentCMS(doc: IContentCMSInput) {
-      return models.CMS.create(doc);
+      return models.CMS.create({
+        ...doc,
+        postUrlField: this.normalizePostUrlField(doc.postUrlField),
+      });
     }
     public static async updateContentCMS(_id: string, doc: IContentCMSInput) {
-      return models.CMS.findOneAndUpdate({ _id }, doc, { new: true });
+      return models.CMS.findOneAndUpdate(
+        { _id },
+        {
+          ...doc,
+          postUrlField: this.normalizePostUrlField(doc.postUrlField),
+        },
+        { new: true },
+      );
     }
     public static async deleteContentCMS(_id: string) {
       return models.CMS.findOneAndDelete({ _id });

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
@@ -22,6 +22,7 @@ class CategoryQueryResolver extends BaseQueryResolver {
       query,
       { ...args, clientPortalId, language },
       FIELD_MAPPINGS.CATEGORY,
+      'category',
     );
   }
 
@@ -48,34 +49,38 @@ class CategoryQueryResolver extends BaseQueryResolver {
       query,
       language,
       FIELD_MAPPINGS.CATEGORY,
+      clientPortalId,
+      'category',
     );
   }
 
   async cpCategories(_parent: any, args: any, context: IContext): Promise<any> {
-    const { models } = context;
-    const { language, clientPortalId } = args;
+    const { models, clientPortal } = context;
+    const { language } = args;
+    const clientPortalId = args.clientPortalId || clientPortal?._id;
 
     const query: any = {
       clientPortalId,
       status: 'active',
     };
 
-    const { list } = await this.getListWithTranslations(
+    return this.getListWithTranslations(
       models.Categories,
       query,
       { ...args, clientPortalId, language },
       FIELD_MAPPINGS.CATEGORY,
+      'category',
     );
-
-    return list;
   }
 }
 
-const resolver = new CategoryQueryResolver({} as IContext);
 export const contentCmsCategoryQueries: Record<string, Resolver> = {
-  cmsCategories: resolver.cmsCategories.bind(resolver),
-  cmsCategory: resolver.cmsCategory.bind(resolver),
-  cpCategories: resolver.cpCategories.bind(resolver),
+  cmsCategories: (_parent: any, args: any, context: IContext) =>
+    new CategoryQueryResolver(context).cmsCategories(_parent, args, context),
+  cmsCategory: (_parent: any, args: any, context: IContext) =>
+    new CategoryQueryResolver(context).cmsCategory(_parent, args, context),
+  cpCategories: (_parent: any, args: any, context: IContext) =>
+    new CategoryQueryResolver(context).cpCategories(_parent, args, context),
 };
 
 contentCmsCategoryQueries.cpCategories.wrapperConfig = {

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -1,9 +1,80 @@
 import { BaseQueryResolver, FIELD_MAPPINGS } from '@/cms/utils/base-resolvers';
+import {
+  CMS_DEFAULT_POST_URL_FIELD,
+  CMS_POST_URL_FIELDS,
+  CMSPostUrlField,
+} from '@/cms/@types/cms';
 import { getQueryBuilder } from '@/cms/utils/query-builders';
 import { IContext } from '~/connectionResolvers';
 import { Resolver } from 'erxes-api-shared/core-types';
 
 class PostQueryResolver extends BaseQueryResolver {
+  private async getPostUrlField(
+    clientPortalId: string,
+    models: IContext['models'],
+  ): Promise<CMSPostUrlField> {
+    const cms = await models.CMS.findOne({ clientPortalId })
+      .select({ postUrlField: 1 })
+      .lean();
+
+    if (
+      cms?.postUrlField &&
+      CMS_POST_URL_FIELDS.includes(cms.postUrlField as CMSPostUrlField)
+    ) {
+      return cms.postUrlField as CMSPostUrlField;
+    }
+
+    return CMS_DEFAULT_POST_URL_FIELD;
+  }
+
+  private async buildPostLookupQuery(
+    args: {
+      _id?: string;
+      slug?: string;
+      identifier?: string;
+      clientPortalId?: string;
+    },
+    models: IContext['models'],
+  ) {
+    const { _id, slug, identifier, clientPortalId } = args;
+
+    if (_id) {
+      return clientPortalId ? { _id, clientPortalId } : { _id };
+    }
+
+    if (slug) {
+      if (!clientPortalId) {
+        throw new Error('clientPortalId is required when querying by slug');
+      }
+
+      return { slug, clientPortalId };
+    }
+
+    if (!identifier) {
+      return null;
+    }
+
+    if (!clientPortalId) {
+      throw new Error(
+        'clientPortalId is required when querying by configured post URL',
+      );
+    }
+
+    const postUrlField = await this.getPostUrlField(clientPortalId, models);
+
+    if (postUrlField === 'count') {
+      const count = Number(identifier);
+
+      if (Number.isNaN(count)) {
+        return null;
+      }
+
+      return { count, clientPortalId };
+    }
+
+    return { [postUrlField]: identifier, clientPortalId };
+  }
+
   /**
    * Cms posts
    */
@@ -30,11 +101,14 @@ class PostQueryResolver extends BaseQueryResolver {
 
   async cmsPost(_parent: any, args: any, context: IContext): Promise<any> {
     const { models } = context;
-    const { _id, slug, language, clientPortalId } = args;
+    const { _id, slug, identifier, language, clientPortalId } = args;
 
-    if (!_id && !slug) return null;
+    const query = await this.buildPostLookupQuery(
+      { _id, slug, identifier, clientPortalId },
+      models,
+    );
 
-    const query = slug ? { slug, clientPortalId } : { _id };
+    if (!query) return null;
 
     // clientPortalId must be passed explicitly — admin queries have no
     // clientPortal in context, so the base resolver cannot fall back to it.
@@ -162,11 +236,14 @@ class PostQueryResolver extends BaseQueryResolver {
 
   async cpPost(_parent: any, args: any, context: IContext): Promise<any> {
     const { clientPortal, models } = context;
-    const { _id, slug, language } = args;
+    const { _id, slug, identifier, language } = args;
 
-    if (!_id && !slug) return null;
+    const query = await this.buildPostLookupQuery(
+      { _id, slug, identifier, clientPortalId: clientPortal._id },
+      models,
+    );
 
-    const query = slug ? { slug, clientPortalId: clientPortal._id } : { _id };
+    if (!query) return null;
 
     return this.getItemWithTranslation(
       models.Posts,

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
@@ -7,6 +7,7 @@ export const types = `
     content: String
     language: String
     languages: [String]
+    postUrlField: String
     createdAt: Date
     updatedAt: Date
 
@@ -21,6 +22,7 @@ export const inputs = `
     content: String
     language: String
     languages: [String]
+    postUrlField: String
   }
 `;
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
@@ -160,14 +160,14 @@ const commonPostQuerySelectorPagination = `
   `;
 
 export const queries = `
-      cmsPost(_id: String, slug: String, language: String): Post
+      cmsPost(_id: String, slug: String, identifier: String, language: String, clientPortalId: String): Post
       cmsPosts(clientPortalId: String, ${commonPostQuerySelector}): [Post]
       cmsPostList(clientPortalId: String, ${commonPostQuerySelector}): PostList
       cmsTranslations(objectId: String, type: String): [Translation]
   
       cpPosts(language: String, webId: String, ${commonPostQuerySelector}): [Post]
       cpPostList(language: String, webId: String, ${commonPostQuerySelector}): PostList
-      cpPost(_id: String, slug: String, language: String, clientPortalId: String): Post
+      cpPost(_id: String, slug: String, identifier: String, language: String, clientPortalId: String): Post
       cpPostListWithPagination(language: String, ${commonPostQuerySelectorPagination}): PostListPagination
   `;
 

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
@@ -325,6 +325,42 @@ const tourQueries: Record<string, Resolver> = {
     return list;
   },
 
+  cpBmsTourCategories: async (
+    _root,
+    { parentId, name, branchId, language },
+    { models }: IContext,
+  ) => {
+    const selector: any = {};
+
+    if (parentId) {
+      selector.parentId = parentId;
+    } else if (parentId === null) {
+      selector.parentId = null;
+    }
+    if (name) selector.name = { $regex: escapeRegExp(name), $options: 'i' };
+    if (branchId) selector.branchId = branchId;
+
+    // No language — return raw sorted list
+    if (!language) {
+      return models.BmsTourCategories.find(selector).sort({
+        order: 1,
+        name: 1,
+      });
+    }
+
+    // With language — overlay translations
+    const { list } = await getBmsListWithTranslations(
+      models,
+      models.BmsTourCategories,
+      models.TourCategoryTranslations,
+      selector,
+      { branchId, language, orderBy: { order: 1, name: 1 } },
+      TOUR_CATEGORY_FIELD_MAPPINGS,
+    );
+
+    return list;
+  },
+
   cpBmsTourDetail(
     _root: any,
     { _id, language }: { _id: string; language?: string },
@@ -586,3 +622,4 @@ tourQueries.cpBmsToursTotalCount.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmsTourDetail.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroup.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroupDetail.wrapperConfig = { forClientPortal: true };
+tourQueries.cpBmsTourCategories.wrapperConfig = {forClientPortal:true};

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
@@ -622,4 +622,4 @@ tourQueries.cpBmsToursTotalCount.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmsTourDetail.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroup.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroupDetail.wrapperConfig = { forClientPortal: true };
-tourQueries.cpBmsTourCategories.wrapperConfig = {forClientPortal:true};
+tourQueries.cpBmsTourCategories.wrapperConfig = { forClientPortal: true };

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
@@ -12,6 +12,7 @@ import {
   TOUR_FIELD_MAPPINGS,
   applyTourTranslation,
   TOUR_CATEGORY_FIELD_MAPPINGS,
+  shouldSkipTranslation,
 } from '@/bms/utils/translations';
 
 function buildDateSelector(
@@ -99,6 +100,41 @@ const mergeCategoryFilterIds = ({
   const merged = [...(categoryIds || []), ...(tags || [])].filter(Boolean);
   return merged.length ? [...new Set(merged)] : undefined;
 };
+
+async function applyTranslationsToTours(
+  models: IContext['models'],
+  tours: any[],
+  language?: string,
+  branchId?: string,
+) {
+  if (!language || !tours.length || !branchId) {
+    return tours;
+  }
+
+  const skip = await shouldSkipTranslation(models, branchId, language);
+
+  if (skip) {
+    return tours;
+  }
+
+  const translations = await models.TourTranslations.find({
+    objectId: { $in: tours.map((tour) => String(tour._id)) },
+    language,
+  }).lean();
+
+  const translationMap = new Map(
+    translations.map((translation) => [
+      String(translation.objectId),
+      translation,
+    ]),
+  );
+
+  return tours.map((tour) => {
+    const translation = translationMap.get(String(tour._id));
+
+    return translation ? applyTourTranslation(tour, translation) : tour;
+  });
+}
 
 const tourQueries: Record<string, Resolver> = {
   async bmsTours(
@@ -315,6 +351,7 @@ const tourQueries: Record<string, Resolver> = {
       status,
       innerDate,
       branchId,
+      language,
       startDate1,
       endDate1,
       startDate2,
@@ -382,7 +419,20 @@ const tourQueries: Record<string, Resolver> = {
       },
     ]);
 
-    return { list: [...group], total };
+    return {
+      list: await Promise.all(
+        group.map(async (item) => ({
+          ...item,
+          items: await applyTranslationsToTours(
+            models,
+            item.items || [],
+            language,
+            branchId,
+          ),
+        })),
+      ),
+      total,
+    };
   },
 
   async cpBmToursGroup(
@@ -395,6 +445,7 @@ const tourQueries: Record<string, Resolver> = {
       innerDate,
       branchId,
       webId,
+      language,
       startDate1,
       endDate1,
       startDate2,
@@ -463,21 +514,68 @@ const tourQueries: Record<string, Resolver> = {
       },
     ]);
 
-    return { list: [...group], total };
+    return {
+      list: await Promise.all(
+        group.map(async (item) => ({
+          ...item,
+          items: await applyTranslationsToTours(
+            models,
+            item.items || [],
+            language,
+            branchId,
+          ),
+        })),
+      ),
+      total,
+    };
   },
 
-  async bmToursGroupDetail(_root, { groupCode, status }, { models }: IContext) {
+  async bmToursGroupDetail(
+    _root,
+    { groupCode, status, language },
+    { models }: IContext,
+  ) {
     const list = await models.Tours.find({ groupCode, status });
-    return { _id: groupCode, items: list };
+    const translatedItems = await Promise.all(
+      list.map((tour) =>
+        getBmsItemWithTranslation(
+          models,
+          models.Tours,
+          models.TourTranslations,
+          { _id: tour._id },
+          language,
+          TOUR_FIELD_MAPPINGS,
+          undefined,
+          applyTourTranslation,
+        ),
+      ),
+    );
+
+    return { _id: groupCode, items: translatedItems.filter(Boolean) };
   },
 
   async cpBmToursGroupDetail(
     _root,
-    { groupCode, status },
+    { groupCode, status, language },
     { models }: IContext,
   ) {
     const list = await models.Tours.find({ groupCode, status });
-    return { _id: groupCode, items: list };
+    const translatedItems = await Promise.all(
+      list.map((tour) =>
+        getBmsItemWithTranslation(
+          models,
+          models.Tours,
+          models.TourTranslations,
+          { _id: tour._id },
+          language,
+          TOUR_FIELD_MAPPINGS,
+          undefined,
+          applyTourTranslation,
+        ),
+      ),
+    );
+
+    return { _id: groupCode, items: translatedItems.filter(Boolean) };
   },
 };
 

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
@@ -221,14 +221,14 @@ export const queries = `
   bmsTourCategories(parentId: String, name: String, branchId: String, language: String): [TourCategory]
   bmsOrders(tourId: String, customerId: String, branchId: String, ${GQL_CURSOR_PARAM_DEFS}): BmsOrderListResponse
   bmsOrderDetail(_id: String!): BmsOrder
-  bmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS): GroupTour
-  bmToursGroupDetail(groupCode: String, status: String): GroupTourItem
+  bmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, language: String): GroupTour
+  bmToursGroupDetail(groupCode: String, status: String, language: String): GroupTourItem
 
   cpBmsTours(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, webId: String, language: String): TourListResponse
   cpBmsToursTotalCount(branchId: String, webId: String): Int
   cpBmsTourDetail(_id: String!, branchId: String, language: String): Tour
-  cpBmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, webId: String): GroupTour
-  cpBmToursGroupDetail(groupCode: String, status: String): GroupTourItem
+  cpBmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, webId: String, language: String): GroupTour
+  cpBmToursGroupDetail(groupCode: String, status: String, language: String): GroupTourItem
   cpBmsOrders(tourId: String, customerId: String, branchId: String, ${GQL_CURSOR_PARAM_DEFS}): BmsOrderListResponse
 `;
 

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
@@ -230,6 +230,7 @@ export const queries = `
   cpBmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, webId: String, language: String): GroupTour
   cpBmToursGroupDetail(groupCode: String, status: String, language: String): GroupTourItem
   cpBmsOrders(tourId: String, customerId: String, branchId: String, ${GQL_CURSOR_PARAM_DEFS}): BmsOrderListResponse
+  cpBmsTourCategories(parentId: String, name: String, branchId: String, language: String): [TourCategory]
 `;
 
 const categoryParams = `

--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -52,14 +52,12 @@ const POST_URL_FIELD_OPTIONS = [
   { value: 'slug', label: 'Post Slug' },
 ] as const;
 
-const POST_URL_FIELD_EXAMPLES: Record<
-  WebsiteFormType['postUrlField'],
-  string
-> = {
-  _id: 'fSY5zj2QmcnXUNSnF9sYo',
-  count: '1',
-  slug: 'my-first-post',
-};
+const POST_URL_FIELD_EXAMPLES: Record<WebsiteFormType['postUrlField'], string> =
+  {
+    _id: 'fSY5zj2QmcnXUNSnF9sYo',
+    count: '1',
+    slug: 'my-first-post',
+  };
 
 export function WebsiteDrawer({
   website,
@@ -361,10 +359,7 @@ export function WebsiteDrawer({
                 <Form.Item>
                   <Form.Label>Post URL Field</Form.Label>
                   <Form.Control>
-                    <Select
-                      value={field.value}
-                      onValueChange={field.onChange}
-                    >
+                    <Select value={field.value} onValueChange={field.onChange}>
                       <Select.Trigger>
                         <Select.Value placeholder="Select post URL field" />
                       </Select.Trigger>

--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -36,6 +36,7 @@ interface Website {
   createdAt: string;
   languages?: string[];
   language?: string;
+  postUrlField?: '_id' | 'count' | 'slug';
 }
 
 interface WebsiteDrawerProps {
@@ -44,6 +45,21 @@ interface WebsiteDrawerProps {
   onClose: () => void;
   onSuccess?: () => void;
 }
+
+const POST_URL_FIELD_OPTIONS = [
+  { value: '_id', label: 'Post ID' },
+  { value: 'count', label: 'Post Count' },
+  { value: 'slug', label: 'Post Slug' },
+] as const;
+
+const POST_URL_FIELD_EXAMPLES: Record<
+  WebsiteFormType['postUrlField'],
+  string
+> = {
+  _id: 'fSY5zj2QmcnXUNSnF9sYo',
+  count: '1',
+  slug: 'my-first-post',
+};
 
 export function WebsiteDrawer({
   website,
@@ -70,8 +86,26 @@ export function WebsiteDrawer({
       kind: 'client',
       languages: [],
       language: '',
+      postUrlField: '_id',
     },
   });
+
+  const selectedClientPortalId = form.watch('kind');
+  const selectedPostUrlField = form.watch('postUrlField');
+  const selectedClientPortal = clientPortals.find(
+    (portal) => portal._id === selectedClientPortalId,
+  );
+  const rawDomain = selectedClientPortal?.domain || '';
+  const normalizedDomain = rawDomain
+    ? rawDomain.startsWith('http')
+      ? rawDomain
+      : `https://${rawDomain}`
+    : '';
+  const previewPathSegment =
+    POST_URL_FIELD_EXAMPLES[selectedPostUrlField || '_id'];
+  const previewUrl = normalizedDomain
+    ? `${normalizedDomain.replace(/\/+$/, '')}/${previewPathSegment}`
+    : `/${previewPathSegment}`;
 
   useEffect(() => {
     if (isOpen) {
@@ -86,6 +120,7 @@ export function WebsiteDrawer({
           kind: website.clientPortalId || '',
           languages: website.languages || [],
           language: website.language || '',
+          postUrlField: website.postUrlField || '_id',
         });
       } else {
         form.reset({
@@ -96,6 +131,7 @@ export function WebsiteDrawer({
           kind: 'client',
           languages: [],
           language: '',
+          postUrlField: '_id',
         });
       }
     }
@@ -202,7 +238,7 @@ export function WebsiteDrawer({
   });
 
   const onSubmit = (data: WebsiteFormType) => {
-    const { name, description, language, languages } = data;
+    const { name, description, language, languages, postUrlField } = data;
 
     if (isEditing && website?._id) {
       updateCMS({
@@ -214,6 +250,7 @@ export function WebsiteDrawer({
             language: language || undefined,
             languages: languages || [],
             clientPortalId: data.kind,
+            postUrlField,
           },
         },
       });
@@ -228,6 +265,7 @@ export function WebsiteDrawer({
           language: language || undefined,
           languages: languages || [],
           clientPortalId: data.kind,
+          postUrlField,
           content: 'hello',
         },
       },
@@ -314,6 +352,41 @@ export function WebsiteDrawer({
                   </Form.Item>
                 );
               }}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="postUrlField"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Post URL Field</Form.Label>
+                  <Form.Control>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select post URL field" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {POST_URL_FIELD_OPTIONS.map((option) => (
+                          <Select.Item key={option.value} value={option.value}>
+                            {option.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                  <p className="text-xs text-muted-foreground">
+                    Choose which post field the public website will use in post
+                    URLs.
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Preview: {previewUrl}
+                  </p>
+                  <Form.Message className="text-destructive" />
+                </Form.Item>
+              )}
             />
 
             <Form.Field

--- a/frontend/plugins/content_ui/src/modules/cms/constants/websiteFormSchema.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/constants/websiteFormSchema.ts
@@ -8,6 +8,7 @@ export const websiteFormSchema = z.object({
   kind: z.string().min(1, 'Client Portal is required'),
   languages: z.array(z.string()).default([]),
   language: z.string().default(''),
+  postUrlField: z.enum(['_id', 'count', 'slug']).default('_id'),
 });
 
 export type WebsiteFormType = z.infer<typeof websiteFormSchema>;

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/mutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/mutations.ts
@@ -10,6 +10,7 @@ export const CONTENT_CREATE_CMS = gql`
       language
       languages
       name
+      postUrlField
       updatedAt
       content
     }
@@ -26,6 +27,7 @@ export const CONTENT_UPDATE_CMS = gql`
       language
       languages
       name
+      postUrlField
       updatedAt
       content
     }

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
@@ -11,6 +11,7 @@ export const CONTENT_CMS_LIST = gql`
       name
       languages
       language
+      postUrlField
       description
     }
   }


### PR DESCRIPTION
## Summary by Sourcery

Add configurable post URL field support for CMS websites and extend tourism and content APIs with translation-aware tour and category queries.

New Features:
- Expose a client-portal-aware cpBmsTourCategories query and add language-aware tour group detail queries in the tourism API.
- Introduce configurable post URL field handling in the CMS so posts can be resolved by ID, count, or slug, including support for a generic identifier argument in admin and client portal post queries.
- Add UI and schema support in the CMS website settings to select and preview the post URL field used for public URLs.

Enhancements:
- Normalize and persist CMS postUrlField values on create and update to ensure valid configuration and sensible defaults.
- Refine content category resolvers to pass type information into translation helpers and construct resolvers per request context.
- Apply centralized translation logic for grouped tour queries, including an optimization to skip translations when appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable post URL field selection for CMS websites—choose from `_id`, `count`, or `slug` to determine post URL generation.
  * Enabled language parameter support for tour categories and grouped tour queries, allowing localized tour content retrieval.
  * Expanded post query lookups to support identifier-based retrieval in addition to existing methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->