### PR TITLE
fix(backend): Update README and fixing Email, IMAP and SMTP problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cd erxes
 pnpm install
 
 # Set up environment variables
-cp .env.example .env
+cp .env.sample .env
 # Edit .env and configure MONGO_URL, REDIS_HOST, etc.
 
 # Start core services (Gateway + Core API)

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
@@ -27,14 +27,16 @@ export const listenIntegration = async (
             60000,
           );
         } catch (e) {
-          if (!(e instanceof ResourceLockedError)) {
-            console.error(
-              `[IMAP] Unexpected error acquiring lock for integration ${integration._id}:`,
-              e,
-            );
+          if (e instanceof ResourceLockedError) {
+            return resolve({ reconnect: false, error: e as Error });
           }
           
-          return resolve({ reconnect: false });
+          console.error(
+            `[IMAP] Transient error acquiring lock for integration ${integration._id}:`,
+            e,
+          );
+          
+          return resolve({ reconnect: true, error: e as Error });
         }
 
         if (lock) {

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
@@ -26,8 +26,8 @@ export const listenIntegration = async (
             [`${subdomain}:imap:integration:${integration._id}`],
             60000,
           );
-        } catch (e) {
-          lock = null;
+        } catch {
+          return resolve({ reconnect: false });
         }
 
         if (lock) {
@@ -187,7 +187,7 @@ export const listenIntegration = async (
           if (lock) {
             try {
               await lock.release();
-            } catch (e) {
+            } catch {
               // best-effort
             }
             lock = null;

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/listener.ts
@@ -5,7 +5,7 @@ import { saveMessages } from './messageSaver';
 import { throttle } from 'lodash';
 import { redlock } from './redlock';
 import { ListenResult } from '../../../shared/types';
-import { Lock } from 'redlock';
+import { Lock, ResourceLockedError } from 'redlock';
 
 export const listenIntegration = async (
   subdomain: string,
@@ -26,7 +26,14 @@ export const listenIntegration = async (
             [`${subdomain}:imap:integration:${integration._id}`],
             60000,
           );
-        } catch {
+        } catch (e) {
+          if (!(e instanceof ResourceLockedError)) {
+            console.error(
+              `[IMAP] Unexpected error acquiring lock for integration ${integration._id}:`,
+              e,
+            );
+          }
+          
           return resolve({ reconnect: false });
         }
 

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/messageSaver.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/messageSaver.ts
@@ -108,6 +108,9 @@ const saveMessage = async (
     });
   }
 
+  const body: string =
+    (msg.html !== false && msg.html) || msg.textAsHtml || msg.text || '';
+
   const conversationMessage = await models.ImapMessages.create({
     inboxIntegrationId: integration.inboxId,
     inboxConversationId: conversationId,
@@ -116,7 +119,7 @@ const saveMessage = async (
     inReplyTo: msg.inReplyTo,
     references: msg.references,
     subject: msg.subject,
-    body: msg.html ?? '',
+    body,
     to: msg.to?.value ?? [],
     cc: msg.cc?.value ?? [],
     bcc: msg.bcc?.value ?? [],
@@ -133,7 +136,7 @@ const saveMessage = async (
 
   await pConversationClientMessageInserted(subdomain, {
     _id: String(conversationMessage._id),
-    content: msg.html ?? '',
+    content: body,
     conversationId,
   });
 };

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
@@ -227,7 +227,9 @@ export const loadImapMessageClass = (models: IModels) => {
       }
 
       /* ── send via SMTP ────────────────────────────────────────── */
-      if (!integration.smtpHost) {
+      const smtpHost = integration.smtpHost?.trim();
+      
+      if (!smtpHost) {
         throw new Error(
           'SMTP host is not configured for this integration. Please set the SMTP host in integration settings.',
         );
@@ -237,7 +239,7 @@ export const loadImapMessageClass = (models: IModels) => {
       const secure = smtpPort === 465;
 
       const transporter = nodemailer.createTransport({
-        host: integration.smtpHost,
+        host: smtpHost,
         port: smtpPort,
         secure,
         requireTLS: !secure,

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
@@ -2,9 +2,9 @@ import { Document, Model, Schema } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import * as nodemailer from 'nodemailer';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { htmlToPlainText } from './utils';
 
 /* ── shared sub-types ───────────────────────────────────────────────── */
-
 interface IMapMail {
   name: string;
   address: string;
@@ -253,8 +253,8 @@ export const loadImapMessageClass = (models: IModels) => {
         ...(replyToMessageId ? [replyToMessageId] : []),
       ].filter(Boolean);
 
-      // Strip HTML tags for plain-text fallback; required by strict SMTP servers
-      const textBody = body ? body.replace(/<[^>]+>/g, '') : undefined;
+      // Plain-text fallback
+      const textBody = body ? htmlToPlainText(body) : undefined;
 
       const mailOptions: nodemailer.SendMailOptions = {
         from,

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/models.ts
@@ -227,6 +227,12 @@ export const loadImapMessageClass = (models: IModels) => {
       }
 
       /* ── send via SMTP ────────────────────────────────────────── */
+      if (!integration.smtpHost) {
+        throw new Error(
+          'SMTP host is not configured for this integration. Please set the SMTP host in integration settings.',
+        );
+      }
+
       const smtpPort = Number(integration.smtpPort) || 465;
       const secure = smtpPort === 465;
 
@@ -234,6 +240,7 @@ export const loadImapMessageClass = (models: IModels) => {
         host: integration.smtpHost,
         port: smtpPort,
         secure,
+        requireTLS: !secure,
         auth: {
           user: integration.mainUser || integration.user,
           pass: integration.password,
@@ -246,6 +253,9 @@ export const loadImapMessageClass = (models: IModels) => {
         ...(replyToMessageId ? [replyToMessageId] : []),
       ].filter(Boolean);
 
+      // Strip HTML tags for plain-text fallback; required by strict SMTP servers
+      const textBody = body ? body.replace(/<[^>]+>/g, '') : undefined;
+
       const mailOptions: nodemailer.SendMailOptions = {
         from,
         to,
@@ -253,6 +263,7 @@ export const loadImapMessageClass = (models: IModels) => {
         bcc: bcc?.length ? bcc : undefined,
         subject,
         html: body,
+        text: textBody,
         inReplyTo: replyToMessageId,
         references: refsChain.length ? refsChain : undefined,
         attachments: (attachments ?? []).map((a) => ({

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
@@ -101,14 +101,19 @@ export const listenIntegrationById = async (
 };
 
 export const htmlToPlainText = (html: string): string => {
-  return html
+  const MAX_INPUT = 200_000;
+  const safe = html.length > MAX_INPUT ? html.slice(0, MAX_INPUT) : html;
+
+  return safe
     // Block elements → paragraph break
-    .replace(/<\/(p|div|h[1-6]|blockquote|pre|ul|ol|dl)\s*>/gi, '\n\n')
+    // Non-capturing group + bounded \s{0,64} eliminates O(n²) backtracking.
+    .replace(/<\/(?:p|div|h[1-6]|blockquote|pre|ul|ol|dl)\s{0,64}>/gi, '\n\n')
     // List items / table rows → single newline
-    .replace(/<\/(li|tr|dt|dd)\s*>/gi, '\n')
+    .replace(/<\/(?:li|tr|dt|dd)\s{0,64}>/gi, '\n')
     // Line breaks → newline
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
+    .replace(/<br\s{0,64}\/?>/gi, '\n')
+    // Strip remaining tags — bounded {0,10000} makes worst-case O(n) not O(n²).
+    .replace(/<[^>]{0,10000}>/g, '')
     // Common HTML entities
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
@@ -99,3 +99,29 @@ export const listenIntegrationById = async (
 
   await listenIntegration(subdomain, integration, models);
 };
+
+export const htmlToPlainText = (html: string): string => {
+  return html
+    // Block elements → paragraph break
+    .replace(/<\/(p|div|h[1-6]|blockquote|pre|ul|ol|dl)\s*>/gi, '\n\n')
+    // List items / table rows → single newline
+    .replace(/<\/(li|tr|dt|dd)\s*>/gi, '\n')
+    // Line breaks → newline
+    .replace(/<br\s*\/?>/gi, '\n')
+    // Common HTML entities
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    // Strip all remaining tags
+    .replace(/<[^>]+>/g, '')
+    // Collapse runs of 3+ newlines to two
+    .replace(/\n{3,}/g, '\n\n')
+    // Trim leading/trailing whitespace on each line
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .trim();
+};

--- a/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/imap/utils.ts
@@ -108,6 +108,7 @@ export const htmlToPlainText = (html: string): string => {
     .replace(/<\/(li|tr|dt|dd)\s*>/gi, '\n')
     // Line breaks → newline
     .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
     // Common HTML entities
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
@@ -115,8 +116,6 @@ export const htmlToPlainText = (html: string): string => {
     .replace(/&quot;/gi, '"')
     .replace(/&#39;|&apos;/gi, "'")
     .replace(/&nbsp;/gi, ' ')
-    // Strip all remaining tags
-    .replace(/<[^>]+>/g, '')
     // Collapse runs of 3+ newlines to two
     .replace(/\n{3,}/g, '\n\n')
     // Trim leading/trailing whitespace on each line


### PR DESCRIPTION
- Added an early `return resolve({ reconnect: false })` in the catch block so a lock contention is treated as "already covered, skip."

- Added a hard throw if smtpHost is blank, set `requireTLS: !secure` and added a plain-text body via `body.replace`

- Replaced `msg.html ?? ''` with `(msg.html !== false && msg.html) || msg.textAsHtml || msg.text || ''`

## Summary by Sourcery

Improve IMAP email handling reliability and SMTP configuration validation while updating setup documentation.

Bug Fixes:
- Prevent unnecessary IMAP reconnects by short‑circuiting when integration lock acquisition fails due to contention.
- Ensure outbound SMTP messages include a plain‑text body fallback for servers that require it.
- Prefer available HTML or text variants when saving IMAP message bodies to avoid empty content in stored messages and notifications.
- Fail fast when SMTP host is not configured for an integration instead of attempting to send with an invalid configuration.

Enhancements:
- Enforce TLS usage when not using SMTPS by setting the SMTP transport to require TLS.
- Simplify lock release error handling to be best‑effort without logging noise.

Documentation:
- Update README environment setup instructions to reference the correct sample env file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start installation to copy .env.sample into .env

* **Bug Fixes**
  * IMAP listener now avoids unnecessary reconnects on lock acquisition failures
  * Message saving now preserves content from HTML or text variants to prevent blank bodies
  * Added validation to prevent sending mail when SMTP host is missing

* **New Features**
  * Added HTML-to-plain-text conversion to generate reliable text fallbacks for emails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->