### PR TITLE
fix(frontline): rate-limit Facebook OAuth login route (alert #1112)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
@@ -1,4 +1,5 @@
 import express, { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { loginMiddleware } from '@/integrations/facebook/middlewares/loginMiddleware';
 import {
   facebookGetPost,
@@ -8,8 +9,19 @@ import {
 } from '@/integrations/facebook/controller/controller';
 export const router: Router = express.Router();
 
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    errorCode: 'RATE_LIMIT_EXCEEDED',
+    message: 'Too many login requests, please try again later.',
+  },
+});
+
 // Facebook routes
-router.get('/fblogin', loginMiddleware);
+router.get('/fblogin', loginLimiter, loginMiddleware);
 
 router.get('/get-post', async (req, res, next) => {
   try {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
@@ -11,7 +11,7 @@ export const router: Router = express.Router();
 
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 30,
   standardHeaders: true,
   legacyHeaders: false,
   message: {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts
@@ -1,5 +1,5 @@
-import express, { Router } from 'express';
-import rateLimit from 'express-rate-limit';
+import express, { Request, Router } from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { loginMiddleware } from '@/integrations/facebook/middlewares/loginMiddleware';
 import {
   facebookGetPost,
@@ -9,15 +9,35 @@ import {
 } from '@/integrations/facebook/controller/controller';
 export const router: Router = express.Router();
 
+/**
+ * Pick the rightmost X-Forwarded-For hop (the last trusted proxy in the chain),
+ * matching the pattern used by core-api/fileRoutes and core-api/main. The
+ * leftmost XFF entry is attacker-controllable, so we never trust it.
+ */
+const getClientIp = (req: Request): string => {
+  const xff = req.headers['x-forwarded-for'];
+  if (xff) {
+    const parts = (Array.isArray(xff) ? xff[0] : xff).split(',');
+    return parts[parts.length - 1].trim();
+  }
+  return req.ip || 'unknown';
+};
+
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 30,
+  // Per OWASP guidance, don't count successful auth flows toward the limit;
+  // we only want to slow down repeated failures / probing.
+  skipSuccessfulRequests: true,
+  keyGenerator: (req) => ipKeyGenerator(getClientIp(req)),
+  handler: (_req, res) => {
+    res.status(429).json({
+      errorCode: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many login requests, please try again later.',
+    });
+  },
   standardHeaders: true,
   legacyHeaders: false,
-  message: {
-    errorCode: 'RATE_LIMIT_EXCEEDED',
-    message: 'Too many login requests, please try again later.',
-  },
 });
 
 // Facebook routes


### PR DESCRIPTION
## Closes alert #1112

- **Rule:** `js/missing-rate-limiting` (CodeQL, security_severity_level: high)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1112
- **File:** `backend/plugins/frontline_api/src/modules/integrations/facebook/routes.ts:12`
- **CWEs:** CWE-307, CWE-400, CWE-770

## Reproduction (before fix)

`routes.ts:12` mounted the Facebook OAuth login handler with no rate limiter:

```ts
router.get('/fblogin', loginMiddleware);
```

`loginMiddleware` performs the expensive operations CodeQL flags on every hit:

1. Four MongoDB config reads (`getConfig` × 4) + a Mongoose connection through `generateModels(subdomain)`.
2. An outbound HTTPS round-trip to `graph.facebook.com` (`graph.getOauthUrl` redirect, or `graph.authorize` + `me?fields=...` when `?code=` is present).
3. Authorization-side writes: `FacebookAccounts.findOne` then either `updateOne` of an existing account token or `create` + `repairIntegrations` for every linked integration. CodeQL's `most_recent_instance.message` references this exact range (`loginMiddleware.ts#L66C10-L113C5`) — `"performs authorization, but is not rate-limited"`.

The endpoint is reachable unauthenticated through the gateway at `/pl:frontline/facebook/fblogin`. A flood with `ab -n 100000 -c 200` saturates the Mongo connection pool and Facebook Graph API quota, classic CWE-770 DoS against an unrestricted, expensive, public endpoint.

## Fix

Add an `express-rate-limit` middleware (`windowMs: 15 * 60 * 1000`, `max: 100`) in front of `loginMiddleware` on the `/fblogin` route. Pattern matches the existing repo convention for OAuth callbacks:

- `backend/core-api/src/modules/organization/routes.ts` — `callbackLimiter` for `/ml-callback` (same threshold, same threat model).
- `backend/core-api/src/routes/fileRoutes.ts` — `createLimiter`-built `readLimiter` / `uploadLimiter`.
- `backend/erxes-api-shared/src/utils/start-plugin.ts` — `subscriptionFileLimiter`.

`express-rate-limit ^8.0.1` is already a dep of `erxes-api-shared` (which `frontline_api` consumes). `applyTrustProxy(app)` is set in `start-plugin.ts:136`, so `req.ip` correctly reflects the real client through XFF — the default `keyGenerator` is appropriate.

## Verification (after fix)

`router.get('/fblogin', loginLimiter, loginMiddleware);` — the limiter sits between the route mount and the expensive handler. Repeat traffic from a single IP exceeding 100 reqs / 15 min receives:

```json
{ "errorCode": "RATE_LIMIT_EXCEEDED", "message": "Too many login requests, please try again later." }
```

…with standard `RateLimit-*` headers. Threshold is intentionally generous so legitimate retries / multi-user OAuth bursts are not blocked; only abnormal high-frequency abuse from one IP is throttled.

## Notes

- `pnpm nx affected:build --uncommitted` passes locally (cache hit on `erxes-api-shared`, full compile of `frontline_api`).
- Lint failures in `frontline_api` are all pre-existing, unrelated files (e.g., `Bots.ts`, `messengerWidget.bundle.js`, `customResolvers/status.ts`); the edited `routes.ts` introduces no new lint errors.
- Scope intentionally minimal: only `/fblogin` is rate-limited. The Facebook webhook routes (`/receive` GET/POST) need higher / different limits because they accept legitimate FB-side bursts and were not flagged by CodeQL — out of scope for this alert.
- The alert will move to `state: fixed` after the next CodeQL re-scan of `main` post-merge (typically 30 min – a few hours, not on PR merge directly).

## Summary by Sourcery

Bug Fixes:
- Add a rate limiter middleware to the `/fblogin` Facebook OAuth login endpoint to prevent excessive, unauthenticated requests from overloading backend and external services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to Facebook login: 15-minute window, 30-request cap, and a clear structured 429 error when the limit is exceeded to reduce excessive login attempts.
  * Other Facebook integration endpoints continue to operate as before with no behavioral changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7627)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->