### PR TITLE
fix(frontline): wrap Instagram message mid lookup with $eq (alert #1215)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -132,7 +132,7 @@ export const receiveMessage = async (
   }
 
   const existingMessage = await models.InstagramConversationMessages.findOne({
-    mid,
+    mid: { $eq: mid },
   });
 
   if (!existingMessage) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts
@@ -131,6 +131,13 @@ export const receiveMessage = async (
     throw new Error(e.message);
   }
 
+  // Defense in depth: even with the $eq wrap below preventing operator-shape
+  // injection at the Mongoose layer, reject non-string / empty `mid` early so
+  // we never run a duplicate-detection lookup on a malformed webhook payload.
+  if (typeof mid !== 'string' || mid.length === 0) {
+    return;
+  }
+
   const existingMessage = await models.InstagramConversationMessages.findOne({
     mid: { $eq: mid },
   });


### PR DESCRIPTION
## Closes alert #1215

- **Rule:** `js/sql-injection` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1215
- **File:** `backend/plugins/frontline_api/src/modules/integrations/instagram/controller/receiveMessage.ts:134`

## Reproduction (before fix)

**Taint source:** Instagram webhook payload `activity.message.mid` (or `postback.mid`).

**Flow:** `mid` (line 31) is plucked from the JSON-parsed webhook body with no type validation, then passed as a bare query field to `models.InstagramConversationMessages.findOne({ mid })` at line 134. Mongoose accepts operator-shaped objects in field positions, so a payload of `{"message": {"mid": {"$ne": null}}}` makes the query return the first historical message instead of looking up by id — short-circuiting the new-message path and suppressing the downstream `triggerInstagramAutomation` step.

## Fix

Wrap `mid` with the `$eq` operator so Mongoose interprets the value as a literal equality regardless of shape:
```ts
const existingMessage = await models.InstagramConversationMessages.findOne({
  mid: { $eq: mid },
});
```

Matches the pattern already adopted across sibling alerts (#1200/1201/1202/1203) on `store.ts`.

## Verification (after fix)

Payload `{"message": {"mid": {"$ne": null}}}` now resolves to `{ mid: { $eq: { $ne: null } } }`, which Mongoose treats as a literal equality against the object `{$ne: null}` — no document matches, `existingMessage` is `null`, and the normal "new message" path runs.

## Notes

- `pnpm nx affected --target=build` (with `erxes-api-shared` pre-rebuilt) passes locally.
- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.

## Summary by Sourcery

Bug Fixes:
- Guard the Instagram conversation message lookup against MongoDB operator-shaped `mid` payloads by wrapping the field in an `$eq` comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram message lookup reliability: messages missing a valid message ID are now ignored.
  * Matching logic made more precise to reduce missed or incorrect message matches and avoid processing malformed messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7661)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->