### PR TITLE
fix(frontline): sanitize Facebook webhook Mongoose queries via safeEq helper (alerts #938-948, #950)

### DIFF
--- a/backend/erxes-api-shared/src/utils/index.ts
+++ b/backend/erxes-api-shared/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './random';
 export * from './redis';
 export * from './saas';
 export * from './sanitize';
+export * from './security';
 export * from './service-discovery';
 export * from './start-plugin';
 export * from './trpc';

--- a/backend/erxes-api-shared/src/utils/security/index.ts
+++ b/backend/erxes-api-shared/src/utils/security/index.ts
@@ -1,0 +1,1 @@
+export * from './sanitizeMongoQuery';

--- a/backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.spec.ts
+++ b/backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.spec.ts
@@ -1,0 +1,19 @@
+import { safeEq } from './sanitizeMongoQuery';
+
+describe('safeEq', () => {
+  it('wraps primitive strings as { $eq: value }', () => {
+    expect(safeEq('user-123')).toEqual({ $eq: 'user-123' });
+  });
+
+  it('wraps numbers and booleans', () => {
+    expect(safeEq(42)).toEqual({ $eq: 42 });
+    expect(safeEq(true)).toEqual({ $eq: true });
+  });
+
+  it('neutralises operator-shaped payloads (NoSQL injection class)', () => {
+    const malicious = { $ne: null } as unknown as string;
+    const wrapped = safeEq(malicious);
+    expect(wrapped).toEqual({ $eq: { $ne: null } });
+    expect(Object.keys(wrapped)).toEqual(['$eq']);
+  });
+});

--- a/backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.ts
+++ b/backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.ts
@@ -1,0 +1,14 @@
+type MongoEqExpr<T> = { $eq: T };
+
+/**
+ * Wrap a value for safe use in a Mongoose query field where the value
+ * originates from untrusted input (HTTP body, webhook payload, query params).
+ *
+ * Mongoose treats `{ field: value }` as an equality match when `value` is a
+ * primitive, but if an attacker can supply a query-operator subdocument like
+ * `{ $ne: null }` or `{ $gt: '' }`, the same shape becomes a NoSQL query
+ * predicate. Wrapping as `{ field: { $eq: value } }` forces Mongoose to treat
+ * the entire payload as the literal value to match, neutralizing the
+ * operator-injection class flagged by CodeQL `js/sql-injection`.
+ */
+export const safeEq = <T>(value: T): MongoEqExpr<T> => ({ $eq: value });

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
@@ -15,7 +15,7 @@ import {
   getPostLink,
   uploadMedia,
 } from '@/integrations/facebook/utils';
-import { graphqlPubsub, sendTRPCMessage } from 'erxes-api-shared/utils';
+import { graphqlPubsub, safeEq, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 import { sendAutomationTrigger } from 'erxes-api-shared/core-modules';
 
@@ -32,7 +32,9 @@ export const getOrCreateCustomer = async (
 
   const { facebookPageTokensMap = {} } = integration;
 
-  let customer = await models.FacebookCustomers.findOne({ userId });
+  let customer = await models.FacebookCustomers.findOne({
+    userId: safeEq(userId),
+  });
   if (customer) {
     return customer;
   }
@@ -115,20 +117,20 @@ export const getOrCreateComment = async (
   customer: IFacebookCustomer,
 ) => {
   const mainConversation = await models.FacebookCommentConversation.findOne({
-    comment_id: commentParams.comment_id,
+    comment_id: safeEq(commentParams.comment_id),
   });
   const parentConversation = await models.FacebookCommentConversation.findOne({
-    comment_id: commentParams.parent_id,
+    comment_id: safeEq(commentParams.parent_id),
   });
   const replyConversation =
     await models.FacebookCommentConversationReply.findOne({
-      comment_id: commentParams.comment_id,
+      comment_id: safeEq(commentParams.comment_id),
     });
   if (mainConversation || replyConversation) {
     return;
   }
   const post = await models.FacebookPostConversations.findOne({
-    postId: commentParams.post_id,
+    postId: safeEq(commentParams.post_id),
   });
   let attachment: any[] = [];
   if (commentParams.photo) {
@@ -165,11 +167,11 @@ export const getOrCreateComment = async (
   }
   let conversation;
   conversation = await models.FacebookCommentConversation.findOne({
-    comment_id: commentParams.comment_id,
+    comment_id: safeEq(commentParams.comment_id),
   });
   if (conversation === null) {
     conversation = await models.FacebookCommentConversation.findOne({
-      comment_id: commentParams.parent_id,
+      comment_id: safeEq(commentParams.parent_id),
     });
   }
   try {
@@ -307,7 +309,7 @@ export const getOrCreatePostConversation = async (
 ) => {
   try {
     let postConversation = await models.FacebookPostConversations.findOne({
-      postId,
+      postId: safeEq(postId),
     });
 
     const facebookPost = await fetchFacebookPostDetails(pageId, models, params);
@@ -321,11 +323,11 @@ export const getOrCreatePostConversation = async (
 
       if (hasPostContentChanged) {
         await models.FacebookPostConversations.updateOne(
-          { postId },
+          { postId: safeEq(postId) },
           { $set: { content: facebookPost.content } },
         );
         const updatedPost = await models.FacebookPostConversations.findOne({
-          postId,
+          postId: safeEq(postId),
         });
         return updatedPost;
       } else {
@@ -354,7 +356,7 @@ export const getOrCreatePost = async (
   }
 
   let post = await models.FacebookPostConversations.findOne({
-    postId: postParams.post_id,
+    postId: safeEq(postParams.post_id),
   });
 
   if (post) {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
@@ -6,7 +6,11 @@ import {
 import { generateAttachmentUrl } from '@/integrations/facebook/commonUtils';
 import { debugError, debugFacebook } from '@/integrations/facebook/debuggers';
 import * as AWS from 'aws-sdk';
-import { randomAlphanumeric, sendTRPCMessage } from 'erxes-api-shared/utils';
+import {
+  randomAlphanumeric,
+  safeEq,
+  sendTRPCMessage,
+} from 'erxes-api-shared/utils';
 import * as graph from 'fbgraph';
 import { IModels } from '~/connectionResolvers';
 import { SUBSCRIBED_FIELDS } from './constants';
@@ -388,7 +392,7 @@ export const getFacebookUser = async (
   } catch (e) {
     if (e.message.includes('access token')) {
       await models.FacebookIntegrations.updateOne(
-        { facebookPageIds: pageId },
+        { facebookPageIds: safeEq(pageId) },
         { $set: { healthStatus: 'page-token', error: `${e.message}` } },
       );
     }


### PR DESCRIPTION
## Closes 12 code-scanning alerts — rule `js/sql-injection` (error)

All twelve alerts share the rule `js/sql-injection` (NoSQL operator-injection variant) and live inside the `facebook/` integration module of `frontline_api`. Bundled into one PR per the established project preference for identical-rule + same-module clusters; per-site reproductions and bundle manifest below.

| Alert | Sink |
|---|---|
| [#938](https://github.com/erxes/erxes/security/code-scanning/938) | `facebook/controller/store.ts:35` `FacebookCustomers.findOne({ userId })` |
| [#939](https://github.com/erxes/erxes/security/code-scanning/939) | `facebook/controller/store.ts:117` `FacebookCommentConversation.findOne({ comment_id: commentParams.comment_id })` |
| [#940](https://github.com/erxes/erxes/security/code-scanning/940) | `facebook/controller/store.ts:120` `FacebookCommentConversation.findOne({ comment_id: commentParams.parent_id })` |
| [#941](https://github.com/erxes/erxes/security/code-scanning/941) | `facebook/controller/store.ts:124` `FacebookCommentConversationReply.findOne({ comment_id: commentParams.comment_id })` |
| [#942](https://github.com/erxes/erxes/security/code-scanning/942) | `facebook/controller/store.ts:130` `FacebookPostConversations.findOne({ postId: commentParams.post_id })` |
| [#943](https://github.com/erxes/erxes/security/code-scanning/943) | `facebook/controller/store.ts:167` `FacebookCommentConversation.findOne({ comment_id: commentParams.comment_id })` |
| [#944](https://github.com/erxes/erxes/security/code-scanning/944) | `facebook/controller/store.ts:171` `FacebookCommentConversation.findOne({ comment_id: commentParams.parent_id })` |
| [#945](https://github.com/erxes/erxes/security/code-scanning/945) | `facebook/controller/store.ts:309` `FacebookPostConversations.findOne({ postId })` |
| [#946](https://github.com/erxes/erxes/security/code-scanning/946) | `facebook/controller/store.ts:323` `FacebookPostConversations.updateOne({ postId }, …)` |
| [#947](https://github.com/erxes/erxes/security/code-scanning/947) | `facebook/controller/store.ts:327` `FacebookPostConversations.findOne({ postId })` |
| [#948](https://github.com/erxes/erxes/security/code-scanning/948) | `facebook/controller/store.ts:356` `FacebookPostConversations.findOne({ postId: postParams.post_id })` |
| [#950](https://github.com/erxes/erxes/security/code-scanning/950) | `facebook/utils.ts:391` `FacebookIntegrations.updateOne({ facebookPageIds: pageId }, …)` |

## Reproduction (one taint chain feeds every sink)

Facebook webhooks POST to the `frontline` plugin's webhook endpoint. The controller spreads `event.value` directly and forwards `entry.id` (pageId), `event.value.from.id` (userId), and `event.value.{comment_id,parent_id,post_id}` to `receiveComment` / `getOrCreateCustomer` / `getOrCreateComment` / `getOrCreatePost` / `getOrCreatePostConversation` / `fetchFacebookPostDetails`. TypeScript types those parameters as `string`, but the runtime accepts any JSON shape — nothing validates that incoming values are primitives.

**Attacker payload** (one shape exercises every sink in the chain):

```json
{
  "entry": [
    {
      "id": { "$ne": null },
      "changes": [
        {
          "field": "feed",
          "value": {
            "from": { "id": { "$ne": null } },
            "comment_id": { "$ne": null },
            "parent_id": { "$ne": null },
            "post_id": { "$ne": null }
          }
        }
      ]
    }
  ]
}
```

Each `findOne({ field: untrustedValue })` then becomes `findOne({ field: { $ne: null } })`, which matches the first arbitrary `FacebookCustomers` / `FacebookCommentConversation` / `FacebookPostConversations` / `FacebookIntegrations` row regardless of which integration or tenant it belongs to. The early-return `if (customer) return customer` hand-off then exposes someone else's customer document, mis-routes the conversation, or, in the `updateOne` sites (#946, #950), writes the wrong record.

## Fix

Introduces `safeEq()` in `backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.ts` and refactors all 12 flagged sites to use it. `safeEq(value)` wraps the value as `{ $eq: value }`, forcing Mongoose to treat the entire payload as the literal value to match. An attacker-supplied operator subdocument becomes `{ $eq: { $ne: null } }`, which is an equality-against-an-object — it matches nothing and the not-found branch runs as intended.

Recipe matches the established convention from PR #7626 (Instagram findOne sites), PR #7646 (Instagram comment_id), and PR #935 (saas-mongo-connection). The helper consolidates the 11 in-file paste sites into one named call so future flagged sites have a single canonical fix.

### Why a helper, not inline?

12 sites is over the in-skill threshold for helper extraction (≥4). The same anti-pattern recurs in Instagram (covered by other in-flight PRs) and `saas-mongo-connection.ts` (already merged via #935). One named export in `erxes-api-shared/utils/security/` is the right home for it and gives a single place to tighten the contract (runtime type guard, telemetry) later without re-touching every consumer.

### Why not also refactor the `$in: pageId` sites at lines 29–31 / 390?

CodeQL did not flag them and PR #7626 explicitly left the analogous Instagram sites alone — keeping scope tight to maintain parity with the established review pattern. Filed as a follow-up consideration rather than expanding this PR.

## Verification

- `pnpm nx build erxes-api-shared` — green
- `pnpm nx affected -t build --uncommitted` — green across 16 affected projects
- Lint errors that surfaced in `nx affected -t lint` are all pre-existing and outside the touched files; zero new lint errors introduced.
- Helper carries a spec (`sanitizeMongoQuery.spec.ts`) covering primitive wrap + operator-shape neutralisation.

## Alerts will auto-close after the next CodeQL re-scan of `main`

GitHub's PR-to-alert Development-panel link is unfortunately not exposed via API (verified empirically on prior runs). After merge, CodeQL re-scans `main` typically within 30 min – a few hours; the alerts will move to `state: fixed` then.

## Bundle manifest

```
# Bundle manifest — alert-fix-938

- **Tier:** B (same-module bundle; helper extracted for cross-plugin reuse)
- **Rule:** js/sql-injection (error severity, CWE-89/90/943)
- **Seed alert:** #938
- **All alerts in bundle:** #938, #939, #940, #941, #942, #943, #944, #945, #946, #947, #948, #950
- **Files touched:**
  - backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts (alerts #938, #939, #940, #941, #942, #943, #944, #945, #946, #947, #948)
  - backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts (alert #950)
  - backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.ts (new helper)
  - backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.spec.ts (unit test)
  - backend/erxes-api-shared/src/utils/security/index.ts (new barrel)
  - backend/erxes-api-shared/src/utils/index.ts (re-export)
- **Helper introduced:** backend/erxes-api-shared/src/utils/security/sanitizeMongoQuery.ts (`safeEq`)
- **Helper consumers (refactor scope):** flagged sites 12, opportunistic non-flagged sites 0 (kept scope tight — internal `_id` lookups elsewhere take values from prior DB reads or GraphQL-resolved context, not webhook bodies)
- **Why bundled:** All 12 alerts share rule.id and live in the same plugin module (`facebook/`). The fix recipe is mechanically identical at every sink — wrap field value in `{ $eq: ... }`. Recipe is proven by recent PRs #7626/#7646 (Instagram) and #935 (saas-mongo-connection).
- **Why not split:** Splitting into 12 PRs would re-litigate the same fix recipe 12 times in AI review and balloon the alert-fix throughput cost. Helper extraction further consolidates 11 in-file paste-sites into a single named call.
- **Why not in plugin-local utils:** Identical pattern already exists in instagram/controller/store.ts (PR #7626 in flight) and saas-mongo-connection.ts (merged via #935). Cross-plugin reuse justifies erxes-api-shared placement.
- **Per-alert reproductions:** /tmp/erxes-sec/repro-938.md ... /tmp/erxes-sec/repro-950.md (12 files)
- **Alert #1085 (instagram/controller/store.ts:116) explicitly dropped:** Covered opportunistically by in-flight PR #7626 (`alert-fix-1203`). Verified by inspecting that PR's diff — line 116 (`parentConversation` findOne) IS patched there despite not being named in the PR body. Including it here would create a merge conflict. The skill's pre-flight #2 caught this.
```

## Summary by Sourcery

Introduce a shared helper to safely use untrusted values in Mongo/Mongoose equality queries and apply it to Facebook webhook handling in the frontline integration to address security findings.

Bug Fixes:
- Sanitize Facebook integration Mongoose queries that used untrusted webhook values to prevent NoSQL operator injection and misrouted or incorrect record access/updates.

Enhancements:
- Add a reusable safeEq helper in the shared security utilities to wrap untrusted values in Mongo $eq expressions and re-export it through existing utility barrels for cross-plugin use.

Tests:
- Add unit tests for the sanitizeMongoQuery safeEq helper to verify correct wrapping and operator-neutralization behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database query security across the Facebook integration module to defend against NoSQL injection attacks. Comprehensive security safeguards have been implemented for customer management, comment processing, and post conversation operations. This important security update provides stronger data protection mechanisms, improves overall system resilience, and effectively protects against potential security threats and vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->