### PR TITLE
feat(relations): add cpGetRelationsByEntity query for client portal

### DIFF
--- a/backend/core-api/src/modules/relations/graphql/queries.ts
+++ b/backend/core-api/src/modules/relations/graphql/queries.ts
@@ -1,6 +1,7 @@
+import { Resolver } from 'erxes-api-shared/core-types';
 import { IModels } from '~/connectionResolvers';
 
-export const relationsQueries = {
+export const relationsQueries: Record<string, Resolver<any, any, any>> = {
   getRelationsByEntity: async (
     _parent: undefined,
     {
@@ -23,4 +24,24 @@ export const relationsQueries = {
   ) => {
     return models.Relations.getRelationsByEntities({ contentType, contentId });
   },
+
+  cpGetRelationsByEntity: async (
+    _parent: undefined,
+    {
+      contentType,
+      contentId,
+      relatedContentType,
+    }: { contentType: string; contentId: string; relatedContentType: string },
+    { models }: { models: IModels },
+  ) => {
+    return models.Relations.getRelationsByEntity({
+      contentType,
+      contentId,
+      relatedContentType,
+    });
+  },
+};
+
+relationsQueries.cpGetRelationsByEntity.wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/core-api/src/modules/relations/graphql/schema.ts
+++ b/backend/core-api/src/modules/relations/graphql/schema.ts
@@ -24,6 +24,7 @@ export const types = `
 export const queries = `
     getRelationsByEntity(contentType: String!, contentId: String!, relatedContentType: String!): [Relation!]
     getRelationsByEntities(contentTypes: [String!]!, contentIds: [String!]!): [Relation!]
+    cpGetRelationsByEntity(contentType: String!, contentId: String!, relatedContentType: String!): [Relation!]
 `;
 
 export const mutations = `


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce cpGetRelationsByEntity GraphQL query for fetching relations scoped for the client portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GraphQL query for retrieving relations between entities, designed for client portal usage. The query follows the same parameters and response structure as existing relation queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->