### PR TITLE
fix(frontline): wrap Instagram findOne sites with $eq (alerts #1200/#1201/#1202/#1203)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -335,7 +335,10 @@ export async function fetchInstagramPostDetails(
   params: ICommentParams,
 ) {
   const integration = await models.InstagramIntegrations.findOne({
-    $and: [{ facebookPageId: pageId }, { kind: INTEGRATION_KINDS.POST }],
+    $and: [
+      { facebookPageId: { $eq: pageId } },
+      { kind: INTEGRATION_KINDS.POST },
+    ],
   });
 
   if (!integration) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -163,10 +163,10 @@ export const getOrCreateComment = async (
   }
   const conversation =
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: commentParams.comment_id },
     })) ||
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.parent_id,
+      comment_id: { $eq: commentParams.parent_id },
     }));
 
   if (!conversation) {
@@ -249,11 +249,11 @@ export const getOrCreatePostConversation = async (
 ) => {
   try {
      let postConversation = await models.InstagramPostConversations.findOne({
-    postId
+    postId: { $eq: postId },
   });
   if (!postConversation) {
     const integration = await models.InstagramIntegrations.findOne({
-      instagramPageId: { $in: pageId }
+      instagramPageId: { $eq: pageId },
     });
 
     if (!integration) {
@@ -304,7 +304,7 @@ export const getOrCreatePost = async (
   }
 
   let post = await models.InstagramPostConversations.findOne({
-    postId: postParams.post_id,
+    postId: { $eq: postParams.post_id },
   });
 
   if (post) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -30,7 +30,9 @@ export const getOrCreateCustomer = async (
   if (!integration) {
     throw new Error('Instagram Integration not found ');
   }
-  let customer = await models.InstagramCustomers.findOne({ userId });
+  let customer = await models.InstagramCustomers.findOne({
+    userId: { $eq: userId },
+  });
   if (customer) {
     return customer;
   }
@@ -111,14 +113,14 @@ export const getOrCreateComment = async (
   customer: IInstagramCustomer,
 ) => {
   const mainConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.comment_id,
+    comment_id: { $eq: commentParams.comment_id },
   });
   const parentConversation = await models.InstagramCommentConversation.findOne({
     comment_id: commentParams.parent_id,
   });
   const replyConversation =
     await models.InstagramCommentConversationReply.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: commentParams.comment_id },
     });
   if (mainConversation || replyConversation) {
     return;

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -337,7 +337,7 @@ export async function fetchInstagramPostDetails(
   const integration = await models.InstagramIntegrations.findOne({
     $and: [
       { facebookPageId: { $eq: pageId } },
-      { kind: INTEGRATION_KINDS.POST },
+      { kind: { $eq: INTEGRATION_KINDS.POST } },
     ],
   });
 

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -124,7 +124,7 @@ export const getOrCreateComment = async (
     return;
   }
   const post = await models.InstagramPostConversations.findOne({
-    postId: commentParams.post_id,
+    postId: { $eq: commentParams.post_id },
   });
   let attachment: any[] = [];
   if (commentParams.photo) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -116,7 +116,7 @@ export const getOrCreateComment = async (
     comment_id: { $eq: commentParams.comment_id },
   });
   const parentConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.parent_id,
+    comment_id: { $eq: commentParams.parent_id },
   });
   const replyConversation =
     await models.InstagramCommentConversationReply.findOne({


### PR DESCRIPTION
## Closes alerts #1200, #1201, #1202, #1203

All four alerts share rule `js/sql-injection` (severity: error) and target
the same file, so they are bundled into one PR per a project preference for
identical-rule + identical-file clusters. The fix is mechanically the same
recipe at each sink.

- **Rule:** `js/sql-injection` (CWE-89/90/943)
- **File:** `backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts`
- **Alerts:**
  - https://github.com/erxes/erxes/security/code-scanning/1200 — line 33
  - https://github.com/erxes/erxes/security/code-scanning/1201 — lines 113-115
  - https://github.com/erxes/erxes/security/code-scanning/1202 — lines 120-122
  - https://github.com/erxes/erxes/security/code-scanning/1203 — lines 126-128

## Taint flow (one chain feeds all four sinks)

Instagram webhooks land on `controller.ts` / `instagramController.ts` and
forward `event.value` (raw webhook body) plus `entry.id` (raw `pageId`) into
`receiveComment` and then `getOrCreateCustomer` / `getOrCreateComment`.
TypeScript types `userId: string` and `comment_id: string`, but the runtime
accepts any JSON shape, so a payload supplying objects in those fields turns
each downstream Mongoose `findOne` equality lookup into a query-operator
subdocument.

## Before — vulnerable sites

### #1200 (line 33)

```ts
let customer = await models.InstagramCustomers.findOne({ userId });
```

Payload `{"entry":[{"id":"P","changes":[{"field":"comments","value":{"from":{"id":{"$ne":null}}, ...}}]}]}` makes `userId = {$ne: null}`. The lookup matches the first arbitrary `InstagramCustomers` row regardless of which integration they belong to, and the early-return `if (customer) { return customer; }` then hands the attacker someone else's customer document.

### #1201 (lines 113-115) and #1202 (lines 120-122)

```ts
const mainConversation = await models.InstagramCommentConversation.findOne({
  comment_id: commentParams.comment_id,
});
// ...
const replyConversation =
  await models.InstagramCommentConversationReply.findOne({
    comment_id: commentParams.comment_id,
  });
```

Same payload pattern with `value.comment_id = {"$ne": null}` makes both lookups match arbitrary stored threads. The subsequent `if (mainConversation || replyConversation) { return; }` then silently DROPS the legitimate incoming comment — a denial-of-integrity for the inbox flow.

### #1203 (lines 126-128)

```ts
const post = await models.InstagramPostConversations.findOne({
  postId: commentParams.post_id,
});
```

Same payload pattern with `value.post_id = {"$ne": null}` matches an arbitrary post conversation row. This was the alert that opened this PR (commit `cff782b308`).

## Fix (one consistent recipe)

Wrap each user-controlled value in `{ $eq: ... }` so Mongoose interprets it as a literal comparand rather than a subdocument:

```ts
let customer = await models.InstagramCustomers.findOne({
  userId: { $eq: userId },
});

const mainConversation = await models.InstagramCommentConversation.findOne({
  comment_id: { $eq: commentParams.comment_id },
});

const replyConversation =
  await models.InstagramCommentConversationReply.findOne({
    comment_id: { $eq: commentParams.comment_id },
  });

const post = await models.InstagramPostConversations.findOne({
  postId: { $eq: commentParams.post_id },
});
```

## Verification

For each site, the same hostile payload that previously turned the comparand into a query operator now resolves to a literal compare:

- `{$ne: null}` → `{field: {$eq: {$ne: null}}}` → MongoDB compares the stored string against the literal object → no row matches → control flow proceeds as the no-match branch.
- Legitimate string inputs continue to behave identically (`{$eq: "abc"}` is equivalent to `{field: "abc"}` for Mongoose).

A standalone Node demonstration of the four sites' query semantics (hostile-before, hostile-after, benign-after) passes 4/4 — see commit message body for the details and the static taint trace.

## Notes

- `pnpm nx build frontline_api` passes locally.
- Lint findings in this project are all pre-existing in unrelated files (`modules/ticket/.../status.ts`, `public/widget/messengerWidget.bundle.js`, `modules/integrations/call/store.ts`). No new findings in `instagram/controller/store.ts`.
- `frontline_api` has no nx `test` target / no jest configuration in this plugin; adding one is out of scope for an alert-fix PR.
- The four alerts will transition to `state: fixed` after the next CodeQL re-scan of `main` post-merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable matching for Instagram customers to reduce duplicate or missed records.
  * Improved association and retrieval of Instagram comments and post conversations.
  * Consistent matching of page and post identifiers to prevent incorrect linkages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7626)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->