### PR TITLE
fix(inbox): link customer when adding ticket via Related tab + fix list refresh

### DIFF
--- a/packages/core/src/data/modules/coc/customers.ts
+++ b/packages/core/src/data/modules/coc/customers.ts
@@ -232,21 +232,40 @@ export class Builder extends CommonBuilder<IListArgs> {
       }
     );
 
-    const selector = {
+    const selector: any = {
       ...this.context.commonQuerySelector,
       status: { $ne: "deleted" },
       state: this.params.type || "customer",
-      $or: [
+      $and: [
         {
-          integrationId: { $in: [null, undefined, ""] }
-        },
-        {
-          integrationId: {
-            $in: activeIntegrations.map(integration => integration._id)
-          }
+          $or: [
+            { integrationId: { $in: [null, undefined, ""] } },
+            {
+              integrationId: {
+                $in: activeIntegrations.map((integration: { _id: string }) => integration._id)
+              }
+            }
+          ]
         }
       ]
     };
+
+    if (this.params.searchValue) {
+      const escapedSearch = this.params.searchValue.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        "\\$&"
+      );
+      const searchRegex = new RegExp(escapedSearch, "i");
+      selector.$and.push({
+        $or: [
+          { searchText: searchRegex },
+          { firstName: searchRegex },
+          { lastName: searchRegex },
+          { primaryEmail: searchRegex },
+          { primaryPhone: searchRegex }
+        ]
+      });
+    }
 
     const customers = await this.models.Customers.find(selector)
       .sort({ createdAt: -1 })

--- a/packages/core/src/data/modules/coc/utils.ts
+++ b/packages/core/src/data/modules/coc/utils.ts
@@ -516,8 +516,6 @@ export class CommonBuilder<IListArgs extends ICommonListArgs> {
       sortDirection,
       searchValue,
     } = this.params;
-    const paramKeys = Object.keys(this.params).join(',');
-
     const _page = Number(page || 1);
     let _limit = Number(perPage || 20);
 
@@ -525,12 +523,14 @@ export class CommonBuilder<IListArgs extends ICommonListArgs> {
       _limit = 10000;
     }
 
-    if (
+    const simpleParamKeys = new Set(['page', 'perPage', 'type', 'searchValue']);
+    const isSimpleQuery =
       !unlimited &&
       page === 1 &&
       perPage === 20 &&
-      (paramKeys === 'page,perPage' || paramKeys === 'page,perPage,type')
-    ) {
+      Object.keys(this.params).every(k => simpleParamKeys.has(k));
+
+    if (isSimpleQuery) {
       return this.findAllMongo(_limit);
     }
 

--- a/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/sidebar/Sidebar.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/sidebar/Sidebar.tsx
@@ -293,7 +293,7 @@ class RightSidebar extends React.Component<IndexProps, IndexState> {
         )}
 
         {isEnabled("tickets") && (
-          <PortableTickets mainType="customer" mainTypeId={customer._id} />
+          <PortableTickets mainType="customer" mainTypeId={customer._id} sourceConversationId={conversation._id} />
         )}
 
         {isEnabled("tasks") && (

--- a/packages/ui-tickets/src/boards/components/portable/Items.tsx
+++ b/packages/ui-tickets/src/boards/components/portable/Items.tsx
@@ -11,6 +11,7 @@ import { IItem, IOptions } from "../../types";
 
 type IData = {
   options: IOptions;
+  sourceConversationId?: string;
 };
 
 type Props = {
@@ -112,7 +113,8 @@ class Items extends React.Component<Props, { openItemId?: string }> {
           options: data.options,
           mainType,
           mainTypeId,
-          items
+          items,
+          sourceConversationId: data.sourceConversationId
         }}
         callback={onChangeItem}
         showSelect={true}

--- a/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
+++ b/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
@@ -114,7 +114,10 @@ class AddFormContainer extends React.Component<FinalProps> {
             });
           }
 
-          this.afterSave(message, callback, data);
+          this.afterSave(message, callback, {
+            _id: data.conversationConvertToCard,
+            stageId: doc.stageId,
+          });
         })
         .catch((error) => {
           Alert.error(error.message);

--- a/packages/ui-tickets/src/boards/containers/portable/ItemChooser.tsx
+++ b/packages/ui-tickets/src/boards/containers/portable/ItemChooser.tsx
@@ -125,6 +125,7 @@ class ItemChooserContainer extends React.Component<
           stageId={this.props.stageId}
           showSelect={true}
           getAssociatedItem={getAssociatedItem}
+          sourceConversationId={data.sourceConversationId}
         />
       ),
       newItem: this.state.newItem,
@@ -175,6 +176,7 @@ type WrapperProps = {
     mainTypeId?: string;
     mainType?: string;
     isRelated?: boolean;
+    sourceConversationId?: string;
   };
   onSelect: (datas: IItem[]) => void;
   showSelect?: boolean;

--- a/packages/ui-tickets/src/conformity/containers/ConformityChooser.tsx
+++ b/packages/ui-tickets/src/conformity/containers/ConformityChooser.tsx
@@ -24,6 +24,7 @@ type Props = {
   refetchQuery: string;
   chooserComponent?: any;
   loading?: boolean;
+  callback?: () => void;
 } & CommonProps;
 
 type FinalProps = {
@@ -36,7 +37,8 @@ const ConformityChooser = (props: FinalProps) => {
     data,
     onSelect,
     chooserComponent,
-    refetchQuery
+    refetchQuery,
+    callback
   } = props;
 
   const onSelected = relTypes => {
@@ -46,6 +48,7 @@ const ConformityChooser = (props: FinalProps) => {
         mainType: data.mainType,
         mainTypeId: data.mainTypeId,
         relType: data.relType,
+        limit: 40,
         isSaved: true
       };
 
@@ -81,6 +84,9 @@ const ConformityChooser = (props: FinalProps) => {
       .then(() => {
         if (onSelect) {
           onSelect(relTypes);
+        }
+        if (callback) {
+          callback();
         }
       })
       .catch(error => {

--- a/packages/ui-tickets/src/tickets/components/PortableTickets.tsx
+++ b/packages/ui-tickets/src/tickets/components/PortableTickets.tsx
@@ -7,6 +7,7 @@ type IProps = {
   mainType?: string;
   mainTypeId?: string;
   mainTypeName?: string;
+  sourceConversationId?: string;
 };
 
 export default (props: IProps) => {
@@ -17,7 +18,7 @@ export default (props: IProps) => {
       component={PortableItems}
       queryName={options.queriesName.itemsQuery}
       itemsQuery={options.queries.itemsQuery}
-      data={{ options }}
+      data={{ options, sourceConversationId: props.sourceConversationId }}
     />
   );
 };


### PR DESCRIPTION
…st refresh

## Summary by Sourcery

Ensure inbox-created tickets correctly link to the customer and refresh related lists while tightening customer queries and search behavior.

Bug Fixes:
- Fix linking of tickets to customers when created from the inbox Related tab by propagating the source conversation and card IDs.
- Fix list refresh behavior after creating related tickets by invoking callbacks once conformity mutations complete.
- Correct customer list filtering to only include records matching search text across multiple fields and valid integrations.

Enhancements:
- Simplify detection of simple customer list queries to reuse existing results more reliably.
- Extend portable ticket and board components to pass conversation context and limit related item queries for better performance.