### PR TITLE
fix(posclient): replace biased cryptoRandom helper with unbiased RNG

### DIFF
--- a/backend/plugins/posclient_api/src/modules/posclient/utils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils.ts
@@ -377,7 +377,7 @@ export const prepareSettlePayment = async (
         }
       } catch (e) {
         ebarimtResponses.push({
-          _id: `Err${cryptoRandom()}`,
+          _id: `Err${crypto.randomUUID()}`,
           id: 'Error',
           type: ebarimtData.type,
           date: moment(new Date()).format('"yyyy-MM-dd HH:mm:ss'),
@@ -555,10 +555,3 @@ export const prepareSettlePayment = async (
   }
 };
 
-export function cryptoRandom() {
-  // Generate a random 6-byte buffer (48 bits of entropy)
-  const randomBuffer = crypto.randomBytes(6);
-  // Convert to a number between 0 and 1
-  const randomNumber = randomBuffer.readUIntBE(0, 6) / 0x1000000000000; // 2^48
-  return randomNumber;
-}

--- a/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { nanoid } from 'nanoid';
+import * as crypto from 'node:crypto';
 
 import { checkDirectDiscount } from './directDiscount';
 import { checkLoyalties } from './loyalties';
@@ -30,7 +31,31 @@ import { getCompanyInfo } from '~/modules/posclient/db/models/PutData';
 import { IOrderInput, IOrderItemInput } from '~/modules/posclient/@types/types';
 import { IProductDocument } from '~/modules/posclient/@types/products';
 import { IPayment } from '~/modules/posclient/graphql/resolvers/mutations/orders';
-import { cryptoRandom } from '~/modules/posclient/utils';
+
+/**
+ * Returns an unbiased positive integer in `[1, maxSkipNumber]` for jittering
+ * sequential order numbers, using Node's cryptographically secure RNG.
+ *
+ * Falls back to `1` when no valid bound is supplied so callers keep the
+ * original "skip by at least one" behavior for missing or malformed config.
+ *
+ * @param maxSkipNumber - Upper bound (inclusive). Must be a finite number
+ *                        strictly greater than 1; non-integers are floored.
+ * @returns An integer in `[1, maxSkipNumber]`, or `1` when the bound is
+ *          missing, non-finite, or ≤ 1.
+ */
+const getRandomSkipAddend = (maxSkipNumber: number | undefined): number => {
+  if (
+    typeof maxSkipNumber !== 'number' ||
+    !Number.isFinite(maxSkipNumber) ||
+    maxSkipNumber <= 1
+  ) {
+    return 1;
+  }
+  const upperExclusive = Math.floor(maxSkipNumber) + 1;
+  // crypto.randomInt(min, max) returns an unbiased integer in [min, max).
+  return crypto.randomInt(1, upperExclusive);
+};
 
 export const generateOrderNumber = async (
   models: IModels,
@@ -79,11 +104,7 @@ export const generateOrderNumber = async (
       (suffixParts.length === 2 && suffixParts[1]) || suffixParts[0];
 
     const latestNum = Number.parseInt(latestSuffix, 10);
-    const addend =
-      (config?.maxSkipNumber &&
-        config?.maxSkipNumber > 1 &&
-        Math.round(cryptoRandom() * (config.maxSkipNumber - 1) + 1)) ||
-      1;
+    const addend = getRandomSkipAddend(config?.maxSkipNumber);
 
     suffix = String(latestNum + addend).padStart(4, '0');
     number = `${todayStr}_${beginNumber}${suffix}`;
@@ -637,7 +658,7 @@ export const prepareOrderDoc = async (
           Number(addProduct.prices?.[config.token]?.toFixed(2)) || 0;
 
         items.push({
-          _id: cryptoRandom().toString(),
+          _id: nanoid(),
           productId: addProduct._id,
           count: toAddItem.count,
           unitPrice: fixedUnitPrice,
@@ -658,7 +679,7 @@ export const prepareOrderDoc = async (
     if (deliveryProd) {
       const deliveryUnitPrice = deliveryProd.prices?.[config.token || ''] || 0;
       items.push({
-        _id: cryptoRandom().toString(),
+        _id: nanoid(),
         productId: deliveryProd._id,
         count: 1,
         unitPrice: deliveryUnitPrice,

--- a/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
@@ -33,16 +33,29 @@ import { IProductDocument } from '~/modules/posclient/@types/products';
 import { IPayment } from '~/modules/posclient/graphql/resolvers/mutations/orders';
 
 /**
+ * Upper limit for the range passed to `crypto.randomInt`. Node's
+ * `crypto.randomInt(min, max)` requires `max - min <= 2**48 - 1`, and throws
+ * `ERR_OUT_OF_RANGE` otherwise. We clamp the caller-supplied bound below this
+ * ceiling so a misconfigured large value degrades gracefully instead of
+ * crashing order creation.
+ */
+const MAX_RANDOM_SKIP_ADDEND = 2 ** 48 - 1;
+
+/**
  * Returns an unbiased positive integer in `[1, maxSkipNumber]` for jittering
  * sequential order numbers, using Node's cryptographically secure RNG.
  *
  * Falls back to `1` when no valid bound is supplied so callers keep the
  * original "skip by at least one" behavior for missing or malformed config.
+ * Oversized bounds are clamped to {@link MAX_RANDOM_SKIP_ADDEND} to stay
+ * within `crypto.randomInt`'s documented range.
  *
  * @param maxSkipNumber - Upper bound (inclusive). Must be a finite number
- *                        strictly greater than 1; non-integers are floored.
- * @returns An integer in `[1, maxSkipNumber]`, or `1` when the bound is
- *          missing, non-finite, or ≤ 1.
+ *                        strictly greater than 1; non-integers are floored
+ *                        and values above {@link MAX_RANDOM_SKIP_ADDEND}
+ *                        are clamped to it.
+ * @returns An integer in `[1, min(floor(maxSkipNumber), MAX_RANDOM_SKIP_ADDEND)]`,
+ *          or `1` when the bound is missing, non-finite, or ≤ 1.
  */
 const getRandomSkipAddend = (maxSkipNumber: number | undefined): number => {
   if (
@@ -52,9 +65,15 @@ const getRandomSkipAddend = (maxSkipNumber: number | undefined): number => {
   ) {
     return 1;
   }
-  const upperExclusive = Math.floor(maxSkipNumber) + 1;
+  const upperBound = Math.min(
+    Math.floor(maxSkipNumber),
+    MAX_RANDOM_SKIP_ADDEND,
+  );
+  if (upperBound <= 1) {
+    return 1;
+  }
   // crypto.randomInt(min, max) returns an unbiased integer in [min, max).
-  return crypto.randomInt(1, upperExclusive);
+  return crypto.randomInt(1, upperBound + 1);
 };
 
 export const generateOrderNumber = async (


### PR DESCRIPTION
## Summary

- Removes the posclient `cryptoRandom()` helper, which produced biased floats (`crypto.randomBytes(6) / 2^48`) that callers then scaled with `Math.round(… * (N-1) + 1)` — a classic source of non-uniform distribution when the RNG range doesn't divide evenly by N.
- Replaces each call site with the appropriate unbiased primitive:
  - **Order-number jitter** (`orderUtils.ts:85`) — the actually biased call — now uses a typed `getRandomSkipAddend` helper backed by `crypto.randomInt(1, N+1)`, which is unbiased by construction.
  - **Cart-item `_id`** (`orderUtils.ts:640, 661`) — now `nanoid()`, matching the existing pattern on `orderUtils.ts:566`.
  - **Error-response `_id`** (`utils.ts:380`) — now `crypto.randomUUID()`. Zero new dependencies (`crypto` was already imported).

Closes code scanning alert [#988](https://github.com/erxes/erxes/security/code-scanning/988) (`js/biased-cryptographic-random`, high severity).

## Why

The old helper divided a 48-bit integer by 2^48 to get a `[0, 1)` float. That float only has 2^48 distinct values, and scaling it with `Math.round(x * (N-1) + 1)` produces a distribution that is **not uniform** over `[1, N]` — values near the edges get short-changed. For a POS system that uses this to jitter sequential order numbers (an anti-guessing / anti-enumeration measure), bias directly weakens the protection.

`crypto.randomInt(min, max)` is the Node-native primitive that avoids this entire class of bug: it returns an unbiased integer in `[min, max)` via rejection sampling internally.

## Behavior change

- **Order-number addend:** still an integer in `[1, maxSkipNumber]`. Now truly uniform. Fallback to `1` preserved for missing/invalid `maxSkipNumber` (same as prior behavior). Non-integer `maxSkipNumber` is now floored explicitly (`Math.floor`).
- **Cart-item / error `_id`:** shape changes from `"0.12345..."` (float-as-string) to a `nanoid()` / UUID string. Type stays `string`. No code in the repo parses these as numbers; they're treated as opaque identifiers.

## Risks considered

| Risk | Mitigation |
|---|---|
| Other callers of `cryptoRandom` | Repo-wide grep confirmed only 3 callers, all in `posclient_api`, all updated in this commit. |
| `_id` shape change breaks a downstream consumer | Searched repo for `Err0.`, `\`Err\${` parsing, numeric `_id` assumptions — none found. `_id` is opaque throughout. `nanoid` is already the pattern on `orderUtils.ts:566`. |
| `config.maxSkipNumber` type variance | Helper guards with `typeof === 'number'` + `Number.isFinite` + `> 1` + `Math.floor`. Handles undefined, NaN, Infinity, 0, negatives, and non-integer floats — all fall back to `1`. |
| `crypto.randomInt` requires `min < max` | The helper guarantees `1 < Math.floor(maxSkipNumber) + 1` because the guard rejects `maxSkipNumber ≤ 1`. |
| Node API availability | `crypto.randomInt` (14.10+), `crypto.randomUUID` (14.17+), `nanoid` (existing dep). Project requires Node 18+. |

## Verification

- `tsc --noEmit -p backend/plugins/posclient_api/tsconfig.build.json` → exit 0.
- `grep -rn 'cryptoRandom'` across `backend/`, `frontend/`, `apps/` → 0 matches.
- Runtime test against the new `getRandomSkipAddend` helper (14 assertions, all pass):
  - Fallback to `1` for `undefined`, `0`, `1`, negative, `NaN`, `Infinity`.
  - 20 000 samples with `N=10` — every sample in `[1, 10]`, all 10 distinct values produced, max deviation from uniform was 105 (well within tolerance).
  - `maxSkipNumber = 3.7` → max observed value `3` (floor applied).
  - `crypto.randomUUID()` produces 1000 unique strings.

## Test plan

- [ ] Boot posclient_api, open the POS client, place orders, confirm order numbers are generated without errors and advance by a random-looking amount when `maxSkipNumber > 1`.
- [ ] Trigger a delivery order (hits `orderUtils.ts:679`) — confirm the cart item gets a `nanoid()`-style `_id` in the order document.
- [ ] Trigger an ebarimt error path (e.g., misconfigured ebarimt) — confirm the error response has `_id: "Err<uuid>"` shape.
- [ ] Run existing posclient_api test suite (if any) — no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved randomness and uniqueness for order identifiers and generated order numbers to enhance robustness and security.
  * Replaced prior random-number approach with a more secure, unbiased generator and safer bounds handling for skip values.
  * Appended item IDs now use stronger unique identifiers; existing fallback behaviors preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->