### PR TITLE
fix(sales): add client portal deal  edit and fix detail access

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/clientPortal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/clientPortal.ts
@@ -1,24 +1,54 @@
 import { Resolver } from 'erxes-api-shared/core-types';
-import {
-  markResolvers,
-  sendTRPCMessage,
-} from 'erxes-api-shared/utils';
+import { markResolvers, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import { IDeal } from '~/modules/sales/@types';
 import { subscriptionWrapper } from '../utils';
 import { createRelations, getNewOrder } from '~/modules/sales/utils';
 
+const getCPUserId = ({ cpUser, clientPortal }: IContext, doc?: IDeal) =>
+  cpUser?.erxesCustomerId || cpUser?._id || clientPortal?._id || doc?.userId;
+
+const assertCPDealAccess = async (
+  subdomain: string,
+  dealId: string,
+  cpUserId: string,
+  dealUserId?: string,
+) => {
+  if (!cpUserId) {
+    throw new Error('Client portal user required');
+  }
+
+  if (dealUserId === `cp:${cpUserId}`) {
+    return;
+  }
+
+  const relatedDealIds = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'relation',
+    action: 'getRelationIds',
+    input: {
+      contentType: 'core:cp.user',
+      contentId: cpUserId,
+      relatedContentType: 'sales:deal',
+    },
+    defaultValue: [],
+  });
+
+  if (!relatedDealIds.includes(dealId)) {
+    throw new Error('Permission denied');
+  }
+};
+
 export const cpDealMutations: Record<string, Resolver> = {
   async cpDealsAdd(
     _root,
     doc: IDeal & { processId: string; aboveItemId: string },
-    { models, subdomain, cpUser, clientPortal }: IContext,
+    context: IContext,
   ) {
-    const userId =
-      cpUser?.erxesCustomerId ||
-      cpUser?._id ||
-      clientPortal?._id ||
-      doc?.userId;
+    const { models, subdomain } = context;
+    const userId = getCPUserId(context, doc);
 
     doc.initialStageId = doc.stageId;
 
@@ -88,6 +118,66 @@ export const cpDealMutations: Record<string, Resolver> = {
     });
 
     return deal;
+  },
+
+  async cpDealsEdit(
+    _root,
+    {
+      _id,
+      processId: _processId,
+      aboveItemId,
+      ...doc
+    }: IDeal & { _id: string; processId: string; aboveItemId?: string },
+    context: IContext,
+  ) {
+    const { models, subdomain } = context;
+    const userId = getCPUserId(context, doc);
+    const oldDeal = await models.Deals.getDeal(_id);
+
+    await assertCPDealAccess(subdomain, _id, userId, oldDeal.userId);
+
+    const extendedDoc: IDeal & { modifiedAt?: Date } = {
+      ...doc,
+      modifiedAt: new Date(),
+      modifiedBy: `cp:${userId}`,
+    };
+
+    if (doc.stageId && doc.stageId !== oldDeal.stageId) {
+      extendedDoc.stageChangedDate = new Date();
+      extendedDoc.order = await getNewOrder({
+        collection: models.Deals,
+        stageId: doc.stageId,
+        aboveItemId,
+      });
+    }
+
+    if (extendedDoc.propertiesData) {
+      extendedDoc.propertiesData = await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        method: 'mutation',
+        module: 'fields',
+        action: 'validateFieldValues',
+        input: extendedDoc.propertiesData,
+        defaultValue: {},
+      });
+    }
+
+    if (extendedDoc.tagIds?.length) {
+      extendedDoc.tagIds = extendedDoc.tagIds.filter((tagId) => tagId);
+    }
+
+    const updatedDeal = await models.Deals.updateDeal(_id, extendedDoc);
+    const stage = await models.Stages.getStage(updatedDeal.stageId);
+
+    await subscriptionWrapper(models, {
+      action: 'update',
+      deal: updatedDeal,
+      oldDeal,
+      pipelineId: stage.pipelineId,
+    });
+
+    return updatedDeal;
   },
 };
 

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
@@ -32,6 +32,42 @@ const isListEmpty = (value) => {
   return value.length === 1 && value[0].length === 0;
 };
 
+const getCPUserId = ({ cpUser, clientPortal }: IContext) =>
+  cpUser?.erxesCustomerId || cpUser?._id || clientPortal?._id;
+
+const assertCPDealAccess = async (
+  subdomain: string,
+  dealId: string,
+  cpUserId: string,
+  dealUserId?: string,
+) => {
+  if (!cpUserId) {
+    throw new Error('Client portal user required');
+  }
+
+  if (dealUserId === `cp:${cpUserId}`) {
+    return;
+  }
+
+  const relatedDealIds = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'relation',
+    action: 'getRelationIds',
+    input: {
+      contentType: 'core:cp.user',
+      contentId: cpUserId,
+      relatedContentType: 'sales:deal',
+    },
+    defaultValue: [],
+  });
+
+  if (!relatedDealIds.includes(dealId)) {
+    throw new Error('Permission denied');
+  }
+};
+
 export const generateFilter = async (
   models: IModels,
   subdomain: string,
@@ -943,8 +979,18 @@ export const dealQueries: Record<string, Resolver> = {
     return checkItemPermByUser(models, subdomain, user, deal);
   },
 
-  async cpDealDetail(_root, args, ctx: IContext, info) {
-    return dealQueries.dealDetail(_root, args, ctx, info);
+  async cpDealDetail(
+    _root,
+    { _id }: { _id: string },
+    context: IContext,
+  ) {
+    const { models, subdomain } = context;
+    const deal = await models.Deals.getDeal(_id);
+    const userId = getCPUserId(context);
+
+    await assertCPDealAccess(subdomain, _id, userId, deal.userId);
+
+    return deal;
   },
 
   async checkDiscount(

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
@@ -237,4 +237,5 @@ export const mutations = `
   dealsDeleteProductData(processId: String, dealId: String, dataIds: [String]): JSON
 
   cpDealsAdd(name: String, companyIds: [String], customerIds: [String], labelIds: [String], ${mutationParams}): Deal
+  cpDealsEdit(_id: String!, name: String, ${mutationParams}): Deal
 `;


### PR DESCRIPTION
## Summary by Sourcery

Add client portal support for editing deals and enforce access control on client portal deal detail and edit operations based on related user–deal relations.

New Features:
- Expose a cpDealsEdit mutation to allow client portal users to update existing deals.

Bug Fixes:
- Restrict client portal deal detail access to deals owned by or explicitly related to the current client portal user.

Enhancements:
- Centralize client portal user resolution and deal access checks in shared helper functions used by client portal deal mutations and queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to edit deals within the client portal.

* **Improvements**
  * Enhanced access control and permission validation for client portal deal operations to ensure users can only access and modify their authorized deals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->