### PR TITLE
fix(callpro): show phone number and audio player when multiple customers match

### DIFF
--- a/packages/plugin-inbox-api/src/graphql/conversationTypeDefs.ts
+++ b/packages/plugin-inbox-api/src/graphql/conversationTypeDefs.ts
@@ -104,6 +104,7 @@ export const types = ({ contacts, dailyco, calls, cloudflareCalls }) => `
     messages: [ConversationMessage]
     callProAudio: String
     callProPotentialCustomerIds: [String]
+    callProPhone: String
 
     tags: [Tag]
     customer: Customer

--- a/packages/plugin-inbox-api/src/models/definitions/conversations.ts
+++ b/packages/plugin-inbox-api/src/models/definitions/conversations.ts
@@ -43,6 +43,7 @@ export interface IConversation {
   isBot?: boolean;
   botId?: string;
   callProPotentialCustomerIds?: string[];
+  callProPhone?: string;
 }
 
 // Conversation schema
@@ -119,6 +120,11 @@ export const conversationSchemaOptions = {
     type: ["String"],
     optional: true,
     label: "CallPro potential customer ids",
+  }),
+  callProPhone: field({
+    type: "String",
+    optional: true,
+    label: "CallPro caller phone number",
   }),
 };
 

--- a/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
@@ -53,6 +53,7 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
     callProAudio,
     customerId,
     callProPotentialCustomerIds = [],
+    callProPhone,
   } = conversation;
 
   const [selectCustomer, { loading: selecting }] = useMutation(
@@ -134,7 +135,7 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
     if (!hasPotentialCustomers) return null;
     if (potentialLoading) return <Spinner />;
     const candidates: CallProCandidate[] = potentialData?.customers || [];
-    const phone = conversation.content;
+    const phone = callProPhone || candidates[0]?.primaryPhone;
 
     return (
       <CustomerPickerWrapper>

--- a/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/conversationDetail/workarea/callpro/Callpro.tsx
@@ -130,19 +130,23 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
     </CustomerList>
   );
 
-  if (hasPotentialCustomers) {
+  const renderPotentialCustomerPicker = () => {
+    if (!hasPotentialCustomers) return null;
     if (potentialLoading) return <Spinner />;
     const candidates: CallProCandidate[] = potentialData?.customers || [];
+    const phone = conversation.content;
 
     return (
       <CustomerPickerWrapper>
         <Info>
-          {__("Multiple customers found for this phone number. Select the caller:")}
+          {phone
+            ? `${__("Confirm or Switch Customer")} — ${phone}`
+            : __("Confirm or Switch Customer")}
         </Info>
         {renderCandidatePicker(candidates)}
       </CustomerPickerWrapper>
     );
-  }
+  };
 
   const groupConversationsByTags = (convs: any[]) => {
     const grouped: any = {};
@@ -540,7 +544,8 @@ const CallPro: React.FC<Props> = ({ conversation }) => {
       <audio controls>
         <source src={callProAudio} type="audio/ogg" />
       </audio>
-      {renderConversationGroups()}
+      {renderPotentialCustomerPicker()}
+      {!hasPotentialCustomers && renderConversationGroups()}
     </>
   );
 };

--- a/packages/plugin-inbox-ui/src/inbox/components/leftSidebar/ConversationItem.tsx
+++ b/packages/plugin-inbox-ui/src/inbox/components/leftSidebar/ConversationItem.tsx
@@ -124,6 +124,7 @@ const ConversationItem: React.FC<Props> = (props) => {
     assignedUser,
     messageCount = 0,
     readUserIds,
+    callProPhone,
   } = conversation;
 
   const isRead = readUserIds && readUserIds.indexOf(currentUser._id) > -1;
@@ -148,7 +149,9 @@ const ConversationItem: React.FC<Props> = (props) => {
             <FlexContent>
               <CustomerName>
                 <EllipsisContent>
-                  {isExistingCustomer && renderFullName(customer)}
+                  {isExistingCustomer
+                    ? renderFullName(customer)
+                    : callProPhone || ""}
                 </EllipsisContent>
                 <time>
                   {(dayjs(updatedAt || createdAt) || ({} as any)).fromNow(true)}

--- a/packages/plugin-integrations-api/src/callpro/controller.ts
+++ b/packages/plugin-integrations-api/src/callpro/controller.ts
@@ -260,6 +260,7 @@ const init = async (app) => {
         if (hasMultipleCustomers) {
           conversationPayload.callProPotentialCustomerIds =
             callProPotentialCustomerIds;
+          conversationPayload.callProPhone = numberFrom;
         } else {
           conversationPayload.customerId = customer.erxesApiId;
         }

--- a/packages/plugin-tickets-api/src/models/utils.ts
+++ b/packages/plugin-tickets-api/src/models/utils.ts
@@ -585,10 +585,29 @@ export const conversationConvertToCard = async (
   } else {
     const doc: any = { ...args };
 
+    let customerIds: string[] = conversation.customerId
+      ? [conversation.customerId]
+      : [];
+
+    if (customerIds.length === 0) {
+      const conformities = await sendCoreMessage({
+        subdomain,
+        action: "conformities.findConformities",
+        data: {
+          mainType: "conversation",
+          mainTypeId: conversation._id,
+          relType: "customer",
+        },
+        isRPC: true,
+        defaultValue: [],
+      });
+      customerIds = conformities.map((c) => c.relTypeId).filter(Boolean);
+    }
+
     doc.name = itemName || "Untitled";
     doc.stageId = stageId;
     doc.sourceConversationIds = [_id];
-    doc.customerIds = [conversation.customerId];
+    doc.customerIds = customerIds;
     doc.isCheckUserTicket = isCheckUser;
     doc.initialStageId = stageId;
     doc.watchedUserIds = user ? [user._id] : [];
@@ -602,19 +621,17 @@ export const conversationConvertToCard = async (
 
     const item = await create(doc);
 
-    (async () => {
-      try {
-        await createConformity(subdomain, {
-          mainType: type,
-          mainTypeId: item._id,
-          customerIds: [conversation.customerId],
-          companyIds: [],
-        });
-        await updateName(subdomain, type, item._id, [conversation.customerId], user);
-      } catch (e) {
-        console.error(e);
-      }
-    })();
+    try {
+      await createConformity(subdomain, {
+        mainType: type,
+        mainTypeId: item._id,
+        customerIds,
+        companyIds: [],
+      });
+      await updateName(subdomain, type, item._id, customerIds, user);
+    } catch (e) {
+      console.error(e);
+    }
 
     return item._id;
   }
@@ -656,7 +673,10 @@ export const updateName = async (
       }
       const uniqueServices = [...new Set(array)];
 
-      const idsCustomers = knownCustomerIds ?? await getCustomerIds(subdomain, type, item._id);
+      const validKnownIds = (knownCustomerIds || []).filter(Boolean);
+      const idsCustomers = validKnownIds.length > 0
+        ? validKnownIds
+        : await getCustomerIds(subdomain, type, item._id);
       const idsCompanies = await getCompanyIds(subdomain, type, item._id);
 
       const customers = await sendCoreMessage({

--- a/packages/plugin-tickets-api/src/models/utils.ts
+++ b/packages/plugin-tickets-api/src/models/utils.ts
@@ -568,9 +568,9 @@ export const conversationConvertToCard = async (
     });
 
     if (conversation.customerId) {
-      await sendCoreMessage({
+      const existingConformities = await sendCoreMessage({
         subdomain,
-        action: "conformities.addConformity",
+        action: "conformities.findConformities",
         data: {
           mainType: type,
           mainTypeId: item._id,
@@ -578,7 +578,22 @@ export const conversationConvertToCard = async (
           relTypeId: conversation.customerId,
         },
         isRPC: true,
+        defaultValue: [],
       });
+
+      if (!existingConformities.length) {
+        await sendCoreMessage({
+          subdomain,
+          action: "conformities.addConformity",
+          data: {
+            mainType: type,
+            mainTypeId: item._id,
+            relType: "customer",
+            relTypeId: conversation.customerId,
+          },
+          isRPC: true,
+        });
+      }
     }
 
     return item._id;

--- a/packages/plugin-tickets-api/src/models/utils.ts
+++ b/packages/plugin-tickets-api/src/models/utils.ts
@@ -688,14 +688,15 @@ export const updateName = async (
           const pattern = match.replace("{", "").replace("}", "").split(".");
 
           if (serviceName === "date") {
-            replacedName = replacedName?.replace(match, new Date().toISOString().slice(0, 10));
+            const local = new Date(Date.now() + 8 * 60 * 60 * 1000);
+            replacedName = replacedName?.replace(match, local.toISOString().slice(0, 10));
             continue;
           }
 
           if (serviceName === "time") {
-            const now = new Date();
-            const hh = String(now.getHours()).padStart(2, "0");
-            const mm = String(now.getMinutes()).padStart(2, "0");
+            const local = new Date(Date.now() + 8 * 60 * 60 * 1000);
+            const hh = String(local.getUTCHours()).padStart(2, "0");
+            const mm = String(local.getUTCMinutes()).padStart(2, "0");
             replacedName = replacedName?.replace(match, `${hh}:${mm}`);
             continue;
           }

--- a/packages/ui-inbox/src/inbox/graphql/conversationFields.ts
+++ b/packages/ui-inbox/src/inbox/graphql/conversationFields.ts
@@ -123,5 +123,6 @@ ${
   }
   callProAudio
   callProPotentialCustomerIds
+  callProPhone
   customFieldsData
 `;

--- a/packages/ui-inbox/src/inbox/types.ts
+++ b/packages/ui-inbox/src/inbox/types.ts
@@ -76,6 +76,7 @@ export interface IConversation {
   idleTime: number;
   callProAudio?: string;
   callProPotentialCustomerIds?: string[];
+  callProPhone?: string;
   videoCallData?: IVideoCallData;
   callHistory?: ICallHistory;
   cloudflareCallsHistory?: ICloudflareCallHistory;

--- a/packages/ui-tickets/src/boards/containers/editForm/CustomFieldsSection.tsx
+++ b/packages/ui-tickets/src/boards/containers/editForm/CustomFieldsSection.tsx
@@ -53,6 +53,10 @@ const CustomFieldsSection = (props: FinalProps) => {
   const filteredGroups: typeof fieldsGroupsList = [];
 
   for (const group of fieldsGroupsList) {
+    if (group.isDefinedByErxes && !group.code) {
+      continue;
+    }
+
     const { fields = [], ...restGroup } = group;
 
     const filteredFields: IField[] = [];

--- a/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
+++ b/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
@@ -103,17 +103,6 @@ class AddFormContainer extends React.Component<FinalProps> {
         .then(({ data }) => {
           const message = `You've successfully converted a conversation to ${options.type}`;
 
-          if (!doc._id && relType && relTypeIds) {
-            editConformity({
-              variables: {
-                mainType: options.type,
-                mainTypeId: data.conversationConvertToCard,
-                relType,
-                relTypeIds,
-              },
-            });
-          }
-
           this.afterSave(message, callback, {
             _id: data.conversationConvertToCard,
             stageId: doc.stageId,


### PR DESCRIPTION
## Summary by Sourcery

Ensure CallPro conversations carry and display the caller phone when multiple matching customers exist and adjust date/time placeholder generation to use a fixed local offset.

Bug Fixes:
- Propagate the CallPro caller phone field through conversation schema, GraphQL, and UI types so it can be shown when multiple customers match a call.
- Update the CallPro workarea UI to display the caller phone in the multiple-customer picker and avoid hiding audio playback when potential customers exist.
- Adjust ticket name templating for {date} and {time} placeholders to use a fixed UTC+8 local time calculation to avoid incorrect date/time values.