### PR TITLE
fix: ticket departmentIds not saved or filtered correctly

### DIFF
--- a/packages/core/src/data/resolvers/queries/fields.ts
+++ b/packages/core/src/data/resolvers/queries/fields.ts
@@ -199,30 +199,26 @@ const fieldQueries = {
           (pfv && pfv[pipelineId]) ?? group.config?.fieldVisibility;
 
         if (group.isDefinedByErxes) {
+          const allGroupFields = await models.Fields.find({
+            groupId: group._id,
+            contentType: query.contentType,
+          }).sort({ order: 1 });
 
-          if (fv && Object.keys(fv).length > 0) {
-            const shownFieldIds = Object.keys(fv).filter(
-              (id) => fv![id] === true,
-            );
+          const configuredIds = new Set(fv ? Object.keys(fv) : []);
 
-            if (shownFieldIds.length > 0) {
-              const groupFields = await models.Fields.find({
-                groupId: group._id,
-                contentType: query.contentType,
-                _id: { $in: shownFieldIds },
-              }).sort({ order: 1 });
-
-              allFields.push(...groupFields);
+          const visible = allGroupFields.filter((f) => {
+            const id = String(f._id);
+            if (configuredIds.has(id)) {
+              return fv![id] === true;
             }
-          } else {
-            const groupFields = await models.Fields.find({
-              groupId: group._id,
-              contentType: query.contentType,
-              isVisible: { $ne: false },
-            }).sort({ order: 1 });
+        
+            if (isVisibleToCreate !== undefined) {
+              return f.isVisibleToCreate === isVisibleToCreate;
+            }
+            return f.isVisible !== false;
+          });
 
-            allFields.push(...groupFields);
-          }
+          allFields.push(...visible);
         } else {
           const groupFields = await models.Fields.find({
             groupId: group._id,

--- a/packages/plugin-inbox-api/src/graphql/conversationTypeDefs.ts
+++ b/packages/plugin-inbox-api/src/graphql/conversationTypeDefs.ts
@@ -252,6 +252,7 @@ const convertParams = `
   isCheckUser: Boolean
   isHideName: Boolean
   branchIds: [String]
+  departmentIds: [String]
   tagIds:[String]
   stageId: String
   customFieldsData: JSON

--- a/packages/plugin-inbox-api/src/graphql/resolvers/conversationMutations.ts
+++ b/packages/plugin-inbox-api/src/graphql/resolvers/conversationMutations.ts
@@ -65,6 +65,7 @@ interface IConversationConvert {
   isHideName?: boolean;
   customFieldsData?: { [key: string]: any };
   branchIds?: string[];
+  departmentIds?: string[];
   priority?: string;
   assignedUserIds?: string[];
   labelIds?: string[];

--- a/packages/plugin-tickets-api/src/forms.ts
+++ b/packages/plugin-tickets-api/src/forms.ts
@@ -34,11 +34,6 @@ const relations = (type) => {
       relationType: "core:company",
     },
     {
-      name: "departmentsIds",
-      label: "Departments",
-      relationType: "tickets:department",
-    },
-    {
       name: "sourceIds",
       label: "Source",
       relationType: "tickets:source",

--- a/packages/plugin-tickets-api/src/graphql/resolvers/queries/utils.ts
+++ b/packages/plugin-tickets-api/src/graphql/resolvers/queries/utils.ts
@@ -473,32 +473,13 @@ export const generateCommonFilters = async (
     const user = await sendCoreMessage({
       subdomain,
       action: "users.findOne",
-      data: {
-        _id: currentUserId,
-      },
+      data: { _id: currentUserId },
       isRPC: true,
     });
-    const tmp =
-      (await sendCoreMessage({
-        subdomain,
-        action: "departments.findWithChild",
-        data: {
-          query: {
-            supervisorId: currentUserId,
-          },
-          fields: {
-            _id: 1,
-          },
-        },
-        isRPC: true,
-      })) || [];
-    const supervisorDepartmentIds = tmp?.map((x) => x._id) || [];
-    const pipelineDepartmentIds = pipeline.departmentIds || [];
 
-    const commonIds =
-      supervisorDepartmentIds.filter((id) =>
-        pipelineDepartmentIds.includes(id),
-      ) || [];
+    const pipelineDepartmentIds = pipeline.departmentIds || [];
+    const userDepartmentIds: string[] = user?.departmentIds || [];
+    const userBranchIds: string[] = user?.branchIds || [];
 
     const isEligibleSeeAllCards =
       user.role === "system" ||
@@ -506,110 +487,45 @@ export const generateCommonFilters = async (
       (pipeline.excludeCheckUserIds || []).includes(currentUserId);
 
     if (
-      commonIds?.length > 0 &&
-      (pipeline.isCheckUser || pipeline.isCheckDepartment) &&
+      (pipeline.isCheckUser || pipeline.isCheckDepartment || pipeline.isCheckBranch) &&
       !isEligibleSeeAllCards
     ) {
-      // current user is supervisor in departments and this pipeline has included that some of user's departments
-      // so user is eligible to see all cards of people who share same department.
-      const otherDepartmentUsers = await sendCoreMessage({
-        subdomain,
-        action: "users.find",
-        data: {
-          query: { departmentIds: { $in: commonIds } },
-        },
-        isRPC: true,
-        defaultValue: [],
-      });
-      let includeCheckUserIds = otherDepartmentUsers.map((x) => x._id) || [];
-      includeCheckUserIds = includeCheckUserIds.concat(user._id || []);
-
-      const uqinueCheckUserIds = [
-        ...new Set(includeCheckUserIds.concat(currentUserId)),
+      // Creator/assignee always sees their own tickets.
+      const orClauses: any[] = [
+        { userId: currentUserId },
+        { assignedUserIds: { $in: [currentUserId] } },
       ];
 
-      Object.assign(filter, {
-        $or: [
-          { assignedUserIds: { $in: uqinueCheckUserIds } },
-          { userId: { $in: uqinueCheckUserIds } },
-        ],
-      });
-    } else {
-      if (
-        (pipeline.isCheckUser || pipeline.isCheckDepartment) &&
-        !isEligibleSeeAllCards
-      ) {
-        let includeCheckUserIds: string[] = [];
+      if (pipeline.isCheckDepartment && userDepartmentIds.length > 0) {
+        // Primary check: ticket must be tagged with one of the user's departments.
+        orClauses.push({ departmentIds: { $in: userDepartmentIds } });
 
-        if (pipeline.isCheckDepartment) {
-          const userDepartmentIds = user?.departmentIds || [];
-          const commonIds = userDepartmentIds.filter((id) =>
-            pipelineDepartmentIds.includes(id),
-          );
-
-          const otherDepartmentUsers = await sendCoreMessage({
+        // Supervisor extension: also show tickets tagged with departments the user
+        // supervises that are configured on the pipeline.
+        const supervisorDepartments =
+          (await sendCoreMessage({
             subdomain,
-            action: "users.find",
+            action: "departments.findWithChild",
             data: {
-              query: { departmentIds: { $in: commonIds } },
+              query: { supervisorId: currentUserId },
+              fields: { _id: 1 },
             },
             isRPC: true,
             defaultValue: [],
-          });
-
-          for (const departmentUser of otherDepartmentUsers) {
-            includeCheckUserIds = [...includeCheckUserIds, departmentUser._id];
-          }
-
-          if (
-            !!pipelineDepartmentIds.filter((departmentId) =>
-              userDepartmentIds.includes(departmentId),
-            ).length
-          ) {
-            includeCheckUserIds = includeCheckUserIds.concat(user._id || []);
-          }
+          })) || [];
+        const supervisorOverlap = supervisorDepartments
+          .map((d) => d._id)
+          .filter((id) => pipelineDepartmentIds.includes(id));
+        if (supervisorOverlap.length > 0) {
+          orClauses.push({ departmentIds: { $in: supervisorOverlap } });
         }
-
-        const uqinueCheckUserIds = [
-          ...new Set(includeCheckUserIds.concat(currentUserId)),
-        ];
-
-        Object.assign(filter, {
-          $or: [
-            { assignedUserIds: { $in: uqinueCheckUserIds } },
-            { userId: { $in: uqinueCheckUserIds } },
-          ],
-        });
       }
-    }
 
-    const orConditions: any[] = [{ userId: currentUserId }];
-
-    if (pipeline.isCheckBranch === true && user?.branchIds?.length) {
-      orConditions.push({ branchIds: { $in: user.branchIds } });
-    }
-
-    if (pipeline.isCheckDepartment === true) {
-      // Keep department-based visibility: ticket tagged with user's department is visible.
-      if (user?.departmentIds?.length) {
-        orConditions.push({ departmentIds: { $in: user.departmentIds } });
+      if (pipeline.isCheckBranch && userBranchIds.length > 0) {
+        orClauses.push({ branchIds: { $in: userBranchIds } });
       }
-      // Expand to branch-level visibility: ticket tagged with user's branch is also visible.
-      if (user?.branchIds?.length) {
-        orConditions.push({ branchIds: { $in: user.branchIds } });
-      }
-    }
 
-    if (
-      (pipeline.isCheckBranch === true && user?.branchIds?.length) ||
-      (pipeline.isCheckDepartment === true &&
-        (user?.departmentIds?.length || user?.branchIds?.length))
-    ) {
-      if (filter.$or) {
-        filter.$or = [...filter.$or, ...orConditions];
-      } else {
-        filter.$or = orConditions;
-      }
+      Object.assign(filter, { $or: orClauses });
     }
   }
 

--- a/packages/ui-tickets/src/boards/components/editForm/Sidebar.tsx
+++ b/packages/ui-tickets/src/boards/components/editForm/Sidebar.tsx
@@ -57,6 +57,15 @@ class Sidebar extends React.Component<Props> {
               }}
             />
           </FormGroup>
+          <FormGroup>
+            <ControlLabel>{__("Departments")}</ControlLabel>
+            <SelectDepartments
+              name="departmentIds"
+              label="Choose departments"
+              onSelect={onChangeStructure}
+              initialValue={item?.departmentIds}
+            />
+          </FormGroup>
           <ControlLabel>Assigned to</ControlLabel>
           <SelectTeamMembers
             label="Choose users"
@@ -68,29 +77,6 @@ class Sidebar extends React.Component<Props> {
               branchIds,
             }}
           />
-        </FormGroup>
-
-        <FormGroup>
-          {relations.map((relation) => {
-            if (
-              relation.type === "departmentIds" ||
-              relation.relationType === "tickets:department"
-            ) {
-              return (
-                <React.Fragment key={relation._id}>
-                  <ControlLabel>{__("Departments")}</ControlLabel>
-                  <SelectDepartments
-                    name="departmentIds"
-                    label="Choose departments"
-                    onSelect={onChangeStructure}
-                    initialValue={item?.departmentIds}
-                  />
-                </React.Fragment>
-              );
-            }
-
-            return null;
-          })}
         </FormGroup>
 
         {sidebar && sidebar(saveItem)}

--- a/packages/ui-tickets/src/boards/graphql/mutations.ts
+++ b/packages/ui-tickets/src/boards/graphql/mutations.ts
@@ -286,6 +286,7 @@ mutation conversationConvertToCard(
   $isCheckUser: Boolean
   $isHideName: Boolean
   $branchIds: [String]
+  $departmentIds: [String]
   $tagIds: [String]
   $labelIds: [String]
   $priority: String
@@ -306,6 +307,7 @@ mutation conversationConvertToCard(
     isCheckUser: $isCheckUser
     isHideName: $isHideName
     branchIds: $branchIds
+    departmentIds: $departmentIds
     tagIds: $tagIds
     labelIds: $labelIds
     priority: $priority


### PR DESCRIPTION
## Summary by Sourcery

Tighten ticket visibility rules around user, department, and branch checks while wiring department IDs consistently through ticket creation and UI, and adjust dynamic field-group visibility logic for defined-by-Erxes fields.

Bug Fixes:
- Ensure ticket filtering correctly respects a user's own tickets plus department and branch-based visibility, including supervisor department overlap within pipelines.
- Fix department associations not being saved or applied when converting conversations to tickets by exposing departmentIds in GraphQL mutations and UI.

Enhancements:
- Simplify and centralize visibility logic for Erxes-defined field groups by deriving shown fields from group configuration, visibility flags, and create-visibility settings.
- Streamline the ticket sidebar by always showing an explicit Departments selector instead of relying on relation-based configuration.