### PR TITLE
fix(posclient): use literal-dot regex in generateOrderNumber (alert #984)

### DIFF
--- a/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
@@ -5,7 +5,12 @@ import { checkDirectDiscount } from './directDiscount';
 import { checkLoyalties } from './loyalties';
 import { checkPricing } from './pricing';
 import { checkRemainders } from './products';
-import { getPureDate, fixNum, sendTRPCMessage } from 'erxes-api-shared/utils';
+import {
+  getPureDate,
+  fixNum,
+  sendTRPCMessage,
+  escapeRegExp,
+} from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 import {
   IConfig,
@@ -45,15 +50,11 @@ export const generateOrderNumber = async (
 
   if (config?.beginNumber) {
     beginNumber = `${config.beginNumber}.`;
-    // Escape regex meta-characters in the operator-configurable beginNumber,
-    // then match a LITERAL '.' separator. The previous `\.` was a JavaScript
-    // string escape (stripped at parse time), leaving a regex meta-`.` that
-    // matched any character — causing cross-POS collisions on this lookup.
-    const escapedBeginNumber = config.beginNumber.replace(
-      /[.*+?^${}()|[\]\\]/g,
-      '\\$&',
-    );
-    regexSuffix = `${escapedBeginNumber}\\.[0-9]*$`;
+    // Escape regex meta-characters in the operator-configurable beginNumber and
+    // match a LITERAL '.' separator. The previous `\.` was a JavaScript string
+    // escape (stripped at parse time), leaving a regex meta-`.` that matched any
+    // character — causing cross-POS collisions on this lookup.
+    regexSuffix = `${escapeRegExp(config.beginNumber)}\\.[0-9]*$`;
   }
 
   let number = `${todayStr}_${beginNumber}${suffix}`;

--- a/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
@@ -45,7 +45,15 @@ export const generateOrderNumber = async (
 
   if (config?.beginNumber) {
     beginNumber = `${config.beginNumber}.`;
-    regexSuffix = `${config.beginNumber}\.[0-9]*$`;
+    // Escape regex meta-characters in the operator-configurable beginNumber,
+    // then match a LITERAL '.' separator. The previous `\.` was a JavaScript
+    // string escape (stripped at parse time), leaving a regex meta-`.` that
+    // matched any character — causing cross-POS collisions on this lookup.
+    const escapedBeginNumber = config.beginNumber.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    );
+    regexSuffix = `${escapedBeginNumber}\\.[0-9]*$`;
   }
 
   let number = `${todayStr}_${beginNumber}${suffix}`;


### PR DESCRIPTION
## Closes alert #984

- **Rule:** `js/useless-regexp-character-escape` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/984
- **File:** `backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts:48`

## Reproduction (before fix)

`generateOrderNumber()` builds a regex from a template literal:

```ts
regexSuffix = `${config.beginNumber}\.[0-9]*$`;   // ← line 48, flagged
// ...
number: { $regex: new RegExp(`^${todayStr}_${regexSuffix}`) }
```

The `\.` is a *JavaScript* string escape, not a regex one. JS parses `\.`, sees `.` is not a recognised string-escape character, and silently drops the backslash. The runtime string contains a bare `.`, which `new RegExp(...)` then compiles as the regex meta-character "any single character".

```bash
$ node -e "
  const beginNumber='ABC'; const todayStr='20260513';
  const regexSuffix = \`\${beginNumber}\.[0-9]*\$\`;
  console.log('runtime:', JSON.stringify(regexSuffix));
  const re = new RegExp(\`^\${todayStr}_\${regexSuffix}\`);
  console.log('re.source:', re.source);
  console.log('match ABC.0001 (intended):', re.test('20260513_ABC.0001'));
  console.log('match ABCX0001 (wrong)   :', re.test('20260513_ABCX0001'));
  console.log('match ABCz9999 (wrong)   :', re.test('20260513_ABCz9999'));
"
# runtime: "ABC.[0-9]*$"
# re.source: ^20260513_ABC.[0-9]*$
# match ABC.0001 (intended): true
# match ABCX0001 (wrong)   : true
# match ABCz9999 (wrong)   : true
```

A POS whose `beginNumber` is a prefix of another POS's stored numbers can therefore match the wrong `latestOrder` row, returning a wrong suffix and corrupting the generated number.

## Fix

- Use a real regex backslash-dot (`\\.` in the template literal — produces a runtime `\.` that the regex engine sees as a literal dot).
- Also escape regex meta-characters in the operator-configurable `beginNumber` itself, so a `beginNumber` containing `.`, `*`, `+`, etc. is matched literally rather than re-interpreted by the regex engine.

```diff
-    regexSuffix = `${config.beginNumber}\.[0-9]*$`;
+    const escapedBeginNumber = config.beginNumber.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    );
+    regexSuffix = `${escapedBeginNumber}\\.[0-9]*$`;
```

## Verification (after fix)

```bash
$ node -e "
  const escapeRegExp = (s) => s.replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\\$&');
  const beginNumber='ABC'; const todayStr='20260513';
  const regexSuffix = \`\${escapeRegExp(beginNumber)}\\\\.[0-9]*\$\`;
  console.log('runtime:', JSON.stringify(regexSuffix));
  const re = new RegExp(\`^\${todayStr}_\${regexSuffix}\`);
  console.log('re.source:', re.source);
  console.log('match ABC.0001 (intended):', re.test('20260513_ABC.0001'));
  console.log('match ABCX0001 (wrong)   :', re.test('20260513_ABCX0001'));
  console.log('match ABCz9999 (wrong)   :', re.test('20260513_ABCz9999'));
"
# runtime: "ABC\\.[0-9]*$"
# re.source: ^20260513_ABC\.[0-9]*$
# match ABC.0001 (intended): true
# match ABCX0001 (wrong)   : false
# match ABCz9999 (wrong)   : false
```

The dot is now a literal dot; cross-POS prefix collisions on the latest-order lookup are no longer possible.

## Notes

- `pnpm nx build posclient_api` passes locally (`erxes-api-shared` rebuilt first per CLAUDE.md).
- `pnpm nx lint posclient_api`: no new errors or warnings on the touched lines — pre-existing `prefer-const` errors in sibling files (`pricing.ts`) are out of scope.
- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

Fix POS client order number generation to use a literal-dot regex and prevent cross-POS collisions when matching latest orders.

Bug Fixes:
- Ensure generateOrderNumber builds a regex that treats the dot between beginNumber and suffix as a literal character instead of a wildcard.
- Escape regex meta-characters in configurable beginNumber values so order lookups cannot misinterpret them and return numbers from other POS clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order number lookup to escape configurable prefix characters and require a literal separator before digits, preventing broad wildcard matches and avoiding unintended order matches across POS instances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7653)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->