### PR TITLE
add query

### DIFF
--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
@@ -345,6 +345,41 @@ const tourQueries: Record<string, Resolver> = {
     return list;
   },
 
+  cpBmsTourCategories: async (
+    _root,
+    { parentId, name, branchId, language },
+    { models }: IContext,
+  ) => {
+    const selector: any = {};
+
+    if (parentId) {
+      selector.parentId = parentId;
+    } else if (parentId === null) {
+      selector.parentId = null;
+    }
+    if (name) selector.name = { $regex: escapeRegExp(name), $options: 'i' };
+    if (branchId) selector.branchId = branchId;
+
+    // No language — return raw sorted list
+    if (!language) {
+      return models.BmsTourCategories.find(selector).sort({
+        order: 1,
+        name: 1,
+      });
+    }
+
+    // With language — overlay translations
+    const { list } = await getBmsListWithTranslations(
+      models,
+      models.BmsTourCategories,
+      models.TourCategoryTranslations,
+      selector,
+      { branchId, language, orderBy: { order: 1, name: 1 } },
+      TOUR_CATEGORY_FIELD_MAPPINGS,
+    );
+    return list;
+  },
+
   cpBmsTourDetail(
     _root: any,
     { _id, language }: { _id: string; language?: string },
@@ -644,3 +679,4 @@ tourQueries.cpBmsToursTotalCount.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmsTourDetail.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroup.wrapperConfig = { forClientPortal: true };
 tourQueries.cpBmToursGroupDetail.wrapperConfig = { forClientPortal: true };
+tourQueries.cpBmsTourCategories.wrapperConfig = { forClientPortal: true };

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
@@ -234,6 +234,7 @@ export const queries = `
   bmToursGroup(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, language: String): GroupTour
   bmToursGroupDetail(groupCode: String, status: String, language: String): GroupTourItem
 
+  cpBmsTourCategories(parentId: String, name: String, branchId: String, language: String): [TourCategory]
   cpBmsTours(branchId: String, categoryIds: [String], name: String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String], startDate1: Date, startDate2: Date, endDate1: Date, endDate2: Date, date_status: DATE_STATUS, webId: String, language: String): TourListResponse
   cpBmsToursTotalCount(branchId: String, webId: String): Int
   cpBmsTourDetail(_id: String!, branchId: String, language: String): Tour


### PR DESCRIPTION
## Summary by Sourcery

Add a client-portal tour categories GraphQL query that supports optional filtering and language-aware translations.

New Features:
- Introduce cpBmsTourCategories GraphQL query for fetching tour categories with optional parent, name, branch, and language filters.

Enhancements:
- Expose cpBmsTourCategories with wrapper configuration for client portal usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a new GraphQL query to retrieve tour categories with optional filtering by parent category, name, and branch, including multi-language translation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->