### PR TITLE
fix(frontline): wrap Instagram integration lookup with $eq (alert #1210)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts
@@ -24,8 +24,8 @@ export const getOrCreateCustomer = async (
   kind: string,
 ) => {
   const integration = await models.InstagramIntegrations.findOne({
-    instagramPageId: pageId,
-    kind,
+    instagramPageId: { $eq: pageId },
+    kind: { $eq: kind },
   });
   if (!integration) {
     throw new Error('Instagram Integration not found ');


### PR DESCRIPTION
## Closes alert #1210

- **Rule:** `js/sql-injection` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1210
- **File:** `backend/plugins/frontline_api/src/modules/integrations/instagram/controller/store.ts:26-29`

## Reproduction (before fix)

### Taint source

Meta posts Instagram webhooks to a publicly reachable endpoint. The handler treats every field of the request body as untrusted — the relevant field is `entry[].id`, which the controller forwards verbatim as `pageId`.

### Trace

1. `controller.ts:126` — `await receiveComment(models, subdomain, event.value, entry.id);` — `entry.id` is the raw webhook value (typed `any`, no runtime narrowing).
2. `receiveComment.ts:38-44` — `getOrCreateCustomer(models, subdomain, pageId, userId, INTEGRATION_KINDS.POST)` — `pageId` is forwarded as-is.
3. `store.ts:26-29` (the alert):

   ```ts
   const integration = await models.InstagramIntegrations.findOne({
     instagramPageId: pageId,
     kind,
   });
   ```

   Mongoose treats the value of `instagramPageId` as a query subdocument when it is an object, so a non-string `pageId` becomes a query operator.

### Example payload

POST body that makes the lookup match the first non-null integration document in the collection, regardless of which tenant or page it actually belongs to:

```json
{
  "object": "instagram",
  "entry": [{
    "id": {"$ne": null},
    "time": 1715000000,
    "changes": [{"field": "comments", "value": {"from": {"id": "attacker"}, "comment_id": "x", "post_id": "y", "message": "hi"}}]
  }]
}
```

CodeQL sees `entry.id` (untrusted, `any`) flowing into `instagramPageId` in a `findOne`. The downstream effect is that the integration row picked up is the wrong tenant's, so the subsequent `getOrCreateCustomer` writes a customer against an unrelated integration and `receiveInboxMessage` routes the attacker's payload into someone else's inbox.

`kind` in this same `findOne` is filled from `INTEGRATION_KINDS.POST` / `INTEGRATION_KINDS.MESSENGER` at every call site, but CodeQL can't see that statically — the parameter is typed `string` and the taint analyzer treats it as user-controlled. Both fields land in the same alert range.

## Fix

Wrap both query values with Mongoose's `$eq` operator so a non-primitive input is interpreted as a literal value rather than a query subdocument:

```ts
const integration = await models.InstagramIntegrations.findOne({
  instagramPageId: { $eq: pageId },
  kind: { $eq: kind },
});
```

## Verification (after fix)

- `pageId = {$ne: null}` → query becomes `{instagramPageId: {$eq: {$ne: null}}}`. MongoDB compares the stored `instagramPageId` (a string) to the literal object `{$ne: null}`, never finds a match, and `integration` is `null`. The function then throws `Instagram Integration not found` rather than attaching to an unrelated tenant.
- `pageId = "real-page-id"` (the legitimate case) → `{instagramPageId: {$eq: "real-page-id"}}`, equivalent to `{instagramPageId: "real-page-id"}`. Mongoose `findOne` continues to return the expected document. Behavior preserved.

This is the same precedent used in commit ffc6084886 for the sibling `comment_id` lookup at line 163.

## Notes

- `pnpm nx build frontline_api` passes locally.
- Lint errors in the project are all pre-existing in other files (`modules/ticket/.../status.ts`, `public/widget/messengerWidget.bundle.js`, `modules/integrations/call/store.ts`) — none touch the changed file.
- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.
- Sibling alerts in the same file (#1212/#1201/#1202/#1203/#1216) each get their own PR per the one-alert-per-PR rule.

## Summary by Sourcery

Bug Fixes:
- Ensure Instagram integration lookup treats incoming page and kind values as literal equality matches to prevent operator-based query manipulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram account handling to ensure proper customer data retrieval and synchronization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7647)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
