### PR TITLE
fix(frontline): wrap Facebook checkIsBot botId lookup with $eq (alert #949)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/utils/messageUtils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/utils/messageUtils.ts
@@ -63,7 +63,7 @@ export const checkIsBot = async (models: IModels, message, recipientId) => {
   if (message?.payload) {
     const payload = JSON.parse(message?.payload || '{}');
     if (payload.botId) {
-      selector = { _id: payload.botId };
+      selector = { _id: { $eq: payload.botId } };
     }
   }
   const bot = await models.FacebookBots.findOne(selector);


### PR DESCRIPTION
## Closes alert #949

- **Rule:** `js/sql-injection` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/949
- **File:** `backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/utils/messageUtils.ts:69`

## Reproduction (before fix)

`checkIsBot` was calling `models.FacebookBots.findOne({ _id: payload.botId })` where `payload` is `JSON.parse`'d from an attacker-controlled Facebook webhook field (`message.quick_reply.payload` or `postback.payload`, both populated by the inbound webhook body in `controller/receiveMessage.ts`).

Taint trace:
1. **Source:** inbound Facebook Messenger webhook hits `receiveMessage` and sets `message.payload = postback.payload || message.quick_reply.payload`.
2. **Sink:** `checkIsBot(models, message, recipient.id)` runs `JSON.parse(message.payload)` then assigns `selector = { _id: payload.botId }`.

A malicious actor able to deliver a Facebook webhook submits:

```json
{
  "object": "page",
  "entry": [{
    "id": "<pageId>",
    "messaging": [{
      "sender": { "id": "attacker" },
      "recipient": { "id": "<pageId>" },
      "timestamp": 1716000000000,
      "postback": {
        "mid": "m_x",
        "title": "click",
        "payload": "{\"botId\":{\"$ne\":null}}"
      }
    }]
  }]
}
```

After `JSON.parse`, `payload.botId === { $ne: null }`. Mongoose then runs `FacebookBots.findOne({ _id: { $ne: null } })`, returning the first bot in the database irrespective of which page the message was sent to. The conversation is then created with `isBot: true, botId: <leaked-bot-id>`, polluting state across pages.

## Fix

Wrap the user-controlled `botId` value with `{ $eq: ... }`:

```ts
selector = { _id: { $eq: payload.botId } };
```

When `payload.botId` is a string this is behaviour-identical to before. When it is an operator object, Mongoose casts the value side of `$eq` to the schema type for `_id` (ObjectId) and the cast fails, yielding no match — the NoSQL operator injection is neutralised.

Mirrors the same pattern already applied to the Instagram integration in earlier alert PRs (#1200/#1201/#1202/#1203/#1210/#1211).

## Verification (after fix)

Replaying the attack payload `{"botId":{"$ne":null}}`:
- `selector` becomes `{ _id: { $eq: { $ne: null } } }`.
- Mongoose casts the value side of `$eq` to the ObjectId schema type; the operator object fails to cast, yielding no document match. `bot` is `null`.
- The CodeQL data-flow path now terminates at a `$eq` literal-value position which the rule treats as safe.

## Notes

- `pnpm nx build frontline_api` passes locally (with `erxes-api-shared` rebuilt first).
- Lint shows pre-existing errors in unrelated files; none introduced by this one-line change.
- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

Bug Fixes:
- Ensure Facebook botId lookups use an $eq wrapper to prevent attacker-controlled payloads from injecting query operators into the _id selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal bot query logic for improved database operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->