### PR TITLE
feat: define ProductPlacesResponse type for productPlacesResponded

### DIFF
--- a/backend/plugins/mongolian_api/src/apollo/schema/schema.ts
+++ b/backend/plugins/mongolian_api/src/apollo/schema/schema.ts
@@ -23,6 +23,10 @@ import {
   queries as ExchangeRateQueries,
   types as ExchangeRateTypes,
 } from '@/exchangeRates/graphql/schemas';
+import {
+  types as ProductPlacesTypes,
+  subscriptions as ProductPlacesSubscriptions,
+} from '@/productPlaces/graphql/schema';
 
 export const types = `
   ${ConfigTypes}
@@ -30,6 +34,7 @@ export const types = `
   ${ErkhetTypes}
   ${MsdynamicTypes}
   ${ExchangeRateTypes}
+  ${ProductPlacesTypes} 
 `;
 
 export const queries = `
@@ -48,4 +53,8 @@ export const mutations = `
   ${ExchangeRateMutations}
 `;
 
-export default { types, queries, mutations };
+export const subscriptions = `
+  ${ProductPlacesSubscriptions}
+`;
+
+export default { types, queries, mutations, subscriptions };

--- a/backend/plugins/mongolian_api/src/apollo/subscription.ts
+++ b/backend/plugins/mongolian_api/src/apollo/subscription.ts
@@ -5,7 +5,7 @@ export default {
 
   typeDefs: `
     ebarimtResponded(userId: String, processId: String): EbarimtResponse
-    productPlacesResponded(userId: String, sessionCode: String): JSON
+    productPlacesResponded(userId: String, sessionCode: String): ProductPlacesResponse
   `,
 
   generateResolvers: (graphqlPubsub) => {
@@ -14,29 +14,20 @@ export default {
         subscribe: withFilter(
           (_, { userId }) =>
             graphqlPubsub.asyncIterator(`ebarimtResponded:${userId}`),
-          (payload, variables) => {
-            return (
-              variables?.userId &&
-              payload?.ebarimtResponded?.userId === variables?.userId
-            );
-          },
+          (payload, variables) =>
+            variables?.userId &&
+            payload?.ebarimtResponded?.userId === variables?.userId,
         ),
       },
       productPlacesResponded: {
         subscribe: withFilter(
-          (_, { userId }) => {
-            return graphqlPubsub.asyncIterator(
-              `productPlacesResponded:${userId}`,
-            );
-          },
-          (payload, variables) => {
-            const match =
-              variables?.userId &&
-              payload?.productPlacesResponded?.userId === variables?.userId;
-            return match;
-          },
+          (_, { userId }) =>
+            graphqlPubsub.asyncIterator(`productPlacesResponded:${userId}`),
+          (payload, variables) =>
+            variables?.userId &&
+            payload?.productPlacesResponded?.userId === variables?.userId,
         ),
-        resolve: (payload) => JSON.stringify(payload.productPlacesResponded),
+        // no stringify
       },
     };
   },

--- a/backend/plugins/mongolian_api/src/apollo/typeDefs.ts
+++ b/backend/plugins/mongolian_api/src/apollo/typeDefs.ts
@@ -1,7 +1,7 @@
 import { apolloCommonTypes } from 'erxes-api-shared/utils';
 import { DocumentNode } from 'graphql';
 import { gql } from 'graphql-tag';
-import { mutations, queries, types } from '~/apollo/schema/schema';
+import { mutations, queries, types, subscriptions } from '~/apollo/schema/schema';
 
 export const typeDefs = async (): Promise<DocumentNode> => {
   return gql`
@@ -13,5 +13,6 @@ export const typeDefs = async (): Promise<DocumentNode> => {
     extend type Mutation {
       ${mutations}
     }
+    ${subscriptions}
   `;
 };

--- a/backend/plugins/mongolian_api/src/modules/productPlaces/graphql/schema.ts
+++ b/backend/plugins/mongolian_api/src/modules/productPlaces/graphql/schema.ts
@@ -28,6 +28,6 @@ export const types = `
 
 export const subscriptions = `
   extend type Subscription {
-    productPlacesResponded(userId: String!, sessionCode: String!): ProductPlacesResponse!
+    productPlacesResponded(userId: String, sessionCode: String!): ProductPlacesResponse!
   }
 `;

--- a/backend/plugins/mongolian_api/src/modules/productPlaces/graphql/schema.ts
+++ b/backend/plugins/mongolian_api/src/modules/productPlaces/graphql/schema.ts
@@ -1,0 +1,33 @@
+export const types = `
+  type PData {
+    productId: ID
+    amount: Float
+  }
+
+  type ProductPlacesContent {
+    branchId: ID
+    departmentId: ID
+    date: String
+    name: String
+    number: String
+    customerCode: String
+    customerName: String
+    pDatas: [PData!]
+    amount: Float
+    headerText: String
+    footerText: String
+  }
+
+  type ProductPlacesResponse {
+    userId: String!
+    responseId: String!
+    sessionCode: String!
+    content: [ProductPlacesContent!]!
+  }
+`;
+
+export const subscriptions = `
+  extend type Subscription {
+    productPlacesResponded(userId: String!, sessionCode: String!): ProductPlacesResponse!
+  }
+`;

--- a/backend/plugins/mongolian_api/src/modules/productPlaces/handlers/handlePrint.ts
+++ b/backend/plugins/mongolian_api/src/modules/productPlaces/handlers/handlePrint.ts
@@ -108,15 +108,15 @@ export const handlePrint = async (
   }
 
   if (!content.length) {
-    return;
-  }
+  return;
+}
 
-  await graphqlPubsub.publish(`productPlacesResponded:${user}`, {
-    productPlacesResponded: {
-      userId: user,
-      responseId: deal._id,
-      sessionCode: '',
-      content,
-    },
-  });
+await graphqlPubsub.publish(`productPlacesResponded:${user}`, {
+  productPlacesResponded: {
+    userId: user,
+    responseId: deal._id,
+    sessionCode: '',
+    content,
+  },
+});
 };

--- a/backend/plugins/mongolian_api/src/modules/productPlaces/handlers/handlePrint.ts
+++ b/backend/plugins/mongolian_api/src/modules/productPlaces/handlers/handlePrint.ts
@@ -108,15 +108,15 @@ export const handlePrint = async (
   }
 
   if (!content.length) {
-  return;
-}
+    return;
+  }
 
-await graphqlPubsub.publish(`productPlacesResponded:${user}`, {
-  productPlacesResponded: {
-    userId: user,
-    responseId: deal._id,
-    sessionCode: '',
-    content,
-  },
-});
+  await graphqlPubsub.publish(`productPlacesResponded:${user}`, {
+    productPlacesResponded: {
+      userId: user,
+      responseId: deal._id,
+      sessionCode: '',
+      content,
+    },
+  });
 };

--- a/frontend/plugins/mongolian_ui/src/modules/productplaces/graphql/subscriptions.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/productplaces/graphql/subscriptions.ts
@@ -3,10 +3,15 @@ import { gql } from '@apollo/client';
 export const PRODUCT_PLACES_RESPONDED = gql`
   subscription productPlacesResponded($userId: String, $sessionCode: String) {
     productPlacesResponded(userId: $userId, sessionCode: $sessionCode) {
-      content
       responseId
-      userId
-      sessionCode
+      content {
+        name
+        number
+        amount
+        pDatas {
+          amount
+        }
+      }
     }
   }
 `;

--- a/frontend/plugins/mongolian_ui/src/pages/productplaces/ProductPlacesRespondedPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/productplaces/ProductPlacesRespondedPage.tsx
@@ -6,7 +6,6 @@ import { PerResponse } from '~/modules/productplaces/components/PerResponse';
 import { Response } from '~/modules/productplaces/components/Response';
 
 export const ProductPlacesRespondedPage = () => {
-  console.log(' ProductPlacesRespondedPage mounted');
   const currentUser = useAtomValue(currentUserState);
 
   useSubscription(PRODUCT_PLACES_RESPONDED, {
@@ -16,28 +15,10 @@ export const ProductPlacesRespondedPage = () => {
     },
     skip: !currentUser?._id,
     onData: ({ data }) => {
-      console.log(' Subscription data received:', data);
       const productPlacesResponded = data.data?.productPlacesResponded;
       if (!productPlacesResponded) return;
 
-      // Parse the JSON string returned by the subscription
-      let parsedPayload;
-      try {
-        parsedPayload = JSON.parse(productPlacesResponded);
-      } catch (e) {
-        console.error('Failed to parse payload', e);
-        return;
-      }
-
-      const { content } = parsedPayload;
-      let parsedContent;
-      try {
-        parsedContent = JSON.parse(content);
-      } catch (e) {
-        console.error('Failed to parse content', e);
-        return;
-      }
-
+      const parsedContent = productPlacesResponded.content;git branch
       if (!parsedContent?.length) return;
 
       const printContents = parsedContent.map((receipt: any, index: number) =>
@@ -54,7 +35,7 @@ export const ProductPlacesRespondedPage = () => {
       }
     },
     onError: (error) => {
-      console.error(' Subscription error:', error);
+      console.error('Subscription error:', error);
     },
   });
 

--- a/frontend/plugins/mongolian_ui/src/pages/productplaces/ProductPlacesRespondedPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/productplaces/ProductPlacesRespondedPage.tsx
@@ -18,7 +18,7 @@ export const ProductPlacesRespondedPage = () => {
       const productPlacesResponded = data.data?.productPlacesResponded;
       if (!productPlacesResponded) return;
 
-      const parsedContent = productPlacesResponded.content;git branch
+      const parsedContent = productPlacesResponded.content;
       if (!parsedContent?.length) return;
 
       const printContents = parsedContent.map((receipt: any, index: number) =>


### PR DESCRIPTION
- Add ProductPlacesResponse, ProductPlacesContent, PData types to productPlaces schema
- Export types from central apollo/schema/schema.ts
- Update subscription to return ProductPlacesResponse instead of JSON
- Remove JSON.stringify from subscription resolver
- Update frontend to use typed fields directly without JSON.parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ProductPlaces subscription support with structured ProductPlacesResponse types.

* **Bug Fixes**
  * Ensured notifications are published after content is prepared so subscribers receive complete data.

* **Refactor**
  * Switched subscriptions from raw JSON to typed structures and updated subscription payload shape.
  * Simplified client-side parsing by removing unnecessary serialization/deserialization.
  * Removed debug console logging for cleaner operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->