### PR TITLE
feat: edit tour with multi-date creates additional tours

### DIFF
--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -352,6 +352,18 @@ export const TourEditForm = ({
         ? normalizedStartDates.slice(1)
         : [];
 
+      const targetBranchId = branchId ?? tourDetail?.branchId;
+
+      if (additionalDates.length > 0 && !targetBranchId) {
+        toast({
+          title: 'Error',
+          description:
+            'Branch ID is required to create additional tours for the selected dates',
+          variant: 'destructive',
+        });
+        return;
+      }
+
       await editTour({
         id: tourId,
         language: resolvedPrimaryLanguage || undefined,
@@ -371,8 +383,6 @@ export const TourEditForm = ({
           ? 'unscheduled'
           : getDateStatus(primaryStartDate),
       });
-
-      const targetBranchId = branchId ?? tourDetail?.branchId;
 
       if (additionalDates.length > 0 && targetBranchId) {
         const groupCode = tourDetail?.groupCode || nanoid(8);

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -3,10 +3,12 @@ import { useForm, useWatch, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@apollo/client';
 import { useEffect, useMemo, useState } from 'react';
+import { nanoid } from 'nanoid';
 import { TourSideTab, TourOrdersSidePanel } from './TourOrdersSidePanel';
 
 import { GET_ITINERARIES } from '../../itinerary/graphql/queries';
 import { useEditTour } from '../hooks/useEditTour';
+import { useCreateTour } from '../hooks/useCreateTour';
 import { useTourDetail } from '../hooks/useTourDetail';
 import { useTourLanguage } from '../hooks/useTourLanguage';
 import { TourFieldLanguageSwitch } from '../../_components/TourFieldLanguageSwitch';
@@ -67,6 +69,9 @@ const isSameDay = (left: Date, right: Date) =>
   left.getMonth() === right.getMonth() &&
   left.getDate() === right.getDate();
 
+const sortDates = (dates: Date[]) =>
+  [...dates].sort((a, b) => a.getTime() - b.getTime());
+
 const getDateStatus = (
   startDate?: Date,
 ): 'scheduled' | 'unscheduled' | 'running' => {
@@ -95,6 +100,7 @@ export const TourEditForm = ({
 }: Props) => {
   const { toast } = useToast();
   const { editTour, loading: editLoading } = useEditTour();
+  const { createTour, loading: createLoading } = useCreateTour();
   const [editorResetKey, setEditorResetKey] = useState(0);
   const [sideTabLocal, setSideTabLocal] = useState<TourSideTab | null>(null);
 
@@ -334,9 +340,17 @@ export const TourEditForm = ({
 
       const isFlexible = values.isFlexibleDate;
 
-      const normalizedStartDate = Array.isArray(values.startDate)
-        ? values.startDate?.[0]
-        : values.startDate;
+      const normalizedStartDates =
+        !isFlexible && values.startDate
+          ? Array.isArray(values.startDate)
+            ? sortDates(values.startDate)
+            : [values.startDate]
+          : [];
+
+      const primaryStartDate = normalizedStartDates[0];
+      const additionalDates = values.isGroupTour
+        ? normalizedStartDates.slice(1)
+        : [];
 
       await editTour({
         id: tourId,
@@ -345,22 +359,62 @@ export const TourEditForm = ({
         pricingOptions: normalizedPricingOptions,
         translations: sanitizedTranslations,
         dateType: isFlexible ? 'flexible' : 'fixed',
-        startDate: isFlexible ? undefined : normalizedStartDate,
+        startDate: isFlexible ? undefined : primaryStartDate,
         endDate: isFlexible
           ? undefined
-          : normalizedStartDate && values.duration
-          ? calculateEndDate(normalizedStartDate, values.duration)
+          : primaryStartDate && values.duration
+          ? calculateEndDate(primaryStartDate, values.duration)
           : undefined,
         availableFrom: isFlexible ? values.availableFrom : undefined,
         availableTo: isFlexible ? values.availableTo : undefined,
         dateStatus: isFlexible
           ? 'unscheduled'
-          : getDateStatus(normalizedStartDate),
+          : getDateStatus(primaryStartDate),
       });
+
+      const targetBranchId = branchId ?? tourDetail?.branchId;
+
+      if (additionalDates.length > 0 && targetBranchId) {
+        const groupCode = tourDetail?.groupCode || nanoid(8);
+
+        await Promise.all(
+          additionalDates.map((selectedDate, idx) => {
+            const computedEndDate = calculateEndDate(
+              selectedDate,
+              values.duration,
+            );
+
+            const refNumber = `${restValues.refNumber}-${String(
+              idx + 2,
+            ).padStart(2, '0')}`;
+
+            return createTour({
+              variables: {
+                branchId: targetBranchId,
+                language: resolvedPrimaryLanguage || undefined,
+                ...restValues,
+                refNumber,
+                pricingOptions: normalizedPricingOptions,
+                dateType: 'fixed',
+                startDate: selectedDate,
+                endDate: computedEndDate,
+                availableFrom: undefined,
+                availableTo: undefined,
+                date_status: getDateStatus(selectedDate),
+                groupCode,
+                translations: sanitizedTranslations,
+              },
+            });
+          }),
+        );
+      }
 
       toast({
         title: 'Success',
-        description: 'Tour updated successfully',
+        description:
+          additionalDates.length > 0
+            ? `Tour updated and ${additionalDates.length} new tour(s) created`
+            : 'Tour updated successfully',
       });
 
       onSuccess?.();
@@ -373,7 +427,7 @@ export const TourEditForm = ({
       });
     }
   };
-  const loading = editLoading || tourLoading;
+  const loading = editLoading || createLoading || tourLoading;
 
   return (
     <Form {...form}>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/graphql/queries.ts
@@ -128,6 +128,7 @@ export const GET_TOUR_DETAIL = gql`
       _id
       branchId
       language
+      groupCode
       advanceCheck
       advancePercent
       categoryIds

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/hooks/useTourDetail.ts
@@ -50,6 +50,7 @@ export interface ITourDetail {
   _id: string;
   branchId?: string;
   language?: string;
+  groupCode?: string;
   advanceCheck?: boolean;
   advancePercent?: number;
   content?: string;


### PR DESCRIPTION
## Summary by Sourcery

Support creating additional grouped tours when editing a multi-date fixed tour and expose group metadata in tour detail.

New Features:
- Automatically create additional fixed-date tours for extra selected dates when editing a group tour, assigning sequential reference numbers and shared group codes.
- Display a success message that reflects both the updated tour and the number of newly created tours when applicable.

Enhancements:
- Include tour creation loading state in the tour edit form to prevent interaction while additional tours are being created.
- Expose groupCode on tour detail GraphQL queries and types to support grouped tour behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group tour editing now auto-creates separate tour instances for multiple fixed start dates and groups them together.
  * Deterministic primary/additional date selection: earliest fixed date is used as primary; others become additional tours.

* **Improvements**
  * Scheduling handling refined for flexible vs. fixed dates to ensure consistent display and status.
  * Success messaging and loading indicators updated to reflect creation of additional tours and combined operation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->