### PR TITLE
fix(core-api): wrap telnyx webhook telnyxId lookup with $eq (alert #1040)

### DIFF
--- a/backend/core-api/src/modules/broadcast/utils/telnyx.ts
+++ b/backend/core-api/src/modules/broadcast/utils/telnyx.ts
@@ -45,7 +45,9 @@ export const saveTelnyxHookData = async (models: IModels, data: any) => {
   if (data?.payload) {
     const { to = [], id } = data.payload;
 
-    const initialRequest = await models.SmsRequests.findOne({ telnyxId: id });
+    const initialRequest = await models.SmsRequests.findOne({
+      telnyxId: { $eq: id },
+    });
 
     if (initialRequest) {
       const receiver = to.find(

--- a/backend/core-api/src/modules/broadcast/utils/telnyx.ts
+++ b/backend/core-api/src/modules/broadcast/utils/telnyx.ts
@@ -50,6 +50,11 @@ export const saveTelnyxHookData = async (models: IModels, data: any) => {
     // $eq wrapper below this gives defense-in-depth against NoSQL
     // operator injection from the unauthenticated webhook body.
     if (typeof id !== 'string') {
+      // Surface rejected payloads so suspicious / malformed webhook traffic
+      // is visible in the logs (no PII — only the unexpected type tag).
+      console.warn('Telnyx webhook rejected: non-string id', {
+        type: typeof id,
+      });
       return;
     }
 

--- a/backend/core-api/src/modules/broadcast/utils/telnyx.ts
+++ b/backend/core-api/src/modules/broadcast/utils/telnyx.ts
@@ -45,6 +45,14 @@ export const saveTelnyxHookData = async (models: IModels, data: any) => {
   if (data?.payload) {
     const { to = [], id } = data.payload;
 
+    // Fail fast on malformed payloads so non-string id values (objects,
+    // arrays, numbers) cannot reach the Mongoose query. Combined with the
+    // $eq wrapper below this gives defense-in-depth against NoSQL
+    // operator injection from the unauthenticated webhook body.
+    if (typeof id !== 'string') {
+      return;
+    }
+
     const initialRequest = await models.SmsRequests.findOne({
       telnyxId: { $eq: id },
     });

--- a/backend/core-api/src/modules/broadcast/utils/telnyx.ts
+++ b/backend/core-api/src/modules/broadcast/utils/telnyx.ts
@@ -51,9 +51,16 @@ export const saveTelnyxHookData = async (models: IModels, data: any) => {
     // operator injection from the unauthenticated webhook body.
     if (typeof id !== 'string') {
       // Surface rejected payloads so suspicious / malformed webhook traffic
-      // is visible in the logs (no PII — only the unexpected type tag).
+      // is visible in the logs. Capture only non-PII shape metadata
+      // (types, constructor name, array length) — never raw values or
+      // phone numbers — so investigators can distinguish probing
+      // attempts from buggy integrations.
       console.warn('Telnyx webhook rejected: non-string id', {
         type: typeof id,
+        idConstructor:
+          id === null || id === undefined ? null : id?.constructor?.name,
+        hasToField: Array.isArray(to),
+        toLength: Array.isArray(to) ? to.length : 0,
       });
       return;
     }


### PR DESCRIPTION
## Closes alert #1040

- **Rule:** `js/sql-injection` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1040
- **File:** `backend/core-api/src/modules/broadcast/utils/telnyx.ts:48`

## Reproduction (before fix)

### Taint source
`req.body.data` in `backend/core-api/src/modules/broadcast/routes/telnyx.ts:7`:

```ts
const { data, subdomain } = req.body;
...
await saveTelnyxHookData(models, data);
```

The Telnyx webhook endpoint at `POST /webhook` (and `GET /webhook-failover`) accepts an unvalidated JSON body and passes the `data` field straight through.

### Path to sink
`saveTelnyxHookData` (`utils/telnyx.ts:44`) destructures `data.payload.id`:

```ts
const { to = [], id } = data.payload;
const initialRequest = await models.SmsRequests.findOne({ telnyxId: id });  // SINK
```

No `typeof id === 'string'` check, no Joi/Zod validation, no `$eq` wrapping. Mongoose interprets a plain object value as a query operator expression.

### Concrete attack payload
```bash
curl -X POST 'https://<host>/<broadcast-mount>/webhook' \
  -H 'Content-Type: application/json' \
  --data '{
    "subdomain": "victim",
    "data": {
      "payload": {
        "id": { "$ne": null },
        "to": [{ "phone_number": "+15555550100", "status": "queued" }]
      }
    }
  }'
```

Mongoose receives `findOne({ telnyxId: { $ne: null } })` and returns the first SmsRequest row that has any `telnyxId`. The subsequent `updateRequest` call (lines 61-65 in the original) overwrites that record's `status`, `responseData`, and `statusUpdates` with attacker-controlled values, letting the caller pivot to / corrupt arbitrary SMS request records.

Other equivalent payloads: `{"$regex": "."}`, `{"$gt": ""}`, `{"$in": ["valid-id-1","valid-id-2"]}`.

## Fix

Wrap the `telnyxId` lookup with `{ $eq: id }`, forcing Mongoose to compare the field against the literal value of `id`. This is the same pattern already applied across the frontline Instagram lookups (alerts #1200, #1201, #1202, #1203 on the same backlog) and matches the CodeQL rule's own recommended remediation:

> For NoSQL queries, make use of an operator like MongoDB's `$eq` to ensure that untrusted data is interpreted as a literal value and not as a query object.

## Verification (after fix)

With `id = { $ne: null }`, Mongoose now receives `findOne({ telnyxId: { $eq: { $ne: null } } })`. The `$eq` operator compares the field against the literal object `{ $ne: null }` (rather than evaluating it as an operator expression), so no document matches and the `if (initialRequest)` branch is skipped. The pivot/enumeration vector is closed.

A legitimate webhook delivery with a primitive string `id` continues to work identically — `$eq` accepts scalar primitives as-is.

## Notes

- The build/lint failures pre-existing on `origin/main` (TypeScript errors in `cpUser/auth.ts`, lint errors in `template/graphql/mutations/template.ts`, etc.) are unrelated to this PR; the diff is a 1-call, 3-line change in `broadcast/utils/telnyx.ts` and introduces no new lint or type issues on that file.
- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

Bug Fixes:
- Prevent NoSQL operator injection in Telnyx webhook SmsRequests.findOne lookup by wrapping telnyxId in a $eq comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-fast handling for malformed incoming SMS webhooks: invalid payloads are skipped early and a non-PII warning is logged to aid diagnosis.
  * More explicit matching logic for incoming webhook IDs to make message-to-request/status updates more reliable and reduce missed or incorrect updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7657)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->