### PR TITLE
fix(inbox):  customFields

### DIFF
--- a/packages/ui-tickets/src/boards/containers/editForm/CustomFieldsSection.tsx
+++ b/packages/ui-tickets/src/boards/containers/editForm/CustomFieldsSection.tsx
@@ -53,10 +53,9 @@ const CustomFieldsSection = (props: FinalProps) => {
   const filteredGroups: typeof fieldsGroupsList = [];
 
   for (const group of fieldsGroupsList) {
-    if (group.isDefinedByErxes && !group.code) {
-      continue;
-    }
-
+    if (["Basic information", "Relations"].includes(group.name)) {
+        continue;
+     }
     const { fields = [], ...restGroup } = group;
 
     const filteredFields: IField[] = [];

--- a/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
+++ b/packages/ui-tickets/src/boards/containers/portable/AddForm.tsx
@@ -103,7 +103,7 @@ class AddFormContainer extends React.Component<FinalProps> {
         .then(({ data }) => {
           const message = `You've successfully converted a conversation to ${options.type}`;
 
-          if (!doc._id && relType && relTypeIds) {
+          if (!doc._id && relType && relType !== "customer" && relTypeIds) {
             editConformity({
               variables: {
                 mainType: options.type,


### PR DESCRIPTION
## Summary by Sourcery

Adjust ticket custom field groups and conversation conversion behavior in the inbox ticket UI.

Bug Fixes:
- Hide the 'Basic information' and 'Relations' custom field groups from the ticket edit form UI.
- Prevent conformity edits when converting a conversation if the related type is a customer.