### PR TITLE
fix empty table bug after editing cell in ProductsTable in Sales/Deal

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
@@ -14,7 +14,7 @@ const Products = ({ deal, refetch }: { deal: IDeal; refetch: () => void }) => {
   return (
     <div className="relative">
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v)}>
-        <Tabs.List className="bg-accent rounded-md mb-4 w-fit px-1 border-none !no-underline">
+        <Tabs.List className="bg-accent rounded-md mb-4 w-fit px-1 border-none no-underline!">
           <Tabs.Trigger
             className="w-20 cursor-pointer font-normal data-[state=active]:bg-background data-[state=active]:shadow after:content-none after:border-none after:shadow-none after:bg-transparent"
             value="product"

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/getProductColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/getProductColumns.tsx
@@ -1,4 +1,3 @@
-
 import {
   Checkbox,
   CurrencyCode,
@@ -22,8 +21,6 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { useUpdateProductRecord } from '../hooks/useProductRecord';
 import { calculateProductValues } from '../hooks/useProductCalculations';
-import { useAtomValue } from 'jotai';
-import { onLocalChangeAtom } from '../productTableAtom';
 
 export const ProductNumberField = ({
   value,
@@ -35,7 +32,7 @@ export const ProductNumberField = ({
 
   return (
     <NumberField
-     key={`${_id}-${field}-${value}`}
+      key={`${_id}-${field}-${value}`}
       value={value}
       scope={`product-${_id}-${field}`}
       onSave={(value) => {
@@ -51,10 +48,8 @@ export const ProductCalculatedNumberField = ({
   _id,
   product,
 }: INumberFieldContainerProps & { product: IProductData }) => {
-
   const { updateRecord } = useUpdateProductRecord();
- const onLocalChange = useAtomValue(onLocalChangeAtom);
- 
+
   return (
     <NumberField
       value={value}
@@ -63,7 +58,6 @@ export const ProductCalculatedNumberField = ({
         const base = { ...product, [field]: value };
         const updates = calculateProductValues(field, base);
         const fullUpdate = { [field]: value, ...updates };
-        onLocalChange?.(_id, fullUpdate);
         updateRecord(product, fullUpdate);
       }}
     />
@@ -128,12 +122,10 @@ export const ProductAssigneeField = ({
 export const ProductCurrencyField = ({
   value,
   field,
-  _id,
   product,
 }: {
   value: CurrencyCode;
   field: string;
-  _id: string;
   product: IProductData;
 }) => {
   const { updateRecord } = useUpdateProductRecord();
@@ -152,12 +144,10 @@ export const ProductCurrencyField = ({
 export const ProductUOMField = ({
   value,
   field,
-  _id,
   product,
 }: {
   value: string;
   field: string;
-  _id: string;
   product: IProductData;
 }) => {
   const { updateRecord } = useUpdateProductRecord();
@@ -173,12 +163,10 @@ export const ProductUOMField = ({
 export const ProductBranchField = ({
   value,
   field,
-  _id,
   product,
 }: {
   value: string;
   field: string;
-  _id: string;
   product: IProductData;
 }) => {
   const { updateRecord } = useUpdateProductRecord();
@@ -197,12 +185,10 @@ export const ProductBranchField = ({
 export const ProductDepartmentField = ({
   value,
   field,
-  _id,
   product,
 }: {
   value: string;
   field: string;
-  _id: string;
   product: IProductData;
 }) => {
   const { updateRecord } = useUpdateProductRecord();
@@ -266,7 +252,6 @@ export const currency: ColumnDef<IProductData> = {
         <ProductCurrencyField
           value={cell.getValue() as CurrencyCode}
           field="currency"
-          _id={cell.row.original._id}
           product={cell.row.original}
         />
       </RecordTableInlineCell>
@@ -284,7 +269,6 @@ export const uom: ColumnDef<IProductData> = {
         <ProductUOMField
           value={cell.getValue() as string}
           field="uom"
-          _id={cell.row.original._id}
           product={cell.row.original}
         />
       </RecordTableInlineCell>
@@ -301,7 +285,6 @@ export const branch: ColumnDef<IProductData> = {
       <ProductBranchField
         value={cell.getValue() as string}
         field="branchId"
-        _id={cell.row.original._id}
         product={cell.row.original}
       />
     );
@@ -320,7 +303,6 @@ export const department: ColumnDef<IProductData> = {
         <ProductDepartmentField
           value={cell.getValue() as string}
           field="departmentId"
-          _id={cell.row.original._id}
           product={cell.row.original}
         />
       </RecordTableInlineCell>

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealsEditProductData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealsEditProductData.tsx
@@ -23,8 +23,7 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
           title: 'Success',
           variant: 'success',
         });
-        options?.onCompleted?.(data);
-        const newDocs = data.dealsEditProductData.productData;
+        const nextProductsData = data.dealsEditProductData.productsData;
 
         // Update Apollo cache manually
         client.cache.modify({
@@ -34,10 +33,12 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
           }),
           fields: {
             products(existingProducts = []) {
-              return [...existingProducts, ...newDocs];
+              return [...existingProducts, ...nextProductsData];
             },
           },
         });
+
+        options?.onCompleted?.(data);
       },
       onError: (e) => {
         toast({


### PR DESCRIPTION
## Summary by Sourcery

Fix product table update behavior after inline edits in deal details and adjust related product field components.

Bug Fixes:
- Ensure updated product data is correctly merged into the Apollo cache after editing products in a deal, preventing the products table from becoming empty.

Enhancements:
- Simplify product field components by removing unused local change atom wiring and redundant props from currency, UOM, branch, and department fields.
- Tweak the products tab list styling in the deal detail view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected tab underline styling in product detail views for improved visual consistency.

* **Refactor**
  * Simplified product field components and optimized data update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->