### PR TITLE
fix category list by alphabetical order

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
@@ -9,7 +9,8 @@ export type FieldType =
   | 'select'
   | 'radio'
   | 'file'
-  | 'image';
+  | 'image'
+  | 'spreadsheet';
 
 export interface ICustomField {
   _id: string;
@@ -48,4 +49,5 @@ export const FIELD_TYPES: { value: FieldType; label: string }[] = [
   { value: 'radio', label: 'Radio' },
   { value: 'file', label: 'File' },
   { value: 'image', label: 'Image' },
+  { value: 'spreadsheet', label: 'Spreadsheet (Excel paste)' },
 ];

--- a/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
@@ -6,6 +6,7 @@ import {
   Switch,
   DatePicker,
 } from 'erxes-ui';
+import { SpreadsheetInput } from './SpreadsheetInput';
 
 export interface FieldDefinition {
   _id: string;
@@ -134,6 +135,15 @@ export const CustomFieldInput = ({
               </label>
             ))}
           </div>
+        );
+
+      case 'spreadsheet':
+        return (
+          <SpreadsheetInput
+            value={typeof value === 'string' ? value : ''}
+            onChange={onChange}
+            placeholder={field.placeholder}
+          />
         );
 
       case 'multiSelect': {

--- a/frontend/plugins/content_ui/src/modules/cms/posts/SpreadsheetInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/SpreadsheetInput.tsx
@@ -76,8 +76,7 @@ export const SpreadsheetInput = ({
   const addRow = () =>
     onChange(serializeTsv([...grid, Array(numCols).fill('')]));
 
-  const addCol = () =>
-    onChange(serializeTsv(grid.map((row) => [...row, ''])));
+  const addCol = () => onChange(serializeTsv(grid.map((row) => [...row, ''])));
 
   const removeRow = (r: number) => {
     if (grid.length <= 1) return;
@@ -131,9 +130,7 @@ export const SpreadsheetInput = ({
                     <input
                       type="text"
                       value={cell}
-                      placeholder={
-                        r === 0 && c === 0 ? placeholder : undefined
-                      }
+                      placeholder={r === 0 && c === 0 ? placeholder : undefined}
                       onChange={(e) => updateCell(r, c, e.target.value)}
                       onPaste={(e) => handlePaste(r, c, e)}
                       className="w-full min-w-24 px-2 py-1 outline-none focus:bg-accent bg-transparent"

--- a/frontend/plugins/content_ui/src/modules/cms/posts/SpreadsheetInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/SpreadsheetInput.tsx
@@ -1,0 +1,161 @@
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { Button } from 'erxes-ui';
+import { useMemo, type ClipboardEvent } from 'react';
+
+interface SpreadsheetInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+type Grid = string[][];
+
+const parseTsv = (tsv: string): Grid => {
+  if (!tsv) return [['']];
+  const rows = tsv.split(/\r?\n/).map((row) => row.split('\t'));
+  return rows.length > 0 ? rows : [['']];
+};
+
+const serializeTsv = (grid: Grid): string =>
+  grid.map((row) => row.join('\t')).join('\n');
+
+const normalizeGrid = (grid: Grid): Grid => {
+  const maxCols = Math.max(1, ...grid.map((row) => row.length));
+  return grid.map((row) => {
+    const copy = [...row];
+    while (copy.length < maxCols) copy.push('');
+    return copy;
+  });
+};
+
+const writePastedCells = (
+  grid: Grid,
+  pasted: Grid,
+  startRow: number,
+  startCol: number,
+): Grid => {
+  const copy: Grid = grid.map((row) => [...row]);
+  for (let i = 0; i < pasted.length; i++) {
+    const rowIdx = startRow + i;
+    while (copy.length <= rowIdx) copy.push([]);
+    const pastedRow = pasted[i];
+    for (let j = 0; j < pastedRow.length; j++) {
+      const colIdx = startCol + j;
+      while (copy[rowIdx].length <= colIdx) copy[rowIdx].push('');
+      copy[rowIdx][colIdx] = pastedRow[j];
+    }
+  }
+  return normalizeGrid(copy);
+};
+
+export const SpreadsheetInput = ({
+  value,
+  onChange,
+  placeholder,
+}: SpreadsheetInputProps) => {
+  const grid = useMemo(() => normalizeGrid(parseTsv(value)), [value]);
+  const numCols = grid[0]?.length ?? 1;
+
+  const updateCell = (r: number, c: number, next: string) => {
+    const copy: Grid = grid.map((row) => [...row]);
+    copy[r][c] = next;
+    onChange(serializeTsv(copy));
+  };
+
+  const handlePaste = (
+    r: number,
+    c: number,
+    e: ClipboardEvent<HTMLInputElement>,
+  ) => {
+    const text = e.clipboardData.getData('text');
+    if (!text.includes('\t') && !text.includes('\n')) return;
+    e.preventDefault();
+    onChange(serializeTsv(writePastedCells(grid, parseTsv(text), r, c)));
+  };
+
+  const addRow = () =>
+    onChange(serializeTsv([...grid, Array(numCols).fill('')]));
+
+  const addCol = () =>
+    onChange(serializeTsv(grid.map((row) => [...row, ''])));
+
+  const removeRow = (r: number) => {
+    if (grid.length <= 1) return;
+    onChange(serializeTsv(grid.filter((_, i) => i !== r)));
+  };
+
+  const removeCol = (c: number) => {
+    if (numCols <= 1) return;
+    onChange(serializeTsv(grid.map((row) => row.filter((_, i) => i !== c))));
+  };
+
+  return (
+    <div className="border rounded-md overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead className="bg-muted">
+            <tr>
+              <th className="w-10" />
+              {grid[0].map((_, c) => (
+                <th
+                  key={c}
+                  className="p-1 text-center border-l border-b font-normal"
+                >
+                  <button
+                    type="button"
+                    onClick={() => removeCol(c)}
+                    className="text-muted-foreground hover:text-destructive inline-flex"
+                    title="Remove column"
+                  >
+                    <IconTrash size={12} />
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {grid.map((row, r) => (
+              <tr key={r}>
+                <td className="bg-muted text-center border-b">
+                  <button
+                    type="button"
+                    onClick={() => removeRow(r)}
+                    className="text-muted-foreground hover:text-destructive inline-flex"
+                    title="Remove row"
+                  >
+                    <IconTrash size={12} />
+                  </button>
+                </td>
+                {row.map((cell, c) => (
+                  <td key={c} className="border-l border-b p-0">
+                    <input
+                      type="text"
+                      value={cell}
+                      placeholder={
+                        r === 0 && c === 0 ? placeholder : undefined
+                      }
+                      onChange={(e) => updateCell(r, c, e.target.value)}
+                      onPaste={(e) => handlePaste(r, c, e)}
+                      className="w-full min-w-24 px-2 py-1 outline-none focus:bg-accent bg-transparent"
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex gap-2 p-2 border-t bg-muted items-center">
+        <Button type="button" size="sm" variant="outline" onClick={addRow}>
+          <IconPlus size={14} /> Add row
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={addCol}>
+          <IconPlus size={14} /> Add column
+        </Button>
+        <p className="text-xs text-muted-foreground ml-auto">
+          Paste Excel data into any cell
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CategoryField.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CategoryField.tsx
@@ -13,6 +13,9 @@ export const CategoryField = ({
   categories,
   websiteId,
 }: CategoryFieldProps) => {
+  const sortedCategories = [...(categories || [])].sort((a, b) =>
+    (a?.label || '').localeCompare(b?.label || ''),
+  );
   const {
     newCategoryName,
     setNewCategoryName,
@@ -33,10 +36,10 @@ export const CategoryField = ({
           <Form.Control>
             <div className="flex gap-2">
               <MultipleSelector
-                value={categories.filter((o) =>
+                value={sortedCategories.filter((o) =>
                   (field.value || []).includes(o.value),
                 )}
-                options={categories}
+                options={sortedCategories}
                 placeholder="Select"
                 hidePlaceholderWhenSelected={true}
                 emptyIndicator="Empty"

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
@@ -79,7 +79,10 @@ export const SelectCategoriesProvider = ({
   });
 
   const categories = useMemo(
-    () => data?.cmsCategories?.list || [],
+    () =>
+      [...(data?.cmsCategories?.list || [])].sort((a, b) =>
+        (a?.name || '').localeCompare(b?.name || ''),
+      ),
     [data?.cmsCategories?.list],
   );
 


### PR DESCRIPTION
## Summary by Sourcery

Sort CMS post categories alphabetically before displaying them in selection components.

Enhancements:
- Ensure the add-post category multi-select displays categories in alphabetical order by label.
- Ensure the shared categories provider memoizes and returns categories sorted alphabetically by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native spreadsheet custom field type with an in-place TSV-backed spreadsheet editor (editable grid, paste support, add/remove rows & columns).
* **Bug Fixes**
  * Categories in post creation and selection interfaces now display in consistent alphabetical order for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->