### PR TITLE
fix(sales): add cpSalesCheckFreeTimes and fix cpSalesBoards pipelines…

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/donate/graphql/resolvers/queries/donate.ts
+++ b/backend/plugins/loyalty_api/src/modules/donate/graphql/resolvers/queries/donate.ts
@@ -67,4 +67,16 @@ export const donateQueries = {
 
     return { list, totalCount };
   },
+
+  async cpDonatesMain(
+    _root: undefined,
+    params: IDonateListParams,
+    context: IContext,
+  ) {
+    return donateQueries.donatesMain(_root, params, context);
+  },
+};
+
+(donateQueries.cpDonatesMain as any).wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/plugins/loyalty_api/src/modules/donate/graphql/schemas/donate.ts
+++ b/backend/plugins/loyalty_api/src/modules/donate/graphql/schemas/donate.ts
@@ -54,6 +54,7 @@ const mainQueryParams = `
 export const queries = `
   donates(${queryParams}): DonateListResponse
   donatesMain(${mainQueryParams}, clientPortal:String): DonateMainResponse
+  cpDonatesMain(${mainQueryParams}, clientPortal:String): DonateMainResponse
 `;
 
 const mutationParams = `

--- a/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/queries/scoreCampaign.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/queries/scoreCampaign.ts
@@ -157,4 +157,16 @@ export const scoreCampaignQueries = {
 
     return value;
   },
+
+  async cpCheckOwnerScore(
+    _root: undefined,
+    args: { ownerId: string; ownerType: string; campaignId: string; clientPortal: string },
+    context: IContext,
+  ) {
+    return scoreCampaignQueries.checkOwnerScore(_root, args, context);
+  },
+};
+
+(scoreCampaignQueries.cpCheckOwnerScore as any).wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/queries/scoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/queries/scoreLog.ts
@@ -50,6 +50,14 @@ export const scoreLogQueries = {
     return models.ScoreLogs.getScoreLogs(params);
   },
 
+  async cpScoreLogList(
+    _root: undefined,
+    params: IScoreLogParams,
+    { models }: IContext,
+  ) {
+    return models.ScoreLogs.getScoreLogs(params);
+  },
+
   async scoreLogStatistics(
     _root: undefined,
     params: IScoreLogParams,
@@ -57,4 +65,8 @@ export const scoreLogQueries = {
   ) {
     return models.ScoreLogs.getStatistic(params);
   },
+};
+
+(scoreLogQueries.cpScoreLogList as any).wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/plugins/loyalty_api/src/modules/score/graphql/schemas/scoreCampaign.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/graphql/schemas/scoreCampaign.ts
@@ -43,6 +43,7 @@ export const queries = `
   scoreCampaignAttributes(serviceName:String): JSON
   scoreCampaignServices: JSON
   checkOwnerScore(ownerId:String,ownerType:String,campaignId:String,action:String,clientPortal:String): JSON
+  cpCheckOwnerScore(ownerId:String,ownerType:String,campaignId:String,action:String,clientPortal:String): JSON
 `;
 
 const mutationParams = `

--- a/backend/plugins/loyalty_api/src/modules/score/graphql/schemas/scoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/graphql/schemas/scoreLog.ts
@@ -65,6 +65,7 @@ const queryParams = `
 export const queries = `
   scoreLogs(${queryParams} ${GQL_CURSOR_PARAM_DEFS}): ScoreLogListResponse
   scoreLogList(${queryParams}, clientPortal:String): ScoreLogListResponse
+  cpScoreLogList(${queryParams}, clientPortal:String): ScoreLogListResponse
   scoreLogStatistics(${queryParams}): JSON
 `;
 

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/customResolvers/board.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/customResolvers/board.ts
@@ -12,6 +12,14 @@ export default {
       return board.pipelines;
     }
 
+    if (!user) {
+      return models.Pipelines.find({
+        boardId: board._id,
+        status: { $ne: 'archived' },
+        visibility: 'public',
+      }).lean();
+    }
+
     if (user.isOwner) {
       return models.Pipelines.find({
         boardId: board._id,

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/boards.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/boards.ts
@@ -503,8 +503,24 @@ export const boardQueries = {
 
     return intervals;
   },
+
+  async cpSalesCheckFreeTimes(
+    _root,
+    { pipelineId, intervals },
+    context: IContext,
+  ) {
+    return boardQueries.salesCheckFreeTimes(
+      _root,
+      { pipelineId, intervals },
+      context,
+    );
+  },
 };
 
 (boardQueries.cpSalesBoards as any).wrapperConfig = {
+  forClientPortal: true,
+};
+
+(boardQueries.cpSalesCheckFreeTimes as any).wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/board.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/board.ts
@@ -37,6 +37,7 @@ export const queries = `
   salesBoardContentTypeDetail(contentType: String, contentId: String): JSON
   salesBoardLogs(action: String, content:JSON, contentId: String): JSON
   salesCheckFreeTimes(pipelineId: String, intervals: [SalesInterval]): JSON
+  cpSalesCheckFreeTimes(pipelineId: String, intervals: [SalesInterval]): JSON
 `;
 
 const mutationParams = `


### PR DESCRIPTION
… crash when user is null

## Summary by Sourcery

Expose a client-portal-compatible free-time check query and prevent pipeline resolution crashes when the requesting user is null.

New Features:
- Add cpSalesCheckFreeTimes GraphQL query that proxies the existing salesCheckFreeTimes logic for client portal usage.

Bug Fixes:
- Avoid crashes in board pipeline resolution by handling cases where the user context is null and falling back to public, non-archived pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unauthenticated users can view public pipelines on the current board.
  * Client-portal variants added for: checking sales pipeline availability/time slots, listing donate main results, checking owner score, and viewing score logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->