### PR TITLE
feat: add cp queries on BMSitinerary

### DIFF
--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/itinerary.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/itinerary.ts
@@ -5,11 +5,12 @@ import {
   ITINERARY_FIELD_MAPPINGS,
   applyItineraryTranslation,
 } from '@/bms/utils/translations';
+import { Resolver } from 'erxes-api-shared/core-types';
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-const itineraryQueries = {
+const itineraryQueries : Record<string, Resolver> = {
   async bmsItineraries(
     _root,
     { branchId, name, language, ...params },
@@ -46,6 +47,48 @@ const itineraryQueries = {
       applyItineraryTranslation,
     );
   },
+  async cpBmsItineraries(
+    _root,
+    { branchId, name, language, ...params },
+    { models }: IContext,
+  ) {
+    const selector: any = {};
+    if (branchId) selector.branchId = branchId;
+    if (name) selector.name = { $regex: escapeRegExp(name), $options: 'i' };
+
+    return getBmsListWithTranslations(
+      models,
+      models.Itineraries,
+      models.ItineraryTranslations,
+      selector,
+      { ...params, branchId, language },
+      ITINERARY_FIELD_MAPPINGS,
+      applyItineraryTranslation,
+    );
+  },
+  async cpBmsItineraryDetail(
+    _root,
+    { _id, language }: { _id: string; language?: string },
+    { models }: IContext,
+  ) {
+    return getBmsItemWithTranslation(
+      models,
+      models.Itineraries,
+      models.ItineraryTranslations,
+      { _id },
+      language,
+      ITINERARY_FIELD_MAPPINGS,
+      undefined,
+      applyItineraryTranslation,
+    );
+  },
 };
 
 export default itineraryQueries;
+
+itineraryQueries.cpBmsItineraries.wrapperConfig={
+  forClientPortal:true,
+}
+itineraryQueries.cpBmsItineraryDetail.wrapperConfig={
+  forClientPortal:true,
+}

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/itinerary.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/itinerary.ts
@@ -112,6 +112,8 @@ export const types = `
 export const queries = `
   bmsItineraries(${GQL_CURSOR_PARAM_DEFS}, branchId: String, name: String, language: String): ItineraryListResponse
   bmsItineraryDetail(_id: String!, language: String): Itinerary
+  cpBmsItineraries(${GQL_CURSOR_PARAM_DEFS}, branchId: String, name: String, language: String): ItineraryListResponse
+  cpBmsItineraryDetail(_id: String!, language: String): Itinerary
 `;
 
 const params = `


### PR DESCRIPTION
## Summary by Sourcery

Add client-portal specific itinerary queries and type annotations for BMS itinerary resolvers.

New Features:
- Expose cpBmsItineraries and cpBmsItineraryDetail GraphQL queries for client portal access to itineraries.

Enhancements:
- Type itineraryQueries as a resolver map using the shared Resolver type.
- Mark new client portal itinerary resolvers with wrapper configuration for client portal usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added itinerary browsing and detail view capabilities to the client portal with support for filtering by branch and name, plus multi-language support for itinerary content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->