### PR TITLE
feat(inbox): add CallProSwitcher component

### DIFF
--- a/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
@@ -130,19 +130,23 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
     </CustomerList>
   );
 
-  if (hasPotentialCustomers) {
+  const renderPotentialCustomerPicker = () => {
+    if (!hasPotentialCustomers) return null;
     if (potentialLoading) return <Spinner />;
     const candidates: CallProCandidate[] = potentialData?.customers || [];
+    const phone = conversation.content;
 
     return (
       <CustomerPickerWrapper>
         <Info>
-          {__("Multiple customers found for this phone number. Select the caller:")}
+          {phone
+            ? `${__("Confirm or Switch Customer")} — ${phone}`
+            : __("Confirm or Switch Customer")}
         </Info>
         {renderCandidatePicker(candidates)}
       </CustomerPickerWrapper>
     );
-  }
+  };
 
   const groupConversationsByTags = (convs: any[]) => {
     const grouped: any = {};
@@ -540,7 +544,8 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
       <audio controls>
         <source src={callProAudio} type="audio/ogg" />
       </audio>
-      {renderConversationGroups()}
+      {renderPotentialCustomerPicker()}
+      {!hasPotentialCustomers && renderConversationGroups()}
     </>
   );
 };


### PR DESCRIPTION
## Summary by Sourcery

Update CallPro call handling UI to separate potential customer selection from conversation grouping and improve the header copy when multiple customers are associated with a call.

Enhancements:
- Extract a dedicated potential customer picker renderer that displays a clearer 'Confirm or Switch Customer' message with the caller phone number when available.
- Adjust the CallPro layout so that conversation groups are only shown when there are no potential customers to choose from.