### PR TITLE
fix(erxes-api-shared): wrap subdomain Mongo queries with $eq in saas-mongo-connection (alert #935)

### DIFF
--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -140,9 +140,15 @@ export const updateSaasOrganization = async (
   subdomain: string,
   update: object,
 ) => {
+  if (typeof subdomain !== 'string' || subdomain.length === 0) {
+    throw new Error('subdomain must be a non-empty string');
+  }
   await getSaasCoreConnection();
 
-  return coreModelOrganizations.updateOne({ subdomain }, { $set: update });
+  return coreModelOrganizations.updateOne(
+    { subdomain: { $eq: subdomain } },
+    { $set: update },
+  );
 };
 
 export const getSaasOrganizationDetail = async ({
@@ -150,10 +156,13 @@ export const getSaasOrganizationDetail = async ({
 }: {
   subdomain: string;
 }) => {
+  if (typeof subdomain !== 'string' || subdomain.length === 0) {
+    return {};
+  }
   await getSaasCoreConnection();
 
   const organization = await coreModelOrganizations
-    .findOne({ subdomain })
+    .findOne({ subdomain: { $eq: subdomain } })
     .lean();
 
   if (!organization) {


### PR DESCRIPTION
## Closes alert #935 — rule `js/sql-injection` (error)

| Alert | Location | URL |
|---|---|---|
| #935 | `backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts:156` | [link](https://github.com/erxes/erxes/security/code-scanning/935) |

## Reproduction (before fix)

## Before

### Taint source
`subdomain` is the destructured parameter of `getSaasOrganizationDetail({ subdomain }: { subdomain: string })`. The TypeScript annotation does NOT enforce runtime — Mongoose accepts whatever value reaches it.

Concrete callers (the actual taint sources):
- `backend/core-api/src/modules/organization/routes.ts:36, 84` — Express route handlers; `subdomain` extracted from request body/host
- `backend/core-api/src/utils/saas/index.ts:24` — request-derived
- `backend/core-api/src/modules/organization/team-member/graphql/mutations.ts:318` — GraphQL resolver context, subdomain pulled from request host header
- `backend/core-api/src/modules/auth/utils.ts:48` — auth flow, request-derived
- `backend/erxes-api-shared/src/utils/service-discovery.ts:61` — internal use (lower risk, but shares the same code path)

Every external caller derives `subdomain` from request data (host header / body / cookie). An operator-controlled or attacker-controlled value can reach `coreModelOrganizations.findOne` unchanged.

### Path
```
saas-mongo-connection.ts:148
  export const getSaasOrganizationDetail = async ({ subdomain }: { subdomain: string }) => {
    await getSaasCoreConnection();
    const organization = await coreModelOrganizations
      .findOne({ subdomain })       // <-- SINK (line 156)
      .lean();
    ...
```

### Example payload
HTTP request body / header that resolves to:
```json
{ "subdomain": { "$gt": "" } }
```
Mongoose sees `{ subdomain: { $gt: "" } }` — a valid operator-shape query — and returns the FIRST organization whose subdomain is greater than the empty string (i.e., almost any record). The attacker now reads arbitrary org metadata (bundleId, ownerEmail, charge plan, installation details) without knowing a real subdomain.

A more dangerous variant lands further down the function: the returned `organization._id` is used at line 168 to fetch the related `installation`, and at lines 174-189 to enumerate bundles, addons, and experiences. So a single injected operator query exposes the org's full SaaS billing context.

### Why the sink is unsafe
`findOne({ field: untrusted })` in Mongoose treats `untrusted` as an operator object if it is one. Per CodeQL `js/sql-injection` help: query inputs whose structure is attacker-controlled enable NoSQL injection. The same fix recipe is already in use across this codebase (e.g., PR #7661, #7626, #7646, #7647 — Instagram fixes wrap field values with `{ $eq: value }` plus an early `typeof === 'string'` guard).

## Fix

Same per-site `{ $eq: value }` + type-guard pattern used by recent Instagram NoSQL-injection fixes on this repo (PR #7626, #7646, #7647, #7661):

```diff
 export const updateSaasOrganization = async (
   subdomain: string,
   update: object,
 ) => {
+  if (typeof subdomain !== 'string' || subdomain.length === 0) {
+    throw new Error('subdomain must be a non-empty string');
+  }
   await getSaasCoreConnection();

-  return coreModelOrganizations.updateOne({ subdomain }, { $set: update });
+  return coreModelOrganizations.updateOne(
+    { subdomain: { $eq: subdomain } },
+    { $set: update },
+  );
 };

 export const getSaasOrganizationDetail = async ({ subdomain }: { subdomain: string }) => {
+  if (typeof subdomain !== 'string' || subdomain.length === 0) {
+    return {};
+  }
   await getSaasCoreConnection();

   const organization = await coreModelOrganizations
-    .findOne({ subdomain })
+    .findOne({ subdomain: { $eq: subdomain } })
     .lean();
```

`updateSaasOrganization` on line 145 was **not** flagged by CodeQL but shares the parameter, the trust model, and the anti-pattern — fixed opportunistically so it doesn't become alert #N+1 on the next scan.

## Verification (after fix)

## After

(Filled in after fix — wraps `findOne` and the sibling `updateOne` on line 145 with `{ $eq: subdomain }`, and adds an early `typeof subdomain !== 'string' || subdomain.length === 0` guard. CodeQL recognizes `$eq` as a sanitizer for this rule, so the alert closes on the next scan.)

---

**Verification after fix:**
- Line 156 `findOne` now reads: `coreModelOrganizations.findOne({ subdomain: { $eq: subdomain } })`
- Sibling line 145 `updateOne` similarly wrapped (opportunistic, same parameter, same anti-pattern)
- Both functions early-return / throw if `typeof subdomain !== 'string' || subdomain.length === 0` — matches the type-guard pattern from PR #7661 and the rest of this repo's recent NoSQL-injection fixes.

## Notes

- `pnpm nx build erxes-api-shared` passes (preconstruct rebuilt the dist/).
- `pnpm nx build core-api` passes against the new dist — the primary consumer of these functions.
- `pnpm nx lint erxes-api-shared`: zero new errors/warnings in `saas-mongo-connection.ts` (pre-existing lint findings in unrelated files unchanged).
- Alert will transition to `fixed` after the next CodeQL re-scan of `main` post-merge (typically 30 min to a few hours).
- The PR-to-alert Development-panel link is a manual UI click on this repo — see the boxed instruction printed below.

## Summary by Sourcery

Sanitize SaaS organization MongoDB queries that use the subdomain field to prevent NoSQL injection and ensure safer access to organization details and updates.

Bug Fixes:
- Prevent NoSQL injection in getSaasOrganizationDetail by wrapping the subdomain query in an $eq operator and validating the subdomain input.
- Harden updateSaasOrganization against unsafe subdomain input by enforcing a non-empty string and using an $eq-based query filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of organization subdomain parameters before database operations.
  * Enhanced organization data retrieval to properly handle invalid subdomain inputs.
  * Refined query filtering for more reliable organization lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->