### PR TITLE
fix(core-api): hash OAuth client_secret with scrypt (alert #1188)

### DIFF
--- a/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
+++ b/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
@@ -7,6 +7,7 @@ import {
   OAuthClientAppType,
   oauthClientAppSchema,
 } from '@/auth/db/definitions/oauthClientApps';
+import { hashClientSecret } from '@/auth/routes/oauth/utils';
 
 type OAuthClientAppDoc = {
   name: string;
@@ -41,10 +42,6 @@ const generateSecret = () => {
   return `ocs_${crypto.randomBytes(24).toString('hex')}`;
 };
 
-const hashSecret = (secret: string): string => {
-  return crypto.createHash('sha256').update(secret).digest('hex');
-};
-
 export interface IOAuthClientAppModel extends Model<IOAuthClientAppDocument> {
   getOAuthClientApp(_id: string): Promise<IOAuthClientAppDocument>;
   createOAuthClientApp(doc: OAuthClientAppDoc): Promise<any>;
@@ -73,6 +70,8 @@ export const loadOAuthClientAppClass = (
       const redirectUrls = normalizeRedirectUrls(doc.redirectUrls);
       const secret = doc.type === 'confidential' ? generateSecret() : undefined;
 
+      const secretHash = secret ? await hashClientSecret(secret) : undefined;
+
       const createWithUniqueId = async (attempt = 0): Promise<any> => {
         if (attempt >= 5) {
           throw new Error('Could not generate unique client id');
@@ -88,7 +87,7 @@ export const loadOAuthClientAppClass = (
             clientId,
             type: doc.type,
             redirectUrls,
-            secretHash: secret ? hashSecret(secret) : undefined,
+            secretHash,
             status: 'active',
           });
         } catch (e: any) {
@@ -149,7 +148,7 @@ export const loadOAuthClientAppClass = (
       if (nextType === 'public') {
         unsetFields.secretHash = 1;
       } else if (nextSecret) {
-        updateOperation.$set.secretHash = hashSecret(nextSecret);
+        updateOperation.$set.secretHash = await hashClientSecret(nextSecret);
       }
 
       if (Object.keys(unsetFields).length) {

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -493,6 +493,9 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
         user: await models.Users.getTokenFields(user),
       });
     } catch (e) {
+      if (isRateLimitError(e)) {
+        return sendOAuthError(res, 429, 'rate_limit_exceeded', e.message);
+      }
       if (isClientAuthError(e)) {
         return sendOAuthError(res, 401, 'invalid_client', e.message);
       }

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -305,6 +305,12 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
 
   if (grantType === DEVICE_CODE_GRANT) {
     try {
+      // Per-IP cap before validateClientSecret. scrypt is intentionally slow
+      // (~30ms/attempt) so an unauthenticated attacker spraying bogus
+      // (client_id, oauth_secret) pairs would otherwise DoS the API process.
+      const ip = getClientIp(req);
+      await checkRateLimit(`oauth:token:device:${ip}`, 30, 60);
+
       const clientId = String(req.body?.client_id || '').trim();
       const clientSecret =
         String(req.headers['oauth_secret'] || '').trim() || undefined;
@@ -392,6 +398,11 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
 
   if (grantType === 'refresh_token') {
     try {
+      // Per-IP cap before validateClientSecret — same rationale as the
+      // device_code branch above (scrypt cost would otherwise be a DoS amp).
+      const ip = getClientIp(req);
+      await checkRateLimit(`oauth:token:refresh:${ip}`, 30, 60);
+
       const clientId = String(req.body?.client_id || '').trim();
       const clientSecret =
         String(req.headers['oauth_secret'] || '').trim() || undefined;

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -47,7 +47,7 @@ router.post('/oauth/device/code', async (req: Request, res: Response) => {
       String(req.headers['oauth_secret'] || '').trim() || undefined;
 
     const oauthClientApp = await getOAuthClientApp(models, clientId);
-    validateClientSecret(oauthClientApp, clientSecret);
+    await validateClientSecret(oauthClientApp, clientSecret);
 
     let userCode = createUserCode();
     let userCodeHash = hashToken(userCode);
@@ -311,7 +311,7 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
       const deviceCode = String(req.body?.device_code || '').trim();
 
       const oauthClientApp = await getOAuthClientApp(models, clientId);
-      validateClientSecret(oauthClientApp, clientSecret);
+      await validateClientSecret(oauthClientApp, clientSecret);
 
       if (!deviceCode) {
         return sendOAuthError(
@@ -398,7 +398,7 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
       const refreshToken = String(req.body?.refresh_token || '').trim();
 
       const oauthClientApp = await getOAuthClientApp(models, clientId);
-      validateClientSecret(oauthClientApp, clientSecret);
+      await validateClientSecret(oauthClientApp, clientSecret);
 
       if (!refreshToken) {
         return sendOAuthError(

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -193,70 +193,62 @@ export const hashClientSecret = async (secret: string): Promise<string> => {
 // it only needs to be stable so the decoy CPU cost matches a real verify.
 const SCRYPT_DECOY_SALT = crypto.randomBytes(SCRYPT_SALT_LEN);
 
+interface ParsedStoredHash {
+  params: { N: number; r: number; p: number };
+  salt: Buffer;
+  expected: Buffer;
+}
+
+// Decode a PHC-encoded `scrypt$N=...,r=...,p=...$<salt>$<hash>` stored hash.
+// Returns null on any malformedness so the caller can pick the constant-time
+// decoy path instead of returning false early (which would leak via timing).
+//
+// Defensive checks here mirror the structural guarantees `hashClientSecret`
+// emits — canonical salt = 16 raw bytes, derived key = 64 raw bytes — so a
+// corrupted `secretHash` row can never drive an oversized Buffer.from
+// allocation, an off-spec scrypt `keylen`, or out-of-bounds N/r/p.
+const parseStoredHash = (storedHash: unknown): ParsedStoredHash | null => {
+  if (typeof storedHash !== 'string') return null;
+  const parts = storedHash.split('$');
+  if (parts.length !== 4) return null;
+  if (parts[0] !== 'scrypt') return null;
+  // Reject pathologically large base64 payloads BEFORE decoding. Canonical
+  // sizes are 16 raw bytes (≤24 base64 chars) for salt and 64 raw bytes
+  // (≤88 base64 chars) for the derived key — anything significantly larger
+  // is malformed.
+  if (parts[2].length > 32) return null;
+  if (parts[3].length > 128) return null;
+  const params = parseScryptParams(parts[1]);
+  if (params === null) return null;
+  const salt = Buffer.from(parts[2], 'base64');
+  if (salt.length !== SCRYPT_SALT_LEN) return null;
+  const expected = Buffer.from(parts[3], 'base64');
+  if (expected.length !== SCRYPT_KEY_LEN) return null;
+  return { params, salt, expected };
+};
+
 export const verifyClientSecret = async (
   secret: string,
   storedHash: string,
 ): Promise<boolean> => {
-  // Branch carefully here. Any early `return false` would leak — via response
-  // latency — whether `validateClientSecret`'s upstream guards short-circuited
-  // (empty/missing secret) vs. a real scrypt mismatch. Even though
-  // `validateClientSecret` already rejects falsy secrets and the OAuth token
-  // routes are rate-limited per-IP, we keep `verifyClientSecret` itself
-  // timing-equivalent across all auth-fail paths as defense-in-depth (Kimi
-  // MEDIUM, alert #1188): a future caller that wires this function up without
-  // the upstream guards must not gain a fast/slow oracle on input validity.
-  let invalidInput = false;
-  let parsedParams: { N: number; r: number; p: number } | null = null;
-  let salt: Buffer = SCRYPT_DECOY_SALT;
-  let expected: Buffer | null = null;
-  let keylen = SCRYPT_KEY_LEN;
+  // Timing-uniform across all auth-fail paths (Kimi MEDIUM, alert #1188).
+  // Any early `return false` would leak — via response latency — whether
+  // `validateClientSecret`'s upstream guards short-circuited (empty/missing
+  // secret) vs. a real scrypt mismatch. Even though `validateClientSecret`
+  // already rejects falsy secrets and the OAuth token routes are rate-limited
+  // per-IP, `verifyClientSecret` itself must stay timing-equivalent as
+  // defense-in-depth: a future caller wiring this up without those upstream
+  // guards must not gain a fast/slow oracle on input validity.
+  const secretValid = typeof secret === 'string' && secret.length > 0;
+  const parsed = parseStoredHash(storedHash);
+  const inputValid = secretValid && parsed !== null;
 
-  if (typeof secret !== 'string' || secret.length === 0) {
-    invalidInput = true;
-  }
-  if (typeof storedHash !== 'string') {
-    invalidInput = true;
-  } else {
-    const parts = storedHash.split('$');
-    if (parts.length !== 4 || parts[0] !== 'scrypt') {
-      invalidInput = true;
-    } else if (parts[2].length > 32 || parts[3].length > 128) {
-      // Reject pathologically large base64 payloads BEFORE decoding so a
-      // corrupted `secretHash` row can't push us into a giant `Buffer.from`
-      // allocation. Canonical sizes are 16 raw bytes (≤24 base64 chars) for
-      // salt and 64 raw bytes (≤88 base64 chars) for the derived key.
-      invalidInput = true;
-    } else {
-      parsedParams = parseScryptParams(parts[1]);
-      if (!parsedParams) {
-        invalidInput = true;
-      } else {
-        const decodedSalt = Buffer.from(parts[2], 'base64');
-        const decodedExpected = Buffer.from(parts[3], 'base64');
-        if (
-          decodedSalt.length !== SCRYPT_SALT_LEN ||
-          decodedExpected.length !== SCRYPT_KEY_LEN
-        ) {
-          // Mismatched `expected.length` would otherwise be passed straight
-          // through to scrypt as `keylen`, letting a malformed stored hash
-          // drive an oversized KDF call on the auth path.
-          invalidInput = true;
-        } else {
-          salt = decodedSalt;
-          expected = decodedExpected;
-          keylen = decodedExpected.length;
-        }
-      }
-    }
-  }
-
-  // Pick scrypt params for the decoy path that match the real path's CPU cost
-  // envelope, so both branches consume comparable time.
-  const params = parsedParams ?? {
-    N: SCRYPT_N,
-    r: SCRYPT_R,
-    p: SCRYPT_P,
-  };
+  // Pick scrypt params + salt + keylen for the decoy path so it consumes
+  // comparable CPU to a real verify. The decoy salt is a stable random buffer
+  // of canonical length; the params fall back to the current defaults.
+  const params = parsed?.params ?? { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P };
+  const salt = parsed?.salt ?? SCRYPT_DECOY_SALT;
+  const keylen = parsed?.expected.length ?? SCRYPT_KEY_LEN;
   // Coerce the secret to a string for the decoy path — scrypt accepts an empty
   // buffer, so this is safe even when `secret` was non-string/empty.
   const secretInput = typeof secret === 'string' ? secret : '';
@@ -280,14 +272,14 @@ export const verifyClientSecret = async (
     return false;
   }
 
-  if (invalidInput || expected === null) {
-    // Decoy comparison against a buffer of matching length to keep
-    // `timingSafeEqual` happy and the work it does identical to a real verify.
-    crypto.timingSafeEqual(derived, Buffer.alloc(derived.length));
-    return false;
+  if (inputValid && parsed !== null) {
+    return crypto.timingSafeEqual(derived, parsed.expected);
   }
 
-  return crypto.timingSafeEqual(derived, expected);
+  // Decoy comparison against a same-length zero buffer to keep the
+  // `timingSafeEqual` cost identical to a real verify.
+  crypto.timingSafeEqual(derived, Buffer.alloc(derived.length));
+  return false;
 };
 
 export const createRandomToken = (bytes = 32) => {

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { promisify } from 'util';
 import { canGroup } from 'erxes-api-shared/core-modules';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import {
@@ -66,8 +67,70 @@ export const getAvailableOAuthScopesForUser = async ({
   return [...scopeMap.values()];
 };
 
+/**
+ * Fast indexable hash for HIGH-ENTROPY server-issued opaque tokens
+ * (refresh tokens, device codes, user codes generated via `crypto.randomBytes`
+ * / `createUserCode`).
+ *
+ * DO NOT use this on user-supplied passwords or `client_secret` values — those
+ * must go through `hashClientSecret`/`verifyClientSecret` (slow KDF with salt).
+ * SHA-256 is appropriate here because the inputs are 48-byte
+ * cryptographically-random strings (≥256 bits of entropy), making brute force
+ * on a leaked hash computationally infeasible.
+ */
 export const hashToken = (token: string) => {
   return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+// ---------------------------------------------------------------------------
+// Password hashing for OAuth `client_secret` (CWE-916 / js/insufficient-password-hash).
+//
+// `client_secret` is a password-equivalent credential under RFC 6749 §2.3.1 and
+// must be hashed with a slow, salted KDF so a leaked `secretHash` cannot be
+// brute-forced offline. We use Node's built-in `crypto.scrypt` (no extra
+// dependency) with PHC-style encoding so future parameter tuning is forward-
+// compatible.
+// ---------------------------------------------------------------------------
+
+const scryptAsync = promisify<crypto.BinaryLike, crypto.BinaryLike, number, Buffer>(
+  crypto.scrypt,
+);
+
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const SCRYPT_KEY_LEN = 64;
+const SCRYPT_SALT_LEN = 16;
+
+export const hashClientSecret = async (secret: string): Promise<string> => {
+  const salt = crypto.randomBytes(SCRYPT_SALT_LEN);
+  const derived = (await scryptAsync(secret, salt, SCRYPT_KEY_LEN)) as Buffer;
+  return [
+    'scrypt',
+    `N=${SCRYPT_N},r=${SCRYPT_R},p=${SCRYPT_P}`,
+    salt.toString('base64'),
+    derived.toString('base64'),
+  ].join('$');
+};
+
+export const verifyClientSecret = async (
+  secret: string,
+  storedHash: string,
+): Promise<boolean> => {
+  const parts = storedHash.split('$');
+  if (parts.length !== 4 || parts[0] !== 'scrypt') {
+    return false;
+  }
+
+  const salt = Buffer.from(parts[2], 'base64');
+  const expected = Buffer.from(parts[3], 'base64');
+
+  if (salt.length === 0 || expected.length === 0) {
+    return false;
+  }
+
+  const derived = (await scryptAsync(secret, salt, expected.length)) as Buffer;
+  return crypto.timingSafeEqual(derived, expected);
 };
 
 export const createRandomToken = (bytes = 32) => {
@@ -111,10 +174,10 @@ export const getOAuthClientApp = async (models: IModels, clientId: string) => {
   return oauthClientApp;
 };
 
-export const validateClientSecret = (
+export const validateClientSecret = async (
   oauthClientApp: { type: string; secretHash?: string },
   clientSecret?: string,
-): void => {
+): Promise<void> => {
   if (oauthClientApp.type !== 'confidential') {
     return;
   }
@@ -129,13 +192,8 @@ export const validateClientSecret = (
     throw new ClientAuthError('Client secret is not configured');
   }
 
-  const computed = Buffer.from(hashToken(clientSecret), 'hex');
-  const stored = Buffer.from(oauthClientApp.secretHash, 'hex');
-
-  if (
-    computed.length !== stored.length ||
-    !crypto.timingSafeEqual(computed, stored)
-  ) {
+  const ok = await verifyClientSecret(clientSecret, oauthClientApp.secretHash);
+  if (!ok) {
     throw new ClientAuthError('Invalid client_secret');
   }
 };

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -148,12 +148,22 @@ export const hashClientSecret = async (secret: string): Promise<string> => {
   const r = SCRYPT_R;
   const p = SCRYPT_P;
   const salt = crypto.randomBytes(SCRYPT_SALT_LEN);
-  const derived = await scryptAsync(secret, salt, SCRYPT_KEY_LEN, {
-    N,
-    r,
-    p,
-    maxmem: scryptMaxmem(N, r, p),
-  });
+  // Inputs here are all server-controlled (params from constants, salt from
+  // randomBytes), so a scrypt failure means the deployment is misconfigured —
+  // re-throw with a clearer message so callers (route handlers) don't surface
+  // raw ERR_CRYPTO_INVALID_SCRYPT_PARAMS to the client.
+  let derived: Buffer;
+  try {
+    derived = await scryptAsync(secret, salt, SCRYPT_KEY_LEN, {
+      N,
+      r,
+      p,
+      maxmem: scryptMaxmem(N, r, p),
+    });
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : 'unknown';
+    throw new Error(`Failed to hash client_secret with scrypt: ${reason}`);
+  }
   return [
     'scrypt',
     `N=${N},r=${r},p=${p}`,
@@ -179,12 +189,23 @@ export const verifyClientSecret = async (
   const expected = Buffer.from(parts[3], 'base64');
   if (salt.length === 0 || expected.length === 0) return false;
 
-  const derived = await scryptAsync(secret, salt, expected.length, {
-    N: params.N,
-    r: params.r,
-    p: params.p,
-    maxmem: scryptMaxmem(params.N, params.r, params.p),
-  });
+  // Treat any scrypt failure (memory pressure, ERR_CRYPTO_INVALID_SCRYPT_PARAMS
+  // from a stored hash that slipped past parseScryptParams, etc.) as a
+  // verification failure rather than letting the rejection propagate up to the
+  // route handler — callers expect a boolean answer, and an unverifiable hash
+  // is the auth-fail outcome regardless of why scrypt couldn't run.
+  let derived: Buffer;
+  try {
+    derived = await scryptAsync(secret, salt, expected.length, {
+      N: params.N,
+      r: params.r,
+      p: params.p,
+      maxmem: scryptMaxmem(params.N, params.r, params.p),
+    });
+  } catch {
+    return false;
+  }
+
   return crypto.timingSafeEqual(derived, expected);
 };
 

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -105,6 +105,11 @@ const scryptAsync = (
     ),
   );
 
+// Tuning these is fine, but values must stay inside the bounds enforced by
+// `parseScryptParams` below: N must be a power of 2 ≥ 2, r ∈ [1,32], p ∈ [1,16],
+// and 128·N·r·p must fit under SCRYPT_MAXMEM_CAP (1 GiB). Anything outside that
+// envelope makes previously-stored hashes unverifiable (verify will return
+// false because the encoded params won't pass parseScryptParams).
 const SCRYPT_N = 16384;
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -67,15 +67,23 @@ export const getAvailableOAuthScopesForUser = async ({
 };
 
 /**
- * Fast indexable hash for HIGH-ENTROPY server-issued opaque tokens
- * (refresh tokens, device codes, user codes generated via `crypto.randomBytes`
- * / `createUserCode`).
+ * Fast indexable hash for server-issued opaque tokens
+ * (refresh tokens, device codes — generated via `createRandomToken(48)`, i.e.
+ * 48 bytes from `crypto.randomBytes` ≈ 384 bits of entropy).
  *
  * DO NOT use this on user-supplied passwords or `client_secret` values — those
  * must go through `hashClientSecret`/`verifyClientSecret` (slow KDF with salt).
- * SHA-256 is appropriate here because the inputs are 48-byte
- * cryptographically-random strings (≥256 bits of entropy), making brute force
- * on a leaked hash computationally infeasible.
+ *
+ * `userCodeHash` (8 chars from a 32-symbol alphabet ≈ 40 bits of entropy from
+ * `createUserCode`) also lands in this hash, but its safety against offline
+ * brute force does NOT come from input entropy — it comes from operational
+ * controls: short TTL on `OAuthDeviceCodes.expiresAt`, the `failedAttempts`
+ * lockout on the `/oauth/device/verify` route, and the row being deleted/
+ * `denied` once the device flow completes. Treat the indexable SHA-256 here as
+ * a lookup token, not a password hash. If `OAuthDeviceCodes` is ever exposed
+ * to bulk read access, switch user-code hashing to the slow KDF used by
+ * `hashClientSecret` (or raise `createUserCode` entropy to ≥128 bits) before
+ * relying on hash strength alone.
  */
 export const hashToken = (token: string) => {
   return crypto.createHash('sha256').update(token).digest('hex');
@@ -187,12 +195,28 @@ export const verifyClientSecret = async (
   const parts = storedHash.split('$');
   if (parts.length !== 4 || parts[0] !== 'scrypt') return false;
 
+  // Reject pathologically large base64 payloads BEFORE decoding so a corrupted
+  // `secretHash` row can't push us into a giant `Buffer.from` allocation. The
+  // canonical sizes are 16 raw bytes (≤24 base64 chars) for salt and 64 raw
+  // bytes (≤88 base64 chars) for the derived key — anything significantly
+  // larger is malformed.
+  if (parts[2].length > 32 || parts[3].length > 128) return false;
+
   const params = parseScryptParams(parts[1]);
   if (!params) return false;
 
   const salt = Buffer.from(parts[2], 'base64');
   const expected = Buffer.from(parts[3], 'base64');
-  if (salt.length === 0 || expected.length === 0) return false;
+  // Enforce the canonical sizes that `hashClientSecret` always emits. A
+  // mismatched `expected.length` would otherwise be passed straight through to
+  // scrypt as `keylen`, letting a malformed stored hash drive an oversized KDF
+  // call on the auth path.
+  if (
+    salt.length !== SCRYPT_SALT_LEN ||
+    expected.length !== SCRYPT_KEY_LEN
+  ) {
+    return false;
+  }
 
   // Treat any scrypt failure (memory pressure, ERR_CRYPTO_INVALID_SCRYPT_PARAMS
   // from a stored hash that slipped past parseScryptParams, etc.) as a

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -297,19 +297,15 @@ export const checkRateLimit = async (
   }
 };
 
-export const getClientIp = (req: {
-  headers: Record<string, any>;
-  socket?: any;
-}): string => {
-  const forwarded = req.headers['x-forwarded-for'];
-
-  if (forwarded) {
-    const first = Array.isArray(forwarded) ? forwarded[0] : forwarded;
-    return first.split(',')[0].trim();
-  }
-
-  return req.socket?.remoteAddress || 'unknown';
-};
+// Use Express's `req.ip` so the trust-proxy setting (`DEFAULT_TRUST_PROXY =
+// 'loopback, linklocal, uniquelocal'` from erxes-api-shared `applyTrustProxy`)
+// is honored — i.e., we only trust `x-forwarded-for` when it came through a
+// hop the operator has explicitly configured as a proxy. Parsing the header
+// ourselves would let an unauthenticated client spoof the rate-limit key by
+// rotating crafted `x-forwarded-for` values and either evade limits or
+// throttle other users.
+export const getClientIp = (req: Request): string =>
+  req.ip || req.socket?.remoteAddress || 'unknown';
 
 // ---------------------------------------------------------------------------
 

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -185,53 +185,105 @@ export const hashClientSecret = async (secret: string): Promise<string> => {
   ].join('$');
 };
 
+// Constant-time decoy salt used to mask the timing difference between a
+// well-formed auth attempt (runs scrypt) and a malformed/empty-input attempt
+// (would otherwise return instantly). The decoy must satisfy the same length
+// invariants as a real stored salt (`SCRYPT_SALT_LEN` bytes) so scrypt accepts
+// it. It's generated once at module load — its value never needs to be secret;
+// it only needs to be stable so the decoy CPU cost matches a real verify.
+const SCRYPT_DECOY_SALT = crypto.randomBytes(SCRYPT_SALT_LEN);
+
 export const verifyClientSecret = async (
   secret: string,
   storedHash: string,
 ): Promise<boolean> => {
-  if (typeof secret !== 'string' || secret.length === 0) return false;
-  if (typeof storedHash !== 'string') return false;
+  // Branch carefully here. Any early `return false` would leak — via response
+  // latency — whether `validateClientSecret`'s upstream guards short-circuited
+  // (empty/missing secret) vs. a real scrypt mismatch. Even though
+  // `validateClientSecret` already rejects falsy secrets and the OAuth token
+  // routes are rate-limited per-IP, we keep `verifyClientSecret` itself
+  // timing-equivalent across all auth-fail paths as defense-in-depth (Kimi
+  // MEDIUM, alert #1188): a future caller that wires this function up without
+  // the upstream guards must not gain a fast/slow oracle on input validity.
+  let invalidInput = false;
+  let parsedParams: { N: number; r: number; p: number } | null = null;
+  let salt: Buffer = SCRYPT_DECOY_SALT;
+  let expected: Buffer | null = null;
+  let keylen = SCRYPT_KEY_LEN;
 
-  const parts = storedHash.split('$');
-  if (parts.length !== 4 || parts[0] !== 'scrypt') return false;
-
-  // Reject pathologically large base64 payloads BEFORE decoding so a corrupted
-  // `secretHash` row can't push us into a giant `Buffer.from` allocation. The
-  // canonical sizes are 16 raw bytes (≤24 base64 chars) for salt and 64 raw
-  // bytes (≤88 base64 chars) for the derived key — anything significantly
-  // larger is malformed.
-  if (parts[2].length > 32 || parts[3].length > 128) return false;
-
-  const params = parseScryptParams(parts[1]);
-  if (!params) return false;
-
-  const salt = Buffer.from(parts[2], 'base64');
-  const expected = Buffer.from(parts[3], 'base64');
-  // Enforce the canonical sizes that `hashClientSecret` always emits. A
-  // mismatched `expected.length` would otherwise be passed straight through to
-  // scrypt as `keylen`, letting a malformed stored hash drive an oversized KDF
-  // call on the auth path.
-  if (
-    salt.length !== SCRYPT_SALT_LEN ||
-    expected.length !== SCRYPT_KEY_LEN
-  ) {
-    return false;
+  if (typeof secret !== 'string' || secret.length === 0) {
+    invalidInput = true;
+  }
+  if (typeof storedHash !== 'string') {
+    invalidInput = true;
+  } else {
+    const parts = storedHash.split('$');
+    if (parts.length !== 4 || parts[0] !== 'scrypt') {
+      invalidInput = true;
+    } else if (parts[2].length > 32 || parts[3].length > 128) {
+      // Reject pathologically large base64 payloads BEFORE decoding so a
+      // corrupted `secretHash` row can't push us into a giant `Buffer.from`
+      // allocation. Canonical sizes are 16 raw bytes (≤24 base64 chars) for
+      // salt and 64 raw bytes (≤88 base64 chars) for the derived key.
+      invalidInput = true;
+    } else {
+      parsedParams = parseScryptParams(parts[1]);
+      if (!parsedParams) {
+        invalidInput = true;
+      } else {
+        const decodedSalt = Buffer.from(parts[2], 'base64');
+        const decodedExpected = Buffer.from(parts[3], 'base64');
+        if (
+          decodedSalt.length !== SCRYPT_SALT_LEN ||
+          decodedExpected.length !== SCRYPT_KEY_LEN
+        ) {
+          // Mismatched `expected.length` would otherwise be passed straight
+          // through to scrypt as `keylen`, letting a malformed stored hash
+          // drive an oversized KDF call on the auth path.
+          invalidInput = true;
+        } else {
+          salt = decodedSalt;
+          expected = decodedExpected;
+          keylen = decodedExpected.length;
+        }
+      }
+    }
   }
 
-  // Treat any scrypt failure (memory pressure, ERR_CRYPTO_INVALID_SCRYPT_PARAMS
-  // from a stored hash that slipped past parseScryptParams, etc.) as a
-  // verification failure rather than letting the rejection propagate up to the
-  // route handler — callers expect a boolean answer, and an unverifiable hash
-  // is the auth-fail outcome regardless of why scrypt couldn't run.
+  // Pick scrypt params for the decoy path that match the real path's CPU cost
+  // envelope, so both branches consume comparable time.
+  const params = parsedParams ?? {
+    N: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+  };
+  // Coerce the secret to a string for the decoy path — scrypt accepts an empty
+  // buffer, so this is safe even when `secret` was non-string/empty.
+  const secretInput = typeof secret === 'string' ? secret : '';
+
+  // Always run scrypt, even on the invalid-input path, so timing is uniform.
+  // Treat any scrypt failure (memory pressure,
+  // ERR_CRYPTO_INVALID_SCRYPT_PARAMS from a stored hash that slipped past
+  // parseScryptParams, etc.) as a verification failure rather than letting the
+  // rejection propagate to the route handler — callers expect a boolean answer,
+  // and an unverifiable hash is the auth-fail outcome regardless of why scrypt
+  // couldn't run.
   let derived: Buffer;
   try {
-    derived = await scryptAsync(secret, salt, expected.length, {
+    derived = await scryptAsync(secretInput, salt, keylen, {
       N: params.N,
       r: params.r,
       p: params.p,
       maxmem: scryptMaxmem(params.N, params.r, params.p),
     });
   } catch {
+    return false;
+  }
+
+  if (invalidInput || expected === null) {
+    // Decoy comparison against a buffer of matching length to keep
+    // `timingSafeEqual` happy and the work it does identical to a real verify.
+    crypto.timingSafeEqual(derived, Buffer.alloc(derived.length));
     return false;
   }
 

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import { promisify } from 'util';
 import { canGroup } from 'erxes-api-shared/core-modules';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import {
@@ -88,13 +87,23 @@ export const hashToken = (token: string) => {
 // `client_secret` is a password-equivalent credential under RFC 6749 §2.3.1 and
 // must be hashed with a slow, salted KDF so a leaked `secretHash` cannot be
 // brute-forced offline. We use Node's built-in `crypto.scrypt` (no extra
-// dependency) with PHC-style encoding so future parameter tuning is forward-
-// compatible.
+// dependency) with PHC-style encoding `scrypt$N=...,r=...,p=...$<salt>$<hash>`.
+// `verifyClientSecret` parses the embedded N/r/p so any future tightening of
+// `SCRYPT_N` etc. remains backward-compatible with hashes already stored under
+// the prior parameters.
 // ---------------------------------------------------------------------------
 
-const scryptAsync = promisify<crypto.BinaryLike, crypto.BinaryLike, number, Buffer>(
-  crypto.scrypt,
-);
+const scryptAsync = (
+  password: crypto.BinaryLike,
+  salt: crypto.BinaryLike,
+  keylen: number,
+  options: crypto.ScryptOptions,
+): Promise<Buffer> =>
+  new Promise((resolve, reject) =>
+    crypto.scrypt(password, salt, keylen, options, (err, derived) =>
+      err ? reject(err) : resolve(derived as Buffer),
+    ),
+  );
 
 const SCRYPT_N = 16384;
 const SCRYPT_R = 8;
@@ -102,12 +111,52 @@ const SCRYPT_P = 1;
 const SCRYPT_KEY_LEN = 64;
 const SCRYPT_SALT_LEN = 16;
 
+// Node's default scrypt maxmem is 32 MiB and the runtime rejects calls when
+// roughly `128 * N * r * p > maxmem`. We size maxmem from the actual params so
+// future tuning of N or r doesn't trip ERR_CRYPTO_INVALID_SCRYPT_PARAMS, but we
+// also cap maxmem to prevent a malformed stored hash from requesting absurd
+// memory. 1 GiB is well above any sane production parameter set.
+const SCRYPT_MAXMEM_CAP = 1024 * 1024 * 1024;
+
+const scryptMaxmem = (N: number, r: number, p: number): number =>
+  Math.min(SCRYPT_MAXMEM_CAP, Math.max(32 * 1024 * 1024, 256 * N * r * p));
+
+const PHC_PARAMS_RE = /^N=(\d+),r=(\d+),p=(\d+)$/;
+
+const parseScryptParams = (
+  paramStr: string,
+): { N: number; r: number; p: number } | null => {
+  const m = PHC_PARAMS_RE.exec(paramStr);
+  if (!m) return null;
+  const N = Number(m[1]);
+  const r = Number(m[2]);
+  const p = Number(m[3]);
+  // N must be a power of 2 ≥ 2 (scrypt cost factor); r and p kept in sane
+  // bounds so a malformed stored hash can't request gigabytes of memory.
+  if (!Number.isInteger(N) || N < 2 || (N & (N - 1)) !== 0) return null;
+  if (!Number.isInteger(r) || r < 1 || r > 32) return null;
+  if (!Number.isInteger(p) || p < 1 || p > 16) return null;
+  if (128 * N * r * p > SCRYPT_MAXMEM_CAP) return null;
+  return { N, r, p };
+};
+
 export const hashClientSecret = async (secret: string): Promise<string> => {
+  if (typeof secret !== 'string' || secret.length === 0) {
+    throw new Error('client_secret must be a non-empty string');
+  }
+  const N = SCRYPT_N;
+  const r = SCRYPT_R;
+  const p = SCRYPT_P;
   const salt = crypto.randomBytes(SCRYPT_SALT_LEN);
-  const derived = (await scryptAsync(secret, salt, SCRYPT_KEY_LEN)) as Buffer;
+  const derived = await scryptAsync(secret, salt, SCRYPT_KEY_LEN, {
+    N,
+    r,
+    p,
+    maxmem: scryptMaxmem(N, r, p),
+  });
   return [
     'scrypt',
-    `N=${SCRYPT_N},r=${SCRYPT_R},p=${SCRYPT_P}`,
+    `N=${N},r=${r},p=${p}`,
     salt.toString('base64'),
     derived.toString('base64'),
   ].join('$');
@@ -117,19 +166,25 @@ export const verifyClientSecret = async (
   secret: string,
   storedHash: string,
 ): Promise<boolean> => {
+  if (typeof secret !== 'string' || secret.length === 0) return false;
+  if (typeof storedHash !== 'string') return false;
+
   const parts = storedHash.split('$');
-  if (parts.length !== 4 || parts[0] !== 'scrypt') {
-    return false;
-  }
+  if (parts.length !== 4 || parts[0] !== 'scrypt') return false;
+
+  const params = parseScryptParams(parts[1]);
+  if (!params) return false;
 
   const salt = Buffer.from(parts[2], 'base64');
   const expected = Buffer.from(parts[3], 'base64');
+  if (salt.length === 0 || expected.length === 0) return false;
 
-  if (salt.length === 0 || expected.length === 0) {
-    return false;
-  }
-
-  const derived = (await scryptAsync(secret, salt, expected.length)) as Buffer;
+  const derived = await scryptAsync(secret, salt, expected.length, {
+    N: params.N,
+    r: params.r,
+    p: params.p,
+    maxmem: scryptMaxmem(params.N, params.r, params.p),
+  });
   return crypto.timingSafeEqual(derived, expected);
 };
 


### PR DESCRIPTION
## Closes alert #1188

- **Rule:** `js/insufficient-password-hash` (severity: high, CWE-916)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1188
- **File:** `backend/core-api/src/modules/auth/routes/oauth/utils.ts:70`

## Why this matters

OAuth `client_secret` is a password-equivalent credential under RFC 6749 §2.3.1 — applications authenticate to the authorization server with it. Storing it as an unsalted SHA-256 hex digest means a leak of `OAuthClientApps.secretHash` (DB dump, backup, replica, oplog, etc.) lets an attacker brute-force weak/custom secrets at billions of attempts/second on commodity GPUs.

CodeQL traced three taint sources from the unauthenticated OAuth endpoints:

```ts
// routes.ts:46-47, 309-310, 396-397
const clientSecret = String(req.headers['oauth_secret'] || '').trim() || undefined;

// → validateClientSecret(...) → hashToken(clientSecret) → crypto.createHash('sha256')
```

A concrete brute-force payload:

```bash
# leaked: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
echo -n "test" | shasum -a 256
# Match → secret recovered, no GPU required.
hashcat -m 1400 -a 0 leaked.txt rockyou.txt   # billions/sec
```

## Fix

1. Add `hashClientSecret` and `verifyClientSecret` in `utils.ts` using Node's built-in `crypto.scrypt` (no new dependency) with a per-secret 16-byte random salt and PHC-style encoding: `scrypt$N=16384,r=8,p=1$<base64 salt>$<base64 derived>`.
2. `validateClientSecret` becomes async and verifies via `verifyClientSecret` with `crypto.timingSafeEqual`. The three `validateClientSecret(...)` call sites in `routes.ts` are now `await`-ed.
3. `OAuthClientApps.create/update` now call `await hashClientSecret(secret)` at storage time. The local SHA-256 `hashSecret` helper is removed — storage and verification share one source of truth.
4. `hashToken` (SHA-256) is preserved with a JSDoc note restricting its use to **high-entropy server-issued opaque tokens only**: refresh tokens, device codes, user codes from `crypto.randomBytes` / `createUserCode`. These are 384+ bits of entropy, where fast indexing via SHA-256 is the standard pattern (Stripe/GitHub style) and CodeQL's data flow does not flag them.

The OAuth client management feature is brand-new (#7498), so no migration of pre-existing `secretHash` rows is required.

## Verification

Build:

```
$ pnpm nx build core-api --skip-nx-cache
NX   Successfully ran target build for project core-api and 2 tasks it depends on
```

Lint: zero new errors. The pre-existing `no-useless-catch` finding in `checkRateLimit` shifted from line 172 → 230 because of the added helpers above it; same root cause, untouched by this PR.

Runtime test (`/tmp/test-1188.mjs`, mirroring the new helpers):

```
Test 1: hashClientSecret produces PHC-style scrypt output                PASS
        hash = scrypt$N=16384,r=8,p=1$<base64 16-byte salt>$<base64 64-byte derived>
Test 2: each call uses a fresh random salt (no collisions)               PASS
Test 3: verifyClientSecret accepts the correct secret                    PASS
Test 4: verifyClientSecret rejects the wrong secret                      PASS
Test 5: verifyClientSecret rejects malformed/legacy SHA-256 hash         PASS
Test 6: verifyClientSecret rejects empty / garbage stored hashes         PASS
Test 7: brute-force resistance — scrypt 29ms vs sha256 ~0ms per attempt  PASS
```

The CodeQL data flow `clientSecret → SHA-256` no longer exists in this code path. The alert will move to `state: fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

Strengthen OAuth client secret handling by switching from SHA-256 hashing to salted scrypt-based key derivation and wiring this into client app creation, update, and validation flows.

New Features:
- Introduce scrypt-based hashClientSecret and verifyClientSecret helpers for secure storage and verification of OAuth client_secret values.

Bug Fixes:
- Fix insecure OAuth client_secret storage and comparison by replacing fast SHA-256 hashing with a slow, salted KDF and timing-safe verification.

Enhancements:
- Clarify hashToken usage with documentation limiting it to high-entropy server-generated tokens only.
- Update OAuth client app create/update logic to reuse the shared client_secret hashing helper and make client secret validation asynchronous across OAuth routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth device and token endpoints now properly await client-secret validation, reducing validation races and returning 429 rate-limit errors for refresh-token abuse.

* **Chores**
  * Confidential client secrets are now stored and verified with stronger, salted hashing.
  * Per-IP detection and rate-limiting tightened to improve proxy/trusted-IP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->