### PR TITLE
menu scroll fix, list order and category parent tree in selector and …

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -102,6 +102,59 @@ interface CategoryFormData {
   [key: `customFields.${string}`]: CustomFieldValue | undefined; // Allow dynamic custom field properties
 }
 
+const EMPTY_FORM_VALUES: CategoryFormType = {
+  name: '',
+  slug: '',
+  description: '',
+  parentId: undefined,
+  status: 'active',
+  customFieldsData: [],
+};
+
+const generateSlug = (name: string): string =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const collectDescendantIds = (
+  allCategories: Category[],
+  rootId?: string,
+): Set<string> => {
+  const descendants = new Set<string>();
+  if (!rootId) return descendants;
+
+  const queue: string[] = [rootId];
+  while (queue.length) {
+    const currentId = queue.shift() as string;
+    const children = allCategories.filter((c) => c.parentId === currentId);
+    for (const child of children) {
+      if (!descendants.has(child._id)) {
+        descendants.add(child._id);
+        queue.push(child._id);
+      }
+    }
+  }
+  return descendants;
+};
+
+const categoryToFormValues = (
+  category?: Partial<Category>,
+): CategoryFormType => {
+  if (!category) return EMPTY_FORM_VALUES;
+  return {
+    name: category.name || '',
+    slug: category.slug || '',
+    description: category.description || '',
+    parentId: category.parentId || undefined,
+    status: category.status || 'active',
+    customFieldsData: category.customFieldsData || [],
+  };
+};
+
 export function CmsCategoryDrawer({
   category,
   isOpen,
@@ -112,17 +165,6 @@ export function CmsCategoryDrawer({
   const isEditing = !!category?._id;
   const client = useApolloClient();
   const [isSlugManuallyEdited, setIsSlugManuallyEdited] = useState(false);
-
-  // Function to convert name to slug format
-  const generateSlug = (name: string): string => {
-    return name
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9\s-]/g, '') // Remove special characters except spaces and hyphens
-      .replace(/\s+/g, '-') // Replace spaces with hyphens
-      .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
-      .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
-  };
 
   // Fetch custom field groups first to create schema
   const { data: customFieldsData } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {
@@ -147,38 +189,13 @@ export function CmsCategoryDrawer({
 
   const form = useForm<CategoryFormType>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      name: '',
-      slug: '',
-      description: '',
-      parentId: undefined,
-      status: 'active',
-      customFieldsData: [],
-    },
+    defaultValues: EMPTY_FORM_VALUES,
   });
 
   useEffect(() => {
-    if (category && isOpen) {
-      form.reset({
-        name: category.name || '',
-        slug: category.slug || '',
-        description: category.description || '',
-        parentId: category.parentId || undefined,
-        status: category.status || 'active',
-        customFieldsData: category.customFieldsData || [],
-      });
-      setIsSlugManuallyEdited(false);
-    } else if (isOpen) {
-      form.reset({
-        name: '',
-        slug: '',
-        description: '',
-        parentId: undefined,
-        status: 'active',
-        customFieldsData: [],
-      });
-      setIsSlugManuallyEdited(false);
-    }
+    if (!isOpen) return;
+    form.reset(categoryToFormValues(category));
+    setIsSlugManuallyEdited(false);
   }, [category, isOpen, form]);
 
   // Watch for name changes and update slug accordingly
@@ -186,11 +203,10 @@ export function CmsCategoryDrawer({
   const slugValue = form.watch('slug');
 
   useEffect(() => {
-    if (nameValue && !isSlugManuallyEdited && isOpen) {
-      const generatedSlug = generateSlug(nameValue);
-      if (generatedSlug !== slugValue) {
-        form.setValue('slug', generatedSlug);
-      }
+    if (!isOpen || !nameValue || isSlugManuallyEdited) return;
+    const generatedSlug = generateSlug(nameValue);
+    if (generatedSlug !== slugValue) {
+      form.setValue('slug', generatedSlug);
     }
   }, [nameValue, isSlugManuallyEdited, form, slugValue, isOpen]);
 
@@ -204,20 +220,7 @@ export function CmsCategoryDrawer({
     skip: !isOpen,
   });
   const allCategories: Category[] = catsData?.cmsCategories?.list || [];
-
-  const descendantIds = new Set<string>();
-  if (category?._id) {
-    const queue: string[] = [category._id];
-    while (queue.length) {
-      const currentId = queue.shift() as string;
-      for (const c of allCategories) {
-        if (c.parentId === currentId && !descendantIds.has(c._id)) {
-          descendantIds.add(c._id);
-          queue.push(c._id);
-        }
-      }
-    }
-  }
+  const descendantIds = collectDescendantIds(allCategories, category?._id);
 
   const rawParentOptions: Category[] = allCategories.filter(
     (c: Category) => c._id !== category?._id && !descendantIds.has(c._id),

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -19,12 +19,12 @@ import {
   CategoryFormType,
 } from '../constants/categoryFormSchema';
 
-interface TreeOption {
+interface ITreeOption {
   _id: string;
   label: string;
 }
 
-interface FlatCategory {
+interface IFlatCategory {
   _id: string;
   name: string;
   parentId?: string;
@@ -33,11 +33,11 @@ interface FlatCategory {
 const naturalSort = (a: string, b: string) =>
   a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
 
-function buildTreeOptions(flat: FlatCategory[]): TreeOption[] {
-  const result: TreeOption[] = [];
+function buildTreeOptions(flat: IFlatCategory[]): ITreeOption[] {
+  const result: ITreeOption[] = [];
   const visited = new Set<string>();
 
-  const addWithChildren = (item: FlatCategory, depth: number) => {
+  const addWithChildren = (item: IFlatCategory, depth: number) => {
     if (visited.has(item._id)) return;
     visited.add(item._id);
     const prefix = depth > 0 ? '-'.repeat(depth) + ' ' : '';
@@ -203,9 +203,25 @@ export function CmsCategoryDrawer({
     fetchPolicy: 'cache-first',
     skip: !isOpen,
   });
-  const rawParentOptions: Category[] = (
-    catsData?.cmsCategories?.list || []
-  ).filter((c: Category) => c._id !== category?._id);
+  const allCategories: Category[] = catsData?.cmsCategories?.list || [];
+
+  const descendantIds = new Set<string>();
+  if (category?._id) {
+    const queue: string[] = [category._id];
+    while (queue.length) {
+      const currentId = queue.shift() as string;
+      for (const c of allCategories) {
+        if (c.parentId === currentId && !descendantIds.has(c._id)) {
+          descendantIds.add(c._id);
+          queue.push(c._id);
+        }
+      }
+    }
+  }
+
+  const rawParentOptions: Category[] = allCategories.filter(
+    (c: Category) => c._id !== category?._id && !descendantIds.has(c._id),
+  );
 
   const parentOptions = buildTreeOptions(rawParentOptions);
 

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -115,10 +115,10 @@ const generateSlug = (name: string): string =>
   name
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replaceAll(/[^a-z0-9\s-]/g, '')
+    .replaceAll(/\s+/g, '-')
+    .replaceAll(/-+/g, '-')
+    .replaceAll(/^-+|-+$/g, '');
 
 const collectDescendantIds = (
   allCategories: Category[],
@@ -201,14 +201,15 @@ export function CmsCategoryDrawer({
   // Watch for name changes and update slug accordingly
   const nameValue = form.watch('name');
   const slugValue = form.watch('slug');
+  const isNameDirty = !!form.formState.dirtyFields.name;
 
   useEffect(() => {
-    if (!isOpen || !nameValue || isSlugManuallyEdited) return;
+    if (!isOpen || !nameValue || isSlugManuallyEdited || !isNameDirty) return;
     const generatedSlug = generateSlug(nameValue);
     if (generatedSlug !== slugValue) {
       form.setValue('slug', generatedSlug);
     }
-  }, [nameValue, isSlugManuallyEdited, form, slugValue, isOpen]);
+  }, [nameValue, isSlugManuallyEdited, isNameDirty, form, slugValue, isOpen]);
 
   // Fetch categories for Parent Category select
   const { data: catsData } = useQuery(CMS_CATEGORIES, {

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -19,6 +19,46 @@ import {
   CategoryFormType,
 } from '../constants/categoryFormSchema';
 
+interface TreeOption {
+  _id: string;
+  label: string;
+}
+
+interface FlatCategory {
+  _id: string;
+  name: string;
+  parentId?: string;
+}
+
+const naturalSort = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
+function buildTreeOptions(flat: FlatCategory[]): TreeOption[] {
+  const result: TreeOption[] = [];
+  const visited = new Set<string>();
+
+  const addWithChildren = (item: FlatCategory, depth: number) => {
+    if (visited.has(item._id)) return;
+    visited.add(item._id);
+    const prefix = depth > 0 ? '-'.repeat(depth) + ' ' : '';
+    result.push({ _id: item._id, label: prefix + item.name });
+    flat
+      .filter((c) => c.parentId === item._id)
+      .sort((a, b) => naturalSort(a.name, b.name))
+      .forEach((child) => addWithChildren(child, depth + 1));
+  };
+
+  flat
+    .filter((c) => !c.parentId)
+    .sort((a, b) => naturalSort(a.name, b.name))
+    .forEach((root) => addWithChildren(root, 0));
+  flat.forEach((c) => {
+    if (!visited.has(c._id)) result.push({ _id: c._id, label: c.name });
+  });
+
+  return result;
+}
+
 interface Category {
   _id: string;
   name: string;
@@ -163,9 +203,11 @@ export function CmsCategoryDrawer({
     fetchPolicy: 'cache-first',
     skip: !isOpen,
   });
-  const parentOptions: Category[] = (
+  const rawParentOptions: Category[] = (
     catsData?.cmsCategories?.list || []
   ).filter((c: Category) => c._id !== category?._id);
+
+  const parentOptions = buildTreeOptions(rawParentOptions);
 
   // Custom fields functionality
   const updateCustomFieldValue = useCallback(
@@ -382,7 +424,7 @@ export function CmsCategoryDrawer({
                       <Select.Content>
                         {parentOptions.map((opt) => (
                           <Select.Item key={opt._id} value={opt._id}>
-                            {opt.name}
+                            {opt.label}
                           </Select.Item>
                         ))}
                       </Select.Content>

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
@@ -18,9 +18,8 @@ import { ICategory } from '../types/CategoriesType';
 import { useEditCategory } from '../hooks/useEditCategory';
 
 function getDepthPrefix(depth: number): string {
-  if (depth === 0) return '';
-  if (depth === 1) return '- ';
-  return '-- ';
+  if (depth <= 0) return '';
+  return '-'.repeat(depth) + ' ';
 }
 
 export const createCategoriesColumns = (

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
@@ -17,6 +17,12 @@ import {
 import { ICategory } from '../types/CategoriesType';
 import { useEditCategory } from '../hooks/useEditCategory';
 
+function getDepthPrefix(depth: number): string {
+  if (depth === 0) return '';
+  if (depth === 1) return '- ';
+  return '-- ';
+}
+
 export const createCategoriesColumns = (
   clientPortalId: string,
   onEdit?: (category: any) => void,
@@ -32,7 +38,7 @@ export const createCategoriesColumns = (
       header: () => <RecordTable.InlineHead icon={IconUser} label="Name" />,
       accessorKey: 'name',
       cell: ({ cell }) => {
-        const original = cell.row.original as ICategory;
+        const original = cell.row.original as ICategory & { _depth?: number };
         const [editingCell, setEditingCell] = useState<{
           rowId: string;
           value: string;
@@ -52,6 +58,8 @@ export const createCategoriesColumns = (
           setEditingCell(null);
         };
 
+        const prefix = getDepthPrefix(original._depth ?? 0);
+
         return (
           <Popover
             open={isOpen}
@@ -67,7 +75,10 @@ export const createCategoriesColumns = (
             }}
           >
             <RecordTableInlineCell.Trigger>
-              <span>{cell.getValue() as string}</span>
+              <span>
+                {prefix}
+                {cell.getValue() as string}
+              </span>
             </RecordTableInlineCell.Trigger>
             <RecordTableInlineCell.Content>
               <Input

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
@@ -1,9 +1,41 @@
 import { RecordTable } from 'erxes-ui';
+import { useMemo } from 'react';
 import { createCategoriesColumns } from './CategoriesColumn';
 
 import { CATEGORIES_CURSOR_SESSION_KEY } from '../constants/categoriesCursorSessionKey';
 import { useCategories } from '../hooks/useCategoriesEnhanced';
 import { CategoriesCommandBar } from './categories-command-bar/CategoriesCommandbar';
+import { ICategory } from '../types';
+
+const naturalSort = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
+function sortCategoriesAsTree(
+  flat: ICategory[],
+): (ICategory & { _depth: number })[] {
+  const result: (ICategory & { _depth: number })[] = [];
+  const visited = new Set<string>();
+
+  const addWithChildren = (cat: ICategory, depth: number) => {
+    if (visited.has(cat._id)) return;
+    visited.add(cat._id);
+    result.push({ ...cat, _depth: depth });
+    flat
+      .filter((c) => c.parentId === cat._id)
+      .sort((a, b) => naturalSort(a.name || '', b.name || ''))
+      .forEach((child) => addWithChildren(child, depth + 1));
+  };
+
+  flat
+    .filter((c) => !c.parentId)
+    .sort((a, b) => naturalSort(a.name || '', b.name || ''))
+    .forEach((root) => addWithChildren(root, 0));
+  flat.forEach((c) => {
+    if (!visited.has(c._id)) result.push({ ...c, _depth: 0 });
+  });
+
+  return result;
+}
 
 interface CategoriesRecordTableProps {
   clientPortalId: string;
@@ -25,6 +57,12 @@ export const CategoriesRecordTable = ({
       },
     });
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
+
+  const treeCategories = useMemo(
+    () => sortCategoriesAsTree(categories || []),
+    [categories],
+  );
+
   const columns = createCategoriesColumns(
     clientPortalId,
     onEdit || (() => {}),
@@ -34,7 +72,7 @@ export const CategoriesRecordTable = ({
   return (
     <RecordTable.Provider
       columns={columns}
-      data={categories || []}
+      data={treeCategories}
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name']}
     >

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
@@ -5,7 +5,7 @@ import { createCategoriesColumns } from './CategoriesColumn';
 import { CATEGORIES_CURSOR_SESSION_KEY } from '../constants/categoriesCursorSessionKey';
 import { useCategories } from '../hooks/useCategoriesEnhanced';
 import { CategoriesCommandBar } from './categories-command-bar/CategoriesCommandbar';
-import { ICategory } from '../types';
+import { ICategory } from '@/cms/categories/types';
 
 const naturalSort = (a: string, b: string) =>
   a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });

--- a/frontend/plugins/content_ui/src/modules/cms/menus/Menus.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/Menus.tsx
@@ -55,49 +55,49 @@ export function Menus() {
       </MenusHeader>
       <div className="flex overflow-hidden flex-auto">
         <CmsSidebar />
-        <div className="flex overflow-hidden flex-col flex-auto w-full">
-          <div className="flex-auto">
-            <div className="flex flex-col">
-              <div className="flex pt-2 pl-3 justify-between items-center mb-0">
-                <div className="flex items-center gap-2">
-                  <div className="flex items-center gap-1 rounded-md border p-0.5 bg-muted">
-                    {KIND_OPTIONS.map((opt) => (
-                      <Button
-                        key={opt.label}
-                        size="sm"
-                        variant={kindFilter === opt.value ? 'default' : 'ghost'}
-                        className="h-6 px-2 text-xs"
-                        onClick={() => setKindFilter(opt.value)}
-                      >
-                        {opt.label}
-                      </Button>
-                    ))}
-                  </div>
-                  <span className="text-sm text-gray-600">
-                    Found {totalCount} menus
-                  </span>
-                </div>
+        <div className="flex flex-col w-full overflow-hidden flex-auto">
+          <div className="flex pt-2 pl-3 justify-between items-center mb-0">
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 rounded-md border p-0.5 bg-muted">
+                {KIND_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt.label}
+                    size="sm"
+                    variant={kindFilter === opt.value ? 'default' : 'ghost'}
+                    className="h-6 px-2 text-xs"
+                    onClick={() => setKindFilter(opt.value)}
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
               </div>
+              <span className="text-sm text-gray-600">
+                Found {totalCount} menus
+              </span>
+            </div>
+          </div>
 
-              {!loading && (!menus || menus.length === 0) ? (
-                <div className="rounded-lg overflow-hidden">
-                  <EmptyState
-                    icon={IconMenu}
-                    title="No menus yet"
-                    description="Get started by creating your first menu."
-                    actionLabel="Add menu"
-                    onAction={handleAddMenu}
-                  />
-                </div>
-              ) : (
+          {!loading && (!menus || menus.length === 0) ? (
+            <div className="rounded-lg overflow-hidden">
+              <EmptyState
+                icon={IconMenu}
+                title="No menus yet"
+                description="Get started by creating your first menu."
+                actionLabel="Add menu"
+                onAction={handleAddMenu}
+              />
+            </div>
+          ) : (
+            <div className="overflow-hidden flex-auto p-3">
+              <div className="h-full">
                 <MenusRecordTable
                   clientPortalId={websiteId || ''}
                   kind={kindFilter}
                   onEdit={handleEditMenu}
                 />
-              )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/frontend/plugins/content_ui/src/modules/cms/menus/Menus.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/Menus.tsx
@@ -65,6 +65,7 @@ export function Menus() {
                     size="sm"
                     variant={kindFilter === opt.value ? 'default' : 'ghost'}
                     className="h-6 px-2 text-xs"
+                    aria-pressed={kindFilter === opt.value}
                     onClick={() => setKindFilter(opt.value)}
                   >
                     {opt.label}

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -32,16 +32,18 @@ export const MenusRecordTable = ({
     <RecordTable.Provider
       columns={columns}
       data={menus}
-      className="m-3 pb-1"
+      className="h-full m-3 pb-1"
       stickyColumns={['more', 'checkbox', 'label']}
     >
-      <RecordTable>
-        <RecordTable.Header />
-        <RecordTable.Body>
-          {loading && <RecordTable.RowSkeleton rows={10} />}
-          <RecordTable.RowList />
-        </RecordTable.Body>
-      </RecordTable>
+      <RecordTable.Scroll>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            {loading && <RecordTable.RowSkeleton rows={10} />}
+            <RecordTable.RowList />
+          </RecordTable.Body>
+        </RecordTable>
+      </RecordTable.Scroll>
       <MenusCommandBar onBulkDelete={handleBulkDelete} />
     </RecordTable.Provider>
   );

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -28,7 +28,6 @@ export function buildFlatTree<T extends RawMenuItem>(
 }
 
 export function getDepthPrefix(depth: number): string {
-  if (depth === 0) return '';
-  if (depth === 1) return '- ';
-  return '-- ';
+  if (depth <= 0) return '';
+  return '-'.repeat(depth) + ' ';
 }

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -12,6 +12,12 @@ export function buildFlatTree<T extends RawMenuItem>(
   const addChildren = (parentId: string | null, depth: number) => {
     items
       .filter((item) => (item.parentId || null) === parentId)
+      .sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, {
+          numeric: true,
+          sensitivity: 'base',
+        }),
+      )
       .forEach((item) => {
         result.push({ ...item, depth });
         addChildren(item._id, depth + 1);

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CategoryField.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CategoryField.tsx
@@ -13,9 +13,7 @@ export const CategoryField = ({
   categories,
   websiteId,
 }: CategoryFieldProps) => {
-  const sortedCategories = [...(categories || [])].sort((a, b) =>
-    (a?.label || '').localeCompare(b?.label || ''),
-  );
+  const options = categories || [];
   const {
     newCategoryName,
     setNewCategoryName,
@@ -36,10 +34,10 @@ export const CategoryField = ({
           <Form.Control>
             <div className="flex gap-2">
               <MultipleSelector
-                value={sortedCategories.filter((o) =>
+                value={options.filter((o) =>
                   (field.value || []).includes(o.value),
                 )}
-                options={sortedCategories}
+                options={options}
                 placeholder="Select"
                 hidePlaceholderWhenSelected={true}
                 emptyIndicator="Empty"

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
@@ -27,13 +27,13 @@ const COMBINED_CMS_DATA = gql`
   }
 `;
 
-interface RawCategory {
+interface IRawCategory {
   _id: string;
   name: string;
   parentId?: string;
 }
 
-interface CategoryOption {
+interface ICategoryOption {
   label: string;
   value: string;
 }
@@ -41,11 +41,11 @@ interface CategoryOption {
 const naturalSort = (a: string, b: string) =>
   a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
 
-function buildTreeOptions(rawList: RawCategory[]): CategoryOption[] {
-  const result: CategoryOption[] = [];
+function buildTreeOptions(rawList: IRawCategory[]): ICategoryOption[] {
+  const result: ICategoryOption[] = [];
   const visited = new Set<string>();
 
-  const addWithChildren = (cat: RawCategory, depth: number) => {
+  const addWithChildren = (cat: IRawCategory, depth: number) => {
     if (visited.has(cat._id)) return;
     visited.add(cat._id);
     const prefix = depth > 0 ? '-'.repeat(depth) + ' ' : '';

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
@@ -8,6 +8,7 @@ const COMBINED_CMS_DATA = gql`
       list {
         _id
         name
+        parentId
       }
     }
     cmsTags(clientPortalId: $clientPortalId, limit: $limit) {
@@ -25,6 +26,49 @@ const COMBINED_CMS_DATA = gql`
     }
   }
 `;
+
+interface RawCategory {
+  _id: string;
+  name: string;
+  parentId?: string;
+}
+
+interface CategoryOption {
+  label: string;
+  value: string;
+}
+
+const naturalSort = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
+function buildTreeOptions(rawList: RawCategory[]): CategoryOption[] {
+  const result: CategoryOption[] = [];
+  const visited = new Set<string>();
+
+  const addWithChildren = (cat: RawCategory, depth: number) => {
+    if (visited.has(cat._id)) return;
+    visited.add(cat._id);
+    const prefix = depth > 0 ? '-'.repeat(depth) + ' ' : '';
+    result.push({ label: prefix + cat.name, value: cat._id });
+    rawList
+      .filter((c) => c.parentId === cat._id)
+      .sort((a, b) => naturalSort(a.name, b.name))
+      .forEach((child) => addWithChildren(child, depth + 1));
+  };
+
+  rawList
+    .filter((c) => !c.parentId)
+    .sort((a, b) => naturalSort(a.name, b.name))
+    .forEach((root) => addWithChildren(root, 0));
+
+  rawList.forEach((c) => {
+    if (!visited.has(c._id)) {
+      result.push({ label: c.name, value: c._id });
+    }
+  });
+
+  return result;
+}
 
 export const usePostData = (websiteId: string, selectedType?: string) => {
   const { data: combinedData, loading: combinedLoading } = useQuery(
@@ -47,11 +91,8 @@ export const usePostData = (websiteId: string, selectedType?: string) => {
     fetchPolicy: 'cache-first',
   });
 
-  const categories = (combinedData?.cmsCategories?.list || []).map(
-    (c: any) => ({
-      label: c.name,
-      value: c._id,
-    }),
+  const categories = buildTreeOptions(
+    combinedData?.cmsCategories?.list || [],
   );
 
   const tags = (combinedData?.cmsTags?.tags || []).map((t: any) => ({

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
@@ -81,7 +81,7 @@ export const SelectCategoriesProvider = ({
   const categories = useMemo(
     () =>
       [...(data?.cmsCategories?.list || [])].sort((a, b) =>
-        (a?.name || '').localeCompare(b?.name || ''),
+        (a?.name || '').localeCompare(b?.name || '', undefined, { numeric: true }),
       ),
     [data?.cmsCategories?.list],
   );


### PR DESCRIPTION
…in recordtable

## Summary by Sourcery

Improve CMS menu and category UIs with better scrolling, hierarchical display, and natural sorting.

New Features:
- Display CMS categories and post category options as a hierarchical tree with visual depth indicators based on parent-child relationships.

Bug Fixes:
- Fix menu list layout so scrolling works correctly within the menus view.

Enhancements:
- Wrap the CMS menus record table in a scrollable container and ensure it fills available height for better usability.
- Sort menus, categories, and category selectors using natural (numeric-aware) ordering for more intuitive list ordering.
- Show category hierarchy depth in the categories record table via prefixed labels.
- Reuse tree-building logic for category parent selection in the category drawer and post category selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Categories now display consistently as a hierarchical tree with visual indentation in lists, tables, inline names and selectors.
  * Category ordering uses depth-first traversal with natural, numeric-aware sorting for more intuitive ordering.
  * Parent selection excludes a category and all its descendants and shows indented labels to clarify hierarchy.
  * Slug auto-update is tightened to run only when the name was edited and the slug wasn’t manually changed.
  * Table layouts refined for full-height containers and improved spacing.

* **Bug Fixes**
  * Prevents selecting a category’s own descendant as its parent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->