### PR TITLE
fix(ci): add least-privilege permissions to release workflow (alert #1164)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
         description: 'Version to release (e.g. 3.0.4)'
         required: true
 
+# Least-privilege GITHUB_TOKEN. This workflow only retags Docker Hub images
+# using DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets and does not need write
+# access to the GitHub repo, packages, or any other scope.
+permissions:
+  contents: read
+
 jobs:
   tag-docker-images:
     name: Tag ${{ matrix.image }}


### PR DESCRIPTION
## Closes alert #1164

- **Rule:** `actions/missing-workflow-permissions` (severity: warning)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1164
- **File:** `.github/workflows/release.yml:15-51`

## Reproduction (before fix)

The `tag-docker-images` job in `.github/workflows/release.yml` had no `permissions:` block — neither at workflow root nor at job level. Per GitHub Actions docs, when `permissions:` is omitted, `GITHUB_TOKEN` inherits the repository or organization default, which on older orgs is read/write across the board.

Walking each step in the workflow:
1. `docker/setup-buildx-action@v3` — does not use `GITHUB_TOKEN`.
2. `docker/login-action@v3` — authenticates to Docker Hub via `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN`. Does not use `GITHUB_TOKEN`.
3. `docker buildx imagetools create ...` — calls Docker Hub registry API with the buildx-cached creds. Does not use `GITHUB_TOKEN`.

There is also no `actions/checkout` step. The workflow truly does not need any `GITHUB_TOKEN` write scope, so an unscoped (broad-default) token here is unnecessary attack surface — a compromised dependency in any of the Docker actions could exfiltrate the token and use it to push commits, modify issues, publish packages, etc.

## Fix

Add a top-level `permissions:` block scoped to `contents: read` only. Read-only is the recommended idiomatic minimum, satisfies the CodeQL rule, and matches the workflow's actual needs (no GitHub repo writes anywhere).

```yaml
# Least-privilege GITHUB_TOKEN. This workflow only retags Docker Hub images
# using DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets and does not need write
# access to the GitHub repo, packages, or any other scope.
permissions:
  contents: read
```

## Verification (after fix)

- Top-level `permissions: contents: read` is present BEFORE `jobs:` in `release.yml`.
- The flagged location (lines 15-51, the `tag-docker-images` job) now inherits the explicit top-level permissions, so `GITHUB_TOKEN` is read-only for `contents` and absent for everything else.
- Workflow YAML structure is unchanged otherwise; the Docker Hub login and `imagetools create` calls continue to use the existing `secrets.DOCKERHUB_*` values and are unaffected.

## Notes

- No code project files touched — `pnpm nx affected:build` is a no-op for workflow YAML changes.
- Alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

CI:
- Set explicit top-level permissions in the release workflow so the GITHUB_TOKEN is limited to read-only repository contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow security by implementing least-privilege permissions configuration for enhanced protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->