### PR TITLE
feat: add cpDetail

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
@@ -72,6 +72,31 @@ class CategoryQueryResolver extends BaseQueryResolver {
       'category',
     );
   }
+
+  async cpCmsCategoryDetail(
+    _parent: any,
+    args: any,
+    context: IContext,
+  ): Promise<any> {
+    const { models, clientPortal } = context;
+    const { _id, slug, language } = args;
+    const clientPortalId = clientPortal?._id;
+
+    if (!_id && !slug) {
+      return null;
+    }
+
+    const query = slug ? { slug, clientPortalId } : { _id, clientPortalId };
+
+    return this.getItemWithTranslation(
+      models.Categories,
+      query,
+      language,
+      FIELD_MAPPINGS.CATEGORY,
+      clientPortalId,
+      'category',
+    );
+  }
 }
 
 export const contentCmsCategoryQueries: Record<string, Resolver> = {
@@ -81,8 +106,18 @@ export const contentCmsCategoryQueries: Record<string, Resolver> = {
     new CategoryQueryResolver(context).cmsCategory(_parent, args, context),
   cpCategories: (_parent: any, args: any, context: IContext) =>
     new CategoryQueryResolver(context).cpCategories(_parent, args, context),
+  cpCmsCategoryDetail: (_parent: any, args: any, context: IContext) =>
+    new CategoryQueryResolver(context).cpCmsCategoryDetail(
+      _parent,
+      args,
+      context,
+    ),
 };
 
 contentCmsCategoryQueries.cpCategories.wrapperConfig = {
+  forClientPortal: true,
+};
+
+contentCmsCategoryQueries.cpCmsCategoryDetail.wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
@@ -103,6 +103,25 @@ class PageQueryResolver extends BaseQueryResolver {
 
     return { pages: list, totalCount, pageInfo };
   }
+
+  async cpCmsPageDetail(_parent: any, args: any, context: IContext) {
+    const { models, clientPortal } = context;
+    const { _id, slug, language } = args;
+    const clientPortalId = clientPortal?._id;
+
+    if (!_id && !slug) return null;
+
+    const query = slug ? { slug, clientPortalId } : { _id, clientPortalId };
+
+    return this.getItemWithTranslation(
+      models.Pages,
+      query,
+      language,
+      FIELD_MAPPINGS.PAGE,
+      clientPortalId,
+      'page',
+    );
+  }
 }
 
 const queries: Record<string, Resolver> = {
@@ -120,9 +139,13 @@ const queries: Record<string, Resolver> = {
 
   cpPageList: (_parent: any, args: any, context: IContext) =>
     new PageQueryResolver(context).cpPageList(_parent, args, context),
+
+  cpCmsPageDetail: (_parent: any, args: any, context: IContext) =>
+    new PageQueryResolver(context).cpCmsPageDetail(_parent, args, context),
 };
 
 queries.cpPages.wrapperConfig = { forClientPortal: true };
 queries.cpPageList.wrapperConfig = { forClientPortal: true };
+queries.cpCmsPageDetail.wrapperConfig = { forClientPortal: true };
 
 export default queries;

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
@@ -51,6 +51,7 @@ export const queries = `
     cmsCategory(_id: String, slug: String, language: String, clientPortalId: String): PostCategory
 
     cpCategories(clientPortalId: String, language: String): PostCategoryListResponse
+    cpCmsCategoryDetail(_id: String, slug: String, language: String): PostCategory
 `;
 
 export const mutations = `

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/page.ts
@@ -91,6 +91,7 @@ export const queries = `
 
     cpPages(language: String): [Page]
     cpPageList(language: String, ${GQL_CURSOR_PARAM_DEFS}): PageList
+    cpCmsPageDetail(_id: String, slug: String, language: String): Page
 `;
 
 export const mutations = `


### PR DESCRIPTION
## Summary by Sourcery

Add client portal GraphQL queries to retrieve detailed CMS category and page data by ID or slug with language-specific translations.

New Features:
- Expose cpCmsCategoryDetail GraphQL query for fetching a single client-portal category with translations by ID or slug.
- Expose cpCmsPageDetail GraphQL query for fetching a single client-portal page with translations by ID or slug.

Enhancements:
- Mark new client-portal detail queries with wrapperConfig.forClientPortal to integrate with existing client portal handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GraphQL queries to retrieve category and page details within client portals
  * Both queries support flexible lookups using either ID or slug parameters
  * Multi-language translation support included for content localization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->