### PR TITLE
fix(frontline): wrap commentParams.parent_id with $eq in Instagram comment lookup (alert #1212)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -111,20 +111,20 @@ export const getOrCreateComment = async (
   customer: IInstagramCustomer,
 ) => {
   const mainConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.comment_id,
+    comment_id: { $eq: commentParams.comment_id },
   });
   const parentConversation = await models.InstagramCommentConversation.findOne({
-    comment_id: commentParams.parent_id,
+    comment_id: { $eq: commentParams.parent_id },
   });
   const replyConversation =
     await models.InstagramCommentConversationReply.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: commentParams.comment_id },
     });
   if (mainConversation || replyConversation) {
     return;
   }
   const post = await models.InstagramPostConversations.findOne({
-    postId: commentParams.post_id,
+    postId: { $eq: commentParams.post_id },
   });
   let attachment: any[] = [];
   if (commentParams.photo) {
@@ -161,7 +161,7 @@ export const getOrCreateComment = async (
   }
   const conversation =
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: { $eq: commentParams.comment_id },
     })) ||
     (await models.InstagramCommentConversation.findOne({
       comment_id: { $eq: commentParams.parent_id },

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -164,7 +164,7 @@ export const getOrCreateComment = async (
       comment_id: commentParams.comment_id,
     })) ||
     (await models.InstagramCommentConversation.findOne({
-      comment_id: commentParams.parent_id,
+      comment_id: { $eq: commentParams.parent_id },
     }));
 
   if (!conversation) {


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1212](https://github.com/erxes/erxes/security/code-scanning/1212) (`js/sql-injection`, high).
- `getOrCreateComment` in `instagram/controller/store.ts` fell back to looking up a parent comment via `InstagramCommentConversation.findOne({ comment_id: commentParams.parent_id })`. `commentParams` comes from a webhook payload, so `parent_id` could be an operator object like `{ "$ne": null }` and turn the lookup into NoSQL injection.
- Wrapped the value with `{ $eq: commentParams.parent_id }` so Mongoose treats it as a literal value comparison even if a payload supplies an operator object.

## Change
`backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts`
```diff
- comment_id: commentParams.parent_id,
+ comment_id: { $eq: commentParams.parent_id },
```

## Test plan
- [ ] Existing Instagram comment webhook flow still resolves parent comments.
- [ ] Payload with `parent_id: { "$ne": null }` returns no match (literal comparison).
- [ ] Re-run CodeQL — alert #1212 flips to fixed.

## Summary by Sourcery

Bug Fixes:
- Sanitize Instagram comment parent lookup by forcing the parent_id filter to use an equality comparison, preventing NoSQL injection from operator-shaped payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram comment retrieval and conversation synchronization reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7636)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->