### PR TITLE
fix(content): custom fields mapping and file upload

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -175,12 +175,22 @@ export function CmsCategoryDrawer({
     skip: !isOpen,
   });
 
+  const currentCategoryId = category?._id;
+
   const fieldGroups: FieldGroup[] = (
     customFieldsData?.cmsCustomFieldGroupList?.list || []
-  ).filter(
-    (group: CustomFieldGroup) =>
-      !group.customPostTypeIds || group.customPostTypeIds.length === 0,
-  );
+  ).filter((group: any) => {
+    const ids: string[] = group.customPostTypeIds || [];
+    // show if no restriction, or explicitly includes 'category'
+    const showOnCategory = ids.length === 0 || ids.includes('category');
+    if (!showOnCategory) return false;
+    // if specific categories are set, only show for this category
+    const enabledCategoryIds: string[] = group.enabledCategoryIds || [];
+    if (enabledCategoryIds.length > 0 && currentCategoryId) {
+      return enabledCategoryIds.includes(currentCategoryId);
+    }
+    return true;
+  });
 
   // Create dynamic schema with custom field validations
   const schema = createCategoryFormSchema(
@@ -368,6 +378,7 @@ export function CmsCategoryDrawer({
         </Sheet.Header>
 
         <Form {...form}>
+          <Sheet.Content className="overflow-y-auto">
           <form
             onSubmit={form.handleSubmit(onSubmit)}
             className="p-4 space-y-4"
@@ -501,6 +512,7 @@ export function CmsCategoryDrawer({
               </Button>
             </div>
           </form>
+          </Sheet.Content>
         </Form>
       </Sheet.View>
     </Sheet>

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -50,6 +50,9 @@ export function CustomFields() {
       code: data.code,
       clientPortalId: websiteId,
       customPostTypeIds: data.customPostTypeIds || [],
+      enabledPageIds: data.enabledPageIds || [],
+      enabledCategoryIds: data.enabledCategoryIds || [],
+      enabledPostIds: data.enabledPostIds || [],
       fields: editingGroup?.fields || [],
     };
 
@@ -276,6 +279,7 @@ export function CustomFields() {
         onSubmit={handleGroupSubmit}
         editingGroup={editingGroup}
         customTypes={customTypes}
+        websiteId={websiteId || ''}
       />
 
       <FieldDrawer

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/field-group-drawer/FieldGroupDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/field-group-drawer/FieldGroupDrawer.tsx
@@ -1,7 +1,42 @@
-import { Button, Sheet, Input, MultipleSelector } from 'erxes-ui';
+import { Button, Sheet, Input, MultipleSelector, Select } from 'erxes-ui';
 import { useForm, Controller } from 'react-hook-form';
 import { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
+import { gql } from '@apollo/client';
 import { ICustomFieldGroup } from '../../types/customFieldTypes';
+
+const PAGES_FOR_RULES = gql`
+  query PagesForRules($clientPortalId: String!) {
+    cmsPageList(clientPortalId: $clientPortalId, limit: 100) {
+      pages {
+        _id
+        name
+      }
+    }
+  }
+`;
+
+const CATEGORIES_FOR_RULES = gql`
+  query CategoriesForRules($clientPortalId: String!) {
+    cmsCategories(clientPortalId: $clientPortalId, limit: 100) {
+      list {
+        _id
+        name
+      }
+    }
+  }
+`;
+
+const POSTS_FOR_RULES = gql`
+  query PostsForRules($clientPortalId: String!) {
+    cmsPostList(clientPortalId: $clientPortalId, limit: 100) {
+      posts {
+        _id
+        title
+      }
+    }
+  }
+`;
 
 interface FieldGroupDrawerProps {
   isOpen: boolean;
@@ -9,7 +44,16 @@ interface FieldGroupDrawerProps {
   onSubmit: (data: any) => void;
   editingGroup: ICustomFieldGroup | null;
   customTypes: any[];
+  websiteId: string;
 }
+
+type ShowOnOption = { label: string; value: string };
+
+const BUILT_IN_SHOW_ON: ShowOnOption[] = [
+  { label: 'Pages', value: 'page' },
+  { label: 'Categories', value: 'category' },
+  { label: 'Posts', value: 'post' },
+];
 
 export function FieldGroupDrawer({
   isOpen,
@@ -17,30 +61,94 @@ export function FieldGroupDrawer({
   onSubmit,
   editingGroup,
   customTypes,
+  websiteId,
 }: FieldGroupDrawerProps) {
   const groupForm = useForm({
     defaultValues: {
       label: '',
       code: '',
       customPostTypeIds: [] as string[],
+      enabledPageId: '' as string,
+      enabledCategoryIds: [] as string[],
+      enabledPostIds: [] as string[],
     },
   });
 
+  const { data: pagesData } = useQuery(PAGES_FOR_RULES, {
+    variables: { clientPortalId: websiteId },
+    skip: !websiteId || !isOpen,
+    fetchPolicy: 'cache-first',
+  });
+
+  const { data: categoriesData } = useQuery(CATEGORIES_FOR_RULES, {
+    variables: { clientPortalId: websiteId },
+    skip: !websiteId || !isOpen,
+    fetchPolicy: 'cache-first',
+  });
+
+  const { data: postsData } = useQuery(POSTS_FOR_RULES, {
+    variables: { clientPortalId: websiteId },
+    skip: !websiteId || !isOpen,
+    fetchPolicy: 'cache-first',
+  });
+
+  const pages: ShowOnOption[] = (pagesData?.cmsPageList?.pages || []).map(
+    (p: any) => ({ label: p.name, value: p._id }),
+  );
+
+  const categories: ShowOnOption[] = (
+    categoriesData?.cmsCategories?.list || []
+  ).map((c: any) => ({ label: c.name, value: c._id }));
+
+  const posts: ShowOnOption[] = (postsData?.cmsPostList?.posts || []).map(
+    (p: any) => ({ label: p.title || p._id, value: p._id }),
+  );
+
+  const customTypeOptions: ShowOnOption[] = customTypes.map((t: any) => ({
+    label: `${t.label} (${t.code})`,
+    value: t._id,
+  }));
+
+  const allShowOnOptions: ShowOnOption[] = [
+    ...BUILT_IN_SHOW_ON,
+    ...customTypeOptions,
+  ];
+
   useEffect(() => {
     if (editingGroup) {
+      const enabledPageIds = editingGroup.enabledPageIds || [];
       groupForm.reset({
         label: editingGroup.label,
         code: editingGroup.code || '',
         customPostTypeIds: editingGroup.customPostTypeIds || [],
+        enabledPageId: enabledPageIds[0] || '',
+        enabledCategoryIds: editingGroup.enabledCategoryIds || [],
+        enabledPostIds: editingGroup.enabledPostIds || [],
       });
     } else {
       groupForm.reset({
         label: '',
         code: '',
         customPostTypeIds: [],
+        enabledPageId: '',
+        enabledCategoryIds: [],
+        enabledPostIds: [],
       });
     }
   }, [editingGroup, groupForm, isOpen]);
+
+  const watchedPostTypeIds = groupForm.watch('customPostTypeIds');
+  const showsOnPages = watchedPostTypeIds.includes('page');
+  const showsOnCategories = watchedPostTypeIds.includes('category');
+  const showsOnPosts = watchedPostTypeIds.includes('post');
+
+  const handleSubmit = (data: any) => {
+    // Convert single page select back to array for the parent
+    onSubmit({
+      ...data,
+      enabledPageIds: data.enabledPageId ? [data.enabledPageId] : [],
+    });
+  };
 
   return (
     <Sheet
@@ -58,7 +166,7 @@ export function FieldGroupDrawer({
         </Sheet.Header>
         <Sheet.Content className="overflow-y-auto">
           <form
-            onSubmit={groupForm.handleSubmit(onSubmit)}
+            onSubmit={groupForm.handleSubmit(handleSubmit)}
             className="space-y-4 p-6"
           >
             <div>
@@ -75,6 +183,7 @@ export function FieldGroupDrawer({
                 </p>
               )}
             </div>
+
             <div>
               <label className="block text-sm font-medium mb-2">Code</label>
               <Input
@@ -86,34 +195,87 @@ export function FieldGroupDrawer({
               </p>
             </div>
 
-            <div>
-              <label className="block text-sm font-medium mb-2">
-                Custom Post Types
-              </label>
-              {customTypes.length === 0 ? (
-                <div className="text-sm text-gray-500 p-3 border rounded bg-gray-50">
-                  No custom types available. Create custom types first to assign
-                  them to field groups.
-                </div>
-              ) : (
-                <>
+            {/* Show On */}
+            <div className="space-y-3 pt-2 border-t">
+              <label className="block text-sm font-medium">Show on</label>
+              <p className="text-xs text-muted-foreground -mt-2">
+                Leave empty to show on all content. Select specific surfaces to
+                restrict where this group appears.
+              </p>
+
+              <Controller
+                name="customPostTypeIds"
+                control={groupForm.control}
+                render={({ field }) => {
+                  const selected = allShowOnOptions.filter((o) =>
+                    (field.value || []).includes(o.value),
+                  );
+                  return (
+                    <MultipleSelector
+                      value={selected as any}
+                      options={allShowOnOptions as any}
+                      placeholder="Pages, Categories, Posts, Post types…"
+                      emptyIndicator="No options"
+                      onChange={(selected: any[]) =>
+                        field.onChange(selected.map((s) => s.value))
+                      }
+                    />
+                  );
+                }}
+              />
+
+              {/* Single page selector */}
+              {showsOnPages && (
+                <div className="pl-3 border-l-2 border-muted space-y-1">
+                  <label className="block text-xs font-medium text-muted-foreground">
+                    Specific page (leave empty = all pages)
+                  </label>
                   <Controller
-                    name="customPostTypeIds"
+                    name="enabledPageId"
+                    control={groupForm.control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value || ''}
+                        onValueChange={(val) =>
+                          field.onChange(val === '__all__' ? '' : val)
+                        }
+                      >
+                        <Select.Trigger className="w-full">
+                          <Select.Value placeholder="All pages" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          <Select.Item value="__all__">All pages</Select.Item>
+                          {pages.map((p) => (
+                            <Select.Item key={p.value} value={p.value}>
+                              {p.label}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    )}
+                  />
+                </div>
+              )}
+
+              {/* Specific categories sub-selector */}
+              {showsOnCategories && (
+                <div className="pl-3 border-l-2 border-muted space-y-1">
+                  <label className="block text-xs font-medium text-muted-foreground">
+                    Specific categories (leave empty = all categories)
+                  </label>
+                  <Controller
+                    name="enabledCategoryIds"
                     control={groupForm.control}
                     render={({ field }) => {
-                      const options = customTypes.map((type: any) => ({
-                        label: `${type.label} (${type.code})`,
-                        value: type._id,
-                      }));
-                      const selectedOptions = options.filter((opt: any) =>
-                        (field.value || []).includes(opt.value),
+                      const selected = categories.filter((c) =>
+                        (field.value || []).includes(c.value),
                       );
                       return (
                         <MultipleSelector
-                          value={selectedOptions as any}
-                          options={options as any}
-                          placeholder="Select custom post types"
-                          emptyIndicator="No types found"
+                          value={selected as any}
+                          options={categories as any}
+                          placeholder="All categories"
+                          emptyIndicator="No categories found"
                           onChange={(selected: any[]) =>
                             field.onChange(selected.map((s) => s.value))
                           }
@@ -121,11 +283,36 @@ export function FieldGroupDrawer({
                       );
                     }}
                   />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Select which custom post types this field group applies to.
-                    Leave empty to apply to all types.
-                  </p>
-                </>
+                </div>
+              )}
+
+              {/* Specific posts sub-selector */}
+              {showsOnPosts && (
+                <div className="pl-3 border-l-2 border-muted space-y-1">
+                  <label className="block text-xs font-medium text-muted-foreground">
+                    Specific posts (leave empty = all posts)
+                  </label>
+                  <Controller
+                    name="enabledPostIds"
+                    control={groupForm.control}
+                    render={({ field }) => {
+                      const selected = posts.filter((p) =>
+                        (field.value || []).includes(p.value),
+                      );
+                      return (
+                        <MultipleSelector
+                          value={selected as any}
+                          options={posts as any}
+                          placeholder="All posts"
+                          emptyIndicator="No posts found"
+                          onChange={(selected: any[]) =>
+                            field.onChange(selected.map((s) => s.value))
+                          }
+                        />
+                      );
+                    }}
+                  />
+                </div>
               )}
             </div>
 

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/mutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/mutations.ts
@@ -14,6 +14,9 @@ export const CMS_CUSTOM_FIELD_GROUP_ADD = gql`
         label
         pluralLabel
       }
+      enabledPageIds
+      enabledCategoryIds
+      enabledPostIds
       fields
     }
   }
@@ -36,6 +39,9 @@ export const CMS_CUSTOM_FIELD_GROUP_EDIT = gql`
         label
         pluralLabel
       }
+      enabledPageIds
+      enabledCategoryIds
+      enabledPostIds
       fields
     }
   }

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/queries.ts
@@ -15,6 +15,9 @@ export const CMS_CUSTOM_FIELD_GROUPS = gql`
           label
           pluralLabel
         }
+        enabledPageIds
+        enabledCategoryIds
+        enabledPostIds
         fields
       }
     }

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
@@ -35,6 +35,9 @@ export interface ICustomFieldGroup {
     pluralLabel: string;
   }>;
   fields: ICustomField[];
+  enabledPageIds?: string[];
+  enabledCategoryIds?: string[];
+  enabledPostIds?: string[];
 }
 
 export const FIELD_TYPES: { value: FieldType; label: string }[] = [

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
@@ -794,6 +794,9 @@ export const CMS_CUSTOM_FIELD_GROUPS = gql`
           label
           pluralLabel
         }
+        enabledPageIds
+        enabledCategoryIds
+        enabledPostIds
         fields
       }
     }
@@ -814,6 +817,8 @@ export const CMS_CUSTOM_FIELD_GROUP_ADD = gql`
         label
         pluralLabel
       }
+      enabledPageIds
+      enabledCategoryIds
       fields
     }
   }
@@ -836,6 +841,8 @@ export const CMS_CUSTOM_FIELD_GROUP_EDIT = gql`
         label
         pluralLabel
       }
+      enabledPageIds
+      enabledCategoryIds
       fields
     }
   }

--- a/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
@@ -325,12 +325,22 @@ export function PageDrawer({
     skip: !clientPortalId,
   });
 
+  const currentPageId = page?._id;
+
   const fieldGroups: FieldGroup[] = (
     customFieldsData?.cmsCustomFieldGroupList?.list || []
-  ).filter(
-    (group: FieldGroup) =>
-      !group.customPostTypeIds || group.customPostTypeIds.length === 0,
-  );
+  ).filter((group: any) => {
+    const ids: string[] = group.customPostTypeIds || [];
+    // show if no restriction, or explicitly includes 'page'
+    const showOnPage = ids.length === 0 || ids.includes('page');
+    if (!showOnPage) return false;
+    // if specific pages are set, only show for this page
+    const enabledPageIds: string[] = group.enabledPageIds || [];
+    if (enabledPageIds.length > 0 && currentPageId) {
+      return enabledPageIds.includes(currentPageId);
+    }
+    return true;
+  });
 
   const form = useForm<IPageFormData>({
     defaultValues: {

--- a/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
@@ -5,7 +5,12 @@ import {
   MultipleSelector,
   Switch,
   DatePicker,
+  Button,
+  useErxesUpload,
+  readImage,
 } from 'erxes-ui';
+import { useEffect } from 'react';
+import { IconUpload, IconX, IconPaperclip } from '@tabler/icons-react';
 import { SpreadsheetInput } from './SpreadsheetInput';
 
 export interface FieldDefinition {
@@ -23,6 +28,163 @@ interface CustomFieldInputProps {
   field: FieldDefinition;
   value: CustomFieldValue;
   onChange: (value: string | boolean | string[]) => void;
+}
+
+function ImageFieldInput({
+  value,
+  onChange,
+  buttonLabel = 'Upload file',
+  buttonClassName,
+}: {
+  value: CustomFieldValue;
+  onChange: (value: string) => void;
+  buttonLabel?: string;
+  buttonClassName?: string;
+}) {
+  const url = typeof value === 'string' ? value : '';
+
+  const uploadProps = useErxesUpload({
+    allowedMimeTypes: ['image/*'],
+    maxFiles: 1,
+    maxFileSize: 20 * 1024 * 1024,
+    onFilesAdded: (added) => {
+      if (added[0]?.url) onChange(added[0].url);
+    },
+  });
+
+  useEffect(() => {
+    if (uploadProps.files.length > 0 && !uploadProps.loading) {
+      uploadProps.onUpload();
+    }
+  }, [uploadProps.files.length]);
+
+  return (
+    <div className="space-y-2">
+      {url && (
+        <div className="relative group w-full rounded-md border overflow-hidden aspect-[3/1] bg-muted">
+          <img
+            src={readImage(url)}
+            alt="uploaded"
+            className="w-full h-full object-contain"
+          />
+          <button
+            type="button"
+            onClick={() => onChange('')}
+            className="absolute top-2 right-2 p-1 rounded-md bg-destructive text-white opacity-0 group-hover:opacity-100 transition"
+          >
+            <IconX size={14} />
+          </button>
+        </div>
+      )}
+      <div>
+        <input {...uploadProps.getInputProps()} />
+        <Button
+          variant="outline"
+          className={buttonClassName}
+          type="button"
+          onClick={uploadProps.open}
+          disabled={uploadProps.loading}
+        >
+          <IconUpload size={16} className="mr-2" />
+          {uploadProps.loading ? 'Uploading...' : url ? `Change ${buttonLabel.toLowerCase()}` : buttonLabel}
+        </Button>
+        <p className="text-xs text-muted-foreground mt-1">
+          Max 20MB · JPG, PNG, GIF, WebP, SVG
+        </p>
+      </div>
+      {!!uploadProps.errors.length && (
+        <p className="text-xs text-destructive">
+          {uploadProps.errors[0]?.message || 'Upload failed'}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FileFieldInput({
+  value,
+  onChange,
+  buttonLabel = 'Upload file',
+  buttonClassName,
+}: {
+  value: CustomFieldValue;
+  onChange: (value: string[]) => void;
+  buttonLabel?: string;
+  buttonClassName?: string;
+}) {
+  const urls = Array.isArray(value) ? value : [];
+
+  const uploadProps = useErxesUpload({
+    allowedMimeTypes: [],
+    maxFiles: 1,
+    maxFileSize: 20 * 1024 * 1024,
+    onFilesAdded: (added) => {
+      const url = added[0]?.url;
+      if (url) onChange([url]);
+    },
+  });
+
+  useEffect(() => {
+    if (uploadProps.files.length > 0 && !uploadProps.loading) {
+      uploadProps.onUpload();
+    }
+  }, [uploadProps.files.length]);
+
+  const handleRemove = (url: string) => {
+    onChange(urls.filter((u) => u !== url));
+  };
+
+  return (
+    <div className="space-y-2">
+      {urls.length > 0 && (
+        <div className="relative space-y-1">
+          {urls.map((url) => (
+            <div
+              key={url}
+              className="flex items-center gap-2 border rounded p-2 bg-muted"
+            >
+              <IconPaperclip size={16} className="text-muted-foreground shrink-0" />
+              <span className="text-sm flex-1 truncate">{url}</span>
+              <Button
+                variant="ghost"
+                size="icon"
+                type="button"
+                onClick={() => handleRemove(url)}
+              >
+                <IconX size={16} />
+              </Button>
+            </div>
+          ))}
+          {uploadProps.loading && (
+            <div className="absolute inset-0 bg-white/50 flex items-center justify-center rounded">
+              <span className="text-sm text-gray-500">Uploading...</span>
+            </div>
+          )}
+        </div>
+      )}
+      <div>
+        <input {...uploadProps.getInputProps()} />
+        <Button
+          variant="outline"
+          className={buttonClassName}
+          type="button"
+          onClick={uploadProps.open}
+          disabled={uploadProps.loading}
+        >
+          <IconUpload size={16} className="mr-2" />
+          {uploadProps.loading ? 'Uploading...' : buttonLabel}
+        </Button>
+        <p className="text-xs text-muted-foreground mt-1">
+          Max 20MB
+        </p>
+      </div>
+      {!!uploadProps.errors.length && (
+        <p className="text-xs text-destructive">
+          {uploadProps.errors[0]?.message || 'Upload failed'}
+        </p>
+      )}
+    </div>
+  );
 }
 
 export const CustomFieldInput = ({
@@ -170,6 +332,22 @@ export const CustomFieldInput = ({
           />
         );
       }
+
+      case 'image':
+        return (
+          <ImageFieldInput
+            value={value}
+            onChange={(url) => onChange(url)}
+          />
+        );
+
+      case 'file':
+        return (
+          <FileFieldInput
+            value={value}
+            onChange={(urls) => onChange(urls)}
+          />
+        );
 
       default:
         return (

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
@@ -59,7 +59,7 @@ export const AddPostForm = ({
     availableLanguages,
     defaultLanguage,
     fieldGroups,
-  } = usePostData(websiteId, selectedType);
+  } = usePostData(websiteId, selectedType, currentEditingPost?._id);
 
   const languageOptions = useMemo(
     () =>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostData.tsx
@@ -70,7 +70,7 @@ function buildTreeOptions(rawList: IRawCategory[]): ICategoryOption[] {
   return result;
 }
 
-export const usePostData = (websiteId: string, selectedType?: string) => {
+export const usePostData = (websiteId: string, selectedType?: string, postId?: string) => {
   const { data: combinedData, loading: combinedLoading } = useQuery(
     COMBINED_CMS_DATA,
     {
@@ -111,12 +111,18 @@ export const usePostData = (websiteId: string, selectedType?: string) => {
 
   const fieldGroups = (
     fieldGroupsData?.cmsCustomFieldGroupList?.list || []
-  ).filter(
-    (group: any) =>
-      !group.customPostTypeIds ||
-      group.customPostTypeIds.length === 0 ||
-      group.customPostTypeIds.includes(selectedType),
-  );
+  ).filter((group: any) => {
+    const ids: string[] = group.customPostTypeIds || [];
+    if (ids.length > 0 && !ids.includes(selectedType) && !ids.includes('post')) {
+      return false;
+    }
+    // if specific posts are set, only show for this post
+    const enabledPostIds: string[] = group.enabledPostIds || [];
+    if (enabledPostIds.length > 0 && postId) {
+      return enabledPostIds.includes(postId);
+    }
+    return true;
+  });
 
   return {
     categories,


### PR DESCRIPTION
## Summary by Sourcery

Extend CMS custom field groups with granular visibility rules and support for media/file custom field inputs.

New Features:
- Allow configuring CMS custom field groups to show on specific pages, categories, posts, or custom post types, including per-entity targeting.
- Add image and file custom field types with integrated upload, preview, and basic error handling in the post editor.

Bug Fixes:
- Ensure custom field groups mapped to posts and built‑in types are correctly filtered and displayed in category, page, and post drawers.

Enhancements:
- Update category, page, and post forms to respect custom field group visibility rules based on content type and targeted entity IDs.
- Extend GraphQL queries and mutations to persist enabled page, category, and post IDs on custom field groups.
- Improve custom field group drawer UI to manage visibility rules and surface selection with richer selectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom field groups now support visibility scoping to specific pages, categories, and posts via a new "Show on" configuration interface.
  * Added image and file field types with built-in upload capabilities and previews.
  * Improved form layout with scrollable content containers for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->