### PR TITLE
pmsRooms query range filter updated

### DIFF
--- a/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
@@ -21,25 +21,21 @@ const configQueries: Record<string, Resolver> = {
   async pmsRooms(
     _root,
     {
-      endDate1,
-      endDate2,
-      startDate1,
-      startDate2,
+      endDate,
+      startDate,
       pipelineId,
       perPage = 50,
       page = 1,
       skipStageIds = [],
     }: {
-      startDate1: Date;
-      startDate2: Date;
-      endDate1: Date;
-      endDate2: Date;
+      startDate: Date;
+      endDate: Date;
       pipelineId: string;
       perPage: number;
       page: number;
       skipStageIds: string[];
     },
-    { models, subdomain }: IContext,
+    { subdomain }: IContext,
   ) {
     const stages = await sendTRPCMessage({
       subdomain,
@@ -64,14 +60,8 @@ const configQueries: Record<string, Resolver> = {
           stageId: { $in: newArray },
           productsData: {
             $elemMatch: {
-              startDate: {
-                $gte: new Date(startDate1),
-                $lte: new Date(startDate2),
-              },
-              endDate: {
-                $gte: new Date(endDate1),
-                $lte: new Date(endDate2),
-              },
+              startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
+              endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
             },
           },
         },
@@ -85,19 +75,15 @@ const configQueries: Record<string, Resolver> = {
   async cpPmsRooms(
     _root,
     {
-      endDate1,
-      endDate2,
-      startDate1,
-      startDate2,
+      endDate,
+      startDate,
       pipelineId,
       perPage = 50,
       page = 1,
       skipStageIds = [],
     }: {
-      startDate1: Date;
-      startDate2: Date;
-      endDate1: Date;
-      endDate2: Date;
+      startDate: Date;
+      endDate: Date;
       pipelineId: string;
       perPage: number;
       page: number;
@@ -128,14 +114,8 @@ const configQueries: Record<string, Resolver> = {
           stageId: { $in: newArray },
           productsData: {
             $elemMatch: {
-              startDate: {
-                $gte: new Date(startDate1),
-                $lte: new Date(startDate2),
-              },
-              endDate: {
-                $gte: new Date(endDate1),
-                $lte: new Date(endDate2),
-              },
+              startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
+              endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
             },
           },
         },
@@ -364,3 +344,4 @@ configQueries.cpPmsCheckRooms.wrapperConfig = {
 configQueries.cpPmsRooms.wrapperConfig = {
   forClientPortal: true,
 };
+

--- a/backend/plugins/tourism_api/src/modules/pms/graphql/schemas/configs.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/graphql/schemas/configs.ts
@@ -22,10 +22,10 @@ export const types = `
 export const queries = `
   pmsConfigs: [PmsConfig]
   pmsConfigsGetValue(code:String): PmsConfig
-  pmsRooms(skipStageIds : [String], perPage:Int,page: Int, pipelineId:String! ,endDate1:Date,endDate2:Date, startDate1:Date ,startDate2:Date ): [Deal]
+  pmsRooms(skipStageIds : [String], perPage:Int,page: Int, pipelineId:String! ,endDate:Date, startDate:Date ): [Deal]
   pmsCheckRooms(skipStageIds : [String],pipelineId:String! ,endDate:Date, startDate:Date,ids:[String]): [Product]
 
-  cpPmsRooms(skipStageIds : [String], perPage:Int,page: Int, pipelineId:String! ,endDate1:Date,endDate2:Date, startDate1:Date ,startDate2:Date ): [Deal]
+  cpPmsRooms(skipStageIds : [String], perPage:Int,page: Int, pipelineId:String! ,endDate:Date, startDate:Date  ): [Deal]
   cpPmsCheckRooms(skipStageIds : [String],pipelineId:String! ,endDate:Date, startDate:Date,ids:[String]): [Product]
 `;
 


### PR DESCRIPTION
## Summary by Sourcery

Update PMS room GraphQL queries to use a single date range and return rooms overlapping that range.

Bug Fixes:
- Correct PMS room filters to match rooms whose date ranges overlap a given start and end date instead of requiring them to fall entirely within two separate ranges.

Enhancements:
- Simplify pmsRooms and cpPmsRooms query arguments from four date parameters to a single start and end date pair in resolvers and GraphQL schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range filtering logic for property management system room queries to correctly identify overlapping availability periods.

* **Refactor**
  * Simplified date range parameters in room availability queries from four separate inputs to two consolidated date parameters for improved API usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->