### PR TITLE
fix(frontline): use null-prototype map for PBX queueStates (alert #1111)

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts
@@ -72,7 +72,11 @@ interface PBXEvent {
 
 // State Management
 class QueueStateManager {
-  private queueStates: Record<string, QueueState> = {};
+  // Null-prototype map so a PBX event with extension="__proto__" /
+  // "constructor" cannot resolve via prototype lookup to Object.prototype
+  // (or Object) and have the downstream `queue.waiting = …` / `queue.talking
+  // = …` assignments mutate every plain object in the process.
+  private queueStates: Record<string, QueueState> = Object.create(null);
 
   initializeQueue(extension: string): void {
     if (!this.queueStates[extension]) {
@@ -147,7 +151,7 @@ class QueueStateManager {
   }
 
   resetState(): void {
-    this.queueStates = {};
+    this.queueStates = Object.create(null);
   }
 
   handleCallAnswered(


### PR DESCRIPTION
## Closes alert #1111

- **Rule:** `js/prototype-polluting-assignment` (severity: warning)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/1111
- **File:** `backend/plugins/frontline_api/src/modules/integrations/call/webSocket.ts:329`
- **CodeQL message:** \"This assignment may alter Object.prototype if a malicious '__proto__' string is injected from user controlled input.\"

## Reproduction (before fix)

**Taint source (per CodeQL):** PBX WebSocket message data at line 492 (`this.ws.on('message', ...)`); the JSON-parsed event payload is threaded through to QueueStateManager handlers.

**Flow:**
1. Event payload's `extension` field is extracted and passed to handlers like `removeCall`.
2. Those handlers acquire `queue` via `this.queueStates[extension]`. `queueStates` was a plain object literal `{}` (line 75) — so `this.queueStates["__proto__"]` resolves through JS prototype lookup to **`Object.prototype` itself**.
3. Lines 328-329 then assign `queue.waiting = …filter…` and `queue.talking = …filter…` — i.e., `Object.prototype.waiting = […]` and `Object.prototype.talking = […]`.

**Concrete payload:** A PBX event (or attacker controlling the upstream PBX WebSocket) sends:
```json
{"type":"event","message":{"eventname":"Newchannel","extension":"__proto__","callerid":"1","action":"delete"}}
```
After processing, `({}).waiting` and `({}).talking` are populated **on every plain object in the process** — breaking Mongoose schema scans, Express middleware iteration of `req.body`/`req.query`, `JSON.stringify` round-trips, and similar framework assumptions. A second payload with `extension: "constructor"` lets the attacker mutate the `Object` constructor itself.

## Fix

Switch the `queueStates` backing store to a null-prototype map via `Object.create(null)`. `resetState()` is updated identically.

```ts
private queueStates: Record<string, QueueState> = Object.create(null);
// …
resetState(): void {
  this.queueStates = Object.create(null);
}
```

With a null prototype, `queueStates["__proto__"]` and `queueStates["constructor"]` no longer resolve via prototype lookup — they're plain own-key strings on a container with no parent. The downstream `queue.waiting = …` / `queue.talking = …` assignments can't reach `Object.prototype`. The `Record<string, QueueState>` API surface is unchanged for ordinary keys.

`getAllQueues()` (line 340) still returns `{ ...this.queueStates }` — spread copies own enumerable properties only, so consumers continue to receive a regular plain object.

## Verification (after fix)

- Same malicious payload: `this.queueStates["__proto__"]` returns `undefined`; the `initializeQueue` helper would only create an own key on the null-prototype container if reached — never on Object.prototype.
- Process-wide regression assertion `({}).waiting === undefined` holds after any number of `extension:"__proto__"` events.
- `pnpm nx affected --target=build --uncommitted` passes locally (`frontline_api` build succeeds).

## Summary by Sourcery

Bug Fixes:
- Fix prototype pollution risk when handling PBX WebSocket events by replacing the plain object queue state store with an Object.create(null)-backed map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend stability by preventing certain malformed event payloads from causing unexpected behavior in the communication system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7665)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->