### PR TITLE
feat: add cppost count argument

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -120,16 +120,25 @@ class PostQueryResolver extends BaseQueryResolver {
   private async buildPostLookupQuery(
     args: {
       _id?: string;
+      count?: number;
       slug?: string;
       identifier?: string;
       clientPortalId?: string;
     },
     models: IContext['models'],
   ) {
-    const { _id, slug, identifier, clientPortalId } = args;
+    const { _id, count, slug, identifier, clientPortalId } = args;
 
     if (_id) {
       return clientPortalId ? { _id, clientPortalId } : { _id };
+    }
+
+    if (count !== undefined && count !== null) {
+      if (!clientPortalId) {
+        throw new Error('clientPortalId is required when querying by count');
+      }
+
+      return { count, clientPortalId };
     }
 
     if (slug) {
@@ -191,10 +200,10 @@ class PostQueryResolver extends BaseQueryResolver {
 
   async cmsPost(_parent: any, args: any, context: IContext): Promise<any> {
     const { models } = context;
-    const { _id, slug, identifier, language, clientPortalId } = args;
+    const { _id, count, slug, identifier, language, clientPortalId } = args;
 
     const query = await this.buildPostLookupQuery(
-      { _id, slug, identifier, clientPortalId },
+      { _id, count, slug, identifier, clientPortalId },
       models,
     );
 
@@ -340,10 +349,10 @@ class PostQueryResolver extends BaseQueryResolver {
 
   async cpPost(_parent: any, args: any, context: IContext): Promise<any> {
     const { clientPortal, models } = context;
-    const { _id, slug, identifier, language } = args;
+    const { _id, count, slug, identifier, language } = args;
 
     const query = await this.buildPostLookupQuery(
-      { _id, slug, identifier, clientPortalId: clientPortal._id },
+      { _id, count, slug, identifier, clientPortalId: clientPortal._id },
       models,
     );
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/posts.ts
@@ -175,7 +175,7 @@ const commonPostQuerySelectorPagination = `
   `;
 
 export const queries = `
-      cmsPost(_id: String, slug: String, identifier: String, language: String, clientPortalId: String): Post
+      cmsPost(_id: String, count: Int, slug: String, identifier: String, language: String, clientPortalId: String): Post
       cmsPosts(clientPortalId: String, ${commonPostQuerySelector}): [Post]
       cmsPostList(clientPortalId: String, ${commonPostQuerySelector}): PostList
       cmsMostViewedPosts(clientPortalId: String!, days: Int!, limit: Int, language: String, webId: String, type: String): [Post]
@@ -183,7 +183,7 @@ export const queries = `
   
       cpPosts(language: String, webId: String, ${commonPostQuerySelector}): [Post]
       cpPostList(language: String, webId: String, ${commonPostQuerySelector}): PostList
-      cpPost(_id: String, slug: String, identifier: String, language: String, clientPortalId: String): Post
+      cpPost(_id: String, count: Int, slug: String, identifier: String, language: String, clientPortalId: String): Post
       cpPostListWithPagination(language: String, ${commonPostQuerySelectorPagination}): PostListPagination
       cpMostViewedPosts(days: Int!, limit: Int, language: String, webId: String, type: String): [Post]
   `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Post retrieval API enhanced with `count` parameter support. Users can now specify the desired number of posts to fetch in a single request using the new `count` parameter, enabling greater control over query results and result set management. This addition provides improved flexibility for post retrieval operations and integrates seamlessly with existing query options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->