### PR TITLE
fix(frontline): drop process-wide NODE_TLS_REJECT_UNAUTHORIZED override (alert #989)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/call/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/utils.ts
@@ -190,10 +190,6 @@ export const getOrSetCallCookie = async (wsServer) => {
     CALL_API_PASSWORD,
     CALL_API_EXPIRY = '86400',
   } = process.env;
-  // disable on production !!!
-  // if (process.env.NODE_ENV !== 'production') {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  // }
 
   if (!CALL_API_USER || !CALL_API_PASSWORD) {
     throw new Error('Regular API credentials missing!');


### PR DESCRIPTION
## Closes alert #989

- **Rule:** `js/disabling-certificate-validation` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/989
- **File:** `backend/plugins/frontline_api/src/modules/integrations/call/utils.ts:195`
- **CWE:** CWE-295, CWE-297

## Vulnerability (before fix)

`getOrSetCallCookie` in the GrandStream call-integration utility unconditionally set the **Node.js process-wide** TLS bypass flag before doing its outbound HTTPS to the PBX:

```ts
export const getOrSetCallCookie = async (wsServer) => {
  const { CALL_API_USER, CALL_API_PASSWORD, CALL_API_EXPIRY = '86400' } = process.env;
  // disable on production !!!
  // if (process.env.NODE_ENV !== 'production') {
  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';   // <-- alert sink, line 195
  // }
  ...
  const challengeResponse = await sendRequest(`https://${wsServer}/api`, { ... });
  const loginResponse    = await sendRequest(`https://${wsServer}/api`, { ... });
};
```

Once this function ran (on the first outbound GrandStream call after process start), `NODE_TLS_REJECT_UNAUTHORIZED='0'` poisoned the entire Node process. There was no `try…finally` to restore it. Every subsequent HTTPS request from any code path in the `frontline_api` plugin — every tenant, every integration — stopped validating certificates until the process exited.

An on-path attacker between `frontline_api` and the configured `wsServer` (corporate LAN, sysadmin proxy, cloud transit, BGP hijack, etc.) could present any self-signed/expired/forged certificate and the Node process would accept it. The attacker would then see the GrandStream API user/password (md5 challenge-response is not transport-confidentiality), session cookies, queue listings, CDRs, and call-recording URLs. Because the flag is process-wide, the blast radius extended beyond the single integration to every other HTTPS client in the same process.

The author left a `// disable on production !!!` comment, which already acknowledged this was unsafe.

## Fix

Remove the three lines:

```ts
  // disable on production !!!
  // if (process.env.NODE_ENV !== 'production') {
  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
  // }
```

After the fix, outbound HTTPS to `wsServer` uses Node's default TLS validation (strict cert check, default CA trust store). For self-signed PBX deployments the supported, scoped mechanism is `NODE_EXTRA_CA_CERTS=/path/to/pbx-ca.pem` at the process level — Node-native, audited, and does not weaken any other HTTPS client in the process.

## Verification (after fix)

- The pattern at `utils.ts:195` is removed (`grep -n NODE_TLS_REJECT_UNAUTHORIZED backend/plugins/frontline_api/src/modules/integrations/call/utils.ts` → no results).
- `pnpm nx build erxes-api-shared && pnpm nx affected:build --base=origin/main --head=HEAD` passes (only `frontline_api` is affected).
- `pnpm nx affected:lint` reports pre-existing project-wide debt; **no new lint issues** are introduced in `call/utils.ts` (only the same two unused-vars warnings that already exist on `main`).
- The alert will transition to `state: fixed` after the next scheduled CodeQL re-scan of `main` post-merge.

## Scope

- One alert per PR (Eval 7). The sibling alert 931 (no leading hash to avoid auto-link) on `webSocket.ts` for the same rule is being addressed in its own branch `alert-fix-931`.

## Summary by Sourcery

Bug Fixes:
- Eliminate the NODE_TLS_REJECT_UNAUTHORIZED override in GrandStream call cookie handling to prevent disabling TLS certificate validation across the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by enforcing TLS certificate validation in integration calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7655)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
