### PR TITLE
feat(tour): support adult/child/infant pricing per package

### DIFF
--- a/backend/plugins/tourism_api/src/modules/bms/@types/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/@types/tour.ts
@@ -10,12 +10,20 @@ export interface IGuideItem {
 
 export type DateType = 'fixed' | 'flexible';
 
+export type PassengerType = 'adult' | 'child' | 'infant';
+
+export interface IPricingOptionPrice {
+  type: PassengerType;
+  price: number;
+}
+
 export interface IPricingOption {
   _id: string;
   title: string;
   minPersons: number;
   maxPersons?: number;
-  pricePerPerson: number;
+  prices: IPricingOptionPrice[];
+  pricePerPerson?: number;
   accommodationType?: string;
   domesticFlightPerPerson?: number;
   singleSupplement?: number;

--- a/backend/plugins/tourism_api/src/modules/bms/@types/tourTranslation.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/@types/tourTranslation.ts
@@ -1,10 +1,12 @@
 import { Document } from 'mongoose';
+import { PassengerType } from '@/bms/@types/tour';
 
 export interface IPricingOptionTranslation {
   optionId: string; // matches pricingOption._id in the tour
   title?: string;
   note?: string;
   accommodationType?: string;
+  prices?: Array<{ type: PassengerType; price: number }>;
   pricePerPerson?: number;
   domesticFlightPerPerson?: number;
   singleSupplement?: number;

--- a/backend/plugins/tourism_api/src/modules/bms/db/definitions/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/db/definitions/tour.ts
@@ -3,6 +3,7 @@ import { locationSchema } from '@/bms/db/definitions/itinerary';
 import { TOUR_STATUS_TYPES } from '@/bms/constants';
 import { getEnum } from '~/modules/bms/utils/utils';
 import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+import type { IPricingOption, ITourDocument } from '@/bms/@types/tour';
 
 export const tourCategorySchema = new Schema({
   _id: mongooseStringRandomId,
@@ -33,6 +34,22 @@ export const guideItemSchema = new Schema(
   { _id: false },
 );
 
+const pricingOptionPriceSchema = new Schema(
+  {
+    type: {
+      type: String,
+      enum: ['adult', 'child', 'infant'],
+      required: true,
+    },
+    price: {
+      type: Number,
+      required: true,
+      min: 0.01,
+    },
+  },
+  { _id: false },
+);
+
 export const pricingOptionSchema = new Schema(
   {
     _id: { type: String },
@@ -49,16 +66,33 @@ export const pricingOptionSchema = new Schema(
       type: Number,
       min: 1,
       validate: {
-        validator(value: number) {
+        validator: function (this: IPricingOption, value?: number) {
           return !value || value >= this.minPersons;
         },
         message: 'Max persons must be greater than or equal to min persons',
       },
     },
 
+    prices: {
+      type: [pricingOptionPriceSchema],
+      default: [],
+      validate: {
+        validator: function (
+          this: IPricingOption,
+          prices: IPricingOption['prices'],
+        ) {
+          // Accept new-style prices array OR legacy pricePerPerson
+          const hasNewPrices =
+            Array.isArray(prices) && prices.some((p) => p.type === 'adult');
+          return hasNewPrices || typeof this.pricePerPerson === 'number';
+        },
+        message: 'Adult price is required',
+      },
+    },
+
+    /** @deprecated Use prices[{type:"adult"}] instead. Kept for backward compat. */
     pricePerPerson: {
       type: Number,
-      required: true,
       min: 0.01,
     },
 
@@ -172,7 +206,7 @@ export const tourSchema = new Schema({
     type: [pricingOptionSchema],
     required: true,
     validate: {
-      validator: (v: (typeof pricingOptionSchema)[]) => v.length > 0,
+      validator: (v?: unknown[]) => Array.isArray(v) && v.length > 0,
       message: 'At least one pricing option is required',
     },
   },
@@ -182,17 +216,16 @@ export const tourSchema = new Schema({
   },
 });
 
-tourSchema.pre('save', function (next) {
+tourSchema.pre('save', function (this: ITourDocument, next) {
   if (Array.isArray(this.pricingOptions) && this.pricingOptions.length > 0) {
-    const prices = this.pricingOptions
-      .map((p: { pricePerPerson?: number }) => p.pricePerPerson)
+    const adultPrices = this.pricingOptions
+      .map((p) => {
+        const fromArray = p.prices?.find((pp) => pp.type === 'adult')?.price;
+        return fromArray ?? p.pricePerPerson;
+      })
       .filter((price): price is number => typeof price === 'number');
 
-    if (prices.length > 0) {
-      this.startingPrice = Math.min(...prices);
-    } else {
-      this.startingPrice = undefined;
-    }
+    this.startingPrice = adultPrices.length > 0 ? Math.min(...adultPrices) : undefined;
   } else {
     this.startingPrice = undefined;
   }

--- a/backend/plugins/tourism_api/src/modules/bms/db/definitions/tourTranslation.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/db/definitions/tourTranslation.ts
@@ -2,12 +2,29 @@ import { Schema } from 'mongoose';
 import { mongooseStringRandomId } from 'erxes-api-shared/utils';
 import { ITourTranslationDocument } from '@/bms/@types/tourTranslation';
 
+const pricingOptionPriceSchema = new Schema(
+  {
+    type: {
+      type: String,
+      enum: ['adult', 'child', 'infant'],
+      required: true,
+    },
+    price: {
+      type: Number,
+      required: true,
+      min: 0.01,
+    },
+  },
+  { _id: false },
+);
+
 const pricingOptionTranslationSchema = new Schema(
   {
     optionId: { type: String, required: true },
     title: { type: String, default: '' },
     note: { type: String, default: '' },
     accommodationType: { type: String, default: '' },
+    prices: { type: [pricingOptionPriceSchema], default: [] },
     pricePerPerson: { type: Number },
     domesticFlightPerPerson: { type: Number },
     singleSupplement: { type: Number },

--- a/backend/plugins/tourism_api/src/modules/bms/db/models/Tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/db/models/Tour.ts
@@ -10,6 +10,10 @@ import {
 } from '@/bms/@types/tour';
 import { tourCategorySchema, tourSchema } from '@/bms/db/definitions/tour';
 
+const getAdultPrice = (option: IPricingOption): number | undefined =>
+  option.prices?.find((price) => price.type === 'adult')?.price ??
+  option.pricePerPerson;
+
 export interface ITourModel extends Model<ITourDocument> {
   createTour(doc: ITour, user: any): Promise<ITourDocument>;
   getTour(_id: string): Promise<ITourDocument>;
@@ -136,7 +140,7 @@ export const loadTourClass = (models: IModels) => {
         return undefined;
       }
       const prices = pricingOptions
-        .map((opt) => opt.pricePerPerson)
+        .map(getAdultPrice)
         .filter((p): p is number => typeof p === 'number');
       return prices.length ? Math.min(...prices) : undefined;
     }
@@ -169,13 +173,11 @@ export const loadTourClass = (models: IModels) => {
         }
 
         // 3. price validation
-        if (
-          option.pricePerPerson === undefined ||
-          option.pricePerPerson === null ||
-          option.pricePerPerson <= 0
-        ) {
+        const adultPrice = getAdultPrice(option);
+
+        if (adultPrice === undefined || adultPrice <= 0) {
           throw new Error(
-            `Invalid pricing option "${option.title}": pricePerPerson must be > 0`,
+            `Invalid pricing option "${option.title}": adult price must be > 0`,
           );
         }
 
@@ -187,7 +189,7 @@ export const loadTourClass = (models: IModels) => {
         // 5. duplicate check – normalize for comparison
         const key = `${option.minPersons}|${
           option.maxPersons ?? ''
-        }|${accommodationType}|${option.pricePerPerson}`;
+        }|${accommodationType}|${adultPrice}`;
 
         if (combinations.has(key)) {
           throw new Error(

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/customResolvers/index.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/customResolvers/index.ts
@@ -1,6 +1,6 @@
 import ElementItem from './elementItemResolver';
 import Itinerary from './itineraryResolver';
-import Tour from './tourResolver';
+import Tour, { PricingOption, PricingOptionTranslation } from './tourResolver';
 import BmsBranch from './branchResolver';
 import TourCategory from './tourCategoryResolver';
 import Element from './element';
@@ -9,6 +9,8 @@ export default {
   ElementItem,
   Element,
   Tour,
+  PricingOption,
+  PricingOptionTranslation,
   TourCategory,
   Itinerary,
   BmsBranch,

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/customResolvers/tourResolver.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/customResolvers/tourResolver.ts
@@ -1,5 +1,46 @@
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
+import type { IPricingOptionPrice, PassengerType } from '@/bms/@types/tour';
+
+export interface PricingOptionPriceSource {
+  type?: string | null;
+  price?: number | null;
+}
+
+export interface PricingOptionSource {
+  prices?: PricingOptionPriceSource[] | null;
+  pricePerPerson?: number | null;
+}
+
+const isPassengerType = (
+  value: string | null | undefined,
+): value is PassengerType =>
+  value === 'adult' || value === 'child' || value === 'infant';
+
+const normalizePricingOptionPrices = (
+  option: PricingOptionSource,
+): IPricingOptionPrice[] => {
+  const prices = Array.isArray(option.prices)
+    ? option.prices
+        .filter(
+          (
+            price,
+          ): price is PricingOptionPriceSource & {
+            type: PassengerType;
+            price: number;
+          } => isPassengerType(price.type) && typeof price.price === 'number',
+        )
+        .map((price) => ({ type: price.type, price: price.price }))
+    : [];
+
+  if (prices.length > 0) {
+    return prices;
+  }
+
+  return typeof option.pricePerPerson === 'number'
+    ? [{ type: 'adult', price: option.pricePerPerson }]
+    : [];
+};
 
 const item = {
   async itinerary(touritem: any, _args, { models }: IContext) {
@@ -22,6 +63,14 @@ const item = {
     if (touritem.tagIds?.length) return touritem.tagIds;
     if (touritem.categoryIds?.length) return touritem.categoryIds;
     return [];
+  },
+
+  pricingOptions(touritem: any) {
+    return Array.isArray(touritem.pricingOptions)
+      ? touritem.pricingOptions.filter(
+          (option): option is PricingOptionSource => Boolean(option),
+        )
+      : [];
   },
 
   async categoriesObject(touritem: any, _args, { models }: IContext) {
@@ -90,3 +139,11 @@ const item = {
 };
 
 export default item;
+
+export const PricingOption = {
+  prices: normalizePricingOptionPrices,
+};
+
+export const PricingOptionTranslation = {
+  prices: normalizePricingOptionPrices,
+};

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
@@ -42,12 +42,24 @@ export const types = `
     fixed
     flexible
   }
+  enum PASSENGER_TYPE {
+    adult
+    child
+    infant
+  }
+
+  type PricingOptionPrice {
+    type: PASSENGER_TYPE!
+    price: Float!
+  }
+
   type PricingOption {
     _id: ID!
     title: String!
     minPersons: Int!
     maxPersons: Int
-    pricePerPerson: Float!
+    prices: [PricingOptionPrice!]!
+    pricePerPerson: Float
     accommodationType: String
     domesticFlightPerPerson: Float
     singleSupplement: Float
@@ -59,6 +71,7 @@ export const types = `
     title: String
     note: String
     accommodationType: String
+    prices: [PricingOptionPrice]
     pricePerPerson: Float
     domesticFlightPerPerson: Float
     singleSupplement: Float
@@ -81,11 +94,17 @@ export const types = `
     updatedAt: Date
   }
 
+  input PricingOptionPriceInput {
+    type: PASSENGER_TYPE!
+    price: Float!
+  }
+
   input PricingOptionTranslationInput {
     optionId: String!
     title: String
     note: String
     accommodationType: String
+    prices: [PricingOptionPriceInput]
     pricePerPerson: Float
     domesticFlightPerPerson: Float
     singleSupplement: Float
@@ -198,7 +217,8 @@ export const types = `
     title: String!
     minPersons: Int!
     maxPersons: Int
-    pricePerPerson: Float!
+    prices: [PricingOptionPriceInput!]!
+    pricePerPerson: Float
     accommodationType: String
     domesticFlightPerPerson: Float
     singleSupplement: Float

--- a/backend/plugins/tourism_api/src/modules/bms/utils/translations.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/utils/translations.ts
@@ -145,6 +145,18 @@ export function applyPricingOptionsTranslation<T extends { _id: string }>(
       ...(pt.accommodationType
         ? { accommodationType: pt.accommodationType }
         : {}),
+      ...(Array.isArray(pt.prices) && pt.prices.length
+        ? { prices: pt.prices }
+        : {}),
+      ...(typeof pt.pricePerPerson === 'number'
+        ? { pricePerPerson: pt.pricePerPerson }
+        : {}),
+      ...(typeof pt.domesticFlightPerPerson === 'number'
+        ? { domesticFlightPerPerson: pt.domesticFlightPerPerson }
+        : {}),
+      ...(typeof pt.singleSupplement === 'number'
+        ? { singleSupplement: pt.singleSupplement }
+        : {}),
     };
   });
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/CustomizePdfDialog.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/CustomizePdfDialog.tsx
@@ -186,7 +186,7 @@ export const CustomizePdfDialog: React.FC<CustomizePdfDialogProps> = ({
 
                 <div className="space-y-4">
                   {LABEL_FIELDS.map((field) => (
-                    <div key={field.key} className="space-y-1.5">
+                    <div key={field.key} className="space-y-2">
                       <Label htmlFor={`pdf-label-${field.key}`}>
                         {field.label}
                       </Label>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
@@ -120,7 +120,9 @@ export const TourCreateForm = ({
           title: '',
           minPersons: 1,
           maxPersons: undefined,
-          pricePerPerson: 0,
+          adultPrice: 0,
+          childPrice: undefined,
+          infantPrice: undefined,
           accommodationType: '',
           domesticFlightPerPerson: undefined,
           singleSupplement: undefined,
@@ -276,13 +278,22 @@ export const TourCreateForm = ({
 
       const isFlexible = values.isFlexibleDate;
 
-      const normalizedPricingOptions = pricingOptions.map((opt) => ({
-        ...opt,
-        _id: opt._id || nanoid(8),
-        accommodationType: opt.accommodationType
-          ? opt.accommodationType.trim().toLowerCase()
-          : opt.accommodationType,
-      }));
+      const normalizedPricingOptions = pricingOptions.map((opt) => {
+        const { adultPrice, childPrice, infantPrice, ...rest } = opt as any;
+        const prices = [
+          { type: 'adult', price: adultPrice },
+          ...(childPrice != null ? [{ type: 'child', price: childPrice }] : []),
+          ...(infantPrice != null ? [{ type: 'infant', price: infantPrice }] : []),
+        ];
+        return {
+          ...rest,
+          prices,
+          _id: rest._id || nanoid(8),
+          accommodationType: rest.accommodationType
+            ? rest.accommodationType.trim().toLowerCase()
+            : rest.accommodationType,
+        };
+      });
 
       const sanitizedTranslations = sanitizeTourTranslations(translations);
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
@@ -14,6 +14,7 @@ import {
   sanitizeTourTranslations,
   syncTranslationPricingOptions,
 } from '../utils/translationHelpers';
+import { normalizePricingOptionsForApi } from '../utils/pricingOptions';
 
 import { TourCreateFormSchema, TourFormValues } from '../constants/formSchema';
 
@@ -278,22 +279,8 @@ export const TourCreateForm = ({
 
       const isFlexible = values.isFlexibleDate;
 
-      const normalizedPricingOptions = pricingOptions.map((opt) => {
-        const { adultPrice, childPrice, infantPrice, ...rest } = opt as any;
-        const prices = [
-          { type: 'adult', price: adultPrice },
-          ...(childPrice != null ? [{ type: 'child', price: childPrice }] : []),
-          ...(infantPrice != null ? [{ type: 'infant', price: infantPrice }] : []),
-        ];
-        return {
-          ...rest,
-          prices,
-          _id: rest._id || nanoid(8),
-          accommodationType: rest.accommodationType
-            ? rest.accommodationType.trim().toLowerCase()
-            : rest.accommodationType,
-        };
-      });
+      const normalizedPricingOptions =
+        normalizePricingOptionsForApi(pricingOptions);
 
       const sanitizedTranslations = sanitizeTourTranslations(translations);
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
@@ -17,6 +17,7 @@ import {
   buildTranslationsFromTour,
   sanitizeTourTranslations,
 } from '../utils/translationHelpers';
+import { normalizeTourDetailPricingOptionsForApi } from '../utils/pricingOptions';
 
 const stripTypename = <T extends Record<string, any>>(
   obj: T,
@@ -201,11 +202,7 @@ const FixedDuplicateSheet = ({
     resolvedPrimaryLanguage,
   );
   const normalizedPricingOptions = useMemo(
-    () =>
-      (tour.pricingOptions ?? []).map((opt) => ({
-        ...stripTypename(opt),
-        _id: opt._id || nanoid(8),
-      })),
+    () => normalizeTourDetailPricingOptionsForApi(tour.pricingOptions ?? []),
     [tour.pricingOptions],
   );
   const duplicateTranslations = useMemo(
@@ -220,8 +217,12 @@ const FixedDuplicateSheet = ({
   const form = useForm<FixedFormType>({
     resolver: zodResolver(FixedFormSchema),
     defaultValues: {
-      name: `${primaryTranslation?.name || tour.name || ''}${duplicateNameSuffix}`,
-      refNumber: `${primaryTranslation?.refNumber || tour.refNumber || ''}${duplicateRefNumberSuffix}`,
+      name: `${
+        primaryTranslation?.name || tour.name || ''
+      }${duplicateNameSuffix}`,
+      refNumber: `${
+        primaryTranslation?.refNumber || tour.refNumber || ''
+      }${duplicateRefNumberSuffix}`,
       startDate: tour.startDate ? new Date(tour.startDate) : undefined,
       translations: duplicateTranslations,
     },
@@ -235,8 +236,12 @@ const FixedDuplicateSheet = ({
     if (!open) return;
 
     form.reset({
-      name: `${primaryTranslation?.name || tour.name || ''}${duplicateNameSuffix}`,
-      refNumber: `${primaryTranslation?.refNumber || tour.refNumber || ''}${duplicateRefNumberSuffix}`,
+      name: `${
+        primaryTranslation?.name || tour.name || ''
+      }${duplicateNameSuffix}`,
+      refNumber: `${
+        primaryTranslation?.refNumber || tour.refNumber || ''
+      }${duplicateRefNumberSuffix}`,
       startDate: tour.startDate ? new Date(tour.startDate) : undefined,
       translations: duplicateTranslations,
     });
@@ -438,11 +443,7 @@ const FlexibleDuplicateSheet = ({
     resolvedPrimaryLanguage,
   );
   const normalizedPricingOptions = useMemo(
-    () =>
-      (tour.pricingOptions ?? []).map((opt) => ({
-        ...stripTypename(opt),
-        _id: opt._id || nanoid(8),
-      })),
+    () => normalizeTourDetailPricingOptionsForApi(tour.pricingOptions ?? []),
     [tour.pricingOptions],
   );
   const duplicateTranslations = useMemo(
@@ -457,8 +458,12 @@ const FlexibleDuplicateSheet = ({
   const form = useForm<FlexibleFormType>({
     resolver: zodResolver(FlexibleFormSchema),
     defaultValues: {
-      name: `${primaryTranslation?.name || tour.name || ''}${duplicateNameSuffix}`,
-      refNumber: `${primaryTranslation?.refNumber || tour.refNumber || ''}${duplicateRefNumberSuffix}`,
+      name: `${
+        primaryTranslation?.name || tour.name || ''
+      }${duplicateNameSuffix}`,
+      refNumber: `${
+        primaryTranslation?.refNumber || tour.refNumber || ''
+      }${duplicateRefNumberSuffix}`,
       availableFrom: tour.availableFrom
         ? new Date(tour.availableFrom)
         : undefined,
@@ -475,8 +480,12 @@ const FlexibleDuplicateSheet = ({
     if (!open) return;
 
     form.reset({
-      name: `${primaryTranslation?.name || tour.name || ''}${duplicateNameSuffix}`,
-      refNumber: `${primaryTranslation?.refNumber || tour.refNumber || ''}${duplicateRefNumberSuffix}`,
+      name: `${
+        primaryTranslation?.name || tour.name || ''
+      }${duplicateNameSuffix}`,
+      refNumber: `${
+        primaryTranslation?.refNumber || tour.refNumber || ''
+      }${duplicateRefNumberSuffix}`,
       availableFrom: tour.availableFrom
         ? new Date(tour.availableFrom)
         : undefined,

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -242,7 +242,15 @@ export const TourEditForm = ({
         imageThumbnail: tour.imageThumbnail ?? '',
         attachment: tour.attachment ?? null,
         guides: [],
-        pricingOptions: tour.pricingOptions ?? [],
+        pricingOptions: (tour.pricingOptions ?? []).map((opt: any) => ({
+          ...opt,
+          adultPrice:
+            opt.prices?.find((p: any) => p.type === 'adult')?.price ??
+            opt.pricePerPerson ??
+            0,
+          childPrice: opt.prices?.find((p: any) => p.type === 'child')?.price,
+          infantPrice: opt.prices?.find((p: any) => p.type === 'infant')?.price,
+        })),
         isFlexibleDate: tour.dateType === 'flexible',
         isGroupTour: false,
         startDate: tour.startDate ? new Date(tour.startDate) : undefined,
@@ -305,13 +313,22 @@ export const TourEditForm = ({
         ...restValues
       } = values;
 
-      const normalizedPricingOptions = pricingOptions.map((opt) => ({
-        ...opt,
-        _id: opt._id || nanoid(8),
-        accommodationType: opt.accommodationType
-          ? opt.accommodationType.trim().toLowerCase()
-          : opt.accommodationType,
-      }));
+      const normalizedPricingOptions = pricingOptions.map((opt) => {
+        const { adultPrice, childPrice, infantPrice, ...rest } = opt as any;
+        const prices = [
+          { type: 'adult', price: adultPrice },
+          ...(childPrice != null ? [{ type: 'child', price: childPrice }] : []),
+          ...(infantPrice != null ? [{ type: 'infant', price: infantPrice }] : []),
+        ];
+        return {
+          ...rest,
+          prices,
+          _id: rest._id || nanoid(8),
+          accommodationType: rest.accommodationType
+            ? rest.accommodationType.trim().toLowerCase()
+            : rest.accommodationType,
+        };
+      });
 
       const sanitizedTranslations = sanitizeTourTranslations(
         rawTranslations ?? [],

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -3,7 +3,6 @@ import { useForm, useWatch, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@apollo/client';
 import { useEffect, useMemo, useState } from 'react';
-import { nanoid } from 'nanoid';
 import { TourSideTab, TourOrdersSidePanel } from './TourOrdersSidePanel';
 
 import { GET_ITINERARIES } from '../../itinerary/graphql/queries';
@@ -17,6 +16,7 @@ import {
   syncTranslationPricingOptions,
   resolveMainLanguageName,
 } from '../utils/translationHelpers';
+import { normalizePricingOptionsForApi } from '../utils/pricingOptions';
 
 import { TourCreateFormSchema, TourFormValues } from '../constants/formSchema';
 
@@ -242,15 +242,19 @@ export const TourEditForm = ({
         imageThumbnail: tour.imageThumbnail ?? '',
         attachment: tour.attachment ?? null,
         guides: [],
-        pricingOptions: (tour.pricingOptions ?? []).map((opt: any) => ({
-          ...opt,
-          adultPrice:
-            opt.prices?.find((p: any) => p.type === 'adult')?.price ??
-            opt.pricePerPerson ??
-            0,
-          childPrice: opt.prices?.find((p: any) => p.type === 'child')?.price,
-          infantPrice: opt.prices?.find((p: any) => p.type === 'infant')?.price,
-        })),
+        pricingOptions: (tour.pricingOptions ?? []).map((option) => {
+          const { prices, pricePerPerson, ...rest } = option;
+
+          return {
+            ...rest,
+            adultPrice:
+              prices.find((price) => price.type === 'adult')?.price ??
+              pricePerPerson ??
+              0,
+            childPrice: prices.find((price) => price.type === 'child')?.price,
+            infantPrice: prices.find((price) => price.type === 'infant')?.price,
+          };
+        }),
         isFlexibleDate: tour.dateType === 'flexible',
         isGroupTour: false,
         startDate: tour.startDate ? new Date(tour.startDate) : undefined,
@@ -313,22 +317,8 @@ export const TourEditForm = ({
         ...restValues
       } = values;
 
-      const normalizedPricingOptions = pricingOptions.map((opt) => {
-        const { adultPrice, childPrice, infantPrice, ...rest } = opt as any;
-        const prices = [
-          { type: 'adult', price: adultPrice },
-          ...(childPrice != null ? [{ type: 'child', price: childPrice }] : []),
-          ...(infantPrice != null ? [{ type: 'infant', price: infantPrice }] : []),
-        ];
-        return {
-          ...rest,
-          prices,
-          _id: rest._id || nanoid(8),
-          accommodationType: rest.accommodationType
-            ? rest.accommodationType.trim().toLowerCase()
-            : rest.accommodationType,
-        };
-      });
+      const normalizedPricingOptions =
+        normalizePricingOptionsForApi(pricingOptions);
 
       const sanitizedTranslations = sanitizeTourTranslations(
         rawTranslations ?? [],
@@ -351,8 +341,8 @@ export const TourEditForm = ({
         endDate: isFlexible
           ? undefined
           : normalizedStartDate && values.duration
-            ? calculateEndDate(normalizedStartDate, values.duration)
-            : undefined,
+          ? calculateEndDate(normalizedStartDate, values.duration)
+          : undefined,
         availableFrom: isFlexible ? values.availableFrom : undefined,
         availableTo: isFlexible ? values.availableTo : undefined,
         dateStatus: isFlexible

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
@@ -699,7 +699,9 @@ const TourPricingOptionsFieldContent = ({
       title: '',
       minPersons: '',
       maxPersons: '',
-      pricePerPerson: '',
+      adultPrice: '',
+      childPrice: '',
+      infantPrice: '',
       accommodationType: '',
       domesticFlightPerPerson: '',
       singleSupplement: '',
@@ -828,40 +830,41 @@ const TourPricingOptionsFieldContent = ({
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <Form.Field
-                control={control}
-                name={getFieldName(index, 'accommodationType')}
-                render={({ field, fieldState }) => (
-                  <div className="space-y-2">
-                    <Form.Label
-                      className={fieldState.error ? 'text-destructive' : ''}
-                    >
-                      Accommodation Type
-                      <span className="text-primary">{labelSuffix}</span>
-                    </Form.Label>
-                    <Input
-                      {...field}
-                      value={field.value ?? ''}
-                      onChange={(e) =>
-                        field.onChange(toOptionalString(e.target.value))
-                      }
-                      placeholder="e.g., Hotel, Resort, etc."
-                    />
-                    <Form.Message>{fieldState.error?.message}</Form.Message>
-                  </div>
-                )}
-              />
+            <Form.Field
+              control={control}
+              name={getFieldName(index, 'accommodationType')}
+              render={({ field, fieldState }) => (
+                <div className="space-y-2">
+                  <Form.Label
+                    className={fieldState.error ? 'text-destructive' : ''}
+                  >
+                    Accommodation Type
+                    <span className="text-primary">{labelSuffix}</span>
+                  </Form.Label>
+                  <Input
+                    {...field}
+                    value={field.value ?? ''}
+                    onChange={(e) =>
+                      field.onChange(toOptionalString(e.target.value))
+                    }
+                    placeholder="e.g., Hotel, Resort, etc."
+                  />
+                  <Form.Message>{fieldState.error?.message}</Form.Message>
+                </div>
+              )}
+            />
 
+            <div className="grid grid-cols-3 gap-3">
               <Form.Field
                 control={control}
-                name={getFieldName(index, 'pricePerPerson')}
+                name={getFieldName(index, 'adultPrice')}
                 render={({ field, fieldState }) => (
                   <div className="space-y-2">
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      Price per Person{' '}
+                      Adult Price
+                      <span className="text-primary">{labelSuffix}</span>{' '}
                       <span className="text-destructive">*</span>
                     </Form.Label>
                     <div className="relative">
@@ -878,6 +881,72 @@ const TourPricingOptionsFieldContent = ({
                           field.onChange(toOptionalNumber(e.target.value))
                         }
                         placeholder="0.00"
+                        className="pl-7"
+                      />
+                    </div>
+                    <Form.Message>{fieldState.error?.message}</Form.Message>
+                  </div>
+                )}
+              />
+
+              <Form.Field
+                control={control}
+                name={getFieldName(index, 'childPrice')}
+                render={({ field, fieldState }) => (
+                  <div className="space-y-2">
+                    <Form.Label
+                      className={fieldState.error ? 'text-destructive' : ''}
+                    >
+                      Child Price
+                      <span className="text-primary">{labelSuffix}</span>
+                    </Form.Label>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+                        {symbol}
+                      </span>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        {...field}
+                        value={field.value ?? ''}
+                        onChange={(e) =>
+                          field.onChange(toOptionalNumber(e.target.value))
+                        }
+                        placeholder="Optional"
+                        className="pl-7"
+                      />
+                    </div>
+                    <Form.Message>{fieldState.error?.message}</Form.Message>
+                  </div>
+                )}
+              />
+
+              <Form.Field
+                control={control}
+                name={getFieldName(index, 'infantPrice')}
+                render={({ field, fieldState }) => (
+                  <div className="space-y-2">
+                    <Form.Label
+                      className={fieldState.error ? 'text-destructive' : ''}
+                    >
+                      Infant Price
+                      <span className="text-primary">{labelSuffix}</span>
+                    </Form.Label>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+                        {symbol}
+                      </span>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        {...field}
+                        value={field.value ?? ''}
+                        onChange={(e) =>
+                          field.onChange(toOptionalNumber(e.target.value))
+                        }
+                        placeholder="Optional"
                         className="pl-7"
                       />
                     </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupAddSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupAddSheet.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
 import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
-import { nanoid } from 'nanoid';
 import { Button, Form, Input, Sheet, Spinner, useToast } from 'erxes-ui';
 import { useCreateTour } from '../hooks/useCreateTour';
 import { ITourDetail, useTourDetail } from '../hooks/useTourDetail';
@@ -16,6 +15,7 @@ import {
   buildTranslationsFromTour,
   sanitizeTourTranslations,
 } from '../utils/translationHelpers';
+import { normalizeTourDetailPricingOptionsForApi } from '../utils/pricingOptions';
 import { RHFDatePicker } from './RHFDatePicker';
 
 const GroupTourAddSchema = z.object({
@@ -165,10 +165,7 @@ export const TourGroupAddSheet = ({
 
   const normalizedPricingOptions = useMemo(
     () =>
-      (tourDetail?.pricingOptions ?? []).map((option) => ({
-        ...stripTypename(option),
-        _id: option._id || nanoid(8),
-      })),
+      normalizeTourDetailPricingOptionsForApi(tourDetail?.pricingOptions ?? []),
     [tourDetail?.pricingOptions],
   );
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/formSchema.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/formSchema.ts
@@ -29,7 +29,9 @@ export const PricingOptionTranslationSchema = z.object({
   title: z.string().optional(),
   accommodationType: z.string().optional(),
   note: z.string().optional(),
-  pricePerPerson: optionalNumber(z.number()),
+  adultPrice: optionalNumber(z.number()),
+  childPrice: optionalNumber(z.number()),
+  infantPrice: optionalNumber(z.number()),
   domesticFlightPerPerson: optionalNumber(z.number()),
   singleSupplement: optionalNumber(z.number()),
 });
@@ -50,6 +52,18 @@ export const TourTranslationSchema = z.object({
 });
 
 /* ================= PRICING ================= */
+
+const requiredPrice = z.preprocess(
+  (value) => {
+    if (value === '' || value === null || value === undefined) return undefined;
+    if (typeof value === 'string') {
+      const num = Number(value);
+      return Number.isNaN(num) ? undefined : num;
+    }
+    return value;
+  },
+  z.number({ required_error: 'Price is required' }).min(0.01, 'Price must be greater than 0'),
+);
 
 export const PricingOptionSchema = z.object({
   _id: z.string(),
@@ -73,18 +87,14 @@ export const PricingOptionSchema = z.object({
     z.number().min(1, 'Max persons must be at least 1'),
   ),
 
-  pricePerPerson: z.preprocess(
-    (value) => {
-      if (value === '' || value === null || value === undefined)
-        return undefined;
-      if (typeof value === 'string') {
-        const num = Number(value);
-        return Number.isNaN(num) ? undefined : num;
-      }
-      return value;
-    },
-    z.coerce.number().min(0.01, 'Price must be greater than 0'),
-  ),
+  /** Adult price is required. */
+  adultPrice: requiredPrice,
+
+  /** Child price is optional. Set to undefined/empty to omit from prices array. */
+  childPrice: optionalNumber(z.number().min(0, 'Child price must be 0 or greater')),
+
+  /** Infant price is optional. Set to undefined/empty to omit from prices array. */
+  infantPrice: optionalNumber(z.number().min(0, 'Infant price must be 0 or greater')),
 
   accommodationType: optionalString(),
 
@@ -243,7 +253,9 @@ export type PricingOptionTranslationFormValue = {
   title?: string;
   accommodationType?: string;
   note?: string;
-  pricePerPerson?: number | string;
+  adultPrice?: number | string;
+  childPrice?: number | string;
+  infantPrice?: number | string;
   domesticFlightPerPerson?: number | string;
   singleSupplement?: number | string;
 };

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
@@ -170,6 +170,7 @@ export const GET_TOUR_DETAIL = gql`
           type
           price
         }
+        pricePerPerson
         accommodationType
         domesticFlightPerPerson
         singleSupplement
@@ -196,6 +197,7 @@ export const GET_TOUR_DETAIL = gql`
             type
             price
           }
+          pricePerPerson
           domesticFlightPerPerson
           singleSupplement
         }

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
@@ -166,7 +166,10 @@ export const GET_TOUR_DETAIL = gql`
         title
         minPersons
         maxPersons
-        pricePerPerson
+        prices {
+          type
+          price
+        }
         accommodationType
         domesticFlightPerPerson
         singleSupplement
@@ -189,7 +192,10 @@ export const GET_TOUR_DETAIL = gql`
           title
           accommodationType
           note
-          pricePerPerson
+          prices {
+            type
+            price
+          }
           domesticFlightPerPerson
           singleSupplement
         }

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useCreateTour.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useCreateTour.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { CREATE_TOUR } from '../graphql/mutation';
 import { ITourTranslationInput } from '../utils/translationHelpers';
+import type { PricingOptionInput } from '../utils/pricingOptions';
 
 interface CreateTourResponse {
   bmsTourAdd: {
@@ -49,17 +50,7 @@ export interface ICreateTourVariables {
   joinPercent?: number;
   personCost?: Record<string, any>;
   categoryIds?: string[];
-  pricingOptions?: Array<{
-    _id: string;
-    title: string;
-    minPersons: number;
-    maxPersons?: number;
-    pricePerPerson: number;
-    accommodationType?: string;
-    domesticFlightPerPerson?: number;
-    singleSupplement?: number;
-    note?: string;
-  }>;
+  pricingOptions?: PricingOptionInput[];
   translations?: ITourTranslationInput[];
 }
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useEditTour.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useEditTour.ts
@@ -6,18 +6,7 @@ import {
   GET_TOUR_DETAIL,
 } from '../graphql/queries';
 import { ITourTranslationInput } from '../utils/translationHelpers';
-
-export interface IPricingOption {
-  _id?: string;
-  title: string;
-  minPersons: number;
-  maxPersons?: number;
-  pricePerPerson: number;
-  accommodationType?: string;
-  domesticFlightPerPerson?: number;
-  singleSupplement?: number;
-  note?: string;
-}
+import type { PricingOptionInput } from '../utils/pricingOptions';
 
 export interface IEditTourVariables {
   id: string;
@@ -58,7 +47,7 @@ export interface IEditTourVariables {
   imageThumbnail?: string;
   attachment?: { url: string; name: string; type: string; size: number } | null;
   categoryIds?: string[];
-  pricingOptions?: IPricingOption[];
+  pricingOptions?: PricingOptionInput[];
   translations?: ITourTranslationInput[];
 }
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
@@ -1,12 +1,14 @@
 import { QueryHookOptions, useQuery } from '@apollo/client';
 import { GET_TOUR_DETAIL } from '../graphql/queries';
+import type { PricingOptionPriceInput } from '../utils/pricingOptions';
 
 export interface IPricingOption {
   _id: string;
   title: string;
   minPersons: number;
   maxPersons?: number;
-  pricePerPerson: number;
+  prices: PricingOptionPriceInput[];
+  pricePerPerson?: number;
   accommodationType?: string;
   domesticFlightPerPerson?: number;
   singleSupplement?: number;
@@ -18,6 +20,7 @@ export interface IPricingOptionTranslation {
   title?: string;
   accommodationType?: string;
   note?: string;
+  prices?: PricingOptionPriceInput[];
   pricePerPerson?: number;
   domesticFlightPerPerson?: number;
   singleSupplement?: number;

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/CustomizeTourPdfDialog.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/CustomizeTourPdfDialog.tsx
@@ -128,6 +128,21 @@ const LABEL_FIELDS: Array<{
     placeholder: 'Price / Person',
   },
   {
+    key: 'pricingAdultLabel',
+    label: 'Adult price label',
+    placeholder: 'Adult Price',
+  },
+  {
+    key: 'pricingChildLabel',
+    label: 'Child price label',
+    placeholder: 'Child Price',
+  },
+  {
+    key: 'pricingInfantLabel',
+    label: 'Infant price label',
+    placeholder: 'Infant Price',
+  },
+  {
     key: 'pricingAccommodationLabel',
     label: 'Accommodation label',
     placeholder: 'Accommodation',
@@ -239,10 +254,10 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content className="max-w-5xl overflow-hidden p-0">
+      <Dialog.Content className="max-w-5xl p-0 overflow-hidden">
         <div className="grid max-h-[80vh] md:grid-cols-[1.05fr_0.95fr]">
           <section className="min-h-0 overflow-y-auto bg-background">
-            <Dialog.Header className="border-b bg-muted/30 px-6 py-6">
+            <Dialog.Header className="px-6 py-6 border-b bg-muted/30">
               <Dialog.Title className="text-xl">
                 Customize Tour PDF
               </Dialog.Title>
@@ -252,7 +267,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               </Dialog.Description>
             </Dialog.Header>
 
-            <div className="space-y-4 px-6 py-5">
+            <div className="px-6 py-5 space-y-4">
               <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 <IconLayoutGrid size={14} />
                 Visible Sections
@@ -262,7 +277,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
                 {TOGGLE_OPTIONS.map((option) => (
                   <div
                     key={option.key}
-                    className="rounded-2xl border border-border/60 bg-background px-4 py-4 shadow-sm transition-colors hover:border-primary/30"
+                    className="px-4 py-4 transition-colors border shadow-sm rounded-2xl border-border/60 bg-background hover:border-primary/30"
                   >
                     <div className="flex items-start gap-3">
                       <Checkbox
@@ -300,7 +315,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
                   {ITINERARY_TOGGLE_OPTIONS.map((option) => (
                     <div
                       key={option.key}
-                      className="rounded-2xl border border-border/60 bg-background px-4 py-4 shadow-sm transition-colors hover:border-primary/30"
+                      className="px-4 py-4 transition-colors border shadow-sm rounded-2xl border-border/60 bg-background hover:border-primary/30"
                     >
                       <div className="flex items-start gap-3">
                         <Checkbox
@@ -332,7 +347,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
           </section>
 
           <aside className="min-h-0 overflow-y-auto border-l bg-muted/20">
-            <div className="border-b bg-background/70 px-6 py-6 backdrop-blur">
+            <div className="px-6 py-6 border-b bg-background/70 backdrop-blur">
               <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 <IconForms size={14} />
                 Static Text
@@ -343,8 +358,8 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               </p>
             </div>
 
-            <div className="space-y-4 px-6 py-5">
-              <div className="rounded-2xl border border-border/60 bg-background px-4 py-4 shadow-sm">
+            <div className="px-6 py-5 space-y-4">
+              <div className="px-4 py-4 border shadow-sm rounded-2xl border-border/60 bg-background">
                 <div className="mb-4 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <IconFileDescription size={14} />
                   Tour Labels
@@ -352,7 +367,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
 
                 <div className="space-y-4">
                   {LABEL_FIELDS.map((field) => (
-                    <div key={field.key} className="space-y-1.5">
+                    <div key={field.key} className="space-y-2">
                       <Label htmlFor={`tour-pdf-label-${field.key}`}>
                         {field.label}
                       </Label>
@@ -370,7 +385,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-border/60 bg-background px-4 py-4 shadow-sm">
+              <div className="px-4 py-4 border shadow-sm rounded-2xl border-border/60 bg-background">
                 <div className="mb-4 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <IconFileDescription size={14} />
                   Itinerary Labels
@@ -378,7 +393,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
 
                 <div className="space-y-4">
                   {ITINERARY_LABEL_FIELDS.map((field) => (
-                    <div key={field.key} className="space-y-1.5">
+                    <div key={field.key} className="space-y-2">
                       <Label htmlFor={`tour-itinerary-pdf-label-${field.key}`}>
                         {field.label}
                       </Label>
@@ -396,7 +411,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-dashed border-border/70 bg-background/70 px-4 py-4">
+              <div className="px-4 py-4 border border-dashed rounded-2xl border-border/70 bg-background/70">
                 <p className="text-sm leading-6 text-muted-foreground">
                   Preview refreshes automatically when these values change.
                   Short labels usually fit best in the exported layout.
@@ -404,7 +419,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               </div>
             </div>
 
-            <Dialog.Footer className="sticky bottom-0 border-t bg-background/95 px-6 py-4 backdrop-blur">
+            <Dialog.Footer className="sticky bottom-0 px-6 py-4 border-t bg-background/95 backdrop-blur">
               <Button variant="outline" onClick={onReset}>
                 Reset to defaults
               </Button>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/TourDetailsPage.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/TourDetailsPage.tsx
@@ -22,6 +22,23 @@ interface PricingFact {
   value: string;
 }
 
+const PASSENGER_PRICE_ORDER = ['adult', 'child', 'infant'] as const;
+
+const getPassengerPriceLabel = (
+  type: (typeof PASSENGER_PRICE_ORDER)[number],
+  labels: TourPdfRenderConfig['labels'],
+) => {
+  if (type === 'adult') {
+    return labels.pricingAdultLabel || labels.pricingPerPersonLabel;
+  }
+
+  if (type === 'child') {
+    return labels.pricingChildLabel || 'Child Price';
+  }
+
+  return labels.pricingInfantLabel || 'Infant Price';
+};
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
@@ -40,6 +57,11 @@ const formatPrice = (value?: number) => {
   return new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 2,
   }).format(value);
+};
+
+const formatCurrency = (symbol: string, value?: number) => {
+  const formattedValue = formatPrice(value);
+  return formattedValue ? `${symbol} ${formattedValue}` : '';
 };
 
 const formatPaxRange = (
@@ -219,15 +241,23 @@ export const TourDetailsPage: React.FC<TourDetailsPageProps> = React.memo(
               </Text>
             </View>
             {pricingOptions.map((option, index) => {
+              const priceFacts = PASSENGER_PRICE_ORDER.map((type) => {
+                const price =
+                  option.prices?.find((item) => item.type === type)?.price ??
+                  (type === 'adult' ? option.pricePerPerson : undefined);
+
+                if (typeof price !== 'number') {
+                  return null;
+                }
+
+                return {
+                  label: getPassengerPriceLabel(type, config.labels),
+                  value: formatCurrency(currencySymbol, price),
+                };
+              }).filter((fact): fact is PricingFact => Boolean(fact));
+
               const pricingFacts: PricingFact[] = [
-                typeof option.pricePerPerson === 'number'
-                  ? {
-                      label: config.labels.pricingPerPersonLabel,
-                      value: `${currencySymbol}${formatPrice(
-                        option.pricePerPerson,
-                      )}`,
-                    }
-                  : null,
+                ...priceFacts,
                 option.accommodationType
                   ? {
                       label: config.labels.pricingAccommodationLabel,
@@ -237,17 +267,19 @@ export const TourDetailsPage: React.FC<TourDetailsPageProps> = React.memo(
                 typeof option.domesticFlightPerPerson === 'number'
                   ? {
                       label: config.labels.pricingDomesticFlightLabel,
-                      value: `${currencySymbol}${formatPrice(
+                      value: formatCurrency(
+                        currencySymbol,
                         option.domesticFlightPerPerson,
-                      )}`,
+                      ),
                     }
                   : null,
                 typeof option.singleSupplement === 'number'
                   ? {
                       label: config.labels.pricingSingleSupplementLabel,
-                      value: `${currencySymbol}${formatPrice(
+                      value: formatCurrency(
+                        currencySymbol,
                         option.singleSupplement,
-                      )}`,
+                      ),
                     }
                   : null,
               ].filter((fact): fact is PricingFact => Boolean(fact));

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/pdfBuilder.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/pdfBuilder.tsx
@@ -81,6 +81,7 @@ const mergePricingOptionTranslation = (
     ? { accommodationType: translation.accommodationType }
     : {}),
   ...(translation?.note ? { note: translation.note } : {}),
+  ...(translation?.prices?.length ? { prices: translation.prices } : {}),
   ...(typeof translation?.pricePerPerson === 'number'
     ? { pricePerPerson: translation.pricePerPerson }
     : {}),

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/types.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/types.ts
@@ -26,6 +26,9 @@ export interface TourPdfLabels {
   pricingSectionTitle: string;
   pricingUntitledOptionLabel: string;
   pricingPerPersonLabel: string;
+  pricingAdultLabel: string;
+  pricingChildLabel: string;
+  pricingInfantLabel: string;
   pricingAccommodationLabel: string;
   pricingDomesticFlightLabel: string;
   pricingSingleSupplementLabel: string;
@@ -63,6 +66,9 @@ export const DEFAULT_TOUR_PDF_LABELS: TourPdfLabels = {
   pricingSectionTitle: 'Pricing Options',
   pricingUntitledOptionLabel: 'Untitled option',
   pricingPerPersonLabel: 'Price / Person',
+  pricingAdultLabel: 'Adult Price',
+  pricingChildLabel: 'Child Price',
+  pricingInfantLabel: 'Infant Price',
   pricingAccommodationLabel: 'Accommodation',
   pricingDomesticFlightLabel: 'Domestic Flight',
   pricingSingleSupplementLabel: 'Single Supplement',

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/utils/pricingOptions.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/utils/pricingOptions.ts
@@ -1,0 +1,109 @@
+import { nanoid } from 'nanoid';
+
+import type { TourFormValues } from '../constants/formSchema';
+import type { IPricingOption } from '../hooks/useTourDetail';
+
+export type PassengerType = 'adult' | 'child' | 'infant';
+
+export interface PricingOptionPriceInput {
+  type: PassengerType;
+  price: number;
+}
+
+export interface PricingOptionInput {
+  _id: string;
+  title: string;
+  minPersons: number;
+  maxPersons?: number;
+  prices: PricingOptionPriceInput[];
+  accommodationType?: string;
+  domesticFlightPerPerson?: number;
+  singleSupplement?: number;
+  note?: string;
+}
+
+type PricingOptionFormValue = TourFormValues['pricingOptions'][number];
+
+type WithTypename = {
+  __typename?: string;
+};
+
+type PricingOptionPriceSource = PricingOptionPriceInput & WithTypename;
+
+type PricingOptionSource = Omit<IPricingOption, 'prices'> &
+  WithTypename & {
+    prices?: PricingOptionPriceSource[];
+  };
+
+export const buildPricingOptionPrices = ({
+  adultPrice,
+  childPrice,
+  infantPrice,
+}: Pick<
+  PricingOptionFormValue,
+  'adultPrice' | 'childPrice' | 'infantPrice'
+>): PricingOptionPriceInput[] => {
+  const prices: PricingOptionPriceInput[] = [
+    { type: 'adult', price: adultPrice },
+  ];
+
+  if (typeof childPrice === 'number') {
+    prices.push({ type: 'child', price: childPrice });
+  }
+
+  if (typeof infantPrice === 'number') {
+    prices.push({ type: 'infant', price: infantPrice });
+  }
+
+  return prices;
+};
+
+export const normalizePricingOptionsForApi = (
+  pricingOptions: TourFormValues['pricingOptions'],
+): PricingOptionInput[] =>
+  pricingOptions.map((option) => {
+    const { adultPrice, childPrice, infantPrice, ...rest } = option;
+
+    return {
+      ...rest,
+      prices: buildPricingOptionPrices({
+        adultPrice,
+        childPrice,
+        infantPrice,
+      }),
+      _id: rest._id || nanoid(8),
+      accommodationType: rest.accommodationType
+        ? rest.accommodationType.trim().toLowerCase()
+        : rest.accommodationType,
+    };
+  });
+
+export const normalizeTourDetailPricingOptionsForApi = (
+  pricingOptions: PricingOptionSource[],
+): PricingOptionInput[] =>
+  pricingOptions.map((option) => {
+    const {
+      __typename: _typename,
+      pricePerPerson,
+      prices = [],
+      ...rest
+    } = option;
+
+    const normalizedPrices = prices.map(
+      ({ __typename: _priceTypename, type, price }) => ({
+        type,
+        price,
+      }),
+    );
+
+    return {
+      ...rest,
+      _id: rest._id || nanoid(8),
+      prices:
+        normalizedPrices.length > 0
+          ? normalizedPrices
+          : typeof pricePerPerson === 'number'
+          ? [{ type: 'adult', price: pricePerPerson }]
+          : [],
+    };
+  });

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/utils/translationHelpers.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/utils/translationHelpers.ts
@@ -3,6 +3,16 @@ import {
   TourTranslationFormValue,
 } from '../constants/formSchema';
 
+export interface IPricingOptionTranslationInput {
+  optionId: string;
+  title?: string;
+  accommodationType?: string;
+  note?: string;
+  prices?: Array<{ type: 'adult' | 'child' | 'infant'; price: number }>;
+  domesticFlightPerPerson?: number;
+  singleSupplement?: number;
+}
+
 export interface ITourTranslationInput {
   language: string;
   name?: string;
@@ -13,15 +23,7 @@ export interface ITourTranslationInput {
   info3?: string;
   info4?: string;
   info5?: string;
-  pricingOptions?: Array<{
-    optionId: string;
-    title?: string;
-    accommodationType?: string;
-    note?: string;
-    pricePerPerson?: number;
-    domesticFlightPerPerson?: number;
-    singleSupplement?: number;
-  }>;
+  pricingOptions?: IPricingOptionTranslationInput[];
 }
 
 type TourTranslation = TourTranslationFormValue;
@@ -45,7 +47,9 @@ export const buildEmptyTourTranslations = (
       title: '',
       accommodationType: '',
       note: '',
-      pricePerPerson: '',
+      adultPrice: '',
+      childPrice: '',
+      infantPrice: '',
       domesticFlightPerPerson: '',
       singleSupplement: '',
     })),
@@ -68,6 +72,7 @@ export const buildTranslationsFromTour = (
         title?: string;
         accommodationType?: string;
         note?: string;
+        prices?: Array<{ type: string; price: number }>;
         pricePerPerson?: number;
         domesticFlightPerPerson?: number;
         singleSupplement?: number;
@@ -86,12 +91,26 @@ export const buildTranslationsFromTour = (
       const existingOpt = (existing?.pricingOptions || []).find(
         (p) => p.optionId === optionId,
       );
+
+      const adultPrice =
+        existingOpt?.prices?.find((p) => p.type === 'adult')?.price ??
+        existingOpt?.pricePerPerson ??
+        '';
+
+      const childPrice =
+        existingOpt?.prices?.find((p) => p.type === 'child')?.price ?? '';
+
+      const infantPrice =
+        existingOpt?.prices?.find((p) => p.type === 'infant')?.price ?? '';
+
       return {
         optionId,
         title: existingOpt?.title || '',
         accommodationType: existingOpt?.accommodationType || '',
         note: existingOpt?.note || '',
-        pricePerPerson: existingOpt?.pricePerPerson ?? '',
+        adultPrice,
+        childPrice,
+        infantPrice,
         domesticFlightPerPerson: existingOpt?.domesticFlightPerPerson ?? '',
         singleSupplement: existingOpt?.singleSupplement ?? '',
       };
@@ -131,7 +150,9 @@ export const sanitizeTourTranslations = (
             p.title ||
             p.accommodationType ||
             p.note ||
-            typeof p.pricePerPerson === 'number' ||
+            typeof p.adultPrice === 'number' ||
+            typeof p.childPrice === 'number' ||
+            typeof p.infantPrice === 'number' ||
             typeof p.domesticFlightPerPerson === 'number' ||
             typeof p.singleSupplement === 'number',
         ),
@@ -152,26 +173,33 @@ export const sanitizeTourTranslations = (
             p.title ||
             p.accommodationType ||
             p.note ||
-            typeof p.pricePerPerson === 'number' ||
+            typeof p.adultPrice === 'number' ||
+            typeof p.childPrice === 'number' ||
+            typeof p.infantPrice === 'number' ||
             typeof p.domesticFlightPerPerson === 'number' ||
             typeof p.singleSupplement === 'number',
         )
-        .map((p) => ({
-          optionId: p.optionId,
-          title: p.title || undefined,
-          accommodationType: p.accommodationType || undefined,
-          note: p.note || undefined,
-          pricePerPerson:
-            typeof p.pricePerPerson === 'number' ? p.pricePerPerson : undefined,
-          domesticFlightPerPerson:
-            typeof p.domesticFlightPerPerson === 'number'
-              ? p.domesticFlightPerPerson
-              : undefined,
-          singleSupplement:
-            typeof p.singleSupplement === 'number'
-              ? p.singleSupplement
-              : undefined,
-        })),
+        .map((p) => {
+          const prices: Array<{ type: 'adult' | 'child' | 'infant'; price: number }> = [];
+          if (typeof p.adultPrice === 'number') prices.push({ type: 'adult', price: p.adultPrice });
+          if (typeof p.childPrice === 'number') prices.push({ type: 'child', price: p.childPrice });
+          if (typeof p.infantPrice === 'number') prices.push({ type: 'infant', price: p.infantPrice });
+          return {
+            optionId: p.optionId,
+            title: p.title || undefined,
+            accommodationType: p.accommodationType || undefined,
+            note: p.note || undefined,
+            prices: prices.length > 0 ? prices : undefined,
+            domesticFlightPerPerson:
+              typeof p.domesticFlightPerPerson === 'number'
+                ? p.domesticFlightPerPerson
+                : undefined,
+            singleSupplement:
+              typeof p.singleSupplement === 'number'
+                ? p.singleSupplement
+                : undefined,
+          };
+        }),
     }));
 
   return cleaned.length ? cleaned : undefined;
@@ -196,7 +224,9 @@ export const syncTranslationPricingOptions = (
           title: '',
           accommodationType: '',
           note: '',
-          pricePerPerson: '',
+          adultPrice: '',
+          childPrice: '',
+          infantPrice: '',
           domesticFlightPerPerson: '',
           singleSupplement: '',
         }
@@ -209,10 +239,6 @@ export const syncTranslationPricingOptions = (
 
 /**
  * Returns the main-language name for form initialization.
- *
- * The backend always includes the main language entry in `translations`,
- * so we look it up there first. This works regardless of whether the
- * list query swapped `tour.name` to another language.
  *
  * Fallback chain: translations[mainLang] → tour.name → ''
  */


### PR DESCRIPTION
## Summary by Sourcery

Introduce passenger-type-based pricing for tour packages and propagate the new pricing model across backend schemas, GraphQL types, and frontend forms.

New Features:
- Allow configuring separate adult, child, and infant prices per tour pricing option instead of a single per-person price.
- Expose structured per-passenger-type prices via GraphQL and consume them in tour detail queries and UI forms.

Enhancements:
- Refactor pricing option validation and normalization in backend and frontend to support the new prices array while retaining backward compatibility with legacy pricePerPerson.
- Update translation helpers and schemas to handle per-passenger-type prices for pricing options in localized content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tours now support separate adult, child, and infant prices (per-pricing-option) while keeping legacy per-person pricing as a fallback.
* **UI**
  * Forms and list/detail views updated to enter and display adult/child/infant prices; form validation enforces adult price.
  * PDF label editor and exports include distinct labels for adult/child/infant pricing.
* **API / GraphQL**
  * API and GraphQL payloads now accept/return structured passenger-type prices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->