### PR TITLE
fix(frontline): sanitize Instagram webhook inputs to prevent NoSQL injection

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
@@ -6,19 +6,7 @@ import {
 } from '@/integrations/instagram/controller/store';
 import { ICommentParams } from '@/integrations/instagram/@types/utils';
 import { INTEGRATION_KINDS } from '@/integrations/instagram/constants';
-
-/**
- * Sanitize a value expected to be a string to prevent NoSQL injection.
- * Coerces non-string values (e.g. numbers, objects) to strings, which
- * neutralizes injection objects like {"$gt": ""} by converting them to
- * "[object Object]".
- */
-const sanitizeString = (value: unknown): string => {
-  if (typeof value === 'string') {
-    return value;
-  }
-  return String(value ?? '');
-};
+import { sanitizeString } from '@/integrations/instagram/utils';
 
 export const receiveComment = async (
   models: IModels,

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
@@ -7,29 +7,51 @@ import {
 import { ICommentParams } from '@/integrations/instagram/@types/utils';
 import { INTEGRATION_KINDS } from '@/integrations/instagram/constants';
 
+/**
+ * Sanitize a value expected to be a string to prevent NoSQL injection.
+ * Coerces non-string values (e.g. numbers, objects) to strings, which
+ * neutralizes injection objects like {"$gt": ""} by converting them to
+ * "[object Object]".
+ */
+const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};
+
 export const receiveComment = async (
   models: IModels,
   subdomain: string,
   rawParams: ICommentParams & { media?: { id: string }; text?: string },
   pageId: string,
 ) => {
+  const safePageId = sanitizeString(pageId);
+
   // Normalize Instagram webhook comment format to ICommentParams
   const params: ICommentParams = {
     ...rawParams,
-    post_id: rawParams.post_id || rawParams.media?.id || '',
-    comment_id: rawParams.comment_id || (rawParams as any).id,
+    post_id: sanitizeString(
+      rawParams.post_id || rawParams.media?.id || '',
+    ),
+    comment_id: sanitizeString(
+      rawParams.comment_id || (rawParams as any).id,
+    ),
     message: rawParams.message || rawParams.text,
   };
 
-  const userId = params.from.id;
+  const userId = sanitizeString(params.from?.id);
   const postId = params.post_id;
 
-  if (userId === pageId) {
+  if (userId === safePageId) {
     return;
   }
 
   const integration = await models.InstagramIntegrations.findOne({
-    $and: [{ instagramPageId: pageId }, { kind: INTEGRATION_KINDS.POST }],
+    $and: [
+      { instagramPageId: { $eq: safePageId } },
+      { kind: { $eq: INTEGRATION_KINDS.POST } },
+    ],
   });
   if (!integration) {
     throw new Error('Integration not found');
@@ -38,7 +60,7 @@ export const receiveComment = async (
   const customer = await getOrCreateCustomer(
     models,
     subdomain,
-    pageId,
+    safePageId,
     userId,
     INTEGRATION_KINDS.POST,
   );
@@ -49,7 +71,7 @@ export const receiveComment = async (
 
   const postConversation = await getOrCreatePostConversation(
     models,
-    pageId,
+    safePageId,
     postId,
   );
 
@@ -61,7 +83,7 @@ export const receiveComment = async (
     models,
     subdomain,
     params,
-    pageId,
+    safePageId,
     userId,
     integration,
     customer,

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
@@ -26,21 +26,36 @@ export const receiveComment = async (
   rawParams: ICommentParams & { media?: { id: string }; text?: string },
   pageId: string,
 ) => {
+  const rawPostId = rawParams.post_id || rawParams.media?.id;
+  const rawCommentId = rawParams.comment_id || (rawParams as any).id;
+  const rawFromId = rawParams.from?.id;
+
+  if (
+    pageId == null ||
+    pageId === '' ||
+    rawPostId == null ||
+    rawPostId === '' ||
+    rawCommentId == null ||
+    rawCommentId === '' ||
+    rawFromId == null ||
+    rawFromId === ''
+  ) {
+    throw new Error(
+      'Instagram comment webhook is missing pageId, post_id, comment_id, or from.id',
+    );
+  }
+
   const safePageId = sanitizeString(pageId);
 
   // Normalize Instagram webhook comment format to ICommentParams
   const params: ICommentParams = {
     ...rawParams,
-    post_id: sanitizeString(
-      rawParams.post_id || rawParams.media?.id || '',
-    ),
-    comment_id: sanitizeString(
-      rawParams.comment_id || (rawParams as any).id,
-    ),
+    post_id: sanitizeString(rawPostId),
+    comment_id: sanitizeString(rawCommentId),
     message: rawParams.message || rawParams.text,
   };
 
-  const userId = sanitizeString(params.from?.id);
+  const userId = sanitizeString(rawFromId);
   const postId = params.post_id;
 
   if (userId === safePageId) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
@@ -6,6 +6,7 @@ import {
 } from '@/integrations/instagram/controller/store';
 import { ICommentParams } from '@/integrations/instagram/@types/utils';
 import { INTEGRATION_KINDS } from '@/integrations/instagram/constants';
+import { debugError } from '@/integrations/instagram/debuggers';
 import { sanitizeString } from '@/integrations/instagram/utils';
 
 export const receiveComment = async (
@@ -28,9 +29,10 @@ export const receiveComment = async (
     rawFromId == null ||
     rawFromId === ''
   ) {
-    throw new Error(
-      'Instagram comment webhook is missing pageId, post_id, comment_id, or from.id',
+    debugError(
+      `[instagram.receiveComment] missing required webhook fields: pageId=${pageId ? 'present' : 'missing'} post_id=${rawPostId ? 'present' : 'missing'} comment_id=${rawCommentId ? 'present' : 'missing'} from.id=${rawFromId ? 'present' : 'missing'}`,
     );
+    throw new Error('Invalid Instagram comment webhook payload');
   }
 
   const safePageId = sanitizeString(pageId);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveComment.ts
@@ -19,15 +19,13 @@ export const receiveComment = async (
   const rawCommentId = rawParams.comment_id || (rawParams as any).id;
   const rawFromId = rawParams.from?.id;
 
+  const isEmpty = (v: unknown) => v === null || v === undefined || v === '';
+
   if (
-    pageId == null ||
-    pageId === '' ||
-    rawPostId == null ||
-    rawPostId === '' ||
-    rawCommentId == null ||
-    rawCommentId === '' ||
-    rawFromId == null ||
-    rawFromId === ''
+    isEmpty(pageId) ||
+    isEmpty(rawPostId) ||
+    isEmpty(rawCommentId) ||
+    isEmpty(rawFromId)
   ) {
     debugError(
       `[instagram.receiveComment] missing required webhook fields: pageId=${pageId ? 'present' : 'missing'} post_id=${rawPostId ? 'present' : 'missing'} comment_id=${rawCommentId ? 'present' : 'missing'} from.id=${rawFromId ? 'present' : 'missing'}`,

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -145,9 +145,13 @@ export const receiveMessage = async (
     throw new Error(e.message);
   }
 
-  const existingMessage = await models.InstagramConversationMessages.findOne({
-    mid: { $eq: mid },
-  });
+  // Skip the dedupe lookup when mid is absent, otherwise every mid-less event
+  // would collide on a single { mid: undefined } idempotency key.
+  const existingMessage = mid
+    ? await models.InstagramConversationMessages.findOne({
+        mid: { $eq: mid },
+      })
+    : null;
 
   if (!existingMessage) {
     try {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -14,21 +14,35 @@ import {
 
 const HAS_ATTACHMENT = 'This message has an attachment';
 
+/**
+ * Sanitize a value expected to be a string to prevent NoSQL injection.
+ * Coerces non-string values (e.g. numbers, objects) to strings, which
+ * neutralizes injection objects like {"$gt": ""} by converting them to
+ * "[object Object]".
+ */
+const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};
+
 export const receiveMessage = async (
   models: IModels,
   subdomain: string,
   integration: IInstagramIntegrationDocument,
   activity: IMessageData,
 ) => {
-  const userId = activity.sender.id;
+  const userId = sanitizeString(activity.sender?.id);
   const { recipient, timestamp } = activity;
 
   let message = activity.message as any;
   const postback = activity.postback as any;
 
-  const pageId = recipient.id;
+  const pageId = sanitizeString(recipient?.id);
   const kind = INTEGRATION_KINDS.MESSENGER;
-  const mid = message?.mid || postback?.mid;
+  const rawMid = message?.mid || postback?.mid;
+  const mid = rawMid != null ? sanitizeString(rawMid) : undefined;
   const attachments = message?.attachments;
 
   debugInstagram(`Received message from ${userId} → page ${pageId}`);
@@ -60,8 +74,8 @@ export const receiveMessage = async (
   }
 
   let conversation = await models.InstagramConversations.findOne({
-    senderId: userId,
-    recipientId: pageId,
+    senderId: { $eq: userId },
+    recipientId: { $eq: pageId },
   });
 
   const bot = await checkIsBot(models, message, recipient.id);
@@ -132,7 +146,7 @@ export const receiveMessage = async (
   }
 
   const existingMessage = await models.InstagramConversationMessages.findOne({
-    mid,
+    mid: { $eq: mid },
   });
 
   if (!existingMessage) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -11,21 +11,9 @@ import {
   checkIsBot,
   triggerInstagramAutomation,
 } from '@/integrations/instagram/meta/automation/utils/messageUtils';
+import { sanitizeString } from '@/integrations/instagram/utils';
 
 const HAS_ATTACHMENT = 'This message has an attachment';
-
-/**
- * Sanitize a value expected to be a string to prevent NoSQL injection.
- * Coerces non-string values (e.g. numbers, objects) to strings, which
- * neutralizes injection objects like {"$gt": ""} by converting them to
- * "[object Object]".
- */
-const sanitizeString = (value: unknown): string => {
-  if (typeof value === 'string') {
-    return value;
-  }
-  return String(value ?? '');
-};
 
 export const receiveMessage = async (
   models: IModels,

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -33,13 +33,20 @@ export const receiveMessage = async (
   integration: IInstagramIntegrationDocument,
   activity: IMessageData,
 ) => {
-  const userId = sanitizeString(activity.sender?.id);
   const { recipient, timestamp } = activity;
+
+  if (activity.sender?.id == null || recipient?.id == null) {
+    throw new Error(
+      'Instagram webhook is missing sender.id or recipient.id',
+    );
+  }
+
+  const userId = sanitizeString(activity.sender.id);
 
   let message = activity.message as any;
   const postback = activity.postback as any;
 
-  const pageId = sanitizeString(recipient?.id);
+  const pageId = sanitizeString(recipient.id);
   const kind = INTEGRATION_KINDS.MESSENGER;
   const rawMid = message?.mid || postback?.mid;
   const mid = rawMid != null ? sanitizeString(rawMid) : undefined;
@@ -78,7 +85,7 @@ export const receiveMessage = async (
     recipientId: { $eq: pageId },
   });
 
-  const bot = await checkIsBot(models, message, recipient.id);
+  const bot = await checkIsBot(models, message, pageId);
   const botId = bot?._id;
   let isNewConversation = false;
 

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -24,9 +24,10 @@ export const receiveMessage = async (
   const { recipient, timestamp } = activity;
 
   if (activity.sender?.id == null || recipient?.id == null) {
-    throw new Error(
-      'Instagram webhook is missing sender.id or recipient.id',
+    debugError(
+      `[instagram.receiveMessage] missing required webhook fields: sender.id=${activity.sender?.id ? 'present' : 'missing'} recipient.id=${recipient?.id ? 'present' : 'missing'}`,
     );
+    throw new Error('Invalid Instagram message webhook payload');
   }
 
   const userId = sanitizeString(activity.sender.id);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -38,7 +38,7 @@ export const receiveMessage = async (
   const pageId = sanitizeString(recipient.id);
   const kind = INTEGRATION_KINDS.MESSENGER;
   const rawMid = message?.mid || postback?.mid;
-  const mid = rawMid != null ? sanitizeString(rawMid) : undefined;
+  const mid = rawMid == null ? undefined : sanitizeString(rawMid);
   const attachments = message?.attachments;
 
   debugInstagram(`Received message from ${userId} → page ${pageId}`);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -13,20 +13,9 @@ import {
   getPageAccessTokenFromMap,
   getPostDetails,
   getPostLink,
+  sanitizeString,
 } from '@/integrations/instagram/utils';
 import { IModels } from '~/connectionResolvers';
-
-/**
- * Sanitize a value expected to be a string to prevent NoSQL injection.
- * Coerces non-string values (e.g. numbers) to strings, which also neutralizes
- * injection objects like {"$gt": ""} by converting them to "[object Object]".
- */
-const sanitizeString = (value: unknown): string => {
-  if (typeof value === 'string') {
-    return value;
-  }
-  return String(value ?? '');
-};
 
 export const getOrCreateCustomer = async (
   models: IModels,

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -16,6 +16,18 @@ import {
 } from '@/integrations/instagram/utils';
 import { IModels } from '~/connectionResolvers';
 
+/**
+ * Sanitize a value expected to be a string to prevent NoSQL injection.
+ * Coerces non-string values (e.g. numbers) to strings, which also neutralizes
+ * injection objects like {"$gt": ""} by converting them to "[object Object]".
+ */
+const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};
+
 export const getOrCreateCustomer = async (
   models: IModels,
   subdomain: string,
@@ -23,14 +35,19 @@ export const getOrCreateCustomer = async (
   userId: string,
   kind: string,
 ) => {
+  const safePageId = sanitizeString(pageId);
+  const safeUserId = sanitizeString(userId);
+
   const integration = await models.InstagramIntegrations.findOne({
-    instagramPageId: pageId,
-    kind,
+    instagramPageId: { $eq: safePageId },
+    kind: { $eq: kind },
   });
   if (!integration) {
     throw new Error('Instagram Integration not found ');
   }
-  let customer = await models.InstagramCustomers.findOne({ userId });
+  let customer = await models.InstagramCustomers.findOne({
+    userId: { $eq: safeUserId },
+  });
   if (customer) {
     return customer;
   }
@@ -44,7 +61,7 @@ export const getOrCreateCustomer = async (
   let firstName;
   try {
     instagramUser = await getInstagramUser(
-      userId,
+      safeUserId,
       integration.facebookPageId || '',
       integration.facebookPageTokensMap,
     );
@@ -57,7 +74,7 @@ export const getOrCreateCustomer = async (
   if (firstName) {
     try {
       customer = await models.InstagramCustomers.create({
-        userId,
+        userId: safeUserId,
         firstName,
         integrationId: integration.erxesApiId,
         profilePic: instagramUser.profile_pic,
@@ -110,21 +127,27 @@ export const getOrCreateComment = async (
   integration: IInstagramIntegrationDocument,
   customer: IInstagramCustomer,
 ) => {
+  const safePageId = sanitizeString(pageId);
+  const safeUserId = sanitizeString(userId);
+  const safeCommentId = sanitizeString(commentParams.comment_id);
+  const safeParentId = sanitizeString(commentParams.parent_id);
+  const safePostId = sanitizeString(commentParams.post_id);
+
   const mainConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.comment_id,
+    comment_id: { $eq: safeCommentId },
   });
   const parentConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.parent_id,
+    comment_id: { $eq: safeParentId },
   });
   const replyConversation =
     await models.InstagramCommentConversationReply.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: safeCommentId },
     });
   if (mainConversation || replyConversation) {
     return;
   }
   const post = await models.InstagramPostConversations.findOne({
-    postId: commentParams.post_id,
+    postId: { $eq: safePostId },
   });
   let attachment: any[] = [];
   if (commentParams.photo) {
@@ -141,14 +164,14 @@ export const getOrCreateComment = async (
   }
   const doc = {
     attachments: attachment,
-    recipientId: pageId,
-    senderId: userId,
+    recipientId: safePageId,
+    senderId: safeUserId,
     createdAt: commentParams.post?.updated_time || new Date(),
-    postId: commentParams.post_id,
-    comment_id: commentParams.comment_id,
+    postId: safePostId,
+    comment_id: safeCommentId,
     content: commentParams.message,
     customerId: customer.erxesApiId,
-    parentId: commentParams.parent_id,
+    parentId: safeParentId,
   };
   if (parentConversation) {
     await models.InstagramCommentConversationReply.create({
@@ -161,10 +184,10 @@ export const getOrCreateComment = async (
   }
   const conversation =
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: safeCommentId },
     })) ||
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.parent_id,
+      comment_id: { $eq: safeParentId },
     }));
 
   if (!conversation) {
@@ -246,35 +269,41 @@ export const getOrCreatePostConversation = async (
   postId: string,
 ) => {
   try {
-     let postConversation = await models.InstagramPostConversations.findOne({
-    postId
-  });
-  if (!postConversation) {
-    const integration = await models.InstagramIntegrations.findOne({
-      instagramPageId: { $in: pageId }
+    const safePageId = sanitizeString(pageId);
+    const safePostId = sanitizeString(postId);
+
+    let postConversation = await models.InstagramPostConversations.findOne({
+      postId: { $eq: safePostId },
     });
+    if (!postConversation) {
+      const integration = await models.InstagramIntegrations.findOne({
+        instagramPageId: { $eq: safePageId },
+      });
 
-    if (!integration) {
-      throw new Error("Integration not found");
-    }
-    const { accountId } = integration;
-    const account = await models.InstagramAccounts.findOne({ _id: accountId });
-    if (!account) {
-      throw new Error("account not found");
-    }
+      if (!integration) {
+        throw new Error('Integration not found');
+      }
+      const { accountId } = integration;
+      const account = await models.InstagramAccounts.findOne({
+        _id: { $eq: accountId },
+      });
+      if (!account) {
+        throw new Error('account not found');
+      }
 
-    const getPostDetail = await getPostLink(account.token, postId);
-    const instagramPost = {
-      postId: postId,
-      content: getPostDetail.caption,
-      recipientId: getPostDetail.ig_id,
-      senderId: getPostDetail.ig_id,
-      permalink_url: getPostDetail.permalink,
-      timestamp: getPostDetail.timestamp
-    };
-    postConversation = await models.InstagramPostConversations.create(instagramPost);
-  }
-  return postConversation;
+      const getPostDetail = await getPostLink(account.token, safePostId);
+      const instagramPost = {
+        postId: safePostId,
+        content: getPostDetail.caption,
+        recipientId: getPostDetail.ig_id,
+        senderId: getPostDetail.ig_id,
+        permalink_url: getPostDetail.permalink,
+        timestamp: getPostDetail.timestamp,
+      };
+      postConversation =
+        await models.InstagramPostConversations.create(instagramPost);
+    }
+    return postConversation;
 
   } catch (error) {
     throw new Error(
@@ -302,7 +331,7 @@ export const getOrCreatePost = async (
   }
 
   let post = await models.InstagramPostConversations.findOne({
-    postId: postParams.post_id,
+    postId: { $eq: sanitizeString(postParams.post_id) },
   });
 
   if (post) {
@@ -332,8 +361,14 @@ export async function fetchInstagramPostDetails(
   models: IModels,
   params: ICommentParams,
 ) {
+  const safePageId = sanitizeString(pageId);
+  const safePostId = sanitizeString(params.post_id || '');
+
   const integration = await models.InstagramIntegrations.findOne({
-    $and: [{ facebookPageId: pageId }, { kind: INTEGRATION_KINDS.POST }],
+    $and: [
+      { facebookPageId: { $eq: safePageId } },
+      { kind: { $eq: INTEGRATION_KINDS.POST } },
+    ],
   });
 
   if (!integration) {
@@ -343,20 +378,20 @@ export async function fetchInstagramPostDetails(
   const { facebookPageTokensMap = {} } = integration;
 
   const postDetail = await getPostDetails(
-    pageId,
+    safePageId,
     facebookPageTokensMap,
-    params.post_id || '',
+    safePostId,
   );
 
   if (!postDetail) {
-    throw new Error(`Failed to fetch post details for post ${params.post_id}`);
+    throw new Error(`Failed to fetch post details for post ${safePostId}`);
   }
 
   return {
-    postId: params.post_id,
+    postId: safePostId,
     content: postDetail.message || '',
-    recipientId: pageId,
-    senderId: pageId,
+    recipientId: safePageId,
+    senderId: safePageId,
     permalink_url: postDetail.permalink_url || '',
     timestamp: postDetail.created_time,
   };

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
@@ -418,3 +418,16 @@ export const generateAttachmentMessages = (
 
   return messages;
 };
+
+/**
+ * Sanitize a value expected to be a string to prevent NoSQL injection.
+ * Coerces non-string values (e.g. numbers, objects) to strings, which
+ * neutralizes injection objects like {"$gt": ""} by converting them to
+ * "[object Object]".
+ */
+export const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
@@ -423,11 +423,17 @@ export const generateAttachmentMessages = (
  * Sanitize a value expected to be a string to prevent NoSQL injection.
  * Coerces non-string values (e.g. numbers, objects) to strings, which
  * neutralizes injection objects like {"$gt": ""} by converting them to
- * "[object Object]".
+ * "[object Object]". Unexpected non-string, non-nullish inputs are
+ * logged so we can spot type confusion / probing attempts in monitoring.
  */
 export const sanitizeString = (value: unknown): string => {
   if (typeof value === 'string') {
     return value;
+  }
+  if (value !== null && value !== undefined) {
+    debugError(
+      `[instagram.sanitizeString] received non-string input of type ${typeof value}`,
+    );
   }
   return String(value ?? '');
 };


### PR DESCRIPTION
## Summary

Fixes [code scanning alert #1216](https://github.com/erxes/erxes/security/code-scanning/1216) — `js/sql-injection` (high severity) flagged by CodeQL on `backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts:249-251`.

The Instagram webhook handler at `controller.ts:77-137` accepts arbitrary JSON in `req.body` (no signature verification) and forwards fields like `post_id`, `comment_id`, `recipient.id`, and `entry.id` straight into MongoDB `findOne` calls in `store.ts`, `receiveMessage.ts`, and `receiveComment.ts`. An attacker can POST a payload such as:

```json
{"object":"instagram","entry":[{"id":"x","changes":[{"field":"comments","value":{"post_id":{"$ne":null},"comment_id":"...","from":{"id":"..."}}}]}]}
```

and turn `models.InstagramPostConversations.findOne({ postId })` into `findOne({ postId: { $ne: null } })` — i.e. "match any post," potentially leaking cross-tenant conversation data.

## Eval

A standalone reproducer was used to capture the actual MongoDB filter built for benign and malicious inputs.

**Pre-fix** (vulnerable):
- `postId = {$ne: null}` → query becomes `{ postId: { $ne: null } }` ⚠️
- `postId = {$gt: ""}` → query becomes `{ postId: { $gt: "" } }` ⚠️
- The pre-existing `{ $in: pageId }` line was also broken (`$in` requires an array; `pageId` is a string).

**Post-fix** (safe):
- All malicious objects are coerced to `"[object Object]"` by `sanitizeString`
- Every `findOne` filter uses `{ $eq: <primitive> }`
- No injection vector reaches Mongo

## Changes

- Added `sanitizeString` helper to `store.ts`, `receiveMessage.ts`, `receiveComment.ts` (mirrors the helper added in #7456 for the analogous Facebook alert #1175).
- Sanitized all user-controlled string inputs at entry points: `pageId`, `userId`, `mid`, `post_id`, `comment_id`, `parent_id`.
- Switched all `findOne`/`deleteOne` filters in the affected files to use the explicit `$eq` operator.
- Replaced the buggy `{ instagramPageId: { $in: pageId } }` with `{ instagramPageId: { $eq: pageId } }` since `pageId` is a string, not an array.

## Test plan

- [x] Pre-fix eval reproduces the injection (malicious objects flow into Mongo with `$ne`/`$gt` operators).
- [x] Post-fix eval shows all queries use `$eq` against coerced primitives.
- [x] `tsc --noEmit` on `backend/plugins/frontline_api/tsconfig.build.json` passes with zero errors.
- [ ] CodeQL re-scan confirms alert #1216 closes after merge.

## Summary by Sourcery

Harden Instagram webhook handling in the frontline plugin to prevent NoSQL injection and ensure safe querying of Instagram-related MongoDB collections.

Bug Fixes:
- Sanitize all Instagram webhook-derived string identifiers (page, user, post, comment, parent, and message IDs) before using them in database operations to close a NoSQL injection vector.
- Update MongoDB queries in Instagram integrations to compare against sanitized primitives using the $eq operator instead of relying on raw values or incorrect $in usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation and rejection of malformed Instagram webhooks to stop incomplete events from being processed.
  * Consistent sanitization of Instagram identifiers to avoid misattributed or inconsistent records.
  * Prevented duplicate/merged conversations and messages when IDs are missing or malformed.
  * Tightened lookup matching so events reliably map to the correct customer, conversation, post, and comment.
  * Corrected self-comment detection and ensured sanitized IDs are used throughout downstream processing for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->