### PR TITLE
fix(frontline): guard Instagram bot lookup against payload-driven NoSQL injection (alert #1213)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/utils/messageUtils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/utils/messageUtils.ts
@@ -57,12 +57,19 @@ export const checkIsBot = async (models: IModels, message, recipientId) => {
   let selector: any = { pageId: recipientId };
 
   if (message?.payload) {
-    const payload = JSON.parse(message?.payload || '{}');
+    // payload comes from a webhook body and may be malformed; guard the
+    // JSON.parse so a bad payload cannot crash checkIsBot. Fall back to
+    // the default pageId-only selector when parsing fails.
+    let payload: { botId?: unknown } = {};
+    try {
+      payload = JSON.parse(message.payload);
+    } catch {
+      // Invalid JSON payload, proceed with the default selector.
+    }
     // Coerce/validate botId to a string before using it in the query.
-    // payload comes from a webhook body via JSON.parse, so payload.botId
-    // could be a Mongo operator object (e.g. {$ne: null}) and would turn
-    // the lookup into NoSQL injection. Keep pageId scope to prevent
-    // cross-page bot lookups even when a string bot id is supplied.
+    // payload.botId could be a Mongo operator object (e.g. {$ne: null}) and
+    // would turn the lookup into NoSQL injection. Keep pageId scope to
+    // prevent cross-page bot lookups even when a string bot id is supplied.
     if (typeof payload.botId === 'string' && payload.botId) {
       selector = { _id: payload.botId, pageId: recipientId };
     }

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/utils/messageUtils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/utils/messageUtils.ts
@@ -58,8 +58,13 @@ export const checkIsBot = async (models: IModels, message, recipientId) => {
 
   if (message?.payload) {
     const payload = JSON.parse(message?.payload || '{}');
-    if (payload.botId) {
-      selector = { _id: payload.botId };
+    // Coerce/validate botId to a string before using it in the query.
+    // payload comes from a webhook body via JSON.parse, so payload.botId
+    // could be a Mongo operator object (e.g. {$ne: null}) and would turn
+    // the lookup into NoSQL injection. Keep pageId scope to prevent
+    // cross-page bot lookups even when a string bot id is supplied.
+    if (typeof payload.botId === 'string' && payload.botId) {
+      selector = { _id: payload.botId, pageId: recipientId };
     }
   }
   const bot = await models.InstagramBots.findOne(selector);


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1213](https://github.com/erxes/erxes/security/code-scanning/1213) (`js/sql-injection`, high).
- `checkIsBot` in `instagram/meta/automation/utils/messageUtils.ts` parsed `message.payload` via `JSON.parse` and built `{ _id: payload.botId }`. Because payload originates from a webhook body, `botId` could be an operator object such as `{ \"\$ne\": null }` and pass straight into `models.InstagramBots.findOne`.
- Added a `typeof === 'string'` guard and scoped the query by `pageId` so cross-page bot lookups are not possible even when a literal id is supplied.

## Change
`backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/utils/messageUtils.ts`
```diff
- if (payload.botId) {
-   selector = { _id: payload.botId };
+ if (typeof payload.botId === 'string' && payload.botId) {
+   selector = { _id: payload.botId, pageId: recipientId };
  }
```

## Test plan
- [ ] Bot triggered via a string `botId` in payload still resolves correctly for the page.
- [ ] Payload with `botId: { "\$ne": null }` returns no match (lookup short-circuits).
- [ ] Cross-page payload (string `botId` but for a different page) finds no match.
- [ ] Re-run CodeQL — alert #1213 flips to fixed.

## Summary by Sourcery

Harden Instagram bot lookup against payload-driven NoSQL injection in the frontline API by validating bot IDs and scoping queries by page.

Bug Fixes:
- Prevent NoSQL injection in Instagram bot lookup by requiring botId to be a non-empty string before querying.
- Restrict Instagram bot lookups to the current pageId to avoid cross-page bot resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message parsing and bot detection to avoid errors from malformed data and to ensure bot lookups are correctly scoped to the originating page, preventing cross-page bot mismatches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7637)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->