### PR TITLE
fix: update POS mobileSheet to use new payment widget URL

### DIFF
--- a/apps/posclient-front/modules/checkout/components/paymentTypes/mobileSheet.tsx
+++ b/apps/posclient-front/modules/checkout/components/paymentTypes/mobileSheet.tsx
@@ -17,6 +17,8 @@ import { onError } from "@/components/ui/use-toast"
 
 const MobileSheet = () => {
   const [loading, setLoading] = useState(true)
+  const [invoiceUrl, setInvoiceUrl] = useState<string | null>(null)
+
   const config = useAtomValue(configAtom)
   const amount = useAtomValue(currentAmountAtom)
   const activeOrderId = useAtomValue(activeOrderIdAtom)
@@ -24,45 +26,84 @@ const MobileSheet = () => {
   const customerType = useAtomValue(customerTypeAtom)
   const orderNumber = useAtomValue(orderNumberAtom)
 
-  const [generateInvoiceUrl, { data }] = useMutation(
-    mutations.generateInvoiceUrl,
-    {
-      context: {
-        headers: { "erxes-app-token": config?.erxesAppToken },
-      },
-      client: clientMain,
-      onError(error) {
-        onError(error.message)
-      },
-    }
-  )
+  const [generateInvoiceUrl] = useMutation(mutations.generateInvoiceUrl, {
+    context: {
+      headers: { "erxes-app-token": config?.erxesAppToken },
+    },
+    client: clientMain,
+    onError(error) {
+      onError(error.message)
+      setLoading(false)
+    },
+  })
+
+  // 🔥 generate invoice + set iframe URL
   useEffect(() => {
-    generateInvoiceUrl({
-      variables: {
-        input: {
-          amount,
-          contentType: "pos:orders",
-          contentTypeId: activeOrderId,
-          customerId: customer?._id ? customer?._id : "empty",
-          customerType: customerType || "customer",
-          description: orderNumber + "-" + config?.name + "-" + activeOrderId,
-          paymentIds: config?.paymentIds,
-          data: {
-            posToken: config?.token,
+    const run = async () => {
+      try {
+        console.log("🔥 Generating invoice...")
+
+        const res = await generateInvoiceUrl({
+          variables: {
+            input: {
+              amount,
+              contentType: "pos:orders",
+              contentTypeId: activeOrderId,
+              customerId: customer?._id || "empty",
+              customerType: customerType || "customer",
+              description:
+                orderNumber + "-" + config?.name + "-" + activeOrderId,
+              paymentIds: config?.paymentIds,
+              data: {
+                posToken: config?.token,
+              },
+            },
           },
-        },
-      },
-      onCompleted() {
+        })
+
+        const url = res?.data?.generateInvoiceUrl
+
+        console.log("✅ Invoice URL:", url)
+
+        if (!url) {
+          console.error("❌ No invoice URL returned")
+          setLoading(false)
+          return
+        }
+
+        // ✅ IMPORTANT: use iframe instead of redirect
+        setInvoiceUrl(`http://localhost:4200${url}`)
         setLoading(false)
-      },
-    })
+      } catch (err) {
+        console.error("❌ Error generating invoice:", err)
+        setLoading(false)
+      }
+    }
+
+    run()
   }, [])
 
-  if (loading) {
-    return <Loader />
-  }
+  //  listen for postMessage from widget
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      console.log("📩 RECEIVED:", event.data)
 
-  return <iframe src={data?.generateInvoiceUrl} className="w-full h-full" />
+      if (event.data?.message === "paymentSuccessful") {
+        alert("✅ Payment success (POS)")
+      }
+    }
+
+    window.addEventListener("message", handler)
+
+    return () => window.removeEventListener("message", handler)
+  }, [])
+
+  // UI states
+  if (loading) return <Loader />
+
+  if (!invoiceUrl) return <div>Failed to load payment</div>
+
+  return <iframe src={invoiceUrl} className="w-full h-full border-0" />
 }
 
 export default MobileSheet


### PR DESCRIPTION
- Use http://localhost:4200 as base for payment widget (new standalone app)
- Add proper loading and error handling
- Listen for postMessage to confirm payment success

## Summary by Sourcery

Update POS mobile payment sheet to use the new standalone payment widget and improve its state handling.

New Features:
- Embed the payment widget in an iframe using a generated invoice URL based on the new localhost payment app.
- Handle payment success by listening for postMessage events from the embedded widget.

Bug Fixes:
- Ensure loading state is cleared and a fallback message is shown when invoice URL generation fails.

Enhancements:
- Improve error handling for invoice URL generation by surfacing toast errors and preventing stuck loading states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded payment processing interface to mobile checkout flow
  * Implemented real-time payment success notifications from the payment widget

* **Improvements**
  * Enhanced loading state management during payment processing
  * Improved error handling with better visual feedback when issues occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->