### PR TITLE
add cp mutations on cms

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/category.ts
@@ -1,4 +1,9 @@
+import { Resolver } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
+import {
+  assertOwnedDocument,
+  requireClientPortalId,
+} from '@/cms/graphql/utils/clientPortal';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -35,7 +40,7 @@ const saveCategoryTranslations = async (
   );
 };
 
-export const contentCmsCategoryMutations = {
+export const contentCmsCategoryMutations : Record<string, Resolver> = {
   /**
    * Cms category add
    */
@@ -57,6 +62,59 @@ export const contentCmsCategoryMutations = {
       const defaultLanguage = await getDefaultLanguage(
         models,
         categoryInput.clientPortalId,
+      );
+
+      const fallback =
+        translations.find(
+          (translation: any) => translation?.language === defaultLanguage,
+        ) || translations[0];
+
+      if (fallback) {
+        categoryInput.name = fallback.title || categoryInput.name;
+        categoryInput.description =
+          fallback.content || categoryInput.description;
+        categoryInput.customFieldsData =
+          fallback.customFieldsData || categoryInput.customFieldsData;
+      }
+    }
+
+    const category = await models.Categories.createCategory(categoryInput);
+
+    await saveCategoryTranslations(models, category._id, translations || []);
+
+    return category;
+  },
+
+  cpCmsCategoriesAdd: async (
+    _parent: any,
+    args: any,
+    context: IContext,
+  ): Promise<any> => {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { translations, clientPortalId: _ignored, ...categoryInput } = input;
+    delete categoryInput.language;
+
+    categoryInput.clientPortalId = clientPortalId;
+
+    if (categoryInput.parentId) {
+      await assertOwnedDocument(
+        models.Categories,
+        categoryInput.parentId,
+        clientPortalId,
+        'Parent category not found',
+      );
+    }
+
+    if (
+      (!categoryInput.name || !String(categoryInput.name).trim()) &&
+      Array.isArray(translations) &&
+      translations.length > 0
+    ) {
+      const defaultLanguage = await getDefaultLanguage(
+        models,
+        clientPortalId,
       );
 
       const fallback =
@@ -184,3 +242,7 @@ export const contentCmsCategoryMutations = {
     return models.Categories.toggleStatus(_id);
   },
 };
+
+contentCmsCategoryMutations.cpCmsCategoriesAdd.wrapperConfig={
+  forClientPortal:true,
+}

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/cms.ts
@@ -1,7 +1,9 @@
 import { IContext } from '~/connectionResolvers';
 import { IContentCMSInput } from '@/cms/@types/cms';
+import { Resolver } from 'erxes-api-shared/core-types';
+import { requireClientPortalId } from '@/cms/graphql/utils/clientPortal';
 
-export const contentCmsMutations = {
+export const contentCmsMutations: Record<string, Resolver> = {
   contentCreateCMS: async (
     _parent: any,
     { input }: { input: IContentCMSInput },
@@ -9,6 +11,22 @@ export const contentCmsMutations = {
   ) => {
     return models.CMS.createContentCMS(input);
   },
+
+  cpContentCreateCMS: async (
+    _parent: any,
+    { input }: { input: IContentCMSInput },
+    context: IContext,
+  ) => {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { clientPortalId: _ignored, ...cmsInput } = input || {};
+
+    return models.CMS.createContentCMS({
+      ...cmsInput,
+      clientPortalId,
+    });
+  },
+
   contentUpdateCMS: async (
     _parent: any,
     { id, input }: { id: string; input: IContentCMSInput },
@@ -23,4 +41,9 @@ export const contentCmsMutations = {
   ) => {
     return models.CMS.deleteContentCMS(id);
   },
+};
+
+
+contentCmsMutations.cpContentCreateCMS.wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/customPostType.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/customPostType.ts
@@ -1,12 +1,26 @@
+import { Resolver } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
+import { requireClientPortalId } from '@/cms/graphql/utils/clientPortal';
 const systemTypes = ['page', 'post', 'category'];
 
-const mutations = {
+const mutations : Record<string, Resolver> = {
   async cmsCustomFieldGroupsAdd(_parent: any, args: any, context: IContext) {
     const { models } = context;
     const { input } = args;
 
     return models.CustomFieldGroups.createFieldGroup(input);
+  },
+
+  async cpCmsCustomFieldGroupsAdd(_parent: any, args: any, context: IContext) {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { clientPortalId: _ignored, ...fieldGroupInput } = input;
+
+    return models.CustomFieldGroups.createFieldGroup({
+      ...fieldGroupInput,
+      clientPortalId,
+    });
   },
 
   async cmsCustomFieldGroupsEdit(_parent: any, args: any, context: IContext) {
@@ -34,6 +48,22 @@ const mutations = {
     return models.CustomPostTypes.createCustomPostType(input);
   },
 
+  cpCmsCustomPostTypesAdd(_parent: any, args: any, context: IContext) {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { clientPortalId: _ignored, ...customPostTypeInput } = input;
+
+    if (systemTypes.includes(customPostTypeInput.code)) {
+      throw new Error('Cannot add system post type');
+    }
+
+    return models.CustomPostTypes.createCustomPostType({
+      ...customPostTypeInput,
+      clientPortalId,
+    });
+  },
+
   cmsCustomPostTypesEdit(_parent: any, args: any, context: IContext) {
     const { models } = context;
     const { _id, input } = args;
@@ -56,3 +86,10 @@ const mutations = {
 };
 
 export default mutations;
+
+mutations.cpCmsCustomFieldGroupsAdd.wrapperConfig = {
+  forClientPortal: true,
+};
+mutations.cpCmsCustomPostTypesAdd.wrapperConfig = {
+  forClientPortal: true,
+};

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/page.ts
@@ -1,4 +1,9 @@
+import { Resolver } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
+import {
+  assertOwnedDocument,
+  requireClientPortalId,
+} from '@/cms/graphql/utils/clientPortal';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -33,7 +38,7 @@ const savePageTranslations = async (
   );
 };
 
-const mutations = {
+const mutations : Record<string, Resolver> = {
   async cmsPagesAdd(_parent: any, args: any, context: IContext): Promise<any> {
     const { user, models } = context;
     const { input } = args;
@@ -50,6 +55,55 @@ const mutations = {
       const defaultLanguage = await getDefaultLanguage(
         models,
         pageInput.clientPortalId,
+      );
+
+      const fallback =
+        (defaultLanguage &&
+          translations.find((t: any) => t?.language === defaultLanguage)) ||
+        translations[0];
+
+      if (fallback) {
+        pageInput.name = fallback.title || pageInput.name;
+        pageInput.description = fallback.content || pageInput.description;
+        pageInput.customFieldsData =
+          fallback.customFieldsData || pageInput.customFieldsData;
+      }
+    }
+
+    const page = await models.Pages.createPage(pageInput);
+
+    await savePageTranslations(models, page._id, translations || []);
+
+    return page;
+  },
+
+  async cpCmsPagesAdd(_parent: any, args: any, context: IContext): Promise<any> {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { translations, language, clientPortalId: _ignored, ...pageInput } =
+      input;
+
+    pageInput.clientPortalId = clientPortalId;
+
+    if (pageInput.parentId) {
+      await assertOwnedDocument(
+        models.Pages,
+        pageInput.parentId,
+        clientPortalId,
+        'Parent page not found',
+      );
+    }
+
+    // If name is empty, derive from default-language translation
+    if (
+      (!pageInput.name || !String(pageInput.name).trim()) &&
+      Array.isArray(translations) &&
+      translations.length > 0
+    ) {
+      const defaultLanguage = await getDefaultLanguage(
+        models,
+        clientPortalId,
       );
 
       const fallback =
@@ -130,3 +184,7 @@ const mutations = {
 };
 
 export default mutations;
+
+mutations.cpCmsPagesAdd.wrapperConfig={
+  forClientPortal:true,
+}

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
@@ -1,6 +1,11 @@
 import { Resolver } from 'erxes-api-shared/core-types';
 import { POST_REACTION_TYPES, PostReactionType } from '@/cms/@types/posts';
 import { IContext } from '~/connectionResolvers';
+import {
+  assertOwnedDocument,
+  assertOwnedDocuments,
+  requireClientPortalId,
+} from '@/cms/graphql/utils/clientPortal';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -44,6 +49,73 @@ export const postMutations: Record<string, Resolver> = {
       const defaultLanguage = await getDefaultLanguage(
         models,
         postInput.clientPortalId,
+      );
+
+      const fallback =
+        (defaultLanguage &&
+          translations.find((t: any) => t?.language === defaultLanguage)) ||
+        translations[0];
+
+      if (fallback) {
+        postInput.title = fallback.title || postInput.title;
+        postInput.content = fallback.content || postInput.content;
+        postInput.excerpt = fallback.excerpt || postInput.excerpt;
+        postInput.customFieldsData =
+          fallback.customFieldsData || postInput.customFieldsData;
+      }
+    }
+
+    const post = await models.Posts.createPost(postInput);
+
+    await saveTranslations(models, post._id, translations || []);
+
+    return post;
+  },
+
+  cpCmsPostsAdd: async (_parent, args, context: IContext) => {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { translations, language, clientPortalId: _ignored, ...postInput } =
+      input;
+
+    postInput.clientPortalId = clientPortalId;
+
+    if (Array.isArray(postInput.categoryIds) && postInput.categoryIds.length) {
+      await assertOwnedDocuments(
+        models.Categories,
+        postInput.categoryIds,
+        clientPortalId,
+        'Category not found',
+      );
+    }
+
+    if (Array.isArray(postInput.tagIds) && postInput.tagIds.length) {
+      await assertOwnedDocuments(
+        models.PostTags,
+        postInput.tagIds,
+        clientPortalId,
+        'Tag not found',
+      );
+    }
+
+    if (postInput.webId) {
+      await assertOwnedDocument(
+        models.Web,
+        postInput.webId,
+        clientPortalId,
+        'Web not found',
+      );
+    }
+
+    if (
+      (!postInput.title || !String(postInput.title).trim()) &&
+      Array.isArray(translations) &&
+      translations.length > 0
+    ) {
+      const defaultLanguage = await getDefaultLanguage(
+        models,
+        clientPortalId,
       );
 
       const fallback =
@@ -225,5 +297,8 @@ export const postMutations: Record<string, Resolver> = {
 };
 
 postMutations.cpPostsReact.wrapperConfig = {
+  forClientPortal: true,
+};
+postMutations.cpCmsPostsAdd.wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/tag.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/tag.ts
@@ -1,4 +1,6 @@
+import { Resolver } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
+import { requireClientPortalId } from '@/cms/graphql/utils/clientPortal';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -35,7 +37,7 @@ const saveTagTranslations = async (
   );
 };
 
-export const contentCmsTagMutations = {
+export const contentCmsTagMutations : Record<string, Resolver> = {
   /**
    * Cms tag add
    */
@@ -57,6 +59,46 @@ export const contentCmsTagMutations = {
       const defaultLanguage = await getDefaultLanguage(
         models,
         tagInput.clientPortalId,
+      );
+
+      const fallback =
+        translations.find(
+          (translation: any) => translation?.language === defaultLanguage,
+        ) || translations[0];
+
+      if (fallback) {
+        tagInput.name = fallback.title || tagInput.name;
+      }
+    }
+
+    const tag = await models.PostTags.createTag(tagInput);
+
+    await saveTagTranslations(models, tag._id, translations || []);
+
+    return tag;
+  },
+
+  cpCmsTagsAdd: async (
+    _parent: any,
+    args: any,
+    context: IContext,
+  ): Promise<any> => {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const { translations, clientPortalId: _ignored, ...tagInput } = input;
+    delete tagInput.language;
+
+    tagInput.clientPortalId = clientPortalId;
+
+    if (
+      (!tagInput.name || !String(tagInput.name).trim()) &&
+      Array.isArray(translations) &&
+      translations.length > 0
+    ) {
+      const defaultLanguage = await getDefaultLanguage(
+        models,
+        clientPortalId,
       );
 
       const fallback =
@@ -161,3 +203,8 @@ export const contentCmsTagMutations = {
     return models.PostTags.toggleStatus(_id);
   },
 };
+
+
+contentCmsTagMutations.cpCmsTagsAdd.wrapperConfig={
+  forClientPortal:true,
+}

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/translation.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/translation.ts
@@ -1,5 +1,30 @@
 import { Resolver } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
+import {
+  assertOwnedDocument,
+  requireClientPortalId,
+} from '@/cms/graphql/utils/clientPortal';
+
+const getTranslationTargetModel = (
+  models: IContext['models'],
+  type = 'post',
+) => {
+  const modelMap: Record<string, any> = {
+    post: models.Posts,
+    page: models.Pages,
+    category: models.Categories,
+    tag: models.PostTags,
+    menu: models.MenuItems,
+  };
+
+  const model = modelMap[type];
+
+  if (!model) {
+    throw new Error(`Invalid type: ${type}`);
+  }
+
+  return model;
+};
 
 const mutations: Record<string, Resolver> = {
   /**
@@ -14,6 +39,35 @@ const mutations: Record<string, Resolver> = {
     const { input } = args;
 
     return models.Translations.createTranslation(input);
+  },
+
+  cpCmsAddTranslation: async (
+    _parent: any,
+    args: any,
+    context: IContext,
+  ): Promise<any> => {
+    const { models } = context;
+    const clientPortalId = requireClientPortalId(context);
+    const { input } = args;
+    const type = input.type || 'post';
+    const objectId = input.objectId || input.postId;
+
+    if (!objectId) {
+      throw new Error('objectId is required');
+    }
+
+    await assertOwnedDocument(
+      getTranslationTargetModel(models, type),
+      objectId,
+      clientPortalId,
+      'Object not found',
+    );
+
+    return models.Translations.createTranslation({
+      ...input,
+      objectId,
+      type,
+    });
   },
 
   /**
@@ -57,5 +111,8 @@ const mutations: Record<string, Resolver> = {
 export default mutations;
 
 mutations.cpPostsIncrementViewCount.wrapperConfig = {
+  forClientPortal: true,
+};
+mutations.cpCmsAddTranslation.wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
@@ -58,4 +58,5 @@ export const mutations = `
     cmsCategoriesEdit(_id: String!, input: PostCategoryInput!): PostCategory
     cmsCategoriesRemove(_id: String!): JSON
     cmsCategoriesToggleStatus(_id: String!): PostCategory
+    cpCmsCategoriesAdd(input: PostCategoryInput!): PostCategory
 `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
@@ -33,6 +33,7 @@ export const queries = `
 
 export const mutations = `
   contentCreateCMS(input: ContentCMSInput): ContentCMS
+  cpContentCreateCMS(input: ContentCMSInput): ContentCMS
   contentUpdateCMS(id: String!, input: ContentCMSInput): ContentCMS
   contentDeleteCMS(id: String!): JSON
 `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/customPostType.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/customPostType.ts
@@ -53,7 +53,7 @@ export const inputs = `
     
     description: String
 
-    clientPortalId: String!
+    clientPortalId: String
   }
 
   input CustomFieldGroupInput {
@@ -61,7 +61,7 @@ export const inputs = `
     code: String
     order: Int
     parentId: String
-    clientPortalId: String!
+    clientPortalId: String
     customPostTypeIds: [String]
     enabledPageIds: [String]
     enabledCategoryIds: [String]
@@ -85,10 +85,12 @@ export const queries = `
 
 export const mutations = `
   cmsCustomPostTypesAdd(input: CustomPostTypeInput!): CustomPostType
+  cpCmsCustomPostTypesAdd(input: CustomPostTypeInput!): CustomPostType
   cmsCustomPostTypesEdit(_id: String!, input: CustomPostTypeInput!): CustomPostType
   cmsCustomPostTypesRemove(_id: String!): JSON
 
   cmsCustomFieldGroupsAdd(input: CustomFieldGroupInput!): CustomFieldGroup
+  cpCmsCustomFieldGroupsAdd(input: CustomFieldGroupInput!): CustomFieldGroup
   cmsCustomFieldGroupsEdit(_id: String!, input: CustomFieldGroupInput!): CustomFieldGroup
   cmsCustomFieldGroupsRemove(_id: String!): JSON
 `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/page.ts
@@ -97,4 +97,5 @@ export const mutations = `
     cmsPagesAdd(input: PageInput!): Page
     cmsPagesEdit(_id: String!, input: PageInput!): Page
     cmsPagesRemove(_id: String!): JSON
+    cpCmsPagesAdd(input: PageInput!): Page
 `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
@@ -198,8 +198,10 @@ export const mutations = `
   
       cpPostsIncrementViewCount(_id: String!): Post
       cpPostsReact(_id: String!, reaction: PostReactionType!, action: ReactionModifyType!): Post
+      cpCmsPostsAdd(input: PostInput!): Post
   
       cmsAddTranslation(input: TranslationInput!): Translation
       cmsEditTranslation(input: TranslationInput!): Translation
       cmsDeleteTranslation(_id: String!): JSON
+      cpCmsAddTranslation(input: TranslationInput!): Translation
   `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/tag.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/tag.ts
@@ -52,4 +52,5 @@ export const mutations = `
     cmsTagsAdd(input: PostTagInput!): PostTag
     cmsTagsEdit(_id: String!, input: PostTagInput!): PostTag
     cmsTagsRemove(_id: String!): JSON
+    cpCmsTagsAdd(input: PostTagInput!): PostTag
 `;

--- a/backend/plugins/content_api/src/modules/cms/graphql/utils/clientPortal.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/utils/clientPortal.ts
@@ -1,0 +1,47 @@
+import { IContext } from '~/connectionResolvers';
+
+export const requireClientPortalId = (context: IContext): string => {
+  const clientPortalId = context.clientPortal?._id;
+
+  if (!clientPortalId) {
+    throw new Error('Client portal is required');
+  }
+
+  return clientPortalId;
+};
+
+export const getClientPortalUserId = (context: IContext): string | undefined =>
+  context.cpUser?._id || context.user?._id;
+
+export const assertOwnedDocument = async (
+  model: any,
+  _id: string,
+  clientPortalId: string,
+  errorMessage: string,
+) => {
+  const document = await model.findOne({ _id, clientPortalId }).lean();
+
+  if (!document) {
+    throw new Error(errorMessage);
+  }
+
+  return document;
+};
+
+export const assertOwnedDocuments = async (
+  model: any,
+  _ids: string[],
+  clientPortalId: string,
+  errorMessage: string,
+) => {
+  const documents = await model
+    .find({ _id: { $in: _ids }, clientPortalId })
+    .select({ _id: 1 })
+    .lean();
+
+  if (documents.length !== _ids.length) {
+    throw new Error(errorMessage);
+  }
+
+  return documents;
+};


### PR DESCRIPTION
## Summary by Sourcery

Add client-portal-specific CMS GraphQL mutations that enforce client portal ownership and translation-aware defaults when creating content.

New Features:
- Introduce client portal create mutations for posts, pages, categories, tags, custom post types, custom field groups, and CMS settings, wiring them into the GraphQL schema.
- Allow client portal users to add translations to CMS entities via a dedicated mutation that validates ownership per entity type.

Enhancements:
- Relax GraphQL input schemas so clientPortalId becomes optional, letting server-side logic infer it from the client portal context.
- Centralize client portal context handling and ownership checks in reusable helper utilities for CMS mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new GraphQL mutations for client-portal scoped content creation including posts, pages, categories, tags, custom post types, and translations
  * Implemented automatic language fallback to populate content names and descriptions from available translations
  * Added client portal ownership validation for created content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->