### PR TITLE
feat: add POS payment callback worker with posToken logging

### DIFF
--- a/backend/plugins/payment_api/src/apis/controller.ts
+++ b/backend/plugins/payment_api/src/apis/controller.ts
@@ -85,6 +85,17 @@ export const callbackHandler = async (req, res) => {
         return res.status(400).send('Invoice not found');
       }
 
+      // ===== ШИНЭ: ЛОГ ХЭВЛЭХ =====
+      console.log('======= PAYMENT CALLBACK (controller) =======');
+      console.log('Invoice ID:', invoice._id);
+      console.log('Transaction Amount:', transaction.amount);
+      console.log('Payment Kind:', transaction.paymentKind);
+      console.log('Invoice ContentType:', invoice.contentType);
+      console.log('Invoice ContentTypeId:', invoice.contentTypeId);
+      console.log('Invoice Data:', JSON.stringify(invoice.data));
+      console.log('PosToken:', invoice.data?.posToken);
+      console.log('==============================================');
+
       const result = await models.Invoices.checkInvoice(
         transaction.invoiceId,
         subdomain,
@@ -115,6 +126,39 @@ export const callbackHandler = async (req, res) => {
       const [pluginName, moduleName, collectionType] = splitType(
         invoice.contentType,
       );
+
+      // ===== ШИНЭ: POS РУУ WORKER ИЛГЭЭХ =====
+      if (invoice.data?.posToken) {
+        try {
+          await sendWorkerMessage({
+            subdomain,
+            pluginName: 'pos',
+            queueName: 'payments',
+            jobName: 'paymentCallback',
+            data: {
+              ...invoice,
+              status: 'paid',
+              posToken: invoice.data.posToken,
+              moduleName,
+              collectionType,
+              apiResponse: 'success',
+            },
+            defaultValue: null,
+            timeout: 30000,
+            options: {
+              attempts: 3,
+              backoff: { type: 'exponential', delay: 2000 },
+            },
+          });
+          console.log(
+            `[controller] POS worker message sent for invoice ${invoice._id}, posToken: ${invoice.data.posToken}`,
+          );
+        } catch (e) {
+          console.error(
+            `[controller] Failed to send POS worker message: ${e.message}`,
+          );
+        }
+      }
 
       if (await isEnabled(pluginName)) {
         try {

--- a/backend/plugins/sales_api/src/main.ts
+++ b/backend/plugins/sales_api/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from 'erxes-api-shared/core-modules';
 import { posExportHandlers } from './modules/pos/meta/export/exportHandlers';
 import { permissions } from '~/meta/permissions';
+import { initPaymentsWorker } from './workers/payment';
 
 startPlugin({
   name: 'sales',
@@ -54,6 +55,7 @@ startPlugin({
   },
   onServerInit: async () => {
     // await initMQWorkers(redis);
+    initPaymentsWorker();
   },
   meta: {
     automations,

--- a/backend/plugins/sales_api/src/workers/handlers/paymentCallback.ts
+++ b/backend/plugins/sales_api/src/workers/handlers/paymentCallback.ts
@@ -1,0 +1,11 @@
+export const handlePaymentCallback = async (subdomain: string, data: any) => {
+  console.log('======= SALES WORKER: Payment callback received =======');
+  console.log('Subdomain:', subdomain);
+  console.log('Invoice ID:', data._id);
+  console.log('PosToken:', data.posToken);
+  console.log('Amount:', data.amount);
+  console.log('ContentType:', data.contentType);
+  console.log('ContentTypeId:', data.contentTypeId);
+  console.log('Full data:', JSON.stringify(data, null, 2));
+  console.log('========================================================');
+};

--- a/backend/plugins/sales_api/src/workers/payment.ts
+++ b/backend/plugins/sales_api/src/workers/payment.ts
@@ -1,0 +1,21 @@
+import { createMQWorkerWithListeners, redis } from 'erxes-api-shared/utils';
+import { handlePaymentCallback } from './handlers/paymentCallback';
+
+export const initPaymentsWorker = () => {
+  createMQWorkerWithListeners(
+    'sales',
+    'payments',
+    async (job) => {
+      const { subdomain, data } = job.data;
+      console.log(`[SalesWorker] Received job: ${job.name}`);
+
+      if (job.name === 'paymentCallback' || job.name === 'callback') {
+        await handlePaymentCallback(subdomain, data);
+      } else {
+        console.log(`[SalesWorker] Unhandled job name: ${job.name}`);
+      }
+    },
+    redis,
+    () => console.log('[Worker] Sales worker for queue payments is ready'),
+  );
+};


### PR DESCRIPTION
- payment_api controller.ts logs posToken and sends worker message
- sales_api listens to payments queue for paymentCallback job
- sales_api logs received posToken and invoice details for further settlement

## Summary by Sourcery

Add POS payment callback propagation from payment_api to sales_api via a payments queue worker and enhance logging for POS-related callbacks.

New Features:
- Send POS payment callback messages from payment_api to a dedicated payments queue when invoices contain a posToken.
- Introduce a payments queue worker in sales_api to handle paymentCallback jobs and log received payment and POS token details.

Enhancements:
- Add detailed logging in payment_api and sales_api around POS payment callbacks for easier tracing and settlement investigations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced logging for payment transaction details, including invoice and POS token information.
  * Added dedicated payment callback processing for POS transactions.
  * Implemented improved payment callback handling infrastructure for better transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->