### PR TITLE
fix(frontline): remove TLS verification bypass in PBX WebSocket (alert #931 + #932)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
@@ -14,7 +14,6 @@ const CONFIG = {
   HEARTBEAT_INTERVAL: 30000,
   MAX_RECONNECT_DELAY: 30000,
   RECONNECT_BASE_DELAY: 1000,
-  ALLOW_INSECURE_TLS: process.env.CALL_WS_INSECURE === 'true',
 } as const;
 
 const WS_URL = `wss://${CONFIG.PBX_IP}:${CONFIG.WS_PORT}/websockify`;
@@ -477,11 +476,11 @@ class PBXWebSocketClient {
   }
 
   private connect(): void {
-    this.ws = new WebSocket(
-      WS_URL,
-      undefined,
-      CONFIG.ALLOW_INSECURE_TLS ? { rejectUnauthorized: false } : undefined,
-    );
+    // TLS verification is intentionally left at Node's secure defaults.
+    // If a deployment needs to talk to a PBX presenting a self-signed cert,
+    // the correct fix is to add that PBX's CA to the trust store via
+    // NODE_EXTRA_CA_CERTS at deploy time, NOT to disable cert validation.
+    this.ws = new WebSocket(WS_URL);
     this.setupEventHandlers();
   }
 

--- a/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
@@ -18,9 +18,6 @@ const CONFIG = {
 
 const WS_URL = `wss://${CONFIG.PBX_IP}:${CONFIG.WS_PORT}/websockify`;
 
-// Set up TLS for development
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 // Types
 interface AgentInfo {
   member_extension: string;


### PR DESCRIPTION
## Closes alerts #931 and #932 (same rule, same file — bundled)

- **Rule:** `js/disabling-certificate-validation` (severity: error) — two
  instances in the same file
- **Alerts:**
  - https://github.com/erxes/erxes/security/code-scanning/931 (line 483)
  - https://github.com/erxes/erxes/security/code-scanning/932 (line 23)
- **File:** `backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts`

## Reproduction (before fix)

Static data-flow trace of the vulnerability:

1. **Sink #931 (per-connection):** `new WebSocket(WS_URL, undefined, CONFIG.ALLOW_INSECURE_TLS ? { rejectUnauthorized: false } : undefined)` at line 483. `WS_URL` is `wss://${PBX_IP}:8089/websockify`. When `CALL_WS_INSECURE=true`, the Node TLS client accepts any presented certificate including self-signed and attacker-issued ones.
2. **Sink #932 (process-wide):** `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'` at line 23. This sets a Node-internal flag that `tls.connect` checks BEFORE honoring per-connection options, silently downgrading TLS verification for every outbound HTTPS/WSS in the frontline process — not just the PBX WebSocket.
3. **Why the two combine:** fixing only #931 was caught as a Critical regression by CodeRabbit because #932's global override would still bypass the line-483 change. The fixes are tightly coupled (same file, same rule, same defense) so they are bundled here.
4. **Attacker model:** an attacker on the network path between the frontline-api container and the PBX (compromised router, rogue WiFi, ARP/DNS spoofing inside the data-center VLAN) MITMs the wss:// handshake, captures the API user/password challenge that the plugin sends immediately after connect (`requestChallenge()`), and impersonates either side to harvest live call metadata. With #932 in place, the same MITM also breaks every other outbound TLS made by this process.

## Fix

Two surgical removals:

1. Dropped the conditional `{ rejectUnauthorized: false }` options object from the `new WebSocket(WS_URL)` call. The constructor now uses Node's secure TLS defaults.
2. Removed `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'` and the now-orphan `ALLOW_INSECURE_TLS` config field. There were no other consumers of `ALLOW_INSECURE_TLS` in `backend/` (verified via grep).

Deployments that legitimately need to talk to a PBX with a private CA should add it via `NODE_EXTRA_CA_CERTS` at deploy time (the documented Node.js pattern), not by disabling validation globally.

## Verification (after fix)

- Neither `rejectUnauthorized: false` nor `NODE_TLS_REJECT_UNAUTHORIZED = '0'` appears anywhere in the file (`grep -n` confirms).
- `grep -rn 'ALLOW_INSECURE_TLS' backend/` returns zero hits — the orphan config field is gone.
- The TLS handshake against a self-signed/MITM cert now fails at the OS layer with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` before any application payload is sent.
- All other outbound HTTPS/WSS in this process (axios calls in auth/sync paths, etc.) is no longer silently downgraded.

## Notes

- `pnpm nx build frontline_api` passes locally (the `build:packageJson` tsc step also passes).
- Lint on the changed file is clean. Project-wide lint surfaces pre-existing errors in unrelated files (`status.ts`, `messengerWidget.bundle.js`) which this PR does not touch.
- Both alerts will move to `state: fixed` after the next CodeQL re-scan of `main` post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced strict TLS certificate validation for WebSocket connections by default.
  * Removed the option to bypass certificate validation during development.
  * Self-signed certificates must now be trusted via deployment-level trust store configuration (e.g., adding certificates to the runtime trust store) rather than disabling validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7654)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->