### PR TITLE
fix(posclient): use startsWith for Cloudflare image-delivery check (alert #1073)

### DIFF
--- a/apps/posclient-front/components/ui/image.tsx
+++ b/apps/posclient-front/components/ui/image.tsx
@@ -31,7 +31,7 @@ const Image: FC<
   const [isImageLoading, setIsImageLoading] = useState(true)
   const [srcI, setSrcI] = useState(fixedSrc || fallBack || "/product.png")
   const handleComplete = () => setIsImageLoading(false)
-  const fromCF = srcI.includes("https://imagedelivery.net/")
+  const fromCF = srcI.startsWith("https://imagedelivery.net/")
   const getLoader = () => {
     if (srcI.includes("//:localhost") || srcI.startsWith("/")) {
       return undefined


### PR DESCRIPTION
## Closes alert #1073

- **Rule:** `js/incomplete-url-substring-sanitization` (severity: warning)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1073
- **File:** `apps/posclient-front/components/ui/image.tsx:34`
- **CodeQL message:** \"'https://imagedelivery.net/' can be anywhere in the URL, and arbitrary hosts may come before or after it.\"

## Reproduction (before fix)

The `fromCF` flag at line 34 used `srcI.includes("https://imagedelivery.net/")`, so any URL that merely **contains** that substring would set the flag, which gates:

- Line 70-74: invocation of `cloudflareLoader` with `srcI`. The loader's else-branch (lines 99-102) embeds the URL into `https://erxes.io/cdn-cgi/image/.../<url>` without an allow-list check.
- Line 80: `unoptimized={fromCF}` — disables Next.js' built-in image-source allowlist.

**Concrete payload:**
```
srcI = "https://evil.example/whatever?ref=https://imagedelivery.net/anything"
```
`.includes("https://imagedelivery.net/") === true` → `fromCF = true` → cloudflareLoader runs → `startsWith` check inside the loader is false → falls through to embed the attacker URL into `https://erxes.io/cdn-cgi/image/...` while `unoptimized` bypasses Next.js' remote-image policy.

## Fix

Replace `.includes` with `.startsWith` so `fromCF` is true only when the URL actually begins with the Cloudflare image-delivery prefix. Mirrors the hardened check inside `cloudflareLoader` itself at line 95.

```ts
const fromCF = srcI.startsWith("https://imagedelivery.net/")
```

## Verification (after fix)

- Same payload: `startsWith` is false → `fromCF = false` → Next.js' default loader applies (which enforces its own `remotePatterns`); `unoptimized` is not set.
- Legitimate Cloudflare-delivered images `https://imagedelivery.net/<account>/<id>/<variant>` still pass — behavior unchanged.
- CodeQL data flow no longer reaches a trust-gating sink with substring-only validation.

## Notes

- One-line change; no API or rendering behavior altered for legitimate inputs.
- Standalone Next.js app — not part of `nx affected build` graph, so verification is by inspection + CI's Next.js build.

## Summary by Sourcery

Bug Fixes:
- Ensure the Cloudflare image-delivery flag is only set for URLs that start with the trusted prefix, preventing attacker-controlled URLs that merely contain the substring from bypassing Next.js image security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare image detection logic to more accurately identify image delivery URLs, ensuring the correct image loader is applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7664)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->