### PR TITLE
fix(core-api): rate-limit GET /export/template/:templateId (alert #1182)

### DIFF
--- a/backend/core-api/src/modules/template/routes.ts
+++ b/backend/core-api/src/modules/template/routes.ts
@@ -1,11 +1,41 @@
 import crypto from 'crypto';
 import { extractUserFromHeader, getSubdomain } from 'erxes-api-shared/utils';
 import { Request, Response, Router } from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { generateModels } from '~/connectionResolvers';
 
 const router: Router = Router();
 
 const ALGORITHM = 'aes-256-gcm';
+
+// Reads the rightmost X-Forwarded-For entry because the gateway appends the
+// real client IP — leftmost values are attacker-controllable via forged XFF.
+const getClientIp = (req: Request): string => {
+  const xff = req.headers['x-forwarded-for'];
+  if (xff) {
+    const parts = (Array.isArray(xff) ? xff[0] : xff).split(',');
+    return parts[parts.length - 1].trim();
+  }
+  return req.ip || 'unknown';
+};
+
+// Rate-limit GET /export/template/:templateId. The route authenticates first,
+// so this is defense-in-depth against credential-stuffing-style enumeration of
+// templateIds and against scrape-all-templates loops once a session token has
+// leaked. Limits are IP-keyed (in-memory, per-replica) and IPv6-subnet safe.
+const exportTemplateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 60, // 60 exports per IP per window — generous for humans, tight for scrapers
+  keyGenerator: (req) => ipKeyGenerator(getClientIp(req)),
+  handler: (_req, res) => {
+    res.status(429).json({
+      errorCode: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many template export requests, please try again later.',
+    });
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 /** Reads and validates the TEMPLATE_EXPORT_KEY environment variable. */
 const getEncryptionKey = (): string => {
@@ -91,6 +121,7 @@ const decryptData = (encryptedData: string, key: string): Record<string, unknown
 
 router.get(
   '/export/template/:templateId',
+  exportTemplateLimiter,
   async (req: Request, res: Response) => {
     const user = authenticateRequest(req, res);
     if (!user) return null;

--- a/backend/core-api/src/modules/template/routes.ts
+++ b/backend/core-api/src/modules/template/routes.ts
@@ -8,13 +8,20 @@ const router: Router = Router();
 
 const ALGORITHM = 'aes-256-gcm';
 
-// Reads the rightmost X-Forwarded-For entry because the gateway appends the
-// real client IP — leftmost values are attacker-controllable via forged XFF.
+// Reads the rightmost X-Forwarded-For entry because the gateway prepends
+// `app.set('trust proxy', ...)`-style trust and appends the real client IP —
+// leftmost values are attacker-controllable via a forged XFF header. Falls
+// back to `req.ip` when XFF is missing OR when parsing yields an empty entry
+// (which would otherwise collapse every such request into one rate-limit
+// bucket and amplify, rather than mitigate, the underlying issue).
 const getClientIp = (req: Request): string => {
   const xff = req.headers['x-forwarded-for'];
   if (xff) {
     const parts = (Array.isArray(xff) ? xff[0] : xff).split(',');
-    return parts[parts.length - 1].trim();
+    const candidate = parts[parts.length - 1]?.trim();
+    if (candidate) {
+      return candidate;
+    }
   }
   return req.ip || 'unknown';
 };


### PR DESCRIPTION
## Closes alert #1182

- **Rule:** `js/missing-rate-limiting` (severity: warning)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1182
- **File:** `backend/core-api/src/modules/template/routes.ts:92-141`
- **CodeQL message:** \"This route handler performs authorization, but is not rate-limited.\"

## Reproduction (before fix)

`GET /export/template/:templateId` authenticates via `extractUserFromHeader` (401 if no token), then loads the template and ships an encrypted JSON payload. No rate limit. With a stolen session cookie an attacker can loop:

```
for i in $(seq 1 100000); do
  curl -H "cookie: auth-token=<leaked>" \
    "https://api.example.com/export/template/aaaaaa$(printf '%06d' $i)"
done
```

That enumerates templateIds and exfiltrates every match. CodeQL flags the route as a known sink for the `js/missing-rate-limiting` rule because authorization without throttling is the textbook pattern it fires on.

## Fix

Add an `exportTemplateLimiter` ahead of the route handler, mirroring the pattern already used by `backend/core-api/src/routes/fileRoutes.ts:50-67`:

- **Window / max:** 15 minutes / 60 requests per IP — generous for humans, tight for scrapers.
- **Key:** `ipKeyGenerator(getClientIp(req))` — IPv6-subnet-safe, reading the **rightmost** `X-Forwarded-For` entry because the erxes gateway appends the real client IP (leftmost values are attacker-controllable via forged XFF).
- **Response:** 429 with the codebase-standard `{"errorCode":"RATE_LIMIT_EXCEEDED", "message":"…"}` envelope.

In-memory / per-replica store keeps this change scoped to the route — no new dependency. The sibling `POST /import/template` route is rate-limited by a separate in-flight PR (PR #7643) which adds a Redis-backed limiter; intentionally keeping the two infrastructures in separate PRs so review can scope each independently.

## Verification (after fix)

- Loop above hits `HTTP 429` after 60 requests within 15 minutes; CodeQL data-flow now terminates inside the rate-limit middleware before reaching the route handler.
- Legitimate human workflow (≤60 exports / 15-min) is unaffected.
- `pnpm nx affected --target=build --uncommitted` passes locally.

## Notes

- Same file as PR #7643. Trivial merge conflict on the imports block once one merges; one-alert-per-PR per the project rule.

## Summary by Sourcery

Add IP-based rate limiting to the template export endpoint to mitigate brute-force and enumeration attacks.

Bug Fixes:
- Introduce a rate limiter for GET /export/template/:templateId to prevent unthrottled authenticated template export requests.

Enhancements:
- Derive client IPs from the rightmost X-Forwarded-For entry to resist spoofing and ensure consistent rate-limiting behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented IP-based rate limiting on template export endpoints (60 requests per IP per 15 minutes) to improve stability and prevent excessive usage.
  * When the limit is exceeded, requests receive a 429 response with a structured error message to indicate the rate limit has been reached.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7663)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->