### PR TITLE
feat(tourism): add tour crew assignments (leader/driver/guide)

### DIFF
--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
@@ -40,6 +40,7 @@ import {
   TourAttachmentsField,
   TourDateSchedulingField,
   TourPricingOptionsField,
+  TourGuidesField,
 } from './TourFormFields';
 
 interface Props {
@@ -480,6 +481,14 @@ export const TourCreateForm = ({
                 setValue={form.setValue}
               />
             </div>
+
+            <div className="flex items-center">
+              <div className="flex-1 border-t" />
+              <Form.Label className="mx-2">Crew</Form.Label>
+              <div className="flex-1 border-t" />
+            </div>
+
+            <TourGuidesField control={form.control} />
 
             <div className="flex items-center">
               <div className="flex-1 border-t" />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
@@ -26,6 +26,13 @@ const stripTypename = <T extends Record<string, any>>(
   return rest;
 };
 
+const cloneTourGuides = (
+  guides: ITourDetail['guides'],
+): Array<{ guideId: string; type: string }> =>
+  (guides ?? [])
+    .filter((g): g is { guideId: string; type: string } => Boolean(g?.guideId))
+    .map((g) => ({ guideId: g.guideId, type: g.type ?? 'guide' }));
+
 const duplicateNameSuffix = ' (copy)';
 const duplicateRefNumberSuffix = '-copy';
 
@@ -302,6 +309,7 @@ const FixedDuplicateSheet = ({
         info4: primaryTranslation?.info4 ?? tour.info4,
         info5: primaryTranslation?.info5 ?? tour.info5,
         personCost: tour.personCost,
+        guides: cloneTourGuides(tour.guides),
         pricingOptions: normalizedPricingOptions,
         translations: sanitizeTourTranslations(values.translations),
       },
@@ -548,6 +556,7 @@ const FlexibleDuplicateSheet = ({
         info4: primaryTranslation?.info4 ?? tour.info4,
         info5: primaryTranslation?.info5 ?? tour.info5,
         personCost: tour.personCost,
+        guides: cloneTourGuides(tour.guides),
         pricingOptions: normalizedPricingOptions,
         translations: sanitizeTourTranslations(values.translations),
       },

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -42,6 +42,7 @@ import {
   TourAttachmentsField,
   TourDateSchedulingField,
   TourPricingOptionsField,
+  TourGuidesField,
 } from './TourFormFields';
 
 interface Props {
@@ -241,7 +242,14 @@ export const TourEditForm = ({
         images: tour.images ?? [],
         imageThumbnail: tour.imageThumbnail ?? '',
         attachment: tour.attachment ?? null,
-        guides: [],
+        guides: (tour.guides ?? [])
+          .filter((g): g is { guideId: string; type: string } =>
+            Boolean(g?.guideId),
+          )
+          .map((g) => ({
+            guideId: g.guideId,
+            type: g.type ?? 'guide',
+          })),
         pricingOptions: (tour.pricingOptions ?? []).map((option) => {
           const { prices, pricePerPerson, ...rest } = option;
 
@@ -450,6 +458,14 @@ export const TourEditForm = ({
                     setValue={form.setValue}
                   />
                 </div>
+
+                <div className="flex items-center">
+                  <div className="flex-1 border-t" />
+                  <Form.Label className="mx-2">Crew</Form.Label>
+                  <div className="flex-1 border-t" />
+                </div>
+
+                <TourGuidesField control={form.control} />
 
                 <div className="flex items-center">
                   <div className="flex-1 border-t" />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
@@ -17,12 +17,15 @@ import {
   Label,
   Badge,
 } from 'erxes-ui';
+import { SelectMember } from 'ui-modules';
 import { TourFormValues } from '../constants/formSchema';
+import { GUIDE_TYPES } from '../constants/guideTypes';
 import {
   IconPlus,
   IconTrash,
   IconUpload,
   IconFileText,
+  IconUsers,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useAtomValue } from 'jotai';
@@ -665,6 +668,134 @@ export const TourAttachmentsField = ({
         </Form.Item>
       )}
     />
+  );
+};
+
+export const TourGuidesField = ({
+  control,
+}: {
+  control: Control<TourFormValues>;
+}) => {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'guides',
+  });
+
+  const handleAdd = () => {
+    append({ guideId: '', type: 'guide' });
+  };
+
+  return (
+    <Form.Item className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className='space-y-2'>
+          <Form.Label className="flex items-center gap-2">
+            <IconUsers size={16} />
+            Tour Crew
+          </Form.Label>
+          <Form.Description>
+            Assign team members as tour leader, driver, guide, etc.
+          </Form.Description>
+        </div>
+
+        <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
+          <IconPlus size={16} />
+          Add Crew Member
+        </Button>
+      </div>
+
+      {fields.length === 0 ? (
+        <div className="px-4 py-6 text-sm text-center border border-dashed rounded-lg text-muted-foreground">
+          No crew assigned yet. Click "Add Crew Member" to assign roles.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {fields.map((field, index) => (
+            <div
+              key={field.id}
+              className="grid grid-cols-[1fr_1fr_auto] gap-3 items-start p-3 border rounded-lg bg-card"
+            >
+              <Form.Field
+                control={control}
+                name={`guides.${index}.type`}
+                render={({ field: roleField, fieldState }) => (
+                  <div className="space-y-2">
+                    <Form.Label
+                      className={fieldState.error ? 'text-destructive' : ''}
+                    >
+                      Role <span className="text-destructive">*</span>
+                    </Form.Label>
+                    <Select
+                      onValueChange={roleField.onChange}
+                      value={roleField.value}
+                    >
+                      <Select.Trigger
+                        className={
+                          !roleField.value ? 'text-muted-foreground' : ''
+                        }
+                      >
+                        {roleField.value
+                          ? GUIDE_TYPES.find(
+                              (opt) => opt.value === roleField.value,
+                            )?.label ?? roleField.value
+                          : 'Select role'}
+                      </Select.Trigger>
+                      <Select.Content>
+                        {GUIDE_TYPES.map((option) => (
+                          <Select.Item
+                            key={option.value}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                    <Form.Message>{fieldState.error?.message}</Form.Message>
+                  </div>
+                )}
+              />
+
+              <Form.Field
+                control={control}
+                name={`guides.${index}.guideId`}
+                render={({ field: memberField, fieldState }) => (
+                  <div className="space-y-2">
+                    <Form.Label
+                      className={fieldState.error ? 'text-destructive' : ''}
+                    >
+                      Team Member <span className="text-destructive">*</span>
+                    </Form.Label>
+                    <SelectMember.FormItem
+                      mode="single"
+                      value={memberField.value}
+                      onValueChange={(value) =>
+                        memberField.onChange(
+                          typeof value === 'string' ? value : '',
+                        )
+                      }
+                      placeholder="Select team member"
+                    />
+                    <Form.Message>{fieldState.error?.message}</Form.Message>
+                  </div>
+                )}
+              />
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => remove(index)}
+                aria-label={`Remove crew member ${index + 1}`}
+                className="mt-7"
+              >
+                <IconTrash size={16} />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </Form.Item>
   );
 };
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/formSchema.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/formSchema.ts
@@ -109,9 +109,11 @@ export const PricingOptionSchema = z.object({
 /* ================= GUIDE ================= */
 
 const GuideSchema = z.object({
-  guideId: z.string(),
-  name: z.string().optional(),
+  guideId: z.string().min(1, 'Team member is required'),
+  type: z.string().min(1, 'Role is required'),
 });
+
+export type GuideFormValue = z.infer<typeof GuideSchema>;
 
 /* ================= MAIN SCHEMA ================= */
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/guideTypes.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/constants/guideTypes.ts
@@ -1,0 +1,20 @@
+export const GUIDE_TYPES = [
+  { value: 'leader', label: 'Leader' },
+  { value: 'guide', label: 'Guide' },
+  { value: 'driver', label: 'Driver' },
+  { value: 'assistant', label: 'Assistant' },
+  { value: 'translator', label: 'Translator' },
+  { value: 'cook', label: 'Cook' },
+  { value: 'porter', label: 'Porter' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+export type GuideType = (typeof GUIDE_TYPES)[number]['value'];
+
+export const GUIDE_TYPE_LABELS: Record<string, string> = GUIDE_TYPES.reduce(
+  (acc, opt) => {
+    acc[opt.value] = opt.label;
+    return acc;
+  },
+  {} as Record<string, string>,
+);

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
@@ -161,6 +161,10 @@ export const GET_TOUR_DETAIL = gql`
       startDate
       status
       categoryIds
+      guides {
+        guideId
+        type
+      }
       pricingOptions {
         _id
         title

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useCreateTour.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useCreateTour.ts
@@ -36,7 +36,7 @@ export interface ICreateTourVariables {
   groupSize?: number;
   duration?: number;
   cost?: number;
-  guides?: Array<{ guideId: string; name?: string }>;
+  guides?: Array<{ guideId: string; type: string }>;
   info1?: string;
   info2?: string;
   info3?: string;

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useEditTour.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useEditTour.ts
@@ -34,7 +34,7 @@ export interface IEditTourVariables {
   cost?: number;
   guides?: Array<{
     guideId: string;
-    name?: string;
+    type: string;
   }>;
   refNumber?: string;
   info1?: string;

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
@@ -41,6 +41,11 @@ export interface ITourTranslation {
   pricingOptions?: IPricingOptionTranslation[];
 }
 
+export interface ITourGuide {
+  guideId: string;
+  type: string;
+}
+
 export interface ITourDetail {
   _id: string;
   branchId?: string;
@@ -49,6 +54,7 @@ export interface ITourDetail {
   advancePercent?: number;
   content?: string;
   cost?: number;
+  guides?: ITourGuide[];
   date_status?:
     | 'scheduled'
     | 'unscheduled'


### PR DESCRIPTION
## Summary by Sourcery

Add support for assigning and managing tour crew roles (leader, driver, guide, etc.) on tours across create, edit, view, and duplicate flows.

New Features:
- Introduce a Tour Crew form section allowing multiple team members to be assigned to a tour with explicit roles.
- Add predefined guide/crew role types and labels for use across the tourism UI.

Enhancements:
- Normalize and validate tour guide/crew data structures in schemas, hooks, and duplication logic to consistently use guideId and role type fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added crew member management to tour creation and editing workflows
  * Team members can now be assigned with role types (Leader, Guide, Driver, Assistant, Translator, Cook, Porter, Other)
  * Crew information is now properly preserved when editing or duplicating tours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->