### PR TITLE
feat:Add permission checks to all accounting mutations and queries

### DIFF
--- a/backend/plugins/accounting_api/src/meta/permissions.ts
+++ b/backend/plugins/accounting_api/src/meta/permissions.ts
@@ -1,5 +1,6 @@
 import { IPermissionConfig } from 'erxes-api-shared/core-types';
 
+// Account actions
 const ACTIONS = {
   read: 'accountsRead',
   manage: 'manageAccounts',
@@ -7,7 +8,54 @@ const ACTIONS = {
   merge: 'accountsMerge',
 } as const;
 
+// Category actions
+const CATEGORY_ACTIONS = {
+  manage: 'manageAccountCategories',
+  read: 'readAccountCategories',
+  remove: 'removeAccountCategories',
+} as const;
+
+const TRANSACTION_ACTIONS = {
+  read: 'readTransactions',
+  manage: 'manageTransactions',
+  remove: 'removeTransactions',
+  link: 'linkTransactions',
+} as const;
+
+const VAT_ROW_ACTIONS = {
+  read: 'readVatRows',
+  manage: 'manageVatRows',
+  remove: 'removeVatRows',
+} as const;
+
+const CTAX_ROW_ACTIONS = {
+  read: 'readCtaxRows',
+  manage: 'manageCtaxRows',
+  remove: 'removeCtaxRows',
+} as const;
+
+const ADJ_INV_ACTIONS = {
+  read: 'readAdjustInventories',
+  manage: 'manageAdjustInventories',
+  publish: 'publishAdjustInventories',
+  cancel: 'cancelAdjustInventories',
+  remove: 'removeAdjustInventories',
+  clear: 'clearAdjustInventories',
+} as const;
+
+const CONFIG_ACTIONS = {
+  read: 'readAccountingConfigs',
+  manage: 'manageAccountingConfigs',
+  remove: 'removeAccountingConfigs',
+} as const;
+
+const allTransactionActions = Object.values(TRANSACTION_ACTIONS);
 const allActions = Object.values(ACTIONS);
+const allCategoryActions = Object.values(CATEGORY_ACTIONS); // for admin group
+const allVatRowActions = Object.values(VAT_ROW_ACTIONS);
+const allCtaxRowActions = Object.values(CTAX_ROW_ACTIONS);
+const allAdjInvActions = Object.values(ADJ_INV_ACTIONS);
+const allConfigActions = Object.values(CONFIG_ACTIONS);
 
 export const permissions: IPermissionConfig = {
   plugin: 'accounting',
@@ -16,28 +64,262 @@ export const permissions: IPermissionConfig = {
     {
       name: 'account',
       description: 'Accounting management',
-
       scopes: [
         { name: 'own', description: 'Records user created' },
         { name: 'all', description: 'All records' },
       ],
-
       actions: [
-        { title: 'View accounts', name: ACTIONS.read, description: 'View accounts', always: true },
-        { title: 'Manage accounts', name: ACTIONS.manage, description: 'Create and edit accounts' },
-        { title: 'Remove accounts', name: ACTIONS.remove, description: 'Remove accounts' },
-        { title: 'Merge accounts', name: ACTIONS.merge, description: 'Merge accounts' },
+        {
+          title: 'View accounts',
+          name: ACTIONS.read,
+          description: 'View accounts',
+          always: true,
+        },
+        {
+          title: 'Manage accounts',
+          name: ACTIONS.manage,
+          description: 'Create and edit accounts',
+        },
+        {
+          title: 'Remove accounts',
+          name: ACTIONS.remove,
+          description: 'Remove accounts',
+        },
+        {
+          title: 'Merge accounts',
+          name: ACTIONS.merge,
+          description: 'Merge accounts',
+        },
+      ],
+    },
+
+    // --- accountCategory---
+    {
+      name: 'accountCategory',
+      description: 'Account category management',
+      scopes: [
+        { name: 'own', description: 'Categories created by the user' },
+        { name: 'all', description: 'All categories' },
+      ],
+      actions: [
+        {
+          title: 'View categories',
+          name: CATEGORY_ACTIONS.read,
+          description: 'View account categories',
+          always: true,
+        },
+        {
+          title: 'Manage categories',
+          name: CATEGORY_ACTIONS.manage,
+          description: 'Create, edit account categories',
+        },
+        {
+          title: 'Remove categories',
+          name: CATEGORY_ACTIONS.remove,
+          description: 'Remove account categories',
+        },
+      ],
+    },
+    {
+      name: 'transaction',
+      description: 'Transaction management',
+      scopes: [
+        { name: 'own', description: 'Transactions created by the user' },
+        { name: 'all', description: 'All transactions' },
+      ],
+      actions: [
+        {
+          title: 'View transactions',
+          name: TRANSACTION_ACTIONS.read,
+          description: 'View transactions',
+          always: true,
+        },
+        {
+          title: 'Manage transactions',
+          name: TRANSACTION_ACTIONS.manage,
+          description: 'Create and update transactions',
+        },
+        {
+          title: 'Remove transactions',
+          name: TRANSACTION_ACTIONS.remove,
+          description: 'Delete transactions',
+        },
+        {
+          title: 'Link transactions',
+          name: TRANSACTION_ACTIONS.link,
+          description: 'Link transactions',
+        },
+      ],
+    },
+    {
+      name: 'vatRow',
+      description: 'VAT row management',
+      scopes: [
+        { name: 'own', description: 'VAT rows created by the user' },
+        { name: 'all', description: 'All VAT rows' },
+      ],
+      actions: [
+        {
+          title: 'View VAT rows',
+          name: VAT_ROW_ACTIONS.read,
+          description: 'View VAT rows',
+          always: true,
+        },
+        {
+          title: 'Manage VAT rows',
+          name: VAT_ROW_ACTIONS.manage,
+          description: 'Create and edit VAT rows',
+        },
+        {
+          title: 'Remove VAT rows',
+          name: VAT_ROW_ACTIONS.remove,
+          description: 'Delete VAT rows',
+        },
+      ],
+    },
+    {
+      name: 'ctaxRow',
+      description: 'CTax row management',
+      scopes: [
+        { name: 'own', description: 'CTax rows created by the user' },
+        { name: 'all', description: 'All CTax rows' },
+      ],
+      actions: [
+        {
+          title: 'View CTax rows',
+          name: CTAX_ROW_ACTIONS.read,
+          description: 'View CTax rows',
+          always: true,
+        },
+        {
+          title: 'Manage CTax rows',
+          name: CTAX_ROW_ACTIONS.manage,
+          description: 'Create and edit CTax rows',
+        },
+        {
+          title: 'Remove CTax rows',
+          name: CTAX_ROW_ACTIONS.remove,
+          description: 'Delete CTax rows',
+        },
+      ],
+    },
+    {
+      name: 'adjustInventory',
+      description: 'Inventory adjustment management',
+      scopes: [
+        { name: 'own', description: 'Adjustments created by the user' },
+        { name: 'all', description: 'All adjustments' },
+      ],
+      actions: [
+        {
+          title: 'View adjustments',
+          name: ADJ_INV_ACTIONS.read,
+          description: 'View inventory adjustments',
+          always: true,
+        },
+        {
+          title: 'Manage adjustments',
+          name: ADJ_INV_ACTIONS.manage,
+          description: 'Create and run inventory adjustments',
+        },
+        {
+          title: 'Publish adjustments',
+          name: ADJ_INV_ACTIONS.publish,
+          description: 'Publish an adjustment',
+        },
+        {
+          title: 'Cancel adjustments',
+          name: ADJ_INV_ACTIONS.cancel,
+          description: 'Cancel a published adjustment',
+        },
+        {
+          title: 'Remove adjustments',
+          name: ADJ_INV_ACTIONS.remove,
+          description: 'Delete an adjustment',
+        },
+        {
+          title: 'Clear adjustments',
+          name: ADJ_INV_ACTIONS.clear,
+          description: 'Clear an adjustment',
+        },
+      ],
+    },
+    {
+      name: 'config',
+      description: 'Accounting configuration management',
+      scopes: [
+        { name: 'own', description: 'Configs created by the user' },
+        { name: 'all', description: 'All configs' },
+      ],
+      actions: [
+        {
+          title: 'View configs',
+          name: CONFIG_ACTIONS.read,
+          description: 'View accounting configs',
+          always: true,
+        },
+        {
+          title: 'Manage configs',
+          name: CONFIG_ACTIONS.manage,
+          description: 'Create and update accounting configs',
+        },
+        {
+          title: 'Remove configs',
+          name: CONFIG_ACTIONS.remove,
+          description: 'Delete accounting configs',
+        },
       ],
     },
   ],
-
   defaultGroups: [
     {
       id: 'accounting:admin',
       name: 'Accounting Admin',
       description: 'Full access to Accounting plugin',
       permissions: [
-        { plugin: 'accounting', module: 'account', actions: [...allActions], scope: 'all' },
+        {
+          plugin: 'accounting',
+          module: 'account',
+          actions: [...allActions],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'accountCategory',
+          actions: [...allCategoryActions],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'ctaxRow',
+          actions: [...allCtaxRowActions],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'adjustInventory',
+          actions: [...allAdjInvActions],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'config',
+          actions: [...allConfigActions],
+          scope: 'all',
+        },
+
+        {
+          plugin: 'accounting',
+          module: 'transaction',
+          actions: [...allTransactionActions],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'vatRow',
+          actions: [...allVatRowActions],
+          scope: 'all',
+        },
       ],
     },
     {
@@ -45,7 +327,48 @@ export const permissions: IPermissionConfig = {
       name: 'Accounting Viewer',
       description: 'Read-only access to Accounting plugin',
       permissions: [
-        { plugin: 'accounting', module: 'account', actions: [ACTIONS.read], scope: 'all' },
+        {
+          plugin: 'accounting',
+          module: 'account',
+          actions: [ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'accountCategory',
+          actions: [CATEGORY_ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'adjustInventory',
+          actions: [ADJ_INV_ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'config',
+          actions: [CONFIG_ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'ctaxRow',
+          actions: [CTAX_ROW_ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'transaction',
+          actions: [TRANSACTION_ACTIONS.read],
+          scope: 'all',
+        },
+        {
+          plugin: 'accounting',
+          module: 'vatRow',
+          actions: [VAT_ROW_ACTIONS.read],
+          scope: 'all',
+        },
       ],
     },
   ],

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/accountCategories.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/accountCategories.ts
@@ -9,8 +9,9 @@ const accountCategoriessMutations = {
   async accountCategoriesAdd(
     _root,
     doc: IAccountCategory,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageAccountCategories');
     const accountCategory =
       await models.AccountCategories.createAccountCategory(doc);
     return accountCategory;
@@ -24,8 +25,9 @@ const accountCategoriessMutations = {
   async accountCategoriesEdit(
     _root,
     { _id, ...doc }: { _id: string } & IAccountCategory,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageAccountCategories'); 
     await models.AccountCategories.getAccountCategory({
       _id,
     });
@@ -45,8 +47,9 @@ const accountCategoriessMutations = {
   async accountCategoriesRemove(
     _root,
     { _id }: { _id: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('removeAccountCategories'); 
     await models.AccountCategories.getAccountCategory({ _id });
     const removed = await models.AccountCategories.removeAccountCategory(_id);
 

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/adjustInventories.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/adjustInventories.ts
@@ -7,15 +7,17 @@ const adjustInventoryMutations = {
   async adjustInventoryAdd(
     _root,
     doc: IAdjustInventory,
-    { user, models }: IContext
+    { user, models, checkPermission }: IContext
   ) {
+    await checkPermission('manageAdjustInventories');
     const { beginDate } = await checkValidDate(models, doc);
 
     const adjusting = await models.AdjustInventories.createAdjustInventory({ ...doc, beginDate, createdBy: user._id });
     return adjusting;
   },
 
-  async adjustInventoryPublish(_root, { adjustId }: { adjustId: string }, { models, user }: IContext) {
+  async adjustInventoryPublish(_root, { adjustId }: { adjustId: string }, { models, user, checkPermission }: IContext) {
+    await checkPermission('publishAdjustInventories');
     const adjusting = await models.AdjustInventories.getAdjustInventory(adjustId);
     if (adjusting.status === ADJ_INV_STATUSES.PUBLISH) {
       throw new Error('this adjusting is published');
@@ -43,7 +45,8 @@ const adjustInventoryMutations = {
     return await models.AdjustInventories.getAdjustInventory(adjustId);
   },
 
-  async adjustInventoryCancel(_root, { adjustId }: { adjustId: string }, { models, user }: IContext) {
+  async adjustInventoryCancel(_root, { adjustId }: { adjustId: string }, { models, user, checkPermission }: IContext) {
+    await checkPermission('cancelAdjustInventories');
     const adjusting = await models.AdjustInventories.getAdjustInventory(adjustId);
     if (adjusting.status !== ADJ_INV_STATUSES.PUBLISH) {
       throw new Error('this adjusting cannot be cancel yet, it has not been published.');
@@ -53,11 +56,13 @@ const adjustInventoryMutations = {
     return await models.AdjustInventories.getAdjustInventory(adjustId);
   },
 
-  async adjustInventoryRemove(_root, { adjustId }: { adjustId: string }, { models }: IContext) {
+  async adjustInventoryRemove(_root, { adjustId }: { adjustId: string }, { models, checkPermission }: IContext) {
+    await checkPermission('removeAdjustInventories');
     return await models.AdjustInventories.removeAdjustInventory(adjustId);
   },
 
-  async adjustInventoryClear(_root, { adjustId, date }: { adjustId: string, date?: Date }, { models, user }: IContext) {
+  async adjustInventoryClear(_root, { adjustId, date }: { adjustId: string, date?: Date }, { models, user, checkPermission }: IContext) {
+    await checkPermission('clearAdjustInventories');
     const adjusting = await models.AdjustInventories.getAdjustInventory(adjustId);
     if (![ADJ_INV_STATUSES.DRAFT, ADJ_INV_STATUSES.PROCESS, ADJ_INV_STATUSES.COMPLETE].includes(adjusting.status)) {
       throw new Error('this adjusting cannot be clear yet, it has not been published or running.');
@@ -65,7 +70,8 @@ const adjustInventoryMutations = {
     return await detailsClear(models, user, adjusting, date);
   },
 
-  async adjustInventoryRun(_root, { adjustId }: { adjustId: string }, { models, user, subdomain }: IContext) {
+  async adjustInventoryRun(_root, { adjustId }: { adjustId: string }, { models, user, subdomain, checkPermission }: IContext) {
+    await checkPermission('manageAdjustInventories');
     const adjustInventory = await models.AdjustInventories.getAdjustInventory(adjustId);
 
     if ([ADJ_INV_STATUSES.RUNNING, ADJ_INV_STATUSES.PUBLISH].includes(adjustInventory.status)) {

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/configs.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/configs.ts
@@ -4,32 +4,36 @@ const configMutations = {
   async accountingsConfigsCreate(
     _root,
     { code, value, subId }: { code: string; value: any; subId?: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageAccountingConfigs');
     return await models.Configs.createConfig({ code, subId, value });
   },
 
   async accountingsConfigsUpdate(
     _root,
     { _id, value, subId }: { _id: string; value: any; subId?: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageAccountingConfigs');
     return await models.Configs.updateConfig(_id, value, subId);
   },
 
   async accountingsConfigsRemove(
     _root,
     { _id }: { _id: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('removeAccountingConfigs');
     return await models.Configs.removeConfig(_id);
   },
 
   async accountingsConfigsUpdateByCode(
     _root,
     { configsMap }: { configsMap: any },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageAccountingConfigs');
     const codes = Object.keys(configsMap);
 
     for (const code of codes) {

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/ctaxRows.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/ctaxRows.ts
@@ -6,7 +6,8 @@ const ctaxRowsMutations = {
    * Creates a new account category
    * @param {Object} doc Account category document
    */
-  async ctaxRowsAdd(_root, doc: ICtaxRow, { models }: IContext) {
+  async ctaxRowsAdd(_root, doc: ICtaxRow, { models, checkPermission }: IContext) {
+    await checkPermission('manageCtaxRows');
     const ctaxRow = await models.CtaxRows.createCtaxRow(doc);
 
     return ctaxRow;
@@ -20,8 +21,9 @@ const ctaxRowsMutations = {
   async ctaxRowsEdit(
     _root,
     { _id, ...doc }: { _id: string } & ICtaxRow,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageCtaxRows');
     await models.CtaxRows.getCtaxRow({
       _id,
     });
@@ -36,8 +38,9 @@ const ctaxRowsMutations = {
   async ctaxRowsRemove(
     _root,
     { ctaxRowIds }: { ctaxRowIds: string[] },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('removeCtaxRows');
     await models.CtaxRows.find({
       _id: { $in: ctaxRowIds },
     }).lean();

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/transacations.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/transacations.ts
@@ -5,7 +5,7 @@ const transactionsMutations = {
   async accTransactionsLink(
     _root,
     doc: { ids: string[]; ptrId: string },
-    { user, models, checkPermission },
+    { user, models, checkPermission }: IContext,
   ) {
     await checkPermission('linkTransactions'); 
     const { ids, ptrId } = doc;

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/transacations.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/transacations.ts
@@ -5,8 +5,9 @@ const transactionsMutations = {
   async accTransactionsLink(
     _root,
     doc: { ids: string[]; ptrId: string },
-    { user, models },
+    { user, models, checkPermission },
   ) {
+    await checkPermission('linkTransactions'); 
     const { ids, ptrId } = doc;
     return await models.Transactions.linkTransaction(ids, ptrId);
   },
@@ -16,8 +17,9 @@ const transactionsMutations = {
   async accTransactionsCreate(
     _root,
     { trDocs }: { trDocs: ITransaction[] },
-    { user, models }: IContext,
+    { user, models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageTransactions')
     const transactions = await models.Transactions.createPTransaction(
       trDocs,
       user._id,
@@ -35,8 +37,9 @@ const transactionsMutations = {
       parentId,
       trDocs,
     }: { parentId: string; trDocs: (ITransaction & { _id?: string })[] },
-    { user, models }: IContext,
+    { user, models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageTransactions');
     const transactions = await models.Transactions.updatePTransaction(
       parentId,
       trDocs,
@@ -52,8 +55,9 @@ const transactionsMutations = {
   async accTransactionsRemove(
     _root,
     { parentId, ptrId }: { parentId: string; ptrId: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('removeTransactions');
     const removed = await models.Transactions.removePTransaction({
       parentId,
       ptrId,

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/vatRows.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/vatRows.ts
@@ -6,7 +6,8 @@ const vatRowsMutations = {
    * Creates a new account category
    * @param {Object} doc Account category document
    */
-  async vatRowsAdd(_root, doc: IVatRow, { models }: IContext) {
+  async vatRowsAdd(_root, doc: IVatRow, { models, checkPermission }: IContext) {
+    await checkPermission('manageVatRows');
     const vatRow = await models.VatRows.createVatRow(doc);
 
     return vatRow;
@@ -20,8 +21,9 @@ const vatRowsMutations = {
   async vatRowsEdit(
     _root,
     { _id, ...doc }: { _id: string } & IVatRow,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('manageVatRows');
     await models.VatRows.getVatRow({
       _id,
     });
@@ -37,8 +39,9 @@ const vatRowsMutations = {
   async vatRowsRemove(
     _root,
     { vatRowIds }: { vatRowIds: string[] },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('removeVatRows');
     await models.VatRows.find({
       _id: { $in: vatRowIds },
     }).lean();

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/accountCategories.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/accountCategories.ts
@@ -52,8 +52,10 @@ const accountCategoryQueries = {
   async accountCategories(
     _root,
     { parentId, withChild, searchValue, status, brand, meta },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readAccountCategories');
+
     const filter = await generateFilterCat({
       models,
       status,
@@ -71,8 +73,10 @@ const accountCategoryQueries = {
   async accountCategoriesTotalCount(
     _root,
     { parentId, searchValue, status, withChild, brand, meta },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readAccountCategories');
+
     const filter = await generateFilterCat({
       models,
       parentId,
@@ -87,8 +91,10 @@ const accountCategoryQueries = {
   async accountCategoryDetail(
     _root,
     { _id }: { _id: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readAccountCategories');
+
     return models.AccountCategories.findOne({ _id }).lean();
   },
 };

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/accounts.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/accounts.ts
@@ -185,8 +185,9 @@ const accountQueries = {
   async accountsMain(
     _root,
     params: IQueryParams & ICursorPaginateParams,
-    { models, user, commonQuerySelector }: IContext,
+    { models, user, commonQuerySelector, checkPermission }: IContext,
   ) {
+    await checkPermission('accountsRead');
     const filter = await generateFilter(models, params, user);
 
     params.orderBy ??= { code: 1 };
@@ -198,7 +199,8 @@ const accountQueries = {
     });
   },
 
-  async accounts(_root, params: IQueryParams, { models, user }: IContext) {
+  async accounts(_root, params: IQueryParams, { models, user, checkPermission }: IContext) {
+    await checkPermission('accountsRead');
     const filter = await generateFilter(models, params, user);
 
     const { sortField, sortDirection, page, perPage, ids, excludeIds } = params;
@@ -224,13 +226,15 @@ const accountQueries = {
     );
   },
 
-  async accountsCount(_root, params: IQueryParams, { models, user }: IContext) {
+  async accountsCount(_root, params: IQueryParams, { models, user, checkPermission }: IContext) {
+    await checkPermission('accountsRead');
     const filter = await generateFilter(models, params, user);
 
     return models.Accounts.find(filter).countDocuments();
   },
 
-  async accountDetail(_root, { _id }: { _id: string }, { models }: IContext) {
+  async accountDetail(_root, { _id }: { _id: string }, { models, checkPermission }: IContext) {
+    await checkPermission('accountsRead');
     return models.Accounts.findOne({ _id }).lean();
   },
 };

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/adjustInventories.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/adjustInventories.ts
@@ -67,8 +67,9 @@ const adjustInventoryQueries = {
   async adjustInventories(
     _root,
     params: IQueryParams,
-    { models, user }: IContext,
+    { models, user, checkPermission }: IContext,
   ) {
+    await checkPermission('readAdjustInventories');
     const filter = await generateFilter(models, params, user);
 
     const { sortField, sortDirection, page, perPage } = params;

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/configs.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/configs.ts
@@ -7,40 +7,45 @@ const configQueries = {
   accountingsConfigDetail: async (
     _root,
     { _id }: { _id: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) => {
+    await checkPermission('readAccountingConfigs');
     return await models.Configs.getConfigDetail(_id);
   },
 
   accountingsConfig: async (
     _root,
     { code, subId }: { code: string; subId?: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) => {
+    await checkPermission('readAccountingConfigs');
     return await models.Configs.getConfig(code, subId);
   },
 
   accountingsConfigs: async (
     _root,
     { code }: { code: string },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) => {
+    await checkPermission('readAccountingConfigs');
     return await models.Configs.getConfigs(code);
   },
 
   accountingsConfigsCount: async (
     _root,
     code: string,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) => {
+    await checkPermission('readAccountingConfigs');
     return await models.Configs.find({ code }).countDocuments();
   },
 
   async accountingsConfigsByCode(
     _root,
     params: { codes: string[] },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readAccountingConfigs');
     // TODO: remove code, like migration
     await models.Configs.updateMany(
       { subId: { $exists: false } },

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/ctaxRows.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/ctaxRows.ts
@@ -22,7 +22,8 @@ const generateFilterCat = async ({ kinds, searchValue, status }) => {
 };
 
 const ctaxRowQueries = {
-  async ctaxRows(_root, { kinds, searchValue, status }, { models }: IContext) {
+  async ctaxRows(_root, { kinds, searchValue, status }, { models, checkPermission }: IContext) {
+    await checkPermission('readCtaxRows');
     const filter = await generateFilterCat({
       kinds,
       status,
@@ -40,8 +41,9 @@ const ctaxRowQueries = {
   async ctaxRowsCount(
     _root,
     { kinds, searchValue, status },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readCtaxRows');
     const filter = await generateFilterCat({
       searchValue,
       status,
@@ -50,7 +52,8 @@ const ctaxRowQueries = {
     return models.CtaxRows.find(filter).countDocuments();
   },
 
-  async ctaxRowDetail(_root, { _id }: { _id: string }, { models }: IContext) {
+  async ctaxRowDetail(_root, { _id }: { _id: string }, { models, checkPermission }: IContext) {
+    await checkPermission('readCtaxRows');
     return models.CtaxRows.findOne({ _id }).lean();
   },
 };

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/inventories.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/inventories.ts
@@ -6,8 +6,9 @@ const configQueries = {
   async getAccLastIncomePrice(
     _root,
     { productIds }: { productIds: string[] },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('accountsRead');
     const aggByProductId = await models.Transactions.aggregate([
       {
         $match: {
@@ -48,8 +49,9 @@ const configQueries = {
       branchId: string;
       departmentId: string;
     },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('accountsRead');
     return await activeCost(
       models,
       accountId,

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/journalReport.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/journalReport.ts
@@ -47,8 +47,9 @@ const journalReportQueries = {
   async journalReportData(
     _root,
     params: IReportParams & ICursorPaginateParams,
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('accountsRead');
     const { groupRule, report, ...filters } = params;
     const firstGroupRules = getFirstGroupRule([], groupRule);
     const records = await getRecords(subdomain, models, report, firstGroupRules, filters, user);
@@ -58,8 +59,9 @@ const journalReportQueries = {
   async journalReportMore(
     _root,
     params: IReportParams & ICursorPaginateParams,
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('accountsRead');
     const { report, ...filters } = params;
     const trDetails = await getRecMore(subdomain, models, report, filters, user)
     return { trDetails }

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/transactionsCommon.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/transactionsCommon.ts
@@ -287,8 +287,9 @@ const transactionCommon = {
   async accTransactionsDetail(
     _root,
     params: { _id: string },
-    { models, user }: IContext,
+    { models, user, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const { _id } = params;
     let firstTr = await models.Transactions.getTransaction({
       $or: [{ _id }, { parentId: _id }],
@@ -326,8 +327,9 @@ const transactionCommon = {
   async accTransactionsMain(
     _root,
     params: IQueryParams & ICursorPaginateParams,
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
 
     // Set default orderBy
@@ -347,8 +349,9 @@ const transactionCommon = {
   async accTransactions(
     _root,
     params: IQueryParams & { page: number; perPage: number },
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
 
     const { sortField, sortDirection, page, perPage, ids, excludeIds } = params;
@@ -379,8 +382,9 @@ const transactionCommon = {
   async accTransactionsCount(
     _root,
     params: IQueryParams,
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
 
     return models.Transactions.find(filter).countDocuments();
@@ -389,8 +393,9 @@ const transactionCommon = {
   async accTrRecordsMain(
     _root,
     params: IRecordsParams & ICursorPaginateParams,
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
     const { ids, excludeIds } = params;
 
@@ -431,8 +436,9 @@ const transactionCommon = {
   async accTrRecords(
     _root,
     params: IRecordsParams & { page: number; perPage: number },
-    { models, user, subdomain }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
     const { sortField, sortDirection, page, perPage, ids, excludeIds } = params;
 
@@ -474,8 +480,9 @@ const transactionCommon = {
   async accTrRecordsCount(
     _root,
     params: IRecordsParams,
-    { models, subdomain, user }: IContext,
+    { models, subdomain, user, checkPermission }: IContext,
   ) {
+    await checkPermission('readTransactions');
     const filter = await generateFilter(subdomain, models, params, user);
 
     const count = await models.Transactions.aggregate([

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/vatRows.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/queries/vatRows.ts
@@ -22,7 +22,8 @@ const generateFilterCat = async ({ kinds, searchValue, status }) => {
 };
 
 const vatRowQueries = {
-  async vatRows(_root, { kinds, searchValue, status }, { models }: IContext) {
+  async vatRows(_root, { kinds, searchValue, status }, { models, checkPermission }: IContext) {
+    await checkPermission('readVatRows');
     const filter = await generateFilterCat({
       kinds,
       status,
@@ -40,8 +41,9 @@ const vatRowQueries = {
   async vatRowsCount(
     _root,
     { kinds, searchValue, status },
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) {
+    await checkPermission('readVatRows');
     const filter = await generateFilterCat({
       searchValue,
       status,
@@ -50,7 +52,8 @@ const vatRowQueries = {
     return models.VatRows.find(filter).countDocuments();
   },
 
-  async vatRowDetail(_root, { _id }: { _id: string }, { models }: IContext) {
+  async vatRowDetail(_root, { _id }: { _id: string }, { models, checkPermission }: IContext) {
+    await checkPermission('readVatRows');
     return models.VatRows.findOne({ _id }).lean();
   },
 };


### PR DESCRIPTION
## Summary by Sourcery

Add fine-grained permission configuration and enforcement across accounting plugin modules.

New Features:
- Introduce distinct permission actions for accounts, account categories, transactions, VAT rows, CTax rows, inventory adjustments, and accounting configs, with corresponding modules and scopes in the accounting plugin.

Enhancements:
- Extend default accounting admin and viewer groups to cover all new accounting modules and their respective read/manage/remove-style actions.
- Enforce permission checks on accounting GraphQL queries and mutations for accounts, categories, transactions, inventory adjustments, VAT/CTax rows, configs, journal reports, and inventory-related reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded permission controls across accounting modules: categories, transactions, VAT rows, CTax rows, inventory adjustments, and configs.
  * Enforced authorization on queries and mutations throughout accounting: role-based read, create, update, publish/cancel, run and delete operations now require appropriate permissions.
  * Updated default role access: admin granted full access; viewer granted read-only across new modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->