### PR TITLE
go to settings and action

### DIFF
--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteAssignment } from '../hooks/useDeleteAssignment';
 import { IAssignment } from '../types/assignmentTypes';
 
@@ -24,9 +25,14 @@ export const AssignmentMoreColumnCell = ({
   const { removeAssignment, loading } = useDeleteAssignment();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (assignmentId: string) => {
     setEditAssignmentId(assignmentId);
+  };
+
+  const handleSeeAssignments = () => {
+    navigate(`/loyalty/assignments?assignmentCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const AssignmentMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-assignments" onSelect={handleSeeAssignments}>
+              <IconTicket /> See assignments
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteCoupon } from '../hooks/useDeleteCoupon';
 import { ICoupon } from '../types/couponTypes';
 
@@ -24,9 +25,14 @@ export const CouponMoreColumnCell = ({
   const { removeCoupon, loading } = useDeleteCoupon();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (couponId: string) => {
     setEditCouponId(couponId);
+  };
+
+  const handleSeeCoupons = () => {
+    navigate(`/loyalty/coupons?couponCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const CouponMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-coupons" onSelect={handleSeeCoupons}>
+              <IconTicket /> See coupons
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonateMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonateMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteDonation } from '../hooks/useDeleteDonation';
 import { IDonation } from '../types/donationTypes';
 
@@ -24,9 +25,14 @@ export const DonationMoreColumnCell = ({
   const { removeDonation, loading } = useDeleteDonation();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (donationId: string) => {
     setEditDonationId(donationId);
+  };
+
+  const handleSeeDonates = () => {
+    navigate(`/loyalty/donates?voucherCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const DonationMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-donates" onSelect={handleSeeDonates}>
+              <IconTicket /> See donates
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteLottery } from '../hooks/useDeleteLottery';
 import { ILottery } from '../types/lotteryTypes';
 
@@ -24,9 +25,14 @@ export const LotteryMoreColumnCell = ({
   const { removeLottery, loading } = useDeleteLottery();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (lotteryId: string) => {
     setEditLotteryId(lotteryId);
+  };
+
+  const handleSeeLotteries = () => {
+    navigate(`/loyalty/lotteries?voucherCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const LotteryMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-lotteries" onSelect={handleSeeLotteries}>
+              <IconTicket /> See lotteries
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteSpin } from '../hooks/useDeleteSpin';
 import { ISpin } from '../types/spinTypes';
 
@@ -24,9 +25,14 @@ export const SpinMoreColumnCell = ({
   const { removeSpin, loading } = useDeleteSpin();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (spinId: string) => {
     setEditSpinId(spinId);
+  };
+
+  const handleSeeSpins = () => {
+    navigate(`/loyalty/spins?voucherCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const SpinMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-spins" onSelect={handleSeeSpins}>
+              <IconTicket /> See spins
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherMoreColumn.tsx
@@ -9,8 +9,9 @@ import {
   useToast,
   useQueryState,
 } from 'erxes-ui';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconTicket } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
+import { useNavigate } from 'react-router';
 import { useDeleteVoucher } from '../hooks/useDeleteVoucher';
 import { IVoucher } from '../types/voucherTypes';
 
@@ -24,9 +25,14 @@ export const VoucherMoreColumnCell = ({
   const { removeVoucher, loading } = useDeleteVoucher();
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleEdit = (voucherId: string) => {
     setEditVoucherId(voucherId);
+  };
+
+  const handleSeeVouchers = () => {
+    navigate(`/loyalty/vouchers?voucherCampaignId=${_id}`);
   };
   const handleDelete = () => {
     if (!_id) return;
@@ -67,6 +73,9 @@ export const VoucherMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-vouchers" onSelect={handleSeeVouchers}>
+              <IconTicket /> See vouchers
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/AssignmentPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/AssignmentPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
-import { PageSubHeader } from 'erxes-ui';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { AssignmentRecordTable } from '~/modules/loyalties/assignments/components/AssignmentRecordTable';
 import { AssignmentFilter } from '~/modules/loyalties/assignments/components/AssignmentFilter';
@@ -7,6 +9,12 @@ import { AssignmentAddModal } from '~/modules/loyalties/assignments/components/A
 
 const AssignmentHeaderActions = () => (
   <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/assignment">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
     <AssignmentAddModal />
   </div>
 );

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/CouponPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/CouponPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
-import { PageSubHeader } from 'erxes-ui';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { Export } from 'ui-modules';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { CouponRecordTable } from '~/modules/loyalties/coupons/components/CouponRecordTable';
@@ -8,6 +10,12 @@ import { CouponFilter } from '~/modules/loyalties/coupons/components/CouponFilte
 
 const CouponHeaderActions = () => (
   <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/coupon">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
     <Export pluginName="loyalty" moduleName="coupon" collectionName="coupon" />
     <CouponAddModal />
   </div>

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/DonatePage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/DonatePage.tsx
@@ -1,15 +1,29 @@
 import { useEffect } from 'react';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { DonateRecordTable } from '~/modules/loyalties/donates/components/DonateRecordTable';
 import { DonateAddSheet } from '~/modules/loyalties/donates/components/DonateAddSheet';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { DonateFilter } from '~/modules/loyalties/donates/components/DonateFilter';
-import { PageSubHeader } from 'erxes-ui';
+
+const DonateHeaderActions = () => (
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/donate">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
+    <DonateAddSheet />
+  </div>
+);
 
 export const DonatePage = () => {
   const { setAction } = useLoyaltyHeaderAction();
 
   useEffect(() => {
-    setAction(<DonateAddSheet />);
+    setAction(<DonateHeaderActions />);
     return () => setAction(null);
   }, [setAction]);
 

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/LotteryPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/LotteryPage.tsx
@@ -1,15 +1,29 @@
 import { useEffect } from 'react';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { LotteryRecordTable } from '~/modules/loyalties/lotteries/components/LotteryRecordTable';
 import { LotteryAddSheet } from '~/modules/loyalties/lotteries/components/LotteryAddSheet';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { LotteryFilter } from '~/modules/loyalties/lotteries/components/LotteryFilter';
-import { PageSubHeader } from 'erxes-ui';
+
+const LotteryHeaderActions = () => (
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/lottery">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
+    <LotteryAddSheet />
+  </div>
+);
 
 export const LotteryPage = () => {
   const { setAction } = useLoyaltyHeaderAction();
 
   useEffect(() => {
-    setAction(<LotteryAddSheet />);
+    setAction(<LotteryHeaderActions />);
     return () => setAction(null);
   }, [setAction]);
 

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/SpinPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/SpinPage.tsx
@@ -1,15 +1,29 @@
 import { useEffect } from 'react';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { SpinRecordTable } from '~/modules/loyalties/spin/components/SpinRecordTable';
 import { SpinAddSheet } from '~/modules/loyalties/spin/components/SpinAddSheet';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { SpinFilter } from '~/modules/loyalties/spin/components/SpinFilter';
-import { PageSubHeader } from 'erxes-ui';
+
+const SpinHeaderActions = () => (
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/spin">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
+    <SpinAddSheet />
+  </div>
+);
 
 export const SpinPage = () => {
   const { setAction } = useLoyaltyHeaderAction();
 
   useEffect(() => {
-    setAction(<SpinAddSheet />);
+    setAction(<SpinHeaderActions />);
     return () => setAction(null);
   }, [setAction]);
 

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/VoucherPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/VoucherPage.tsx
@@ -1,15 +1,29 @@
 import { useEffect } from 'react';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { VoucherRecordTable } from '~/modules/loyalties/vouchers/components/VoucherRecordTable';
 import { VoucherAddSheet } from '~/modules/loyalties/vouchers/components/VoucherAddSheet';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { VoucherFilter } from '~/modules/loyalties/vouchers/components/VoucherFilter';
-import { PageSubHeader } from 'erxes-ui';
+
+const VoucherHeaderActions = () => (
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/voucher">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
+    <VoucherAddSheet />
+  </div>
+);
 
 export const VoucherPage = () => {
   const { setAction } = useLoyaltyHeaderAction();
 
   useEffect(() => {
-    setAction(<VoucherAddSheet />);
+    setAction(<VoucherHeaderActions />);
     return () => setAction(null);
   }, [setAction]);
 


### PR DESCRIPTION
## Summary by Sourcery

Add navigation shortcuts between loyalty campaign settings and their corresponding record pages.

New Features:
- Add "Go to settings" header actions to loyalty record pages (donate, lottery, spin, voucher, assignment, coupon) linking to their configuration screens.
- Add "See ..." context menu actions in loyalty campaign settings tables to navigate to the corresponding records filtered by campaign ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "See" options to dropdown menus in loyalty settings (assignments, coupons, donations, lotteries, spins, vouchers) for quick access to filtered item lists.
  * Added "Go to settings" buttons to loyalty pages for quick navigation back to configuration screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->