### PR TITLE
fix(core-api): rate-limit /oauth/token before any DB work (alert #1189)

### DIFF
--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -299,13 +299,20 @@ router.post('/oauth/device/deny', async (req: Request, res: Response) => {
 });
 
 router.post('/oauth/token', async (req: Request, res: Response) => {
-  // Rate-limit the token endpoint by client IP BEFORE doing any DB work
-  // (subdomain lookup, model generation, client_secret bcrypt compare, etc.).
-  // This guards all grant-type branches — device_code, refresh_token, and the
-  // fallback — against brute-force and DoS, in addition to the per-device-code
+  // Rate-limit the token endpoint BEFORE doing any DB work (subdomain lookup,
+  // model generation, client_secret bcrypt compare, etc.). This guards all
+  // grant-type branches — device_code, refresh_token, and the fallback —
+  // against brute-force and DoS, in addition to the per-device-code
   // poll-interval limit enforced inside the device_code branch (RFC 8628 §3.5).
-  // 30 req/IP/min: comfortably above the legitimate device-poll cadence
-  // (12 req/min at the 5s DEVICE_POLL_INTERVAL) and refresh-token rotation rate.
+  //
+  // The bucket key is `client_id + IP` when client_id is present, falling back
+  // to IP only when it isn't. Combining client_id with IP means an attacker
+  // spoofing `X-Forwarded-For` (getClientIp currently trusts that header to
+  // remain compatible with our reverse proxies) cannot exhaust the quota for a
+  // specific legitimate client, and it bounds unique-key growth in Redis under
+  // an IP-rotation attack to one TTL window per (client_id, spoofed-IP) pair.
+  // 30 req/min: comfortably above the legitimate device-poll cadence (12
+  // req/min at the 5s DEVICE_POLL_INTERVAL) and refresh-token rotation rate.
   // The limiter is Redis-backed (see checkRateLimit -> redis.incr/expire) so it
   // works correctly across multiple core-api replicas behind a load balancer.
   let subdomain: string;
@@ -313,7 +320,13 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   let grantType: string;
   try {
     const ip = getClientIp(req);
-    await checkRateLimit(`oauth:token:${ip}`, 30, 60);
+    const rawClientId = String(req.body?.client_id || '').trim();
+    // Salt with a length-bounded, sanitized client_id slice so an oversized or
+    // delimiter-stuffed payload can't blow up the Redis key namespace.
+    const clientIdSalt = rawClientId
+      ? rawClientId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'anon'
+      : 'anon';
+    await checkRateLimit(`oauth:token:${clientIdSalt}:${ip}`, 30, 60);
 
     subdomain = getSubdomain(req);
     models = await generateModels(subdomain);

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -299,6 +299,30 @@ router.post('/oauth/device/deny', async (req: Request, res: Response) => {
 });
 
 router.post('/oauth/token', async (req: Request, res: Response) => {
+  // Rate-limit the token endpoint by client IP BEFORE doing any DB work
+  // (subdomain lookup, model generation, client_secret bcrypt compare, etc.).
+  // This guards all grant-type branches — device_code, refresh_token, and the
+  // fallback — against brute-force and DoS, in addition to the per-device-code
+  // poll-interval limit enforced inside the device_code branch (RFC 8628 §3.5).
+  // 30 req/IP/min: comfortably above the legitimate device-poll cadence
+  // (12 req/min at the 5s DEVICE_POLL_INTERVAL) and refresh-token rotation rate.
+  // The limiter is Redis-backed (see checkRateLimit -> redis.incr/expire) so it
+  // works correctly across multiple core-api replicas behind a load balancer.
+  try {
+    const ip = getClientIp(req);
+    await checkRateLimit(`oauth:token:${ip}`, 30, 60);
+  } catch (e) {
+    if (isRateLimitError(e)) {
+      return sendOAuthError(res, 429, 'slow_down', e.message);
+    }
+    return sendOAuthError(
+      res,
+      400,
+      'invalid_request',
+      e instanceof Error ? e.message : 'Invalid request',
+    );
+  }
+
   const subdomain = getSubdomain(req);
   const models = await generateModels(subdomain);
   const grantType = String(req.body?.grant_type || '').trim();

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -305,13 +305,15 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   // against brute-force and DoS, in addition to the per-device-code
   // poll-interval limit enforced inside the device_code branch (RFC 8628 §3.5).
   //
-  // The bucket key is `client_id + IP` when client_id is present, falling back
-  // to IP only when it isn't. Combining client_id with IP means an attacker
-  // spoofing `X-Forwarded-For` (getClientIp currently trusts that header to
-  // remain compatible with our reverse proxies) cannot exhaust the quota for a
-  // specific legitimate client, and it bounds unique-key growth in Redis under
-  // an IP-rotation attack to one TTL window per (client_id, spoofed-IP) pair.
-  // 30 req/min: comfortably above the legitimate device-poll cadence (12
+  // Two layered buckets, both 30 req/min:
+  //   1. Per-IP — applied unconditionally. The hard ceiling that cannot be
+  //      bypassed by rotating `client_id` values from one source.
+  //   2. Per-(client_id, IP) — fairness layer on top. Prevents an attacker
+  //      that can spoof `X-Forwarded-For` (getClientIp trusts the header for
+  //      compatibility with our reverse proxies) from exhausting a specific
+  //      legitimate client's allowance, and bounds Redis unique-key growth
+  //      under an IP-rotation attack to one TTL window per (client_id, IP).
+  // 30 req/min is comfortably above the legitimate device-poll cadence (12
   // req/min at the 5s DEVICE_POLL_INTERVAL) and refresh-token rotation rate.
   // The limiter is Redis-backed (see checkRateLimit -> redis.incr/expire) so it
   // works correctly across multiple core-api replicas behind a load balancer.
@@ -320,13 +322,28 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   let grantType: string;
   try {
     const ip = getClientIp(req);
+    // Hard per-IP ceiling FIRST: applied unconditionally so rotating
+    // `client_id` values from the same source cannot bypass the global
+    // 30 req/min budget for this endpoint.
+    await checkRateLimit(`oauth:token:ip:${ip}`, 30, 60);
+
     const rawClientId = String(req.body?.client_id || '').trim();
-    // Salt with a length-bounded, sanitized client_id slice so an oversized or
-    // delimiter-stuffed payload can't blow up the Redis key namespace.
+    // Then a per-(client_id, IP) bucket for fairness: prevents an IP-spoofing
+    // attacker (getClientIp trusts X-Forwarded-For for proxy compatibility)
+    // from exhausting a specific legitimate client's quota. Sanitized +
+    // length-bounded so a malicious payload can't blow up the key namespace.
+    // The client_id bucket only runs when a client_id is supplied — anonymous
+    // traffic is already capped by the per-IP bucket above.
     const clientIdSalt = rawClientId
-      ? rawClientId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'anon'
-      : 'anon';
-    await checkRateLimit(`oauth:token:${clientIdSalt}:${ip}`, 30, 60);
+      ? rawClientId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64)
+      : '';
+    if (clientIdSalt) {
+      await checkRateLimit(
+        `oauth:token:client:${clientIdSalt}:${ip}`,
+        30,
+        60,
+      );
+    }
 
     subdomain = getSubdomain(req);
     models = await generateModels(subdomain);

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -308,24 +308,32 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   // (12 req/min at the 5s DEVICE_POLL_INTERVAL) and refresh-token rotation rate.
   // The limiter is Redis-backed (see checkRateLimit -> redis.incr/expire) so it
   // works correctly across multiple core-api replicas behind a load balancer.
+  let subdomain: string;
+  let models: Awaited<ReturnType<typeof generateModels>>;
+  let grantType: string;
   try {
     const ip = getClientIp(req);
     await checkRateLimit(`oauth:token:${ip}`, 30, 60);
+
+    subdomain = getSubdomain(req);
+    models = await generateModels(subdomain);
+    grantType = String(req.body?.grant_type || '').trim();
   } catch (e) {
     if (isRateLimitError(e)) {
       return sendOAuthError(res, 429, 'slow_down', e.message);
     }
+    // Limiter/Redis or subdomain/model-resolution failures are server-side
+    // infrastructure issues, not malformed client input. Map to 503
+    // `temporarily_unavailable` so clients back off instead of retry-storming,
+    // and avoid leaking internal error messages to the caller.
+    console.error('oauth/token pre-handler failure:', e);
     return sendOAuthError(
       res,
-      400,
-      'invalid_request',
-      e instanceof Error ? e.message : 'Invalid request',
+      503,
+      'temporarily_unavailable',
+      'Service temporarily unavailable. Please try again later.',
     );
   }
-
-  const subdomain = getSubdomain(req);
-  const models = await generateModels(subdomain);
-  const grantType = String(req.body?.grant_type || '').trim();
 
   if (grantType === DEVICE_CODE_GRANT) {
     try {

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -334,8 +334,11 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
     // length-bounded so a malicious payload can't blow up the key namespace.
     // The client_id bucket only runs when a client_id is supplied — anonymous
     // traffic is already capped by the per-IP bucket above.
+    // Truncate BEFORE the regex so a pathologically long client_id (e.g. an
+    // attacker shipping megabytes of payload) doesn't force the engine to scan
+    // the whole string just to discard it on slice(0, 64) afterwards.
     const clientIdSalt = rawClientId
-      ? rawClientId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64)
+      ? rawClientId.slice(0, 64).replace(/[^a-zA-Z0-9_-]/g, '')
       : '';
     if (clientIdSalt) {
       await checkRateLimit(
@@ -350,6 +353,11 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
     grantType = String(req.body?.grant_type || '').trim();
   } catch (e) {
     if (isRateLimitError(e)) {
+      // RFC 6585 §4: 429 responses SHOULD carry Retry-After. We use a fixed
+      // 60s window in checkRateLimit above, so 60 is the correct upper bound
+      // for when the bucket will have rolled over and the caller can try
+      // again.
+      res.set('Retry-After', '60');
       return sendOAuthError(res, 429, 'slow_down', e.message);
     }
     // Limiter/Redis or subdomain/model-resolution failures are server-side

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -216,13 +216,22 @@ export const checkRateLimit = async (
 // when present, so without normalization an attacker can mint a fresh bucket
 // per crafted payload (e.g. `1.2.3.4`, `1.2.3.4 `, `1.2.3.4#a`, …) and bypass
 // the per-IP cap. We restrict to the character classes that valid IPv4/IPv6
-// addresses (and the `unknown` fallback) actually use — hex digits, dots,
-// colons, lowercase letters for "unknown" — and hard-bound the length
-// (IPv6 with zone-id maxes out near 45 chars). Anything left empty after
-// stripping collapses to the literal `unknown` bucket, which is still
-// rate-limited but no longer attacker-malleable.
+// addresses actually use — hex digits A-F (preserved in both cases), dots,
+// and colons — and hard-bound the length to 45 chars (the practical upper
+// bound for a textual IPv6 address). Anything left empty after stripping
+// collapses to the literal `unknown` bucket, which is still rate-limited
+// but no longer attacker-malleable.
+//
+// RFC 4007 IPv6 zone identifiers (e.g. `fe80::1%eth0`) are stripped at the
+// `%` separator first, so two link-local clients on different interfaces
+// don't share a bucket purely because the character-class filter erased
+// their zone IDs. In practice the OAuth endpoint isn't reachable over
+// link-local addresses (it sits behind routable proxies), but handling the
+// case keeps the bucket-key per-source-distinguishable wherever it could
+// matter.
 const sanitizeClientIp = (raw: string): string => {
-  const cleaned = raw.replace(/[^a-fA-F0-9.:]/g, '').slice(0, 45);
+  const withoutZone = raw.split('%', 1)[0];
+  const cleaned = withoutZone.replace(/[^a-fA-F0-9.:]/g, '').slice(0, 45);
   return cleaned || 'unknown';
 };
 

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -184,6 +184,21 @@ export const checkRateLimit = async (
   limit: number,
   windowSecs: number,
 ): Promise<void> => {
+  // Defensive: every caller passes literal constants, but a future caller
+  // computing windowSecs/limit from config (or env) could trip a 0/negative
+  // and silently break the limiter (TTL=0 → no expiration on EXPIRE, or
+  // EXPIRE rejected outright). Fail loud instead of degrading.
+  if (!Number.isInteger(windowSecs) || windowSecs <= 0) {
+    throw new Error(
+      `checkRateLimit: windowSecs must be a positive integer (got ${windowSecs})`,
+    );
+  }
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(
+      `checkRateLimit: limit must be a positive integer (got ${limit})`,
+    );
+  }
+
   const current = (await redis.eval(
     RATE_LIMIT_INCR_SCRIPT,
     1,
@@ -196,6 +211,21 @@ export const checkRateLimit = async (
   }
 };
 
+// Sanitize the client-IP string before it's used in a Redis rate-limit key.
+// The IP arrives from `X-Forwarded-For` which is fully attacker-controlled
+// when present, so without normalization an attacker can mint a fresh bucket
+// per crafted payload (e.g. `1.2.3.4`, `1.2.3.4 `, `1.2.3.4#a`, …) and bypass
+// the per-IP cap. We restrict to the character classes that valid IPv4/IPv6
+// addresses (and the `unknown` fallback) actually use — hex digits, dots,
+// colons, lowercase letters for "unknown" — and hard-bound the length
+// (IPv6 with zone-id maxes out near 45 chars). Anything left empty after
+// stripping collapses to the literal `unknown` bucket, which is still
+// rate-limited but no longer attacker-malleable.
+const sanitizeClientIp = (raw: string): string => {
+  const cleaned = raw.replace(/[^a-fA-F0-9.:]/g, '').slice(0, 45);
+  return cleaned || 'unknown';
+};
+
 export const getClientIp = (req: {
   headers: Record<string, any>;
   socket?: any;
@@ -204,10 +234,10 @@ export const getClientIp = (req: {
 
   if (forwarded) {
     const first = Array.isArray(forwarded) ? forwarded[0] : forwarded;
-    return first.split(',')[0].trim();
+    return sanitizeClientIp(String(first).split(',')[0].trim());
   }
 
-  return req.socket?.remoteAddress || 'unknown';
+  return sanitizeClientIp(String(req.socket?.remoteAddress || 'unknown'));
 };
 
 // ---------------------------------------------------------------------------

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -164,23 +164,35 @@ class RateLimitError extends Error {
 export const isRateLimitError = (e: unknown): e is RateLimitError =>
   e instanceof RateLimitError;
 
+// Atomic INCR-and-set-TTL Lua script. INCR + EXPIRE issued as two separate
+// commands is non-atomic: if the EXPIRE command is lost (process crash mid
+// pipeline, network blip after INCR ACKs) the key becomes a permanent counter
+// and Redis memory grows under sustained traffic. Doing both in a single
+// EVAL keeps the counter and its TTL bound together — the EXPIRE is guaranteed
+// to run on the first request iff the INCR returned 1, and the whole script
+// executes atomically on the Redis server.
+const RATE_LIMIT_INCR_SCRIPT = `
+  local n = redis.call('INCR', KEYS[1])
+  if n == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+  end
+  return n
+`;
+
 export const checkRateLimit = async (
   key: string,
   limit: number,
   windowSecs: number,
 ): Promise<void> => {
-  try {
-    const current = await redis.incr(key);
+  const current = (await redis.eval(
+    RATE_LIMIT_INCR_SCRIPT,
+    1,
+    key,
+    String(windowSecs),
+  )) as number;
 
-    if (current === 1) {
-      await redis.expire(key, windowSecs);
-    }
-
-    if (current > limit) {
-      throw new RateLimitError('Too many requests. Please try again later.');
-    }
-  } catch (e) {
-    throw e;
+  if (current > limit) {
+    throw new RateLimitError('Too many requests. Please try again later.');
   }
 };
 


### PR DESCRIPTION
## Summary
- Closes code scanning alert [#1189](https://github.com/erxes/erxes/security/code-scanning/1189) (`js/missing-rate-limiting`, high).
- The `/oauth/token` endpoint accepted `device_code`, `refresh_token` and fallback grants without an IP-level rate limit. Every request triggered a subdomain lookup, model generation and a bcrypt `client_secret` compare — a cheap brute-force surface and DoS amplifier, exactly what CodeQL flags.
- Apply the existing Redis-backed `checkRateLimit` (already used by `/oauth/device/code`, `/oauth/authorize/web`, `/oauth/device/poll`) **before** any DB work. The RFC 8628 §3.5 per-device-code poll-interval check inside the `device_code` branch continues to run.

## Change
`backend/core-api/src/modules/auth/routes/oauth/routes.ts`
- Added IP-level `checkRateLimit('oauth:token:<ip>', 30, 60)` at the top of the `POST /oauth/token` handler.
- On `RateLimitError` returns `429 slow_down`; on other errors returns `400 invalid_request`.

## Why these numbers
- 30 req/IP/min is comfortably above the legitimate device-poll cadence (12 req/min at the 5s `DEVICE_POLL_INTERVAL`) and refresh-token rotation rate.
- Redis-backed via `redis.incr` + `expire`, so the cap applies cluster-wide across multiple core-api replicas.

## Test plan
- [ ] Legitimate device polling (every 5s) keeps working — well under 30/min.
- [ ] 31st request within 60s from the same IP returns `429 slow_down`.
- [ ] After the 60s window, the same IP can request again.
- [ ] Re-run CodeQL — alert #1189 flips to fixed.

## Summary by Sourcery

Bug Fixes:
- Protect the /oauth/token endpoint with a Redis-backed IP rate limit to address missing rate limiting and reduce brute-force/DoS exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-check rate limiting added to the OAuth token endpoint: unconditional per-IP limit (30 requests/min) before further processing; when client_id is provided, an additional per-(client, IP) limit is applied. Exceeding limits returns 429 with OAuth error `slow_down` and a Retry-After header.

* **Bug Fixes**
  * Rate-limit enforcement made atomic and more reliable; internal failures in the pre-check now return 503 with OAuth error `temporarily_unavailable`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->