### PR TITLE
feat(loyalty_api): add stage-change score trigger for loyalty

### DIFF
--- a/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
+++ b/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
@@ -119,6 +119,9 @@ const doScoreCampaignInput = z.object({
   ownerId: z.string(),
   actionMethod: z.string(),
   targetId: z.string(),
+  campaignId: z.string(),               
+  target: z.record(z.any()),           
+  serviceName: z.string().optional(),
 });
 
 const refundLoyaltyScoreInput = z.object({

--- a/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
+++ b/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
@@ -357,6 +357,33 @@ export const appRouter = t.router({
         return { data, status: 'success' };
       }),
 
+    getScoreCampaignsByStage: t.procedure
+  .input(
+    z.object({
+      boardId: z.string(),
+      pipelineId: z.string(),
+      stageId: z.string(),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const { models } = ctx;
+    console.log("🔍 getScoreCampaignsByStage called with:", input);
+    
+    const campaigns = await models.ScoreCampaigns.find({
+      status: 'published',
+      'additionalConfig.cardBasedRule': {
+        $elemMatch: {
+          boardId: input.boardId,
+          pipelineId: input.pipelineId,
+          stageIds: input.stageId
+        }
+      },
+    }).lean();
+    
+    console.log(`📊 Found ${campaigns.length} campaigns`);
+    return campaigns;
+  }),
+
     refundLoyaltyScore: t.procedure
       .input(refundLoyaltyScoreInput)
       .mutation(async ({ ctx, input }) => {

--- a/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
+++ b/backend/plugins/loyalty_api/src/trpc/init-trpc.ts
@@ -361,31 +361,27 @@ export const appRouter = t.router({
       }),
 
     getScoreCampaignsByStage: t.procedure
-  .input(
-    z.object({
-      boardId: z.string(),
-      pipelineId: z.string(),
-      stageId: z.string(),
-    }),
-  )
-  .query(async ({ ctx, input }) => {
-    const { models } = ctx;
-    console.log("🔍 getScoreCampaignsByStage called with:", input);
-    
-    const campaigns = await models.ScoreCampaigns.find({
-      status: 'published',
-      'additionalConfig.cardBasedRule': {
-        $elemMatch: {
-          boardId: input.boardId,
-          pipelineId: input.pipelineId,
-          stageIds: input.stageId
-        }
-      },
-    }).lean();
-    
-    console.log(`📊 Found ${campaigns.length} campaigns`);
-    return campaigns;
-  }),
+      .input(
+        z.object({
+          boardId: z.string(),
+          pipelineId: z.string(),
+          stageId: z.string(),
+        }),
+      )
+      .query(async ({ ctx, input }) => {
+        const { models } = ctx;
+        const campaigns = await models.ScoreCampaigns.find({
+          status: 'published',
+          'additionalConfig.cardBasedRule': {
+            $elemMatch: {
+              boardId: input.boardId,
+              pipelineId: input.pipelineId,
+              stageIds: input.stageId,
+            },
+          },
+        }).lean();
+        return { data: campaigns, status: 'success' };
+      }),
 
     refundLoyaltyScore: t.procedure
       .input(refundLoyaltyScoreInput)

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -18,6 +18,7 @@ import {
 import { addDeal, editDeal } from './utils';
 import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { Resolver } from 'erxes-api-shared/core-types';
+import { processStageChangeScoreCampaigns } from './utils';
 
 export const dealMutations: Record<string, Resolver> = {
   /**
@@ -93,7 +94,15 @@ export const dealMutations: Record<string, Resolver> = {
 
     // Do not call mongolian plugin directly from sales.
     // Instead, emit an event (via logs) that will be handled by afterProcess.
-
+    if (item.stageId !== destinationStageId) {
+    await processStageChangeScoreCampaigns({
+      subdomain,
+      models,
+      deal: updatedItem,
+      newStageId: destinationStageId,
+      user
+    });
+  }
     await itemMover(models, user._id, item, destinationStageId);
 
     await subscriptionWrapper(models, {

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -95,14 +95,14 @@ export const dealMutations: Record<string, Resolver> = {
     // Do not call mongolian plugin directly from sales.
     // Instead, emit an event (via logs) that will be handled by afterProcess.
     if (item.stageId !== destinationStageId) {
-    await processStageChangeScoreCampaigns({
-      subdomain,
-      models,
-      deal: updatedItem,
-      newStageId: destinationStageId,
-      user
-    });
-  }
+      await processStageChangeScoreCampaigns({
+        subdomain,
+        models,
+        deal: updatedItem,
+        newStageId: destinationStageId,
+        user,
+      });
+    }
     await itemMover(models, user._id, item, destinationStageId);
 
     await subscriptionWrapper(models, {

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -15,10 +15,9 @@ import {
   itemMover,
   subscriptionWrapper,
 } from '../utils';
-import { addDeal, editDeal } from './utils';
+import { addDeal, editDeal, processStageChangeScoreCampaigns } from './utils';
 import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { Resolver } from 'erxes-api-shared/core-types';
-import { processStageChangeScoreCampaigns } from './utils';
 
 export const dealMutations: Record<string, Resolver> = {
   /**

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -2,11 +2,13 @@ import { canGroup } from 'erxes-api-shared/core-modules';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import { checkUserIds, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
-import { IDeal } from '~/modules/sales/@types';
+import { IDeal, IDealDocument } from '~/modules/sales/@types';
 import {
   createRelations,
   getNewOrder,
   sendNotifications,
+  getCustomerIds, 
+  getCompanyIds
 } from '~/modules/sales/utils';
 import {
   changeItemStatus,
@@ -15,7 +17,6 @@ import {
   itemMover,
   subscriptionWrapper,
 } from '../utils';
-import { getCustomerIds, getCompanyIds } from '~/modules/sales/utils';
 
 export const addDeal = async ({
   models,
@@ -92,17 +93,15 @@ async function processStageChangeScoreCampaigns({
 }: {
   subdomain: string;
   models: IModels;
-  deal: any;
+  deal: IDealDocument;
   newStageId: string;
   user: IUserDocument;
 }) {
-  console.log("Inside processStageChangeScoreCampaigns", { newStageId });
   try {
     const stage = await models.Stages.getStage(newStageId);
     const pipeline = await models.Pipelines.getPipeline(stage.pipelineId);
-    console.log("Stage found:", stage._id, "Pipeline:", pipeline._id);
-
-    const campaigns = await sendTRPCMessage({
+    
+    const response = await sendTRPCMessage({
       subdomain,
       pluginName: 'loyalty',
       method: 'query',
@@ -115,55 +114,38 @@ async function processStageChangeScoreCampaigns({
       },
       defaultValue: []
     });
-
-    console.log("Found campaigns:", campaigns.length);
+    
+    // response is now { data: campaigns, status: 'success' } or the default []
+    const campaigns = response.data || response; // fallback if not wrapped
     if (!campaigns.length) return;
 
     for (const campaign of campaigns) {
-      console.log("Checking campaign:", campaign._id, "Owner type:", campaign.ownerType);
       const rule = campaign.additionalConfig?.cardBasedRule?.find(
         (r: any) => r.stageIds?.includes(newStageId)
       );
-      console.log("Matched rule:", rule ? "yes" : "no");
       if (!rule) continue;
 
-      // Fetch fresh deal data (for potential other uses)
       const freshDeal = await models.Deals.findById(deal._id).lean();
-      if (!freshDeal) {
-        console.warn(`Deal ${deal._id} not found after update`);
-        continue;
-      }
+      if (!freshDeal) continue;
 
       const actionMethod = rule.actionMethod || 'add';
       const ownerType = campaign.ownerType || 'customer';
       let ownerId: string | undefined;
 
       if (ownerType === 'customer') {
-        // Use the existing helper to get customer IDs
         const customerIds = await getCustomerIds(subdomain, freshDeal._id);
         ownerId = customerIds[0];
-        if (!ownerId) {
-          console.warn(`No customer found for deal ${freshDeal._id}, skipping campaign ${campaign._id}`);
-          continue;
-        }
+        if (!ownerId) continue;
       } else if (ownerType === 'company') {
-        // Use the existing helper to get company IDs
         const companyIds = await getCompanyIds(subdomain, freshDeal._id);
         ownerId = companyIds[0];
-        if (!ownerId) {
-          console.warn(`No company found for deal ${freshDeal._id}, skipping campaign ${campaign._id}`);
-          continue;
-        }
+        if (!ownerId) continue;
       } else if (ownerType === 'user') {
         ownerId = user._id;
       }
 
-      if (!ownerId) {
-        console.warn(`No ${ownerType} found for deal ${deal._id}, skipping campaign ${campaign._id}`);
-        continue;
-      }
+      if (!ownerId) continue;
 
-      console.log("Calling doScoreCampaign for owner:", ownerType, ownerId);
       await sendTRPCMessage({
         subdomain,
         pluginName: 'loyalty',
@@ -182,7 +164,7 @@ async function processStageChangeScoreCampaigns({
       });
     }
   } catch (error) {
-    console.error('Error processing stage-change score campaigns:', error.message);
+    console.error('Error processing stage-change score campaigns:', error instanceof Error ? error.message : error);
   }
 }
 
@@ -343,7 +325,6 @@ export const editDeal = async ({
     return updatedItem;
   }
   
- console.log("processStageChangeScoreCampaigns called", { newStageId: updatedItem.stageId });
  
   await processStageChangeScoreCampaigns({
   subdomain,

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -15,6 +15,7 @@ import {
   itemMover,
   subscriptionWrapper,
 } from '../utils';
+import { getCustomerIds, getCompanyIds } from '~/modules/sales/utils';
 
 export const addDeal = async ({
   models,
@@ -82,6 +83,109 @@ export const addDeal = async ({
   return deal;
 };
 
+async function processStageChangeScoreCampaigns({
+  subdomain,
+  models,
+  deal,
+  newStageId,
+  user
+}: {
+  subdomain: string;
+  models: IModels;
+  deal: any;
+  newStageId: string;
+  user: IUserDocument;
+}) {
+  console.log("Inside processStageChangeScoreCampaigns", { newStageId });
+  try {
+    const stage = await models.Stages.getStage(newStageId);
+    const pipeline = await models.Pipelines.getPipeline(stage.pipelineId);
+    console.log("Stage found:", stage._id, "Pipeline:", pipeline._id);
+
+    const campaigns = await sendTRPCMessage({
+      subdomain,
+      pluginName: 'loyalty',
+      method: 'query',
+      module: 'score',
+      action: 'getScoreCampaignsByStage',
+      input: {
+        boardId: pipeline.boardId,
+        pipelineId: stage.pipelineId,
+        stageId: newStageId
+      },
+      defaultValue: []
+    });
+
+    console.log("Found campaigns:", campaigns.length);
+    if (!campaigns.length) return;
+
+    for (const campaign of campaigns) {
+      console.log("Checking campaign:", campaign._id, "Owner type:", campaign.ownerType);
+      const rule = campaign.additionalConfig?.cardBasedRule?.find(
+        (r: any) => r.stageIds?.includes(newStageId)
+      );
+      console.log("Matched rule:", rule ? "yes" : "no");
+      if (!rule) continue;
+
+      // Fetch fresh deal data (for potential other uses)
+      const freshDeal = await models.Deals.findById(deal._id).lean();
+      if (!freshDeal) {
+        console.warn(`Deal ${deal._id} not found after update`);
+        continue;
+      }
+
+      const actionMethod = rule.actionMethod || 'add';
+      const ownerType = campaign.ownerType || 'customer';
+      let ownerId: string | undefined;
+
+      if (ownerType === 'customer') {
+        // Use the existing helper to get customer IDs
+        const customerIds = await getCustomerIds(subdomain, freshDeal._id);
+        ownerId = customerIds[0];
+        if (!ownerId) {
+          console.warn(`No customer found for deal ${freshDeal._id}, skipping campaign ${campaign._id}`);
+          continue;
+        }
+      } else if (ownerType === 'company') {
+        // Use the existing helper to get company IDs
+        const companyIds = await getCompanyIds(subdomain, freshDeal._id);
+        ownerId = companyIds[0];
+        if (!ownerId) {
+          console.warn(`No company found for deal ${freshDeal._id}, skipping campaign ${campaign._id}`);
+          continue;
+        }
+      } else if (ownerType === 'user') {
+        ownerId = user._id;
+      }
+
+      if (!ownerId) {
+        console.warn(`No ${ownerType} found for deal ${deal._id}, skipping campaign ${campaign._id}`);
+        continue;
+      }
+
+      console.log("Calling doScoreCampaign for owner:", ownerType, ownerId);
+      await sendTRPCMessage({
+        subdomain,
+        pluginName: 'loyalty',
+        method: 'mutation',
+        module: 'score',
+        action: 'doScoreCampaign',
+        input: {
+          ownerType,
+          ownerId,
+          campaignId: campaign._id,
+          target: deal,
+          actionMethod,
+          serviceName: 'sales',
+          targetId: deal._id
+        }
+      });
+    }
+  } catch (error) {
+    console.error('Error processing stage-change score campaigns:', error.message);
+  }
+}
+
 export const editDeal = async ({
   user,
   models,
@@ -132,8 +236,8 @@ export const editDeal = async ({
     // doc.productsData = await checkPricing(subdomain, models, { ...oldDeal, ...doc })
   }
 
-  // await doScoreCampaign(subdomain, models, _id, doc);
-  // await confirmLoyalties(subdomain, _id, doc);
+
+  //await confirmLoyalties(subdomain, _id, doc);
 
   const extendedDoc = {
     ...doc,
@@ -233,14 +337,25 @@ export const editDeal = async ({
     });
   }
 
-  // await doScoreCampaign(subdomain, models, _id, updatedItem);
+  //await doScoreCampaign(subdomain, models, _id, updatedItem);
 
   if (oldDeal.stageId === updatedItem.stageId) {
     return updatedItem;
   }
-
+  
+ console.log("processStageChangeScoreCampaigns called", { newStageId: updatedItem.stageId });
+ 
+  await processStageChangeScoreCampaigns({
+  subdomain,
+  models,
+  deal: updatedItem,
+  newStageId: updatedItem.stageId,
+  user
+});
+ 
   // if task moves between stages
   await itemMover(models, user._id, oldDeal, updatedItem.stageId);
 
   return updatedItem;
 };
+export { processStageChangeScoreCampaigns };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic evaluation and processing of loyalty score campaigns when a deal's stage changes, triggered before cross-stage movement.
  * Scoring API accepts a campaign identifier, a target record, and an optional service name to support targeted scoring calls.
  * New query to retrieve published score campaigns linked to a specific board, pipeline, and stage for targeted campaign discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->