### PR TITLE
fix(frontline): prevent reflected XSS in Instagram webhook verification

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -5,6 +5,11 @@ import { debugError, debugInstagram } from '@/integrations/instagram/debuggers';
 import { getSubdomain, isDev } from 'erxes-api-shared/utils';
 import { generateModels } from '~/connectionResolvers';
 
+// Printable ASCII only (no control chars, no CR/LF) so anything we echo
+// to Meta during the webhook handshake stays inside a single text/plain line.
+const INSTAGRAM_CHALLENGE_PATTERN = /^[\x21-\x7E]+$/;
+const MAX_CHALLENGE_LENGTH = 200;
+
 export const instagramGetPost = async (req, res, next) => {
   try {
     debugInstagram(
@@ -66,9 +71,14 @@ export const instagramSubscription = async (req, res, next) => {
     if (req.query['hub.mode'] === 'subscribe') {
       if (req.query['hub.verify_token'] === INSTAGRAM_VERIFY_TOKEN) {
         const challenge = String(req.query['hub.challenge'] ?? '');
-        // Meta sends an alphanumeric challenge; reject anything else and
-        // respond as text/plain so the value is never interpreted as HTML.
-        if (!/^[A-Za-z0-9]+$/.test(challenge)) {
+        // text/plain on the response is the actual XSS mitigation; this
+        // bound + character whitelist is defense-in-depth so we never echo
+        // an absurd or control-character payload back to Meta.
+        if (
+          challenge.length === 0 ||
+          challenge.length > MAX_CHALLENGE_LENGTH ||
+          !INSTAGRAM_CHALLENGE_PATTERN.test(challenge)
+        ) {
           return res.status(400).type('text/plain').send('Invalid challenge');
         }
         return res.type('text/plain').send(challenge);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -65,10 +65,15 @@ export const instagramSubscription = async (req, res, next) => {
     );
     if (req.query['hub.mode'] === 'subscribe') {
       if (req.query['hub.verify_token'] === INSTAGRAM_VERIFY_TOKEN) {
-        res.send(req.query['hub.challenge']);
-      } else {
-        res.send('OK');
+        const challenge = String(req.query['hub.challenge'] ?? '');
+        // Meta sends an alphanumeric challenge; reject anything else and
+        // respond as text/plain so the value is never interpreted as HTML.
+        if (!/^[A-Za-z0-9]+$/.test(challenge)) {
+          return res.status(400).type('text/plain').send('Invalid challenge');
+        }
+        return res.type('text/plain').send(challenge);
       }
+      return res.type('text/plain').send('OK');
     }
   } catch (e) {
     next(e);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -93,6 +93,7 @@ export const instagramSubscription = async (req, res, next) => {
     return res.status(400).type('text/plain').send('Invalid mode');
   } catch (e) {
     next(e);
+    return;
   }
 };
 export const instagramWebhook = async (req, res) => {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -92,8 +92,7 @@ export const instagramSubscription = async (req, res, next) => {
     // so the request never falls through and hangs until the client times out.
     return res.status(400).type('text/plain').send('Invalid mode');
   } catch (e) {
-    next(e);
-    return;
+    return next(e);
   }
 };
 export const instagramWebhook = async (req, res) => {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -83,7 +83,10 @@ export const instagramSubscription = async (req, res, next) => {
         }
         return res.type('text/plain').send(challenge);
       }
-      return res.type('text/plain').send('OK');
+      // Per Meta's webhook spec, a token mismatch is a failed handshake and
+      // should respond with 403, not 200. Returning 200 here would mislead
+      // Meta into treating the subscription as healthy.
+      return res.status(403).type('text/plain').send('Forbidden');
     }
   } catch (e) {
     next(e);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/controller.ts
@@ -88,6 +88,9 @@ export const instagramSubscription = async (req, res, next) => {
       // Meta into treating the subscription as healthy.
       return res.status(403).type('text/plain').send('Forbidden');
     }
+    // Any other hub.mode (or a missing one) is invalid; respond explicitly
+    // so the request never falls through and hangs until the client times out.
+    return res.status(400).type('text/plain').send('Invalid mode');
   } catch (e) {
     next(e);
   }


### PR DESCRIPTION
## Summary
- Closes GitHub code-scanning alert [#1195](https://github.com/erxes/erxes/security/code-scanning/1195) (`js/reflected-xss`, severity: error)
- The Instagram subscription endpoint echoed `req.query['hub.challenge']` back via `res.send(...)`, which Express serves as `text/html` by default. A crafted value would be reflected and rendered as HTML by browsers.
- Coerce the challenge to a string, validate it matches the alphanumeric shape Meta actually sends (`^[A-Za-z0-9]+$`), and force `Content-Type: text/plain` so the value can never be interpreted as HTML. Reject malformed values with 400.

## Test plan
- [x] `pnpm nx build frontline_api` passes
- [x] Manual: re-run Meta's webhook subscription verification handshake against a dev instance; confirm the challenge is echoed back with `Content-Type: text/plain` and the integration completes
- [x] CodeQL: alert #1195 closes on next scan

## Summary by Sourcery

Bug Fixes:
- Validate and coerce the Instagram hub.challenge parameter and force a text/plain response to eliminate a reflected XSS vector in the webhook verification endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Instagram webhook verification: challenge values are now validated and sanitized (must be non-empty, ≤200 characters, printable ASCII); valid challenges are echoed as plain text.
  * Verification-token mismatches now return 403 "Forbidden".
  * Unsupported or missing webhook modes now return 400 "Invalid mode", improving webhook security and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->