### PR TITLE
refactor: move client portal deal mutations to dedicated resolver and…

### DIFF
--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/clientPortal.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/clientPortal.ts
@@ -29,7 +29,7 @@ export const cpTicketMutations: Record<string, Resolver> = {
       ticketListChanged: { type: 'create', ticket },
     });
 
-    if (ticket && cpUser?.erxesCustomerId) {
+    if (ticket && userId) {
       await sendTRPCMessage({
         subdomain,
         pluginName: 'core',
@@ -40,8 +40,8 @@ export const cpTicketMutations: Record<string, Resolver> = {
           relation: {
             entities: [
               {
-                contentType: 'core:customer',
-                contentId: cpUser.erxesCustomerId,
+                contentType: 'core:cp.user',
+                contentId: userId,
               },
               {
                 contentType: 'frontline:ticket',

--- a/backend/plugins/sales_api/src/apollo/resolvers/mutations.ts
+++ b/backend/plugins/sales_api/src/apollo/resolvers/mutations.ts
@@ -15,6 +15,7 @@ import {
   order as MutationsOrder,
   cover as MutationsCover,
 } from '@/pos/graphql/resolvers/mutations';
+import { cpDealMutations } from '~/modules/sales/graphql/resolvers/mutations/clientPortal';
 
 export const mutations = {
   ...boardMutations,
@@ -30,4 +31,5 @@ export const mutations = {
   ...lastViewedItemMutations,
   ...productReviewMutations,
   ...wishlistMutations,
+  ...cpDealMutations,
 };

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/clientPortal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/clientPortal.ts
@@ -1,0 +1,98 @@
+import { Resolver } from 'erxes-api-shared/core-types';
+import {
+  markResolvers,
+  sendTRPCMessage,
+} from 'erxes-api-shared/utils';
+import { IContext } from '~/connectionResolvers';
+import { IDeal } from '~/modules/sales/@types';
+import { subscriptionWrapper } from '../utils';
+import { createRelations, getNewOrder } from '~/modules/sales/utils';
+
+export const cpDealMutations: Record<string, Resolver> = {
+  async cpDealsAdd(
+    _root,
+    doc: IDeal & { processId: string; aboveItemId: string },
+    { models, subdomain, cpUser, clientPortal }: IContext,
+  ) {
+    const userId =
+      cpUser?.erxesCustomerId ||
+      cpUser?._id ||
+      clientPortal?._id ||
+      doc?.userId;
+
+    doc.initialStageId = doc.stageId;
+
+    const extendedDoc = {
+      ...doc,
+      modifiedBy: `cp:${userId}`,
+      userId: `cp:${userId}`,
+      order: await getNewOrder({
+        collection: models.Deals,
+        stageId: doc.stageId,
+        aboveItemId: doc.aboveItemId,
+      }),
+    };
+
+    if (extendedDoc.propertiesData) {
+      // clean custom field values
+      extendedDoc.propertiesData = await sendTRPCMessage({
+        subdomain,
+
+        pluginName: 'core',
+        method: 'mutation',
+        module: 'fields',
+        action: 'validateFieldValues',
+        input: extendedDoc.propertiesData,
+        defaultValue: {},
+      });
+    }
+
+    const deal = await models.Deals.createDeal(extendedDoc);
+
+    const stage = await models.Stages.getStage(deal.stageId);
+
+    await createRelations(subdomain, {
+      dealId: deal._id,
+      companyIds: doc.companyIds,
+      customerIds: doc.customerIds,
+    });
+
+    if (deal && userId) {
+      await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        method: 'mutation',
+        module: 'relation',
+        action: 'createRelation',
+        input: {
+          relation: {
+            entities: [
+              {
+                contentType: 'core:cp.user',
+                contentId: userId,
+              },
+              {
+                contentType: 'sales:deal',
+                contentId: deal._id,
+              },
+            ],
+          },
+        },
+      });
+    }
+
+    await subscriptionWrapper(models, {
+      action: 'create',
+      deal,
+      pipelineId: stage.pipelineId,
+    });
+
+    return deal;
+  },
+};
+
+markResolvers(cpDealMutations, {
+  wrapperConfig: {
+    forClientPortal: true,
+  },
+});

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -32,14 +32,6 @@ export const dealMutations: Record<string, Resolver> = {
     return await addDeal({ models, subdomain, user, doc });
   },
 
-  async cpDealsAdd(
-    _root,
-    doc: IDeal & { processId: string; aboveItemId: string },
-    { user, models, subdomain }: IContext,
-  ) {
-    return await addDeal({ models, subdomain, user, doc });
-  },
-
   /**
    * Edits a deal
    */
@@ -49,14 +41,6 @@ export const dealMutations: Record<string, Resolver> = {
     { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
-    return await editDeal({ models, subdomain, _id, processId, doc, user });
-  },
-
-  async cpDealsEdit(
-    _root,
-    { _id, processId, ...doc }: IDealDocument & { processId: string },
-    { user, models, subdomain }: IContext,
-  ) {
     return await editDeal({ models, subdomain, _id, processId, doc, user });
   },
 
@@ -291,7 +275,7 @@ export const dealMutations: Record<string, Resolver> = {
     },
     { models, user, checkPermission }: IContext,
   ) {
-    await checkPermission('dealsEdit'); 
+    await checkPermission('dealsEdit');
     const deal = await models.Deals.getDeal(dealId);
     const stage = await models.Stages.getStage(deal.stageId);
 
@@ -325,7 +309,7 @@ export const dealMutations: Record<string, Resolver> = {
     // undefenid or null then true
     const tickUsed = !(stage.defaultTick === false);
     const addDocs = (docs || []).map(
-      (doc) => ({ ...doc, tickUsed }) as IProductData,
+      (doc) => ({ ...doc, tickUsed } as IProductData),
     );
     const productsData: IProductData[] = (deal.productsData || []).concat(
       addDocs,
@@ -399,8 +383,8 @@ export const dealMutations: Record<string, Resolver> = {
       throw new Error('Deals productData not found');
     }
 
-    const productsData: IProductData[] = (deal.productsData || []).map(
-      (data) => (data._id === dataId ? { ...doc } : data),
+    const productsData: IProductData[] = (deal.productsData || []).map((data) =>
+      data._id === dataId ? { ...doc } : data,
     );
 
     const possibleAssignedUsersIds: string[] = (deal.productsData || [])
@@ -519,12 +503,4 @@ export const dealMutations: Record<string, Resolver> = {
       productsData,
     };
   },
-};
-
-dealMutations.cpDealsEdit.wrapperConfig = {
-  forClientPortal: true,
-};
-
-dealMutations.cpDealsAdd.wrapperConfig = {
-  forClientPortal: true,
 };

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
@@ -235,6 +235,4 @@ export const mutations = `
   dealsDeleteProductData(processId: String, dealId: String, dataIds: [String]): JSON
 
   cpDealsAdd(name: String, companyIds: [String], customerIds: [String], labelIds: [String], ${mutationParams}): Deal
-  cpDealsEdit(_id: String!, name: String, ${mutationParams}): Deal
-
 `;


### PR DESCRIPTION
… clean up deal mutation formatting

- add `backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/clientPortal.ts`
- move `cpDealsAdd` logic out of `deals.ts` into client portal-specific resolver
- update relation creation to use `core:cp.user` content type for customer portal user relations
- remove redundant client portal wrapper config from `deals.ts`
- clean up formatting in `deals.ts` for type assertions and permission check
- fix frontline ticket client portal relation mapping to use `core:cp.user` and `userId`

## Summary by Sourcery

Extract client portal deal mutations into a dedicated resolver and align client portal relation mappings for deals and tickets with the cp user model.

New Features:
- Introduce a client portal-specific deal mutations resolver with dedicated cpDealsAdd handling and subscriptions.

Bug Fixes:
- Correct frontline ticket client portal relation mapping to reference core:cp.user by userId instead of customer entities.

Enhancements:
- Refine deal mutation formatting and type assertions for product data updates and permission checks.
- Update client portal deal relation creation to use the core:cp.user content type when linking deals to portal users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized client portal deal creation functionality into dedicated module.
  * Enhanced ticket creation to use flexible user identifier resolution.
  * Streamlined mutation resolver structure for improved modularity.

* **Changes**
  * Updated GraphQL schema to reflect revised deal mutation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->