### PR TITLE
fix(posclient): build cpProducts wildcard regex without unescaped meta chars (alert #1124)

### DIFF
--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/cpProducts.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/cpProducts.ts
@@ -442,15 +442,17 @@ const cpProductQueries: Record<string, Resolver> = {
 
     if (groupedSimilarity === 'config') {
       const getRegex = (str) => {
-        return ['*', '.', '_'].includes(str)
-          ? new RegExp(
-              `^${str
-                .replace(/\./g, '\\.')
-                .replace(/\*/g, '.')
-                .replace(/_/g, '.')}.*`,
-              'igu',
-            )
-          : new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
+        if (['*', '.', '_'].includes(str)) {
+          // Escape all regex meta-characters first (including backslash itself),
+          // then translate the SQL-LIKE-style wildcards back to '.':
+          //   '*' has been escaped to '\*' by escapeRegExp -> rewrite to '.'
+          //   '_' is not a regex meta-character           -> rewrite to '.'
+          const escaped = escapeRegExp(str)
+            .replace(/\\\*/g, '.')
+            .replace(/_/g, '.');
+          return new RegExp(`^${escaped}.*`, 'igu');
+        }
+        return new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
       };
 
       const similarityGroups =


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1124](https://github.com/erxes/erxes/security/code-scanning/1124) (`js/incomplete-sanitization`, high).
- When `groupedSimilarity === 'config'`, `cpProductQueries.getRegex` built the matcher with `str.replace(/\./g, '\\.').replace(/\*/g, '.').replace(/_/g, '.')`. Other regex meta characters in the same `str` (eg `(`, `)`, `+`, `?`, `[`) survived unescaped, which is exactly the case the CodeQL rule warns about.
- Escape every regex meta-character with `escapeRegExp` first, then translate only the SQL-LIKE-style wildcards back to `.`:
  - `*` has been escaped to `\*` by `escapeRegExp` → rewrite to `.`
  - `_` is not a regex meta-character → rewrite to `.`

## Change
`backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/cpProducts.ts`
- `getRegex` now calls `escapeRegExp(str)` first and rewrites `\*` and `_` to `.` afterwards.
- The non-wildcard branch (no `*`/`.`/`_` in input) is unchanged — it already used `escapeRegExp(str)`.

## Test plan
- [ ] Searches with `*` work the same way (`a*` matches `apple`, `andrew`, etc.).
- [ ] Searches with `_` work the same way (`a_ple` matches `apple`).
- [ ] Search input `(test)` no longer reaches `new RegExp` as a literal capture group.
- [ ] Re-run CodeQL — alert #1124 flips to fixed.

## Summary by Sourcery

Bug Fixes:
- Sanitize cpProduct search patterns so that all regex metacharacters are escaped before converting SQL-like wildcards (* and _) into their regex equivalents, preventing unsafe and unintended regex behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved regex pattern handling in product similarity queries to enhance code robustness and ensure proper handling of special characters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7641)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->