### PR TITLE
feat: cpCurrentOrder checks pos-user but dont need on cp

### DIFF
--- a/backend/plugins/content_api/src/modules/webbuilder/graphql/resolvers/mutations/web.ts
+++ b/backend/plugins/content_api/src/modules/webbuilder/graphql/resolvers/mutations/web.ts
@@ -20,6 +20,7 @@ export const webBuilderMutations: Record<string, Resolver> = {
       'terms',
       'blogs',
       'blog',
+      'legal',
     ];
     const tourPages = [
       'tours',

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/orders.ts
@@ -164,7 +164,6 @@ const orderQueries: Record<string, Resolver<any, any, IContext>> = {
     params: ISearchParams,
     { models, config, posUser }: IContext,
   ) {
-    assertPosUser(posUser);
 
     return filterOrders(params, models, config);
   },


### PR DESCRIPTION
## Summary by Sourcery

Extend web builder mutation configuration to treat 'legal' as a main page type and remove the POS user assertion from the cpCurrentOrder order query.

New Features:
- Add support for 'legal' as a main page type in web builder mutations.

Enhancements:
- Relax access enforcement on the cpCurrentOrder POS client order query by removing the POS user requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legal page now automatically included with new web instances

* **Chores**
  * Updated order query validation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->