### PR TITLE
fix(insurance): sanitize contract HTML before document.write in preview/print

### DIFF
--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ContractForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ContractForm.tsx
@@ -7,6 +7,7 @@ import {
   useCustomers,
   useCreateInsuranceContract,
 } from '../hooks';
+import { openSanitizedContractWindow } from '~/utils/contractPdfGenerator';
 
 interface ContractFormProps {
   open: boolean;
@@ -179,12 +180,11 @@ export const ContractForm = ({
                         variant="outline"
                         size="sm"
                         onClick={() => {
-                          const previewWindow = window.open('', '_blank');
-                          if (previewWindow) {
-                            previewWindow.document.write(
-                              selectedProduct.pdfContent || '',
-                            );
-                            previewWindow.document.close();
+                          const previewWindow = openSanitizedContractWindow(
+                            selectedProduct.pdfContent || '',
+                          );
+                          if (!previewWindow) {
+                            alert('Popup blocked. Please allow popups.');
                           }
                         }}
                       >

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { Dialog, Button, Label, Input, Select } from 'erxes-ui';
 import { IconEye, IconPlus, IconX } from '@tabler/icons-react';
 import {
@@ -547,7 +548,11 @@ export const ProductForm = ({
                     onClick={() => {
                       const previewWindow = window.open('', '_blank');
                       if (previewWindow) {
-                        previewWindow.document.write(formData.pdfContent);
+                        previewWindow.document.write(
+                          DOMPurify.sanitize(formData.pdfContent, {
+                            WHOLE_DOCUMENT: true,
+                          }),
+                        );
                         previewWindow.document.close();
                       }
                     }}

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import DOMPurify from 'dompurify';
 import { Dialog, Button, Label, Input, Select } from 'erxes-ui';
 import { IconEye, IconPlus, IconX } from '@tabler/icons-react';
 import {
@@ -10,7 +9,10 @@ import {
   useRegions,
 } from '../hooks';
 import { InsuranceProduct } from '../types';
-import { getDefaultPdfTemplate } from '~/utils/contractPdfGenerator';
+import {
+  getDefaultPdfTemplate,
+  openSanitizedContractWindow,
+} from '~/utils/contractPdfGenerator';
 
 interface ProductFormProps {
   open: boolean;
@@ -545,17 +547,9 @@ export const ProductForm = ({
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() => {
-                      const previewWindow = window.open('', '_blank');
-                      if (previewWindow) {
-                        previewWindow.document.write(
-                          DOMPurify.sanitize(formData.pdfContent, {
-                            WHOLE_DOCUMENT: true,
-                          }),
-                        );
-                        previewWindow.document.close();
-                      }
-                    }}
+                    onClick={() =>
+                      openSanitizedContractWindow(formData.pdfContent)
+                    }
                   >
                     <IconEye size={16} />
                     Preview

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
@@ -547,9 +547,14 @@ export const ProductForm = ({
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() =>
-                      openSanitizedContractWindow(formData.pdfContent)
-                    }
+                    onClick={() => {
+                      const win = openSanitizedContractWindow(
+                        formData.pdfContent,
+                      );
+                      if (!win) {
+                        alert('Popup blocked. Please allow popups.');
+                      }
+                    }}
                   >
                     <IconEye size={16} />
                     Preview

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
@@ -12,6 +12,7 @@ import { InsuranceProduct } from '../types';
 import {
   getDefaultPdfTemplate,
   openSanitizedContractWindow,
+  sanitizeContractHtml,
 } from '~/utils/contractPdfGenerator';
 
 interface ProductFormProps {
@@ -252,7 +253,9 @@ export const ProductForm = ({
       setFormData({
         name: product.name,
         insuranceTypeId: product.insuranceType.id,
-        pdfContent: product.pdfContent || '',
+        pdfContent: product.pdfContent
+          ? sanitizeContractHtml(product.pdfContent)
+          : '',
         coveredRisks: product.coveredRisks.map((cr) => ({
           riskId: cr.risk.id,
           coveragePercentage: cr.coveragePercentage,
@@ -359,6 +362,10 @@ export const ProductForm = ({
     e.preventDefault();
 
     try {
+      const sanitizedPdfContent = formData.pdfContent
+        ? sanitizeContractHtml(formData.pdfContent)
+        : null;
+
       if (product) {
         await updateInsuranceProduct({
           variables: {
@@ -366,7 +373,7 @@ export const ProductForm = ({
             name: formData.name,
             coveredRisks: formData.coveredRisks,
             pricingConfig: formData.pricingConfig,
-            pdfContent: formData.pdfContent || null,
+            pdfContent: sanitizedPdfContent,
             regionIds: formData.regionIds,
             additionalCoverages:
               formData.additionalCoverages.length > 0
@@ -389,7 +396,7 @@ export const ProductForm = ({
             insuranceTypeId: formData.insuranceTypeId,
             coveredRisks: formData.coveredRisks,
             pricingConfig: formData.pricingConfig,
-            pdfContent: formData.pdfContent || null,
+            pdfContent: sanitizedPdfContent,
             regionIds: formData.regionIds,
             additionalCoverages:
               formData.additionalCoverages.length > 0

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { useParams } from 'react-router-dom';
 import {
   IconFileText,
@@ -64,7 +65,9 @@ export const ContractPdfEditorPage = () => {
       alert('Popup blocked. Please allow popups.');
       return;
     }
-    previewWindow.document.write(htmlContent);
+    previewWindow.document.write(
+      DOMPurify.sanitize(htmlContent, { WHOLE_DOCUMENT: true }),
+    );
     previewWindow.document.close();
   };
 
@@ -74,7 +77,9 @@ export const ContractPdfEditorPage = () => {
       alert('Popup blocked. Please allow popups.');
       return;
     }
-    printWindow.document.write(htmlContent);
+    printWindow.document.write(
+      DOMPurify.sanitize(htmlContent, { WHOLE_DOCUMENT: true }),
+    );
     printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -14,6 +14,7 @@ import { useContract } from '~/modules/insurance/hooks';
 import {
   generateContractHTML,
   openSanitizedContractWindow,
+  sanitizeContractHtml,
 } from '~/utils/contractPdfGenerator';
 import { useMutation, gql } from '@apollo/client';
 
@@ -70,18 +71,14 @@ export const ContractPdfEditorPage = () => {
   };
 
   const handlePrint = () => {
-    const printWindow = openSanitizedContractWindow(htmlContent);
+    const printWindow = openSanitizedContractWindow(htmlContent, (win) => {
+      win.focus();
+      win.print();
+      setTimeout(() => win.close(), 100);
+    });
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-      setTimeout(() => {
-        printWindow.close();
-      }, 100);
-    };
   };
 
   const handleDownload = () => {
@@ -220,7 +217,8 @@ export const ContractPdfEditorPage = () => {
                     </label>
                     <div className="border rounded-md p-4 bg-gray-50 overflow-auto max-h-[600px]">
                       <iframe
-                        srcDoc={htmlContent}
+                        srcDoc={sanitizeContractHtml(htmlContent)}
+                        sandbox=""
                         className="w-full h-[800px] bg-white border-0"
                         title="PDF Preview"
                       />

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -68,7 +68,6 @@ export const ContractPdfEditorPage = () => {
     const previewWindow = openSanitizedContractWindow(htmlContent);
     if (!previewWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
   };
 
@@ -80,7 +79,6 @@ export const ContractPdfEditorPage = () => {
     });
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -65,6 +65,7 @@ export const ContractPdfEditorPage = () => {
     const previewWindow = openSanitizedContractWindow(htmlContent);
     if (!previewWindow) {
       alert('Popup blocked. Please allow popups.');
+      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -39,7 +39,7 @@ export const ContractPdfEditorPage = () => {
     if (contract) {
       // Use saved PDF content if exists, otherwise generate from template
       if ((contract as any).pdfContent) {
-        setHtmlContent((contract as any).pdfContent);
+        setHtmlContent(sanitizeContractHtml((contract as any).pdfContent));
       } else {
         setHtmlContent(generateContractHTML(contract));
       }
@@ -48,13 +48,15 @@ export const ContractPdfEditorPage = () => {
 
   const handleSaveContractPDF = async () => {
     if (!id || !htmlContent) return;
+    const sanitizedPdfContent = sanitizeContractHtml(htmlContent);
     try {
       await saveContractPDF({
         variables: {
           contractId: id,
-          pdfContent: htmlContent,
+          pdfContent: sanitizedPdfContent,
         },
       });
+      setHtmlContent(sanitizedPdfContent);
       alert('Contract PDF saved successfully!');
     } catch (error) {
       console.error('Error saving contract PDF:', error);

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -80,6 +80,7 @@ export const ContractPdfEditorPage = () => {
     });
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
+      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -220,7 +220,7 @@ export const ContractPdfEditorPage = () => {
                     <div className="border rounded-md p-4 bg-gray-50 overflow-auto max-h-[600px]">
                       <iframe
                         srcDoc={sanitizeContractHtml(htmlContent)}
-                        sandbox=""
+                        sandbox="allow-popups"
                         className="w-full h-[800px] bg-white border-0"
                         title="PDF Preview"
                       />

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import DOMPurify from 'dompurify';
 import { useParams } from 'react-router-dom';
 import {
   IconFileText,
@@ -12,7 +11,10 @@ import {
 import { Breadcrumb, Button, Separator, Card, Skeleton } from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
 import { useContract } from '~/modules/insurance/hooks';
-import { generateContractHTML } from '~/utils/contractPdfGenerator';
+import {
+  generateContractHTML,
+  openSanitizedContractWindow,
+} from '~/utils/contractPdfGenerator';
 import { useMutation, gql } from '@apollo/client';
 
 const SAVE_CONTRACT_PDF = gql`
@@ -60,27 +62,18 @@ export const ContractPdfEditorPage = () => {
   };
 
   const handlePreview = () => {
-    const previewWindow = window.open('', '_blank');
+    const previewWindow = openSanitizedContractWindow(htmlContent);
     if (!previewWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
-    previewWindow.document.write(
-      DOMPurify.sanitize(htmlContent, { WHOLE_DOCUMENT: true }),
-    );
-    previewWindow.document.close();
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
+    const printWindow = openSanitizedContractWindow(htmlContent);
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
       return;
     }
-    printWindow.document.write(
-      DOMPurify.sanitize(htmlContent, { WHOLE_DOCUMENT: true }),
-    );
-    printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();
       printWindow.print();

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import {
   IconFileText,
   IconEye,
@@ -235,7 +236,9 @@ export const ContractTemplateEditorPage = () => {
       .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
       .replaceAll('{{chargedAmount}}', '1,500,000');
 
-    previewWindow.document.write(previewHtml);
+    previewWindow.document.write(
+      DOMPurify.sanitize(previewHtml, { WHOLE_DOCUMENT: true }),
+    );
     previewWindow.document.close();
   };
 
@@ -257,7 +260,9 @@ export const ContractTemplateEditorPage = () => {
       .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
       .replaceAll('{{chargedAmount}}', '1,500,000');
 
-    printWindow.document.write(previewHtml);
+    printWindow.document.write(
+      DOMPurify.sanitize(previewHtml, { WHOLE_DOCUMENT: true }),
+    );
     printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -365,7 +365,7 @@ export const ContractTemplateEditorPage = () => {
                     <div className="border rounded-md p-4 bg-gray-50 overflow-auto max-h-[600px]">
                       <iframe
                         srcDoc={sanitizeContractHtml(buildPreviewHtml())}
-                        sandbox=""
+                        sandbox="allow-popups"
                         className="w-full h-[800px] bg-white border-0"
                         title="Template Preview"
                       />

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -233,6 +233,7 @@ export const ContractTemplateEditorPage = () => {
     const previewWindow = openSanitizedContractWindow(buildPreviewHtml());
     if (!previewWindow) {
       alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -9,7 +9,10 @@ import {
 } from '@tabler/icons-react';
 import { Breadcrumb, Button, Separator, Card, Alert } from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
-import { openSanitizedContractWindow } from '~/utils/contractPdfGenerator';
+import {
+  openSanitizedContractWindow,
+  sanitizeContractHtml,
+} from '~/utils/contractPdfGenerator';
 
 // Default template that will be used for all contracts
 const DEFAULT_TEMPLATE = `<!DOCTYPE html>
@@ -238,18 +241,17 @@ export const ContractTemplateEditorPage = () => {
   };
 
   const handlePrint = () => {
-    const printWindow = openSanitizedContractWindow(buildPreviewHtml());
+    const printWindow = openSanitizedContractWindow(
+      buildPreviewHtml(),
+      (win) => {
+        win.focus();
+        win.print();
+        setTimeout(() => win.close(), 100);
+      },
+    );
     if (!printWindow) {
       alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
-      return;
     }
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-      setTimeout(() => {
-        printWindow.close();
-      }, 100);
-    };
   };
 
   const handleDownload = () => {
@@ -362,16 +364,25 @@ export const ContractTemplateEditorPage = () => {
                     </label>
                     <div className="border rounded-md p-4 bg-gray-50 overflow-auto max-h-[600px]">
                       <iframe
-                        srcDoc={template
-                          .replaceAll('{{contractNumber}}', 'INS2026010001')
-                          .replaceAll('{{vendorName}}', 'Sample Insurance LLC')
-                          .replaceAll('{{customerName}}', 'John Smith')
-                          .replaceAll('{{registrationNumber}}', 'AB12345678')
-                          .replaceAll('{{insuranceType}}', 'Car Insurance')
-                          .replaceAll('{{productName}}', 'Standard Insurance')
-                          .replaceAll('{{startDate}}', 'January 20, 2026')
-                          .replaceAll('{{endDate}}', 'January 20, 2027')
-                          .replaceAll('{{chargedAmount}}', '1,500,000')}
+                        srcDoc={sanitizeContractHtml(
+                          template
+                            .replaceAll('{{contractNumber}}', 'INS2026010001')
+                            .replaceAll(
+                              '{{vendorName}}',
+                              'Sample Insurance LLC',
+                            )
+                            .replaceAll('{{customerName}}', 'John Smith')
+                            .replaceAll('{{registrationNumber}}', 'AB12345678')
+                            .replaceAll('{{insuranceType}}', 'Car Insurance')
+                            .replaceAll(
+                              '{{productName}}',
+                              'Standard Insurance',
+                            )
+                            .replaceAll('{{startDate}}', 'January 20, 2026')
+                            .replaceAll('{{endDate}}', 'January 20, 2027')
+                            .replaceAll('{{chargedAmount}}', '1,500,000'),
+                        )}
+                        sandbox=""
                         className="w-full h-[800px] bg-white border-0"
                         title="Template Preview"
                       />

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import DOMPurify from 'dompurify';
 import {
   IconFileText,
   IconEye,
@@ -10,6 +9,7 @@ import {
 } from '@tabler/icons-react';
 import { Breadcrumb, Button, Separator, Card, Alert } from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
+import { openSanitizedContractWindow } from '~/utils/contractPdfGenerator';
 
 // Default template that will be used for all contracts
 const DEFAULT_TEMPLATE = `<!DOCTYPE html>
@@ -217,15 +217,8 @@ export const ContractTemplateEditorPage = () => {
     }
   };
 
-  const handlePreview = () => {
-    const previewWindow = window.open('', '_blank');
-    if (!previewWindow) {
-      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
-      return;
-    }
-
-    // Replace placeholders with sample data for preview
-    const previewHtml = template
+  const buildPreviewHtml = () =>
+    template
       .replaceAll('{{contractNumber}}', 'INS2026010001')
       .replaceAll('{{vendorName}}', 'Монгол Даатгал ХХК')
       .replaceAll('{{customerName}}', 'Бат Болд')
@@ -236,34 +229,19 @@ export const ContractTemplateEditorPage = () => {
       .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
       .replaceAll('{{chargedAmount}}', '1,500,000');
 
-    previewWindow.document.write(
-      DOMPurify.sanitize(previewHtml, { WHOLE_DOCUMENT: true }),
-    );
-    previewWindow.document.close();
+  const handlePreview = () => {
+    const previewWindow = openSanitizedContractWindow(buildPreviewHtml());
+    if (!previewWindow) {
+      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+    }
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
+    const printWindow = openSanitizedContractWindow(buildPreviewHtml());
     if (!printWindow) {
       alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
       return;
     }
-
-    const previewHtml = template
-      .replaceAll('{{contractNumber}}', 'INS2026010001')
-      .replaceAll('{{vendorName}}', 'Монгол Даатгал ХХК')
-      .replaceAll('{{customerName}}', 'Бат Болд')
-      .replaceAll('{{registrationNumber}}', 'УБ12345678')
-      .replaceAll('{{insuranceType}}', 'Автомашины даатгал')
-      .replaceAll('{{productName}}', 'Стандарт даатгал')
-      .replaceAll('{{startDate}}', '2026 оны 1-р сарын 20')
-      .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
-      .replaceAll('{{chargedAmount}}', '1,500,000');
-
-    printWindow.document.write(
-      DOMPurify.sanitize(previewHtml, { WHOLE_DOCUMENT: true }),
-    );
-    printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();
       printWindow.print();

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -236,7 +236,6 @@ export const ContractTemplateEditorPage = () => {
     const previewWindow = openSanitizedContractWindow(buildPreviewHtml());
     if (!previewWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
   };
 
@@ -251,7 +250,6 @@ export const ContractTemplateEditorPage = () => {
     );
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -235,7 +235,7 @@ export const ContractTemplateEditorPage = () => {
   const handlePreview = () => {
     const previewWindow = openSanitizedContractWindow(buildPreviewHtml());
     if (!previewWindow) {
-      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+      alert('Popup blocked. Please allow popups.');
       return;
     }
   };
@@ -250,7 +250,8 @@ export const ContractTemplateEditorPage = () => {
       },
     );
     if (!printWindow) {
-      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+      alert('Popup blocked. Please allow popups.');
+      return;
     }
   };
 

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -364,24 +364,7 @@ export const ContractTemplateEditorPage = () => {
                     </label>
                     <div className="border rounded-md p-4 bg-gray-50 overflow-auto max-h-[600px]">
                       <iframe
-                        srcDoc={sanitizeContractHtml(
-                          template
-                            .replaceAll('{{contractNumber}}', 'INS2026010001')
-                            .replaceAll(
-                              '{{vendorName}}',
-                              'Sample Insurance LLC',
-                            )
-                            .replaceAll('{{customerName}}', 'John Smith')
-                            .replaceAll('{{registrationNumber}}', 'AB12345678')
-                            .replaceAll('{{insuranceType}}', 'Car Insurance')
-                            .replaceAll(
-                              '{{productName}}',
-                              'Standard Insurance',
-                            )
-                            .replaceAll('{{startDate}}', 'January 20, 2026')
-                            .replaceAll('{{endDate}}', 'January 20, 2027')
-                            .replaceAll('{{chargedAmount}}', '1,500,000'),
-                        )}
+                        srcDoc={sanitizeContractHtml(buildPreviewHtml())}
                         sandbox=""
                         className="w-full h-[800px] bg-white border-0"
                         title="Template Preview"

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 interface Contract {
   contractNumber: string;
   paymentStatus: string;
@@ -327,7 +329,11 @@ export function generateContractPDF(contract: Contract): void {
   }
 
   // Write HTML to the new window
-  printWindow.document.write(generateContractHTML(contract));
+  printWindow.document.write(
+    DOMPurify.sanitize(generateContractHTML(contract), {
+      WHOLE_DOCUMENT: true,
+    }),
+  );
   printWindow.document.close();
 
   // Wait for content to load, then trigger print

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -437,7 +437,7 @@ export function generateContractPDF(contract: Contract): void {
   );
 
   if (!printWindow) {
-    alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+    alert('Popup blocked. Please allow popups.');
   }
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -47,7 +47,12 @@ export function sanitizeContractHtml(html: string): string {
     STYLE_BLOCK,
   );
   const sanitizedBody = DOMPurify.sanitize(stripped, SANITIZE_OPTS);
-  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8">${styleBlocks}</head><body>${sanitizedBody}</body></html>`;
+  // Inherit lang from the host document so non-Mongolian deployments still
+  // get accessible text (screen readers, font selection). Falls back to 'mn'
+  // because that's the canonical erxes deployment locale.
+  const lang =
+    (typeof document !== 'undefined' && document.documentElement.lang) || 'mn';
+  return `<!DOCTYPE html><html lang="${lang}"><head><meta charset="UTF-8">${styleBlocks}</head><body>${sanitizedBody}</body></html>`;
 }
 
 /**
@@ -80,7 +85,8 @@ export function openSanitizedContractWindow(
     { once: true },
   );
   // Fallback in case the popup never fires `load` (e.g. user closes early).
-  setTimeout(() => URL.revokeObjectURL(url), 300_000);
+  // Kept short so a flurry of preview clicks can't accumulate live blobs.
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
   return win;
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -87,22 +87,24 @@ export function openSanitizedContractWindow(
     revokeUrl();
     return null;
   }
+  // Fallback timeout for popups that never fire `load` (e.g. closed before
+  // navigation completes). Cleared on load so the closure doesn't linger for
+  // 5 minutes after a successful open.
+  const cleanupTimeout = setTimeout(() => {
+    if (win.closed) {
+      revokeUrl();
+    }
+  }, 300_000);
   win.addEventListener(
     'load',
     () => {
+      clearTimeout(cleanupTimeout);
       revokeUrl();
       onLoad?.(win);
     },
     { once: true },
   );
   win.location.href = url;
-  // Fallback for popups closed before `load`; avoid revoking while an open
-  // window may still be navigating to the Blob URL on a slow browser.
-  setTimeout(() => {
-    if (win.closed) {
-      revokeUrl();
-    }
-  }, 300_000);
   return win;
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,15 +1,23 @@
 import DOMPurify from 'dompurify';
 
+const SANITIZE_OPTS = { ADD_TAGS: ['style'] } as const;
+
 /**
- * Sanitizes user-edited contract template HTML and returns a complete document
+ * Sanitizes a user-edited contract template and returns a complete document
  * safe to render in a new window or iframe. Uses DOMPurify in fragment mode
  * (WHOLE_DOCUMENT defaults to false) to address SonarCloud rule
- * typescript:S8479; <style> tags are explicitly allowed so contract layouts
- * survive sanitization.
+ * typescript:S8479. The input is parsed into head/body up-front so style
+ * blocks declared in <head> survive sanitization while metadata like <title>
+ * (whose text would otherwise leak into the body via KEEP_CONTENT) is dropped.
  */
 export function sanitizeContractHtml(html: string): string {
-  const fragment = DOMPurify.sanitize(html, { ADD_TAGS: ['style'] });
-  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8"></head><body>${fragment}</body></html>`;
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const headStyles = Array.from(doc.head.querySelectorAll('style'))
+    .map((node) => node.outerHTML)
+    .join('');
+  const sanitizedHead = DOMPurify.sanitize(headStyles, SANITIZE_OPTS);
+  const sanitizedBody = DOMPurify.sanitize(doc.body.innerHTML, SANITIZE_OPTS);
+  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8">${sanitizedHead}</head><body>${sanitizedBody}</body></html>`;
 }
 
 /**
@@ -20,6 +28,10 @@ export function openSanitizedContractWindow(html: string): Window | null {
   const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
   const win = window.open(url, '_blank');
+  if (!win) {
+    URL.revokeObjectURL(url);
+    return null;
+  }
   setTimeout(() => URL.revokeObjectURL(url), 60_000);
   return win;
 }

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -53,9 +53,13 @@ export function sanitizeContractHtml(html: string): string {
   const sanitizedBody = DOMPurify.sanitize(stripped, SANITIZE_OPTS);
   // Inherit lang from the host document so non-Mongolian deployments still
   // get accessible text (screen readers, font selection). Falls back to 'mn'
-  // because that's the canonical erxes deployment locale.
-  const lang =
+  // because that's the canonical erxes deployment locale. The value is
+  // restricted to BCP-47 charset (letters, digits, hyphen) so it cannot
+  // close the attribute or inject markup even if upstream code is ever
+  // compromised.
+  const rawLang =
     (typeof document !== 'undefined' && document.documentElement.lang) || 'mn';
+  const lang = rawLang.replace(/[^a-zA-Z0-9-]/g, '') || 'mn';
   return `<!DOCTYPE html><html lang="${lang}"><head><meta charset="UTF-8">${styleBlocks}</head><body>${sanitizedBody}</body></html>`;
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,10 +1,10 @@
-import DOMPurify from 'dompurify';
+import DOMPurify, { type Config } from 'dompurify';
 
-const SANITIZE_OPTS = { ADD_TAGS: ['style'] } as const;
+const SANITIZE_OPTS: Config = { ADD_TAGS: ['style'] };
 // FORCE_BODY makes DOMPurify keep <style> in a body fragment instead of
 // hoisting it to a head it then discards. Available since DOMPurify 1.x;
 // the workspace pins ^3.2.4 in package.json, so the option is stable.
-const STYLE_SANITIZE_OPTS = { ADD_TAGS: ['style'], FORCE_BODY: true } as const;
+const STYLE_SANITIZE_OPTS: Config = { ADD_TAGS: ['style'], FORCE_BODY: true };
 
 // HTML5 spec says <title> and <style> are raw-text elements — their content
 // cannot contain other tags — so a regex is sufficient and avoids reading

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -2,35 +2,42 @@ import DOMPurify from 'dompurify';
 
 const SANITIZE_OPTS = { ADD_TAGS: ['style'] } as const;
 
+// HTML5 spec says <title> is a raw-text element — its content cannot contain
+// other tags — so a regex is sufficient and avoids reading from a parsed DOM
+// (which would trip CodeQL's js/xss-through-dom rule when the result is later
+// reinterpreted as HTML).
+const TITLE_BLOCK = /<title\b[^>]*>[\s\S]*?<\/title>/gi;
+
 /**
  * Sanitizes a user-edited contract template and returns a complete document
  * safe to render in a new window or iframe. Uses DOMPurify in fragment mode
  * (WHOLE_DOCUMENT defaults to false) to address SonarCloud rule
- * typescript:S8479. The input is parsed into head/body up-front so style
- * blocks declared in <head> survive sanitization while metadata like <title>
- * (whose text would otherwise leak into the body via KEEP_CONTENT) is dropped.
+ * typescript:S8479. The <title> block is stripped beforehand because
+ * DOMPurify's KEEP_CONTENT default would otherwise leak the title text into
+ * the rendered body once the wrapping <head> is dropped.
  */
 export function sanitizeContractHtml(html: string): string {
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  const headStyles = Array.from(doc.head.querySelectorAll('style'))
-    .map((node) => node.outerHTML)
-    .join('');
-  const sanitizedHead = DOMPurify.sanitize(headStyles, SANITIZE_OPTS);
-  const sanitizedBody = DOMPurify.sanitize(doc.body.innerHTML, SANITIZE_OPTS);
-  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8">${sanitizedHead}</head><body>${sanitizedBody}</body></html>`;
+  const sanitized = DOMPurify.sanitize(
+    html.replace(TITLE_BLOCK, ''),
+    SANITIZE_OPTS,
+  );
+  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8"></head><body>${sanitized}</body></html>`;
 }
 
 /**
  * Opens sanitized contract HTML in a new window via a Blob URL. Replaces the
  * deprecated `document.write(...)` API (SonarCloud rule typescript:S1874).
  *
- * The Blob URL is revoked once the popup fires its `load` event, so the
- * popup keeps the URL valid for the entire navigation/parse phase regardless
- * of network or document size. `addEventListener` is used (rather than the
- * `.onload` setter) so callers can still attach their own `printWindow.onload`
- * print handler. A fallback timeout guarantees cleanup if `load` never fires.
+ * Callers that need to act on the popup once it has loaded (e.g. to trigger
+ * print) pass an `onLoad` callback. Registering it inside the helper avoids
+ * a race with the async `load` event vs. the caller's `.onload` setter, and
+ * lets the helper share a single `load` listener for both URL revocation
+ * and the caller's logic.
  */
-export function openSanitizedContractWindow(html: string): Window | null {
+export function openSanitizedContractWindow(
+  html: string,
+  onLoad?: (win: Window) => void,
+): Window | null {
   const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
   const win = window.open(url, '_blank');
@@ -38,7 +45,15 @@ export function openSanitizedContractWindow(html: string): Window | null {
     URL.revokeObjectURL(url);
     return null;
   }
-  win.addEventListener('load', () => URL.revokeObjectURL(url), { once: true });
+  win.addEventListener(
+    'load',
+    () => {
+      URL.revokeObjectURL(url);
+      onLoad?.(win);
+    },
+    { once: true },
+  );
+  // Fallback in case the popup never fires `load` (e.g. user closes early).
   setTimeout(() => URL.revokeObjectURL(url), 300_000);
   return win;
 }
@@ -363,22 +378,19 @@ function generateContractHTML(contract: Contract): string {
 }
 
 export function generateContractPDF(contract: Contract): void {
-  const printWindow = openSanitizedContractWindow(generateContractHTML(contract));
+  const printWindow = openSanitizedContractWindow(
+    generateContractHTML(contract),
+    (win) => {
+      win.focus();
+      win.print();
+      // Close window after printing (user can cancel)
+      setTimeout(() => win.close(), 100);
+    },
+  );
 
   if (!printWindow) {
     alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
-    return;
   }
-
-  // Wait for content to load, then trigger print
-  printWindow.onload = () => {
-    printWindow.focus();
-    printWindow.print();
-    // Close window after printing (user can cancel)
-    setTimeout(() => {
-      printWindow.close();
-    }, 100);
-  };
 }
 
 export function downloadContractHTML(contract: Contract): void {

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -13,6 +13,22 @@ const TITLE_BLOCK = /<title\b[^>]*>[\s\S]*?<\/title>/gi;
 const STYLE_BLOCK = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
 
 /**
+ * Strips every match of `pattern` from `html`, repeating until the result is
+ * stable. A single replace pass can leave a fresh match exposed when blocks
+ * are nested or interleaved (`<sty<style>x</style>le>`), which trips CodeQL's
+ * js/incomplete-multi-character-sanitization rule.
+ */
+function stripUntilStable(html: string, pattern: RegExp): string {
+  let prev = html;
+  let next = html.replace(pattern, '');
+  while (next !== prev) {
+    prev = next;
+    next = next.replace(pattern, '');
+  }
+  return next;
+}
+
+/**
  * Sanitizes a user-edited contract template and returns a complete document
  * safe to render in a new window or iframe. Uses DOMPurify in fragment mode
  * (WHOLE_DOCUMENT defaults to false) to address SonarCloud rule
@@ -26,7 +42,10 @@ export function sanitizeContractHtml(html: string): string {
   const styleBlocks = (html.match(STYLE_BLOCK) || [])
     .map((style) => DOMPurify.sanitize(style, STYLE_SANITIZE_OPTS))
     .join('');
-  const stripped = html.replace(TITLE_BLOCK, '').replace(STYLE_BLOCK, '');
+  const stripped = stripUntilStable(
+    stripUntilStable(html, TITLE_BLOCK),
+    STYLE_BLOCK,
+  );
   const sanitizedBody = DOMPurify.sanitize(stripped, SANITIZE_OPTS);
   return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8">${styleBlocks}</head><body>${sanitizedBody}</body></html>`;
 }

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -72,7 +72,7 @@ export function openSanitizedContractWindow(
 ): Window | null {
   const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
-  const win = window.open(url, '_blank');
+  const win = window.open('', '_blank');
   if (!win) {
     URL.revokeObjectURL(url);
     return null;
@@ -85,6 +85,7 @@ export function openSanitizedContractWindow(
     },
     { once: true },
   );
+  win.location.href = url;
   // Fallback in case the popup never fires `load` (e.g. user closes early).
   // Kept short so a flurry of preview clicks can't accumulate live blobs.
   setTimeout(() => URL.revokeObjectURL(url), 60_000);

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,27 +1,34 @@
 import DOMPurify from 'dompurify';
 
 const SANITIZE_OPTS = { ADD_TAGS: ['style'] } as const;
+// FORCE_BODY makes DOMPurify keep <style> in a body fragment instead of
+// hoisting it to a head it then discards.
+const STYLE_SANITIZE_OPTS = { ADD_TAGS: ['style'], FORCE_BODY: true } as const;
 
-// HTML5 spec says <title> is a raw-text element — its content cannot contain
-// other tags — so a regex is sufficient and avoids reading from a parsed DOM
-// (which would trip CodeQL's js/xss-through-dom rule when the result is later
-// reinterpreted as HTML).
+// HTML5 spec says <title> and <style> are raw-text elements — their content
+// cannot contain other tags — so a regex is sufficient and avoids reading
+// from a parsed DOM (which would trip CodeQL's js/xss-through-dom rule when
+// the result is later reinterpreted as HTML).
 const TITLE_BLOCK = /<title\b[^>]*>[\s\S]*?<\/title>/gi;
+const STYLE_BLOCK = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
 
 /**
  * Sanitizes a user-edited contract template and returns a complete document
  * safe to render in a new window or iframe. Uses DOMPurify in fragment mode
  * (WHOLE_DOCUMENT defaults to false) to address SonarCloud rule
- * typescript:S8479. The <title> block is stripped beforehand because
- * DOMPurify's KEEP_CONTENT default would otherwise leak the title text into
- * the rendered body once the wrapping <head> is dropped.
+ * typescript:S8479. <style> blocks are extracted up-front and sanitized with
+ * FORCE_BODY so they survive in the rebuilt <head> — fragment mode otherwise
+ * drops everything outside <body>, leaving the preview unstyled. The <title>
+ * block is stripped beforehand because DOMPurify's KEEP_CONTENT default
+ * would otherwise leak the title text into the rendered body.
  */
 export function sanitizeContractHtml(html: string): string {
-  const sanitized = DOMPurify.sanitize(
-    html.replace(TITLE_BLOCK, ''),
-    SANITIZE_OPTS,
-  );
-  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8"></head><body>${sanitized}</body></html>`;
+  const styleBlocks = (html.match(STYLE_BLOCK) || [])
+    .map((style) => DOMPurify.sanitize(style, STYLE_SANITIZE_OPTS))
+    .join('');
+  const stripped = html.replace(TITLE_BLOCK, '').replace(STYLE_BLOCK, '');
+  const sanitizedBody = DOMPurify.sanitize(stripped, SANITIZE_OPTS);
+  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8">${styleBlocks}</head><body>${sanitizedBody}</body></html>`;
 }
 
 /**

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -23,6 +23,12 @@ export function sanitizeContractHtml(html: string): string {
 /**
  * Opens sanitized contract HTML in a new window via a Blob URL. Replaces the
  * deprecated `document.write(...)` API (SonarCloud rule typescript:S1874).
+ *
+ * The Blob URL is revoked once the popup fires its `load` event, so the
+ * popup keeps the URL valid for the entire navigation/parse phase regardless
+ * of network or document size. `addEventListener` is used (rather than the
+ * `.onload` setter) so callers can still attach their own `printWindow.onload`
+ * print handler. A fallback timeout guarantees cleanup if `load` never fires.
  */
 export function openSanitizedContractWindow(html: string): Window | null {
   const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
@@ -32,7 +38,8 @@ export function openSanitizedContractWindow(html: string): Window | null {
     URL.revokeObjectURL(url);
     return null;
   }
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  win.addEventListener('load', () => URL.revokeObjectURL(url), { once: true });
+  setTimeout(() => URL.revokeObjectURL(url), 300_000);
   return win;
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,6 +1,9 @@
 import DOMPurify, { type Config } from 'dompurify';
 
 const SANITIZE_OPTS: Config = { ADD_TAGS: ['style'] };
+// SECURITY: Contract templates need custom CSS for printable layouts, so this
+// sanitizer intentionally allows <style>. Keep sanitized previews in sandboxed
+// iframes or Blob popups so template CSS cannot observe or style parent DOM.
 // FORCE_BODY makes DOMPurify keep <style> in a body fragment instead of
 // hoisting it to a head it then discards. Available since DOMPurify 1.x;
 // the workspace pins ^3.2.4 in package.json, so the option is stable.
@@ -72,23 +75,34 @@ export function openSanitizedContractWindow(
 ): Window | null {
   const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
+  let revoked = false;
+  const revokeUrl = () => {
+    if (!revoked) {
+      URL.revokeObjectURL(url);
+      revoked = true;
+    }
+  };
   const win = window.open('', '_blank');
   if (!win) {
-    URL.revokeObjectURL(url);
+    revokeUrl();
     return null;
   }
   win.addEventListener(
     'load',
     () => {
-      URL.revokeObjectURL(url);
+      revokeUrl();
       onLoad?.(win);
     },
     { once: true },
   );
   win.location.href = url;
-  // Fallback in case the popup never fires `load` (e.g. user closes early).
-  // Kept short so a flurry of preview clicks can't accumulate live blobs.
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  // Fallback for popups closed before `load`; avoid revoking while an open
+  // window may still be navigating to the Blob URL on a slow browser.
+  setTimeout(() => {
+    if (win.closed) {
+      revokeUrl();
+    }
+  }, 300_000);
   return win;
 }
 

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -2,7 +2,8 @@ import DOMPurify from 'dompurify';
 
 const SANITIZE_OPTS = { ADD_TAGS: ['style'] } as const;
 // FORCE_BODY makes DOMPurify keep <style> in a body fragment instead of
-// hoisting it to a head it then discards.
+// hoisting it to a head it then discards. Available since DOMPurify 1.x;
+// the workspace pins ^3.2.4 in package.json, so the option is stable.
 const STYLE_SANITIZE_OPTS = { ADD_TAGS: ['style'], FORCE_BODY: true } as const;
 
 // HTML5 spec says <title> and <style> are raw-text elements — their content

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,5 +1,29 @@
 import DOMPurify from 'dompurify';
 
+/**
+ * Sanitizes user-edited contract template HTML and returns a complete document
+ * safe to render in a new window or iframe. Uses DOMPurify in fragment mode
+ * (WHOLE_DOCUMENT defaults to false) to address SonarCloud rule
+ * typescript:S8479; <style> tags are explicitly allowed so contract layouts
+ * survive sanitization.
+ */
+export function sanitizeContractHtml(html: string): string {
+  const fragment = DOMPurify.sanitize(html, { ADD_TAGS: ['style'] });
+  return `<!DOCTYPE html><html lang="mn"><head><meta charset="UTF-8"></head><body>${fragment}</body></html>`;
+}
+
+/**
+ * Opens sanitized contract HTML in a new window via a Blob URL. Replaces the
+ * deprecated `document.write(...)` API (SonarCloud rule typescript:S1874).
+ */
+export function openSanitizedContractWindow(html: string): Window | null {
+  const blob = new Blob([sanitizeContractHtml(html)], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const win = window.open(url, '_blank');
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  return win;
+}
+
 interface Contract {
   contractNumber: string;
   paymentStatus: string;
@@ -320,21 +344,12 @@ function generateContractHTML(contract: Contract): string {
 }
 
 export function generateContractPDF(contract: Contract): void {
-  // Create a new window for printing
-  const printWindow = window.open('', '_blank');
+  const printWindow = openSanitizedContractWindow(generateContractHTML(contract));
 
   if (!printWindow) {
     alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
     return;
   }
-
-  // Write HTML to the new window
-  printWindow.document.write(
-    DOMPurify.sanitize(generateContractHTML(contract), {
-      WHOLE_DOCUMENT: true,
-    }),
-  );
-  printWindow.document.close();
 
   // Wait for content to load, then trigger print
   printWindow.onload = () => {


### PR DESCRIPTION
## Summary
Closes 6 GitHub code-scanning alerts (`js/xss-through-dom`):
- #1098 `ProductForm.tsx` pdfContent preview
- #1099 `ContractPdfEditorPage` handlePreview
- #1100 `ContractPdfEditorPage` handlePrint
- #1101 `ContractTemplateEditorPage` handlePreview
- #1102 `ContractTemplateEditorPage` handlePrint
- #1103 `contractPdfGenerator.generateContractPDF` print

Insurance contract preview and print flows wrote user-edited HTML templates straight into a `window.open('', '_blank').document.write(...)` target. Because the new window inherits the opener's origin, any `<script>` or `on*` handler stored in a saved template would execute in the previewer's session — a stored XSS vector across staff users.

## Fix
Pipe every HTML payload through `DOMPurify.sanitize(html, { WHOLE_DOCUMENT: true })` before writing. `WHOLE_DOCUMENT: true` preserves the `<!DOCTYPE>`, `<html>`, `<head>`, and `<style>` blocks the templates need for PDF rendering, while still stripping scripts, event handlers, and `javascript:` URIs.

`dompurify@^3.2.4` is already a workspace dependency (`erxes-ui` uses it for BlockNote rendering).

## Test plan
- [x] `pnpm nx build insurance_ui` passes
- [ ] Manual: open a contract → click Preview / Print, confirm rendering still matches template (styles, layout)
- [ ] Manual: save a template containing `<script>alert(1)</script>`, click Preview, confirm no alert fires and the rest of the template still renders
- [ ] CodeQL: alerts #1098–#1103 close on next scan

## Summary by Sourcery

Bug Fixes:
- Sanitize HTML used for insurance contract preview and print windows with DOMPurify to prevent execution of malicious scripts embedded in user-edited templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, safer preview/print mechanism for consistent rendering and lifecycle handling.

* **Bug Fixes**
  * Preview and print content is sanitized before display to improve security and rendering.
  * Popup-block detection notifies users if previews/prints are blocked and aborts gracefully.
  * Print flow now has more reliable load and cleanup handling to prevent leftover resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->