### PR TITLE
ci(kimi-review): gate comment-triggered checkout by author_association (alert #1118)

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -38,29 +38,37 @@ jobs:
         github.event.comment.author_association == 'MEMBER'))
     
     steps:
-      # Step 1: Get PR information (for comment events)
-      - name: Get PR ref (for comments)
+      # Step 1: Resolve the PR head SHA we will check out. Runs on every
+      # trigger so the checkout step doesn't have to fan out branches on
+      # `github.event.pull_request.head.sha` (which is undefined for
+      # `issue_comment` payloads) vs `steps.get-pr.outputs.sha`. For
+      # `pull_request` events the payload already carries the head SHA;
+      # for comment events we look it up via the REST API.
+      - name: Resolve PR head SHA
         id: get-pr
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.issue?.number || context.payload.pull_request?.number;
+            if (context.eventName === 'pull_request') {
+              core.setOutput('sha', context.payload.pull_request.head.sha);
+              return;
+            }
+            const prNumber =
+              context.issue?.number || context.payload.pull_request?.number;
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: prNumber,
             });
-            core.setOutput('ref', pr.data.head.ref);
             core.setOutput('sha', pr.data.head.sha);
 
-      # Step 2: Checkout the code.
-      # Pin to the head SHA (not the ref name) so a post-trigger force-push
-      # by the PR author cannot swap in a different commit between the
-      # get-pr lookup and the actual checkout.
+      # Step 2: Checkout the resolved SHA. Pin to the head SHA (not the
+      # ref name) so a post-trigger force-push by the PR author cannot
+      # swap in a different commit between the get-pr lookup and the
+      # actual checkout.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && steps.get-pr.outputs.sha || github.event.pull_request.head.sha }}
+          ref: ${{ steps.get-pr.outputs.sha }}
 
       # Step 3: Run Kimi Code Review Action
       - uses: xiaoju111a/kimi-actions@main

--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -19,14 +19,24 @@ permissions:
 jobs:
   kimi-review:
     runs-on: ubuntu-latest
-    # Only run on PRs or comment events that start with "/"
+    # Only run on PRs or comment events that start with "/".
+    # Comment-triggered runs additionally require the commenter to be a
+    # repository owner/member/collaborator — otherwise an outside contributor
+    # could post "/review" on their own fork PR and execute attacker-controlled
+    # code in this privileged context (pull-requests: write, secrets available).
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       startsWith(github.event.comment.body, '/')) ||
+       startsWith(github.event.comment.body, '/') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request_review_comment' &&
-       startsWith(github.event.comment.body, '/'))
+       startsWith(github.event.comment.body, '/') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     
     steps:
       # Step 1: Get PR information (for comment events)
@@ -45,10 +55,13 @@ jobs:
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('sha', pr.data.head.sha);
 
-      # Step 2: Checkout the code
+      # Step 2: Checkout the code.
+      # Pin to the head SHA (not the ref name) so a post-trigger force-push
+      # by the PR author cannot swap in a different commit between the
+      # get-pr lookup and the actual checkout.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && steps.get-pr.outputs.ref || github.head_ref }}
+          ref: ${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && steps.get-pr.outputs.sha || github.event.pull_request.head.sha }}
 
       # Step 3: Run Kimi Code Review Action
       - uses: xiaoju111a/kimi-actions@main

--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -21,22 +21,21 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on PRs or comment events that start with "/".
     # Comment-triggered runs additionally require the commenter to be a
-    # repository owner/member/collaborator — otherwise an outside contributor
-    # could post "/review" on their own fork PR and execute attacker-controlled
-    # code in this privileged context (pull-requests: write, secrets available).
+    # repository OWNER or organization MEMBER — COLLABORATOR is intentionally
+    # excluded because outside collaborators can be added with minimal
+    # permissions and would otherwise gain code execution in this privileged
+    # context (pull-requests: write, secrets available).
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        startsWith(github.event.comment.body, '/') &&
        (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR')) ||
+        github.event.comment.author_association == 'MEMBER')) ||
       (github.event_name == 'pull_request_review_comment' &&
        startsWith(github.event.comment.body, '/') &&
        (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+        github.event.comment.author_association == 'MEMBER'))
     
     steps:
       # Step 1: Get PR information (for comment events)


### PR DESCRIPTION
## Closes alert #1118

- **Rule:** `actions/untrusted-checkout/high` (severity: error)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1118
- **File:** `.github/workflows/kimi-review.yml:49-54`
- **CodeQL message:** \"Potential execution of untrusted code on a privileged workflow (issue_comment)\"

## Reproduction (before fix)

The workflow has `pull-requests: write` permission, exposes `secrets.KIMI_API_KEY` and `secrets.GITHUB_TOKEN` to the runner, and triggers on `issue_comment` / `pull_request_review_comment` (privileged base-repo context). The existing `if:` only required the comment body to start with `/` — no commenter-identity check.

**Attack:**
1. Outside contributor A opens a PR with a malicious `package.json` postinstall (or any script the action reads).
2. Any GitHub user B posts `/review` as an `issue_comment` on that PR.
3. Workflow fires in privileged context, checks out A's head, runs `xiaoju111a/kimi-actions` against it → A's code can exfiltrate `KIMI_API_KEY` / `GITHUB_TOKEN`.

A secondary concern: the existing checkout used `steps.get-pr.outputs.ref` (head **ref name**), which is racy — the PR author can force-push between the `get-pr` lookup and the checkout step.

## Fix

1. **Author-association guard.** `issue_comment` and `pull_request_review_comment` runs now require the commenter's `author_association` to be one of `OWNER`, `MEMBER`, or `COLLABORATOR`. Drive-by `/review` comments from outsiders never reach the privileged checkout.
2. **SHA-pinned checkout.** Replaced `steps.get-pr.outputs.ref` with `steps.get-pr.outputs.sha`, and the `pull_request` branch with `github.event.pull_request.head.sha`. Eliminates the post-trigger force-push race.

The `pull_request` trigger path is unchanged — fork PRs still receive automated reviews, but in the unprivileged context where forks don't expose secrets by default.

## Verification (after fix)

- Outsider posting `/review` on a fork PR → `author_association == 'NONE'` or `'FIRST_TIME_CONTRIBUTOR'` → `if:` is false, job does not start.
- Maintainer posting `/review` on the same PR → `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` → job runs, but the checkout step pins to the SHA captured at trigger time, so subsequent force-pushes by the author are inert.
- `pull_request` from a fork → runs in unprivileged context as before; CodeQL `actions/untrusted-checkout` no longer detects a tainted path to a secret-exposing sink.

## Notes

- No source code touched — workflow-only change.
- The third-party action `xiaoju111a/kimi-actions@main` is still pinned to a moving `@main` tag; pinning to a SHA is a separate hardening I'd prefer to do once the action publishes a release tag. Out of scope for this alert.

## Summary by Sourcery

Gate the kimi-review workflow’s privileged runs and harden its checkout behavior to mitigate untrusted-checkout risk.

CI:
- Restrict comment-triggered workflow runs to comments from repository owners, members, or collaborators when using slash commands.
- Change the checkout ref to use the PR head SHA for both comment-triggered and pull_request events to avoid races from post-trigger force-pushes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restricted review workflow so only repository Owners and Members (excluding Collaborators) can trigger it via slash-prefixed comment commands.
  * Improved workflow stability by ensuring comment-triggered reviews run against specific commit SHAs for consistent, reproducible checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7662)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7662)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->