### PR TITLE
fix: logic of customfieldsMap

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/db/definitions/customPostType.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/definitions/customPostType.ts
@@ -44,6 +44,7 @@ export const fieldGroupSchema = new Schema<ICustomFieldGroupDocument>(
 
     enabledPageIds: { type: [String] },
     enabledCategoryIds: { type: [String] },
+    enabledPostIds: { type: [String] },
     type: { type: String, required: true, default: 'user' },
     fields: { type: [fieldSchema], default: [] },
   },

--- a/backend/plugins/content_api/src/modules/cms/graphql/customeResolvers/post.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/customeResolvers/post.ts
@@ -65,9 +65,10 @@ export default {
   },
 
   async customFieldsMap(post: any, _params, { models, subdomain }: IContext) {
+    const postType = post.type || 'post';
     const query: any = {
       $or: [
-        { customPostTypeIds: post.type },
+        { customPostTypeIds: postType },
         { enabledCategoryIds: { $in: post.categoryIds || [] } },
         { enabledPostIds: { $in: [post._id] } },
       ],

--- a/backend/plugins/content_api/src/modules/cms/utils/common.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/common.ts
@@ -28,20 +28,40 @@ export const buildCustomFieldsMap = async (
   customFieldsData: any,
 ) => {
   const jsonMap: any = {};
+  const safeCustomFieldsData = Array.isArray(customFieldsData)
+    ? customFieldsData
+    : [];
 
   if (fieldGroups.length > 0) {
     for (const fieldGroup of fieldGroups) {
-      const fields = await sendTRPCMessage({
-        subdomain,
-        pluginName: 'core',
-        method: 'query',
-        module: 'fields',
-        action: 'find',
-        input: { query: { groupId: fieldGroup._id } },
-      });
+      let fields: any[] = [];
+
+      if (Array.isArray(fieldGroup?.fields)) {
+        fields = fieldGroup.fields;
+      } else if (typeof fieldGroup?.fields === 'string') {
+        try {
+          const parsed = JSON.parse(fieldGroup.fields);
+          fields = Array.isArray(parsed) ? parsed : [];
+        } catch {
+          fields = [];
+        }
+      }
+
+      if (!fields.length) {
+        fields = await sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'fields',
+          action: 'find',
+          input: { query: { groupId: fieldGroup._id } },
+        });
+      }
 
       jsonMap[fieldGroup.code] = fields.reduce((acc, field: any) => {
-        const value = customFieldsData.find((c: any) => c.field === field._id);
+        const value = safeCustomFieldsData.find(
+          (c: any) => c.field === field._id,
+        );
         acc[field.code] = value ? value.value : null;
         return acc;
       }, {});

--- a/frontend/plugins/content_ui/src/modules/cms/posts/graphql/queries/postDetailQuery.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/graphql/queries/postDetailQuery.ts
@@ -82,6 +82,7 @@ export const POST_DETAIL = gql`
         __typename
       }
       customFieldsData
+      customFieldsMap
       __typename
     }
   }


### PR DESCRIPTION
## Summary by Sourcery

Improve how custom field maps are built and queried for CMS posts across backend and frontend.

Bug Fixes:
- Handle non-array custom fields data safely when building the custom fields map.
- Ensure custom field groups fall back to fetching fields from the core service only when not already present on the group.
- Use a default post type when resolving custom field groups to avoid missing matches for posts without an explicit type.

Enhancements:
- Extend custom post type field group schema to support enabling groups for specific post IDs.
- Expose the computed customFieldsMap in the post detail GraphQL query so it is available to the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Improved custom field resolution and mapping for posts
  * Enhanced fallback handling for posts without explicit type assignments
  * Better data normalization for custom field configurations
  * Expanded field group enablement options for various post scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->