### PR TITLE
fix(frontline): sanitize IMAP preview HTML with DOMPurify (alert #1192)

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/integrations/imap/components/ImapConversationDetail.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/imap/components/ImapConversationDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useQuery, useSubscription } from '@apollo/client';
+import DOMPurify from 'dompurify';
 import {
   ScrollArea,
   Spinner,
@@ -82,6 +83,16 @@ const fmtSize = (b?: number) => {
 };
 
 const stripPrefix = (s: string) => s.replace(/^((re|fwd?):\s*)+/gi, '').trim();
+
+/**
+ * Strip every HTML tag from `html` to produce a plain-text preview snippet.
+ * Uses DOMPurify with an empty allow-list so no tag-like substring can survive
+ * (a hand-rolled `/<[^>]+>/g` replace is incomplete — a single pass over
+ * `<scrip<script>x</script>t>` reconstructs `<script>x</script>`, see CodeQL
+ * rule js/incomplete-multi-character-sanitization).
+ */
+const stripHtmlForPreview = (html: string) =>
+  DOMPurify.sanitize(html, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
 
 /** 8 Gmail-style avatar background colors, picked by name hash. */
 const AVATAR_BG = [
@@ -239,7 +250,7 @@ const EmailRow: React.FC<{
                   </span>
                   <span className="text-[12px] text-[#5f6368] dark:text-[#9aa0a6] truncate">
                     {mailData.body
-                      ? mailData.body.replace(/<[^>]+>/g, '').slice(0, 80)
+                      ? stripHtmlForPreview(mailData.body).slice(0, 80)
                       : mailData.subject}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1192](https://github.com/erxes/erxes/security/code-scanning/1192) (`js/incomplete-multi-character-sanitization`, high).
- The IMAP conversation row generated a plain-text preview via `mailData.body.replace(/<[^>]+>/g, '')`. A single pass over a string like `<scrip<script>x</script>t>` reconstructs `<script>x</script>` — exactly the case the CodeQL rule warns about.
- Replaced the regex with `DOMPurify.sanitize(html, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })` so every tag is stripped in one pass. DOMPurify is already used elsewhere in this plugin (`FacebookPostTrigger`, `IgPostTrigger`).

## Change
`frontend/plugins/frontline_ui/src/modules/integrations/imap/components/ImapConversationDetail.tsx`
- Added `stripHtmlForPreview` helper using DOMPurify with empty allow-lists.
- Replaced `.replace(/<[^>]+>/g, '')` in the row preview with `stripHtmlForPreview(mailData.body)`.

## Test plan
- [ ] IMAP conversation list still shows correct text-only previews for plain HTML messages.
- [ ] Adversarial body `<scrip<script>x</script>t>alert(1)</script>` no longer leaks `<script>x</script>` into the preview.
- [ ] Re-run CodeQL — alert #1192 flips to fixed.

## Summary by Sourcery

Bug Fixes:
- Prevent potential HTML/script fragments from leaking into IMAP conversation preview text by replacing regex-based tag stripping with DOMPurify-based sanitization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved email preview text cleaning to more reliably remove HTML formatting and generate plain-text previews for display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7640)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->