### PR TITLE
feat(pos): show paymentTypes in erkhet config with account mapping

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/pos/components/financeConfig/Main.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/components/financeConfig/Main.tsx
@@ -18,7 +18,9 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
   const [account, setAccount] = useState('');
   const [location, setLocation] = useState('');
   const [getRemainder, setGetRemainder] = useState(false);
-  const [paymentTypeConfigs, setPaymentTypeConfigs] = useState<Record<string, string>>({});
+  const [paymentTypeConfigs, setPaymentTypeConfigs] = useState<
+    Record<string, string>
+  >({});
   const [hasChanges, setHasChanges] = useState(false);
 
   const { posDetail, loading: detailLoading, error } = usePosDetail(posId);
@@ -37,7 +39,8 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
       const ptConfigs: Record<string, string> = {};
       for (const key of Object.keys(posDetail.erkhetConfig)) {
         if (key.startsWith('_')) {
-          const val = posDetail.erkhetConfig[key as keyof typeof posDetail.erkhetConfig];
+          const val =
+            posDetail.erkhetConfig[key as keyof typeof posDetail.erkhetConfig];
           if (typeof val === 'string') {
             ptConfigs[key] = val;
           }
@@ -237,7 +240,10 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
                   <Select
                     value={paymentTypeConfigs[`_${pt.type}`] || ''}
                     onValueChange={(val) => {
-                      setPaymentTypeConfigs((prev) => ({ ...prev, [`_${pt.type}`]: val }));
+                      setPaymentTypeConfigs((prev) => ({
+                        ...prev,
+                        [`_${pt.type}`]: val,
+                      }));
                       setHasChanges(true);
                     }}
                   >

--- a/frontend/plugins/sales_ui/src/modules/pos/components/financeConfig/Main.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/components/financeConfig/Main.tsx
@@ -18,6 +18,7 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
   const [account, setAccount] = useState('');
   const [location, setLocation] = useState('');
   const [getRemainder, setGetRemainder] = useState(false);
+  const [paymentTypeConfigs, setPaymentTypeConfigs] = useState<Record<string, string>>({});
   const [hasChanges, setHasChanges] = useState(false);
 
   const { posDetail, loading: detailLoading, error } = usePosDetail(posId);
@@ -32,6 +33,17 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
       setAccount(posDetail.erkhetConfig.account || '');
       setLocation(posDetail.erkhetConfig.location || '');
       setGetRemainder(posDetail.erkhetConfig.getRemainder ?? false);
+
+      const ptConfigs: Record<string, string> = {};
+      for (const key of Object.keys(posDetail.erkhetConfig)) {
+        if (key.startsWith('_')) {
+          const val = posDetail.erkhetConfig[key as keyof typeof posDetail.erkhetConfig];
+          if (typeof val === 'string') {
+            ptConfigs[key] = val;
+          }
+        }
+      }
+      setPaymentTypeConfigs(ptConfigs);
     }
   }, [posDetail]);
 
@@ -78,6 +90,7 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
             account,
             location,
             getRemainder,
+            ...paymentTypeConfigs,
           },
         },
       });
@@ -215,6 +228,34 @@ export const Main: React.FC<MainProps> = ({ posId }) => {
               />
             </div>
           </div>
+
+          {(posDetail?.paymentTypes || []).length > 0 && (
+            <div className="grid grid-cols-3 gap-4">
+              {(posDetail?.paymentTypes || []).map((pt) => (
+                <div className="space-y-2" key={pt.type}>
+                  <Label>{pt.title}</Label>
+                  <Select
+                    value={paymentTypeConfigs[`_${pt.type}`] || ''}
+                    onValueChange={(val) => {
+                      setPaymentTypeConfigs((prev) => ({ ...prev, [`_${pt.type}`]: val }));
+                      setHasChanges(true);
+                    }}
+                  >
+                    <Select.Trigger className="w-full">
+                      <Select.Value placeholder="Select account" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {options.map((opt) => (
+                        <Select.Item key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/plugins/sales_ui/src/modules/pos/constants/index.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/constants/index.tsx
@@ -53,12 +53,12 @@ export const ALLOW_TYPES = [
 ] as const;
 
 export const options = [
-  { value: 'debtAmount', label: 'Debt Account' },
-  { value: 'cashAmount', label: 'Cash Account' },
-  { value: 'cardAmount', label: 'Card Account' },
-  { value: 'card2Amount', label: 'Card Account Additional' },
-  { value: 'mobileAmount', label: 'Mobile Account' },
-  { value: 'debtBarterAmount', label: 'Barter Account' },
+  { value: 'debtAmount', label: 'Зээлийн данс' },
+  { value: 'cashAmount', label: 'Бэлэн мөнгө данс' },
+  { value: 'cardAmount', label: 'Картын данс' },
+  { value: 'card2Amount', label: 'Картын данс нэмэлт' },
+  { value: 'mobileAmount', label: 'Мобайл данс' },
+  { value: 'debtBarterAmount', label: 'Бартер данс' },
 ];
 
 export const DefaultNode: CustomNode = {


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose Erkhet account selection per payment type in the POS finance configuration UI and store the selections alongside the existing Erkhet config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-payment-type account configuration in POS finance settings — assign specific accounts to each payment method via dedicated selection controls.

* **Style**
  * POS account labels updated to Mongolian translations for a localized user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->