### PR TITLE
feat(relations): add cpManageRelations mutation for client portal

### DIFF
--- a/backend/core-api/src/modules/relations/graphql/mutations.ts
+++ b/backend/core-api/src/modules/relations/graphql/mutations.ts
@@ -1,7 +1,7 @@
 import { IRelation, Resolver } from 'erxes-api-shared/core-types';
 import { IModels } from '~/connectionResolvers';
 
-export const relationsMutations: Record<string, Resolver> = {
+export const relationsMutations: Record<string, Resolver<any, any, any>> = {
   createRelation: async (
     _parent: undefined,
     { relation }: { relation: IRelation },

--- a/backend/core-api/src/modules/relations/graphql/mutations.ts
+++ b/backend/core-api/src/modules/relations/graphql/mutations.ts
@@ -1,7 +1,7 @@
-import { IRelation } from 'erxes-api-shared/core-types';
+import { IRelation, Resolver } from 'erxes-api-shared/core-types';
 import { IModels } from '~/connectionResolvers';
 
-export const relationsMutations = {
+export const relationsMutations: Record<string, Resolver> = {
   createRelation: async (
     _parent: undefined,
     { relation }: { relation: IRelation },
@@ -55,4 +55,31 @@ export const relationsMutations = {
       relatedContentIds,
     });
   },
+
+  cpManageRelations: async (
+    _parent: undefined,
+    {
+      contentType,
+      contentId,
+      relatedContentType,
+      relatedContentIds,
+    }: {
+      contentType: string;
+      contentId: string;
+      relatedContentType: string;
+      relatedContentIds: string[];
+    },
+    { models }: { models: IModels },
+  ) => {
+    return await models.Relations.manageRelations({
+      contentType,
+      contentId,
+      relatedContentType,
+      relatedContentIds,
+    });
+  },
+};
+
+relationsMutations.cpManageRelations.wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/core-api/src/modules/relations/graphql/schema.ts
+++ b/backend/core-api/src/modules/relations/graphql/schema.ts
@@ -34,4 +34,7 @@ export const mutations = `
     manageRelations(
         contentType: String!, contentId: String!, relatedContentType: String!, relatedContentIds: [String]
     ): [Relation!]
+    cpManageRelations(
+        contentType: String!, contentId: String!, relatedContentType: String!, relatedContentIds: [String]
+    ): [Relation!]
 `;


### PR DESCRIPTION
## Summary by Sourcery

Add a client-portal-specific GraphQL mutation for managing relations and type the relations mutations map with a shared Resolver type.

New Features:
- Expose a cpManageRelations GraphQL mutation to manage relations from the client portal context.

Enhancements:
- Type the relationsMutations export as a string-to-Resolver map for stronger typing of relation mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-portal relations management API: users can manage relationships between content items (specify content type/ID and related content type with optional related IDs) and receive the updated list of relations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->