### PR TITLE
fix(frontline): sanitize Instagram webhook ids before Mongo lookup (alert #1214)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -14,19 +14,29 @@ import {
 
 const HAS_ATTACHMENT = 'This message has an attachment';
 
+// Coerce a value expected to be a string into a literal string. Non-string
+// inputs (objects, numbers, null) become safe primitives, neutralising NoSQL
+// injection payloads like {"$ne": null} that arrive verbatim from req.body.
+const sanitizeString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return String(value ?? '');
+};
+
 export const receiveMessage = async (
   models: IModels,
   subdomain: string,
   integration: IInstagramIntegrationDocument,
   activity: IMessageData,
 ) => {
-  const userId = activity.sender.id;
+  const userId = sanitizeString(activity.sender.id);
   const { recipient, timestamp } = activity;
 
   let message = activity.message as any;
   const postback = activity.postback as any;
 
-  const pageId = recipient.id;
+  const pageId = sanitizeString(recipient.id);
   const kind = INTEGRATION_KINDS.MESSENGER;
   const mid = message?.mid || postback?.mid;
   const attachments = message?.attachments;
@@ -60,8 +70,8 @@ export const receiveMessage = async (
   }
 
   let conversation = await models.InstagramConversations.findOne({
-    senderId: userId,
-    recipientId: pageId,
+    senderId: { $eq: userId },
+    recipientId: { $eq: pageId },
   });
 
   const bot = await checkIsBot(models, message, recipient.id);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -17,11 +17,17 @@ const HAS_ATTACHMENT = 'This message has an attachment';
 // Coerce a value expected to be a string into a literal string. Non-string
 // inputs (objects, numbers, null) become safe primitives, neutralising NoSQL
 // injection payloads like {"$ne": null} that arrive verbatim from req.body.
+// Objects, arrays, and nullish values are rejected outright (empty string) so
+// that crafted operator payloads never reach Mongo as `[object Object]` or
+// similar lossy coercions.
 const sanitizeString = (value: unknown): string => {
   if (typeof value === 'string') {
     return value;
   }
-  return String(value ?? '');
+  if (value === null || value === undefined || typeof value === 'object') {
+    return '';
+  }
+  return String(value);
 };
 
 export const receiveMessage = async (
@@ -32,11 +38,22 @@ export const receiveMessage = async (
 ) => {
   const userId = sanitizeString(activity.sender.id);
   const { recipient, timestamp } = activity;
+  const pageId = sanitizeString(recipient.id);
+
+  // Fail fast on malformed webhook payloads. After sanitisation, an empty
+  // id means the inbound event lacked a real sender or recipient — letting
+  // it through would collapse unrelated events onto the same conversation
+  // key (senderId='', recipientId='') and corrupt message linkage.
+  if (!userId.trim() || !pageId.trim()) {
+    debugError(
+      'Invalid Instagram webhook payload: missing sender or recipient id',
+    );
+    return;
+  }
 
   let message = activity.message as any;
   const postback = activity.postback as any;
 
-  const pageId = sanitizeString(recipient.id);
   const kind = INTEGRATION_KINDS.MESSENGER;
   const mid = message?.mid || postback?.mid;
   const attachments = message?.attachments;
@@ -74,7 +91,7 @@ export const receiveMessage = async (
     recipientId: { $eq: pageId },
   });
 
-  const bot = await checkIsBot(models, message, recipient.id);
+  const bot = await checkIsBot(models, message, pageId);
   const botId = bot?._id;
   let isNewConversation = false;
 

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -36,9 +36,9 @@ export const receiveMessage = async (
   integration: IInstagramIntegrationDocument,
   activity: IMessageData,
 ) => {
-  const userId = sanitizeString(activity.sender.id);
-  const { recipient, timestamp } = activity;
-  const pageId = sanitizeString(recipient.id);
+  const userId = sanitizeString(activity?.sender?.id);
+  const { recipient, timestamp } = activity ?? {};
+  const pageId = sanitizeString(recipient?.id);
 
   // Fail fast on malformed webhook payloads. After sanitisation, an empty
   // id means the inbound event lacked a real sender or recipient — letting


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1214](https://github.com/erxes/erxes/security/code-scanning/1214) (`js/sql-injection`, high).
- `receiveMessage` in `instagram/controller/receiveMessage.ts` took `activity.sender.id` and `recipient.id` straight from a webhook body and used them as `senderId` / `recipientId` in an `InstagramConversations.findOne`. Non-string inputs (e.g. an operator object `{ "\$ne": null }`) would flow into the query unchanged.
- Added a `sanitizeString` helper that coerces non-string inputs to safe primitives via `String(value ?? '')`, applied it to both ids on entry, and wrapped the lookup keys with `{ \$eq: ... }` so Mongoose treats them as literal values.

## Change
`backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts`
- Introduced `sanitizeString(value: unknown): string`.
- `const userId = sanitizeString(activity.sender.id);` and `const pageId = sanitizeString(recipient.id);` at the top of `receiveMessage`.
- `InstagramConversations.findOne({ senderId: { \$eq: userId }, recipientId: { \$eq: pageId } })`.

## Test plan
- [ ] Legitimate Instagram webhook still resolves the same conversation.
- [ ] Payload with `{ sender: { id: { "\$ne": null } } }` returns no match (literal comparison).
- [ ] Re-run CodeQL — alert #1214 flips to fixed.

## Summary by Sourcery

Bug Fixes:
- Coerce incoming Instagram webhook sender and recipient IDs to literal strings and use equality operators in conversation lookups to neutralize potential NoSQL injection payloads in Mongo queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram webhook handling: sanitize and validate sender and recipient IDs, discard malformed payloads early, and ensure sanitized IDs are used for conversation lookup and bot detection to prevent incorrect conversation merging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7638)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->