### PR TITLE
fix(pos): show service charge amount in daily report

### DIFF
--- a/pos/app/(main)/report/components/reciept.tsx
+++ b/pos/app/(main)/report/components/reciept.tsx
@@ -4,7 +4,7 @@ import {
   reportEndDateAtom,
   reportStartDateAtom,
 } from "@/store"
-import { paymentTypesAtom } from "@/store/config.store"
+import { configAtom, paymentTypesAtom } from "@/store/config.store"
 import { format } from "date-fns"
 import { useAtomValue } from "jotai"
 
@@ -37,9 +37,14 @@ const Flex = ({
 )
 
 type ReportProduct = {
+  _id?: string | null
+  id?: string | null
+  productId?: string | null
   name?: string | null
   code?: string | null
   count?: number
+  unitPrice?: number
+  totalAmount?: number
 }
 
 const normalizeText = (value?: string | null) => value?.trim() || ""
@@ -77,7 +82,16 @@ const getProductLabel = ({ name, code }: ReportProduct) => {
   return `${normalizedName} / ${size}`
 }
 
+const getServiceChargeAmount = (totalAmount = 0, serviceCharge = 0) => {
+  if (!totalAmount || !serviceCharge) {
+    return 0
+  }
+
+  return Math.round(totalAmount * (serviceCharge / (100 + serviceCharge)))
+}
+
 const Receipt = ({ date, report }: any) => {
+  const config = useAtomValue(configAtom)
   const paymentTypes = useAtomValue(paymentTypesAtom)
   const reportStartDate = useAtomValue(reportStartDateAtom)
   const reportEndDate = useAtomValue(reportEndDateAtom)
@@ -189,21 +203,52 @@ const Receipt = ({ date, report }: any) => {
     )
   }
 
-  const renderProduct = (product: ReportProduct) => {
+  const getProductTotal = (product: ReportProduct) =>
+    product.totalAmount || (product.unitPrice || 0) * (product.count || 0)
+
+  const isServiceChargeProduct = (product: ReportProduct) => {
+    const serviceProductId = config?.serviceChargeApplicableProductId
+    const productIds = [product.productId, product._id, product.id].filter(
+      Boolean
+    )
+
+    if (serviceProductId && productIds.includes(serviceProductId)) {
+      return true
+    }
+
+    return normalizeText(product.name).toLowerCase().includes("service charge")
+  }
+
+  const renderProduct = (product: ReportProduct, ordersAmounts?: any) => {
+    const isServiceCharge = isServiceChargeProduct(product)
+    const serviceChargeAmount = getServiceChargeAmount(
+      ordersAmounts?.totalAmount,
+      config?.serviceCharge
+    )
+
     return (
-      <Flex
-        className="pl-2 report-print__product"
+      <div
+        className="report-print__product"
         key={product.code || product.name}
       >
-        {`${getProductLabel(product)}: `}{" "}
-        <span className="report-print__value tabular-nums">
-          {formatNum(product.count)}
-        </span>
-      </Flex>
+        <div className="report-print__product-name">
+          {getProductLabel(product)}
+        </div>
+        <div className="report-print__product-amount tabular-nums">
+          {isServiceCharge ? (
+            formatNum(serviceChargeAmount || getProductTotal(product))
+          ) : (
+            <>
+              {formatNum(product.unitPrice)} * {formatNum(product.count)} ={" "}
+              {formatNum(getProductTotal(product))}
+            </>
+          )}
+        </div>
+      </div>
     )
   }
 
-  const renderCategory = (category: any) => {
+  const renderCategory = (category: any, ordersAmounts?: any) => {
     return (
       <>
         <div key={Math.random()} className="report-print__category">
@@ -211,9 +256,13 @@ const Receipt = ({ date, report }: any) => {
             {`Барааны бүлэг: `} {category.name}
           </b>
         </div>
+        <div className="report-print__product-header">
+          <span>Барааны нэр</span>
+          <span>Үнэ * Тоо = Дүн</span>
+        </div>
 
         {Object.keys(category.products).map((p) =>
-          renderProduct(category.products[p])
+          renderProduct(category.products[p], ordersAmounts)
         )}
       </>
     )
@@ -227,7 +276,9 @@ const Receipt = ({ date, report }: any) => {
           <span>{item.user.email}</span>
         </b>
         {renderAmounts(item.ordersAmounts)}
-        {Object.keys(item.items).map((i) => renderCategory(item.items[i]))}
+        {Object.keys(item.items).map((i) =>
+          renderCategory(item.items[i], item.ordersAmounts)
+        )}
       </div>
     )
   }
@@ -236,37 +287,39 @@ const Receipt = ({ date, report }: any) => {
 
   return (
     <PrintLayout>
-      <div className="flex min-h-[calc(100vh-1rem)] flex-col print:block print:min-h-0">
-        <div className="report-print">
-          <header className="block pb-2 border-b border-black/15">
-            <div className="report-print__title">Өдрийн тайлан</div>
-            <p className="report-print__meta">
-              Хамаарах:{" "}
-              <b className="font-semibold">
-                {format(reportStartDate || new Date(), "yyyy.MM.dd HH:mm")} -{" "}
-                {format(reportEndDate || new Date(), "yyyy.MM.dd HH:mm")}
-              </b>
-            </p>
-            <p className="report-print__meta">
-              Хэвлэсэн:{" "}
-              <b className="font-semibold">
-                {format(new Date(), "yyyy.MM.dd HH:mm")}
-              </b>
-            </p>
-          </header>
-          {Object.keys(report || {}).map((userId) =>
-            renderUser(report[userId])
-          )}
-          <footer className="space-y-1 report-print__signature">
-            <label className="font-semibold">Гарын үсэг:</label>
-            <span> _____________________</span>
-          </footer>
+      <div className="report-preview">
+        <div className="report-preview__paper">
+          <div className="report-print">
+            <header className="block pb-2 border-b border-black/15">
+              <div className="report-print__title">Өдрийн тайлан</div>
+              <p className="report-print__meta">
+                Хамаарах:{" "}
+                <b className="font-semibold">
+                  {format(reportStartDate || new Date(), "yyyy.MM.dd HH:mm")} -{" "}
+                  {format(reportEndDate || new Date(), "yyyy.MM.dd HH:mm")}
+                </b>
+              </p>
+              <p className="report-print__meta">
+                Хэвлэсэн:{" "}
+                <b className="font-semibold">
+                  {format(new Date(), "yyyy.MM.dd HH:mm")}
+                </b>
+              </p>
+            </header>
+            {Object.keys(report || {}).map((userId) =>
+              renderUser(report[userId])
+            )}
+            <footer className="space-y-1 report-print__signature">
+              <label className="font-semibold">Гарын үсэг:</label>
+              <span> _____________________</span>
+            </footer>
+          </div>
         </div>
 
-        <div className="sticky bottom-4 z-10 mt-auto px-4 pb-4 print:hidden">
+        <div className="report-preview__actions print:hidden">
           <Button
             onClick={handlePrint}
-            className="h-9 w-full px-3 text-xs shadow-md"
+            className="h-9 w-full px-3 text-xs shadow-sm"
             size="sm"
           >
             Хэвлэх

--- a/pos/app/reciept/layout.tsx
+++ b/pos/app/reciept/layout.tsx
@@ -14,7 +14,7 @@ const PrintLayout = ({ children }: { children: React.ReactNode }) => {
       <ThermalPaperWidthApplier />
       <div
         className={cn(
-          "m-2 w-[var(--thermal-preview-paper-width)] relative overflow-y-auto min-h-screen space-y-1 border-b p-2 pb-16 text-[12px] font-normal leading-[1.45] text-black shadow-lg print:m-0 print:h-auto print:min-h-0 print:w-full print:max-w-none print:overflow-visible print:p-0 print:shadow-none print:[-webkit-print-color-adjust:exact] print:[print-color-adjust:exact]",
+          "relative m-2 w-[var(--thermal-preview-paper-width)] overflow-y-auto rounded-lg border bg-card p-2 text-[12px] font-normal leading-[1.45] text-card-foreground shadow-sm print:m-0 print:h-auto print:min-h-0 print:w-full print:max-w-none print:overflow-visible print:rounded-none print:border-0 print:bg-white print:p-0 print:text-black print:shadow-none print:[-webkit-print-color-adjust:exact] print:[print-color-adjust:exact]",
           mode === "mobile" && "w-auto print:w-full"
         )}
       >

--- a/pos/styles/globals.css
+++ b/pos/styles/globals.css
@@ -157,6 +157,41 @@
 
 .report-print__product {
   padding-left: 2mm;
+  line-height: 1.25;
+  padding-top: 0.8mm;
+  padding-bottom: 0.8mm;
+}
+
+.report-print__product-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  column-gap: 2mm;
+  margin-top: 1mm;
+  padding: 0.6mm 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.25);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.report-print__product-header > span:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.report-print__product-header > span:last-child {
+  text-align: right;
+}
+
+.report-print__product-name {
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.report-print__product-amount {
+  text-align: right;
+  font-style: italic;
+  overflow-wrap: anywhere;
 }
 
 .report-print__row > :first-child {
@@ -176,6 +211,26 @@
   margin-top: 4mm;
   padding-top: 2.5mm;
   border-top: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.report-preview {
+  display: flex;
+  min-height: calc(100vh - 1rem);
+  flex-direction: column;
+}
+
+.report-preview__paper {
+  overflow: hidden;
+  border-radius: calc(var(--radius) - 2px);
+  background: #fff;
+}
+
+.report-preview__actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
+  margin-top: auto;
+  padding-top: 1rem;
 }
 
 @media print {
@@ -212,6 +267,17 @@
     margin: 0 !important;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
+  }
+
+  .report-preview {
+    display: block;
+    min-height: 0;
+  }
+
+  .report-preview__paper {
+    overflow: visible;
+    border-radius: 0;
+    background: transparent;
   }
 }
 
@@ -257,6 +323,14 @@
 
   .report-print__product {
     padding-left: 7px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+
+  .report-print__product-header {
+    column-gap: 8px;
+    margin-top: 4px;
+    padding: 3px 0;
   }
 
   .report-print__value {


### PR DESCRIPTION
## Summary by Sourcery

Display per-product pricing details and correctly compute service charge amounts in the daily POS report while updating the layout and styling of the printable receipt preview.

New Features:
- Show unit price, quantity, and computed total for each product line in the daily report receipt.
- Calculate and display service charge amounts for designated service charge products based on configured service charge settings.
- Introduce a structured report preview container with dedicated paper and action areas for the daily report print view.

Enhancements:
- Improve receipt print styling, including product headers, typography, and layout for better readability on screen and on printed thermal paper.