### PR TITLE
fix(pos): revert api uri to environment variable

### DIFF
--- a/pos/modules/apolloClient.tsx
+++ b/pos/modules/apolloClient.tsx
@@ -18,8 +18,7 @@ import { getEnv } from "@/lib/utils"
 const env = getEnv()
 
 const httpLink: any = new HttpLink({
-  // uri: `${env.NEXT_PUBLIC_MAIN_API_DOMAIN}/graphql`,
-  uri: "https://belty.app.erxes.io/gateway/graphql",
+  uri: `${env.NEXT_PUBLIC_MAIN_API_DOMAIN}/graphql`,
   credentials: "include",
 })
 


### PR DESCRIPTION
## Summary by Sourcery

Restore the Apollo client HTTP link to read its GraphQL API URI from the environment-configured main API domain instead of a hardcoded remote URL.