### PR TITLE
fix(properties): make icon field optional

### DIFF
--- a/frontend/core-ui/src/modules/properties/components/PropertyAdd.tsx
+++ b/frontend/core-ui/src/modules/properties/components/PropertyAdd.tsx
@@ -43,7 +43,7 @@ export const AddProperty = () => {
         onSubmit={onSubmit}
         loading={loading}
         defaultValues={{
-          icon: '',
+          icon: '123',
           name: '',
           type: type || '',
           isSearchable: false,

--- a/frontend/core-ui/src/modules/properties/components/PropertyEdit.tsx
+++ b/frontend/core-ui/src/modules/properties/components/PropertyEdit.tsx
@@ -19,7 +19,7 @@ export const PropertyEdit = () => {
 
   const navigate = useNavigate();
 
-  const [fieldType, ...relationType] = (fieldDetail?.type?.split(':') || []);
+  const [fieldType, ...relationType] = fieldDetail?.type?.split(':') || [];
 
   const handleSubmit = (data: IPropertyForm) => {
     editProperty({

--- a/frontend/core-ui/src/modules/properties/components/PropertyEdit.tsx
+++ b/frontend/core-ui/src/modules/properties/components/PropertyEdit.tsx
@@ -44,6 +44,7 @@ export const PropertyEdit = () => {
       loading={editPropertyLoading}
       defaultValues={{
         ...fieldDetail,
+        icon: fieldDetail?.icon ?? '123',
         type: fieldType,
         relationType: relationType.join(':'),
       }}

--- a/frontend/core-ui/src/modules/properties/propertySchema.ts
+++ b/frontend/core-ui/src/modules/properties/propertySchema.ts
@@ -19,7 +19,7 @@ export const logicSchema = z.object({
 
 export const propertySchema = z
   .object({
-    icon: z.string().optional(),
+    icon: z.string().default('123'),
     name: z.string().min(1, 'Property name is required'),
     description: z.string().optional(),
     code: z.string().min(1, 'Code is required'),

--- a/frontend/core-ui/src/modules/properties/propertySchema.ts
+++ b/frontend/core-ui/src/modules/properties/propertySchema.ts
@@ -19,7 +19,7 @@ export const logicSchema = z.object({
 
 export const propertySchema = z
   .object({
-    icon: z.string().min(1, 'Icon is required'),
+    icon: z.string().optional(),
     name: z.string().min(1, 'Property name is required'),
     description: z.string().optional(),
     code: z.string().min(1, 'Code is required'),


### PR DESCRIPTION
## Summary by Sourcery

Allow properties to be created or updated without requiring an icon value by making the icon field optional in the property schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Icon is no longer required when creating or editing properties; a default icon is now applied automatically when none is provided.
  * Property add/edit forms now initialize the icon field with the default value and fall back to an existing icon when editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->