### PR TITLE
fix(frontline): fix createdBy null on widget ticket and internal message conversation mismatch

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
@@ -1071,7 +1071,7 @@ export const widgetMutations: Record<string, Resolver> = {
   async widgetTicketCreated(
     _root,
     doc: ITicketWidget,
-    { models, subdomain }: IContext,
+    { models, subdomain, user }: IContext,
   ) {
     const { statusId, ...restFields } = doc;
     const status = await models.Status.findOne({ _id: statusId });
@@ -1108,6 +1108,7 @@ export const widgetMutations: Record<string, Resolver> = {
         stageChangedDate: new Date(),
         searchText: fillSearchTextItem(doc),
         number: Date.now().toString(),
+        createdBy: user?._id,
       });
       await sendTRPCMessage({
         subdomain,

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/handleFacebookMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/handleFacebookMessage.ts
@@ -18,17 +18,7 @@ export const handleFacebookMessage = async (
   const { action, payload } = msg;
   const doc = JSON.parse(payload || '{}');
   if (doc.internal) {
-    const conversation = await models.FacebookConversations.getConversation({
-      erxesApiId: doc.conversationId,
-    });
-
-    return models.ConversationMessages.addMessage(
-      {
-        ...doc,
-        conversationId: conversation._id,
-      },
-      doc.userId,
-    );
+    return models.ConversationMessages.addMessage(doc, doc.userId);
   }
   if (action === 'reply-post') {
     const { conversationId, content = '', attachments = [], userId } = doc;

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/handleInstagramMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/handleInstagramMessage.ts
@@ -32,21 +32,7 @@ export const handleInstagramMessage = async (
   const { action, payload } = msg;
   const doc = JSON.parse(payload || '{}');
   if (doc.internal) {
-    const conversation = await models.InstagramConversations.findOne({
-      erxesApiId: doc.conversationId,
-    });
-
-    if (!conversation) {
-      throw new Error('Conversation not found');
-    }
-
-    return models.InstagramConversationMessages.addMessage(
-      {
-        ...doc,
-        conversationId: conversation._id,
-      },
-      doc.userId,
-    );
+    return models.ConversationMessages.addMessage(doc, doc.userId);
   }
 
  if (action === 'reply-post') {


### PR DESCRIPTION
…age conversation mismatch

## Summary by Sourcery

Fix handling of internal frontline messages and ensure widget-created tickets record their creator.

Bug Fixes:
- Route internal Instagram frontline messages through the standard conversation messages collection to avoid conversation mismatch issues.
- Route internal Facebook frontline messages through the standard conversation messages collection to avoid conversation mismatch issues.
- Populate the createdBy field on tickets created via the widget using the authenticated user from the request context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tickets now automatically track which user created them.

* **Bug Fixes & Improvements**
  * Improved efficiency of Facebook and Instagram message handling by streamlining internal conversation processing and standardizing message storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->