### PR TITLE
Tumurtulga/Total message hiiv

### DIFF
--- a/backend/core-api/src/modules/organization/team-member/graphql/queries.ts
+++ b/backend/core-api/src/modules/organization/team-member/graphql/queries.ts
@@ -171,9 +171,20 @@ export const userQueries = {
       ...NORMAL_USER_SELECTOR,
     };
 
+
+    const { sortField, sortDirection, ...restArgs } = args;
+
+  
+    const orderBy: Record<string, any> = sortField 
+      ? { [sortField]: sortDirection || 1, _id: 1 } 
+      : { username: 1, _id: 1 };
+
     const { list, totalCount, pageInfo } = await cursorPaginate<IUserDocument>({
       model: models.Users,
-      params: args,
+      params: {
+        ...restArgs,
+        orderBy: orderBy as Record<string, any>, // Safe cast to clear the cursor-util type conflict
+      },
       query: selector,
     });
 

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/inboxQueries.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/inboxQueries.ts
@@ -504,4 +504,15 @@ export const reportInboxQueries = {
       percentage: calculatePercentage(s.count, total),
     }));
   },
+async reportTotalMessages(
+  _parent: undefined,
+  _args: undefined,
+  { models }: IContext,
+) {
+  const total = await models.Conversations.countDocuments({});
+
+  return {
+    totalMessages: total,
+  };
+},
 };

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/schema/inbox.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/schema/inbox.ts
@@ -104,6 +104,9 @@ export const types = `
     closed: [ConversationTagProgressItem!]!
     resolved: [ConversationTagProgressItem!]!
   }
+    type TotalMessagesResult {
+    totalMessages: Int!
+  }
 
 `;
 
@@ -121,4 +124,5 @@ export const queries = `
   reportConversationResolved(filters: ConversationReportFilter): ReportMetric
   reportConversationTags(filters: ConversationReportFilter): [ReportTag]
   reportConversationSources(filters: ConversationReportFilter): [ReportSource]
+  reportTotalMessages: TotalMessagesResult!
 `;

--- a/frontend/plugins/frontline_ui/src/modules/report/components/FrontlineReportsList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/FrontlineReportsList.tsx
@@ -32,6 +32,7 @@ import {
 } from '../types/component-registry';
 import { getTopSource } from '../utils';
 import { ReportsViewSkeleton } from './ReportsView';
+import { useReportTotalMessages } from '../hooks/useTotalMessage';
 
 interface CardConfig {
   id: string;
@@ -76,6 +77,9 @@ export const FrontlineReportsList = () => {
         },
       },
     });
+
+const { totalMessages, loading: totalMessagesLoading } =
+  useReportTotalMessages();
   const [cards, setCards] = useState<CardConfig[]>(INITIAL_CARDS);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
@@ -149,7 +153,7 @@ export const FrontlineReportsList = () => {
     );
   };
 
-  if (openLoading || closedLoading || sourcesLoading) {
+  if (openLoading || closedLoading || sourcesLoading || totalMessagesLoading) {
     return <ReportsViewSkeleton />;
   }
 
@@ -269,6 +273,11 @@ export const FrontlineReportsList = () => {
             </div>
           </InfoCard.Content>
         </InfoCard>
+        <InfoCard title="Total Messages">
+  <InfoCard.Content className="text-center">
+    <div>{totalMessages?.totalMessages || 0}</div>
+  </InfoCard.Content>
+</InfoCard>
       </div>
       <ScrollArea>
         <DndContext

--- a/frontend/plugins/frontline_ui/src/modules/report/graphql/queries/getChart.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/graphql/queries/getChart.ts
@@ -115,4 +115,12 @@ export const GET_RESOLVED_CONVERSATIONS_BY_DATE = gql`
       date
     }
   }
-`;
+`
+
+export const REPORT_TOTAL_MESSAGES = gql`
+  query ReportTotalMessages {
+    reportTotalMessages {
+      totalMessages
+    }
+  }
+`;;

--- a/frontend/plugins/frontline_ui/src/modules/report/hooks/useTotalMessage.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/hooks/useTotalMessage.ts
@@ -1,0 +1,13 @@
+import { gql, useQuery } from '@apollo/client';
+import { REPORT_TOTAL_MESSAGES } from '../graphql/queries/getChart';
+
+
+export const useReportTotalMessages = () => {
+  const { data, loading, error } = useQuery(REPORT_TOTAL_MESSAGES);
+
+  return {
+    totalMessages: data?.reportTotalMessages,
+    loading,
+    error,
+  };
+};


### PR DESCRIPTION
## Summary by Sourcery

Add a backend GraphQL query and frontend UI integration to display the total number of messages in reports.

New Features:
- Expose a new GraphQL reportTotalMessages query returning the total count of conversations/messages.
- Display a Total Messages info card in the Frontline reports list showing the overall message count.
- Introduce a frontend hook and query for fetching total messages data from the reports API.

Enhancements:
- Ensure the reports loading skeleton also covers loading state for the total messages metric.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Total Messages" metric to the reports dashboard showing the total number of conversations.
  * Metric is shown in the header stats, defaults to 0 when absent, and is included in the loading state.

* **Backend**
  * Exposes total message count via the reports API for dashboard use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->