### PR TITLE
fix(facebook): add messaging_type MESSAGE_TAG when sending tagged messages outside 24h window

### DIFF
--- a/packages/plugin-facebook-api/src/handleFacebookMessage.ts
+++ b/packages/plugin-facebook-api/src/handleFacebookMessage.ts
@@ -188,7 +188,7 @@ export const handleFacebookMessage = async (
           {
             recipient: { id: senderId },
             message: { text: strippedContent },
-            tag
+            ...(tag ? { messaging_type: 'MESSAGE_TAG', tag } : {})
           },
           conversation.recipientId,
           integrationId
@@ -217,7 +217,7 @@ export const handleFacebookMessage = async (
           {
             recipient: { id: senderId },
             message,
-            tag
+            ...(tag ? { messaging_type: 'MESSAGE_TAG', tag } : {})
           },
           conversation.recipientId,
           integrationId


### PR DESCRIPTION
…sages outside 24h window

## Summary by Sourcery

Bug Fixes:
- Send tagged Facebook messages outside the 24-hour window with messaging_type set to MESSAGE_TAG and include tag fields only when present.