### PR TITLE
loyalty-score-settings-dialog

### DIFF
--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/AddLoyaltyScore.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/AddLoyaltyScore.tsx
@@ -29,6 +29,12 @@ export function AddLoyaltyScoreForm({
         excludeProductIds: [],
         excludeTagIds: [],
       },
+      additionalConfig: {
+        discountCheck: false,
+        cardBasedRule: [
+          { boardId: '', pipelineId: '', stageIds: [], refundStageIds: [] },
+        ],
+      },
       add: { placeholder: '', currencyRatio: '' },
       subtract: { placeholder: '', currencyRatio: '' },
       ownerType: '',
@@ -39,6 +45,15 @@ export function AddLoyaltyScoreForm({
   });
 
   async function onSubmit(data: LoyaltyScoreFormValues) {
+    const cardBasedRule = (data.additionalConfig?.cardBasedRule || [])
+      .filter((rule) => rule.boardId && rule.pipelineId)
+      .map((rule) => ({
+        boardId: rule.boardId,
+        pipelineId: rule.pipelineId,
+        stageIds: rule.stageIds || [],
+        refundStageIds: rule.refundStageIds || [],
+      }));
+
     const variables: AddScoreVariables = {
       title: data.title,
       description: data.description || '',
@@ -51,6 +66,10 @@ export function AddLoyaltyScoreForm({
           data.conditions.excludeProductCategoryIds?.join(','),
         excludeProductIds: data.conditions.excludeProductIds?.join(','),
         excludeTagIds: data.conditions.excludeTagIds?.join(','),
+      },
+      additionalConfig: {
+        discountCheck: data.additionalConfig?.discountCheck ?? false,
+        cardBasedRule,
       },
       add: data.add,
       subtract: data.subtract,

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddMoreFields.tsx
@@ -9,12 +9,14 @@ import {
   Combobox,
   Switch,
 } from 'erxes-ui';
+import { IconSettings } from '@tabler/icons-react';
 import { LoyaltyScoreFormValues } from '../../constants/formSchema';
 import { SelectFieldGroup } from './selects/SelectFieldGroup';
 import { SelectField } from './selects/SelectField';
 import { useQuery } from '@apollo/client';
 import { useState } from 'react';
 import { SCORE_CAMPAIGN_ATTRIBUTES_QUERY } from '../../graphql/queries/scoreCampaignAttributesQuery';
+import { ServiceConfigSheet } from './ServiceConfigSheet';
 
 const AttributionSelect = ({
   serviceName,
@@ -163,6 +165,7 @@ export const LoyaltyScoreAddMoreFields = ({
   const selectedService = form.watch('conditions.serviceName');
   const selectedOwnerType = form.watch('ownerType');
   const selectedFieldGroupId = form.watch('fieldGroupId');
+  const [serviceConfigOpen, setServiceConfigOpen] = useState(false);
 
   return (
     <div className="flex flex-col gap-4 mt-4">
@@ -176,8 +179,29 @@ export const LoyaltyScoreAddMoreFields = ({
               shouldValidate: true,
             })
           }
+          className="justify-between"
         >
-          Sales pipeline
+          <span>Sales pipeline</span>
+          {selectedService === 'sales' && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                setServiceConfigOpen(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.stopPropagation();
+                  setServiceConfigOpen(true);
+                }
+              }}
+              className="inline-flex items-center justify-center rounded-md p-1 hover:bg-white/10"
+              aria-label="Service configurations"
+            >
+              <IconSettings className="size-4" />
+            </span>
+          )}
         </Button>
 
         <Button
@@ -193,6 +217,12 @@ export const LoyaltyScoreAddMoreFields = ({
           POS order
         </Button>
       </div>
+
+      <ServiceConfigSheet
+        form={form}
+        open={serviceConfigOpen}
+        onOpenChange={setServiceConfigOpen}
+      />
 
       {selectedService && (
         <Tabs defaultValue="add" className="w-full">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/ServiceConfigSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/ServiceConfigSheet.tsx
@@ -1,0 +1,225 @@
+import { IconPlus, IconTrash, IconX } from '@tabler/icons-react';
+import { Button, Checkbox, Dialog, Form, ScrollArea } from 'erxes-ui';
+import { UseFormReturn, useFieldArray } from 'react-hook-form';
+import { SelectBoard, SelectPipeline, SelectStage } from 'ui-modules';
+import { LoyaltyScoreFormValues } from '../../constants/formSchema';
+
+const CardBasedRuleRow = ({
+  form,
+  index,
+  onRemove,
+}: {
+  form: UseFormReturn<LoyaltyScoreFormValues>;
+  index: number;
+  onRemove: () => void;
+}) => {
+  const boardId = form.watch(`additionalConfig.cardBasedRule.${index}.boardId`);
+  const pipelineId = form.watch(
+    `additionalConfig.cardBasedRule.${index}.pipelineId`,
+  );
+
+  return (
+    <div className="flex items-end gap-3">
+      <div className="grid grid-cols-4 gap-3 flex-1">
+        <Form.Field
+          control={form.control}
+          name={`additionalConfig.cardBasedRule.${index}.boardId`}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Board</Form.Label>
+              <SelectBoard.FormItem
+                mode="single"
+                value={field.value || ''}
+                onValueChange={(value) => {
+                  field.onChange(Array.isArray(value) ? value[0] : value);
+                  form.setValue(
+                    `additionalConfig.cardBasedRule.${index}.pipelineId`,
+                    '',
+                  );
+                  form.setValue(
+                    `additionalConfig.cardBasedRule.${index}.stageIds`,
+                    [],
+                  );
+                  form.setValue(
+                    `additionalConfig.cardBasedRule.${index}.refundStageIds`,
+                    [],
+                  );
+                }}
+                placeholder="Select..."
+              />
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name={`additionalConfig.cardBasedRule.${index}.pipelineId`}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Pipeline</Form.Label>
+              <SelectPipeline.FormItem
+                mode="single"
+                value={field.value || ''}
+                boardId={boardId}
+                onValueChange={(value) => {
+                  field.onChange(Array.isArray(value) ? value[0] : value);
+                  form.setValue(
+                    `additionalConfig.cardBasedRule.${index}.stageIds`,
+                    [],
+                  );
+                  form.setValue(
+                    `additionalConfig.cardBasedRule.${index}.refundStageIds`,
+                    [],
+                  );
+                }}
+                placeholder="Select..."
+              />
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name={`additionalConfig.cardBasedRule.${index}.stageIds`}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Stages</Form.Label>
+              <SelectStage.FormItem
+                mode="multiple"
+                value={field.value || []}
+                pipelineId={pipelineId}
+                onValueChange={(value) =>
+                  field.onChange(Array.isArray(value) ? value : [value])
+                }
+                placeholder="Select..."
+              />
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name={`additionalConfig.cardBasedRule.${index}.refundStageIds`}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Refund Stages</Form.Label>
+              <SelectStage.FormItem
+                mode="multiple"
+                value={field.value || []}
+                pipelineId={pipelineId}
+                onValueChange={(value) =>
+                  field.onChange(Array.isArray(value) ? value : [value])
+                }
+                placeholder="Select..."
+              />
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      </div>
+
+      <Button
+        type="button"
+        variant="destructive"
+        size="icon"
+        onClick={onRemove}
+        className="mb-1"
+      >
+        <IconTrash className="size-4" />
+      </Button>
+    </div>
+  );
+};
+
+export const ServiceConfigSheet = ({
+  form,
+  open,
+  onOpenChange,
+}: {
+  form: UseFormReturn<LoyaltyScoreFormValues>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'additionalConfig.cardBasedRule',
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} modal>
+      <Dialog.Content className="max-w-5xl h-[70vh] p-0 gap-0 flex flex-col">
+        <Dialog.Header className="border-b py-4 px-8 flex flex-row items-center justify-between shrink-0">
+          <Dialog.Title>Service Configurations</Dialog.Title>
+          <Dialog.Close asChild>
+            <Button type="button" variant="ghost" size="icon">
+              <IconX className="size-4" />
+            </Button>
+          </Dialog.Close>
+        </Dialog.Header>
+
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="p-5 flex flex-col gap-6">
+            <div>
+              <h3 className="text-base font-semibold text-primary mb-3">
+                Product based rule
+              </h3>
+              <Form.Field
+                control={form.control}
+                name="additionalConfig.discountCheck"
+                render={({ field }) => (
+                  <Form.Item className="flex flex-row items-center gap-3">
+                    <Form.Label className="mb-0 uppercase text-xs tracking-wide">
+                      Discount Check (optional)
+                    </Form.Label>
+                    <Form.Control>
+                      <Checkbox
+                        checked={field.value ?? false}
+                        onCheckedChange={field.onChange}
+                      />
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold text-primary mb-3">
+                Deal based rule
+              </h3>
+              <div className="flex flex-col gap-4">
+                {fields.map((fieldItem, index) => (
+                  <CardBasedRuleRow
+                    key={fieldItem.id}
+                    form={form}
+                    index={index}
+                    onRemove={() => remove(index)}
+                  />
+                ))}
+
+                <Button
+                  type="button"
+                  variant="link"
+                  className="self-start text-primary p-0 h-auto"
+                  onClick={() =>
+                    append({
+                      boardId: '',
+                      pipelineId: '',
+                      stageIds: [],
+                      refundStageIds: [],
+                    })
+                  }
+                >
+                  <IconPlus className="size-4" />
+                  Add
+                </Button>
+              </div>
+            </div>
+          </div>
+        </ScrollArea>
+      </Dialog.Content>
+    </Dialog>
+  );
+};

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/hooks/useAddLoyaltyScore.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/hooks/useAddLoyaltyScore.tsx
@@ -8,6 +8,13 @@ export interface AddScoreResult {
   scoreCampaignAdd: any;
 }
 
+export interface CardBasedRuleVariable {
+  boardId?: string;
+  pipelineId?: string;
+  stageIds?: string[];
+  refundStageIds?: string[];
+}
+
 export interface AddScoreVariables {
   title: string;
   description?: string;
@@ -19,6 +26,10 @@ export interface AddScoreVariables {
     excludeProductIds?: string;
     tagIds?: string;
     excludeTagIds?: string;
+  };
+  additionalConfig?: {
+    discountCheck?: boolean;
+    cardBasedRule?: CardBasedRuleVariable[];
   };
   add?: { placeholder?: string; currencyRatio?: string };
   subtract?: { placeholder?: string; currencyRatio?: string };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/constants/formSchema.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/constants/formSchema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+export const cardBasedRuleSchema = z.object({
+  boardId: z.string().optional(),
+  pipelineId: z.string().optional(),
+  stageIds: z.array(z.string()).optional(),
+  refundStageIds: z.array(z.string()).optional(),
+});
+
 export const loyaltyScoreFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
@@ -12,6 +19,12 @@ export const loyaltyScoreFormSchema = z.object({
     excludeTagIds: z.array(z.string()).optional(),
     serviceName: z.string().min(1, 'Service is required'),
   }),
+  additionalConfig: z
+    .object({
+      discountCheck: z.boolean().optional(),
+      cardBasedRule: z.array(cardBasedRuleSchema).optional(),
+    })
+    .optional(),
   add: z
     .object({
       placeholder: z.string().optional(),
@@ -33,3 +46,4 @@ export const loyaltyScoreFormSchema = z.object({
 });
 
 export type LoyaltyScoreFormValues = z.infer<typeof loyaltyScoreFormSchema>;
+export type CardBasedRule = z.infer<typeof cardBasedRuleSchema>;

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/EditScoreForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/EditScoreForm.tsx
@@ -52,6 +52,15 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
         excludeTagIds: (data.conditions.excludeTagIds || []).join(','),
       };
 
+      const cardBasedRule = (data.additionalConfig?.cardBasedRule || [])
+        .filter((rule) => rule.boardId && rule.pipelineId)
+        .map((rule) => ({
+          boardId: rule.boardId,
+          pipelineId: rule.pipelineId,
+          stageIds: rule.stageIds || [],
+          refundStageIds: rule.refundStageIds || [],
+        }));
+
       updateScore({
         variables: {
           _id: scoreDetail._id,
@@ -59,6 +68,10 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
           description: data.description || '',
           serviceName: data.conditions.serviceName,
           restrictions,
+          additionalConfig: {
+            discountCheck: data.additionalConfig?.discountCheck ?? false,
+            cardBasedRule,
+          },
           add: data.add,
           subtract: data.subtract,
           ownerType: data.ownerType,

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/LoyaltyScoreEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/LoyaltyScoreEditSheet.tsx
@@ -43,6 +43,12 @@ export const LoyaltyScoreEditSheet = () => {
         excludeProductIds: [],
         excludeTagIds: [],
       },
+      additionalConfig: {
+        discountCheck: false,
+        cardBasedRule: [
+          { boardId: '', pipelineId: '', stageIds: [], refundStageIds: [] },
+        ],
+      },
       add: { placeholder: '', currencyRatio: '' },
       subtract: { placeholder: '', currencyRatio: '' },
       ownerType: '',
@@ -54,6 +60,17 @@ export const LoyaltyScoreEditSheet = () => {
   useEffect(() => {
     if (scoreDetail && scoreDetail._id === editScoreId) {
       const restrictions = scoreDetail.restrictions || {};
+      const additionalConfig = scoreDetail.additionalConfig || {};
+      const existingRules = Array.isArray(additionalConfig.cardBasedRule)
+        ? additionalConfig.cardBasedRule.map((rule: any) => ({
+            boardId: rule.boardId || '',
+            pipelineId: rule.pipelineId || '',
+            stageIds: Array.isArray(rule.stageIds) ? rule.stageIds : [],
+            refundStageIds: Array.isArray(rule.refundStageIds)
+              ? rule.refundStageIds
+              : [],
+          }))
+        : [];
 
       form.reset({
         title: scoreDetail.title || '',
@@ -68,6 +85,20 @@ export const LoyaltyScoreEditSheet = () => {
           ),
           excludeProductIds: parseIds(restrictions.excludeProductIds),
           excludeTagIds: parseIds(restrictions.excludeTagIds),
+        },
+        additionalConfig: {
+          discountCheck: additionalConfig.discountCheck ?? false,
+          cardBasedRule:
+            existingRules.length > 0
+              ? existingRules
+              : [
+                  {
+                    boardId: '',
+                    pipelineId: '',
+                    stageIds: [],
+                    refundStageIds: [],
+                  },
+                ],
         },
         add: {
           placeholder: scoreDetail.add?.placeholder || '',


### PR DESCRIPTION
## Summary by Sourcery

Add configurable service-level rules for loyalty score campaigns, including discount checks and card-based deal rules, and surface them via a new settings dialog in the score forms.

New Features:
- Introduce additionalConfig in loyalty score forms to support discount checks and card-based rules tied to boards, pipelines, and stages.
- Add a Service Configurations dialog accessible from the sales service button to manage deal-based card rules and product discount checks for loyalty scores.

Enhancements:
- Ensure add and edit loyalty score flows normalize and persist card-based rule configurations consistently in GraphQL variables and form defaults.
- Extend the loyalty score form schema and types with validation for card-based rules and additional configuration payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added card-based rule configuration for loyalty score campaigns, enabling selection of boards, pipelines, and associated stages for rule setup
  * Added settings controls for managing Sales pipeline service configurations
  * Enhanced loyalty score configuration to support refund stage mapping and discount options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7671)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->