### PR TITLE
feat(sales): add cpSalesBoardDetail query for client portal

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/boards.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/boards.ts
@@ -74,6 +74,14 @@ export const boardQueries = {
     return models.Boards.findOne({ _id }).lean();
   },
 
+  async cpSalesBoardDetail(
+    _root: undefined,
+    { _id }: { _id: string },
+    { models }: IContext,
+  ) {
+    return models.Boards.findOne({ _id }).lean();
+  },
+
   /**
    * Get last board
    */
@@ -515,6 +523,10 @@ export const boardQueries = {
       context,
     );
   },
+};
+
+(boardQueries.cpSalesBoardDetail as any).wrapperConfig = {
+  forClientPortal: true,
 };
 
 (boardQueries.cpSalesBoards as any).wrapperConfig = {

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/board.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/board.ts
@@ -31,6 +31,7 @@ export const queries = `
   salesBoardCounts: [SalesBoardCount]
   salesBoardGetLast: SalesBoard
   salesBoardDetail(_id: String!): SalesBoard
+  cpSalesBoardDetail(_id: String!): SalesBoard
   salesConvertToInfo(conversationId: String!): SalesConvertTo
   salesItemsCountByAssignedUser(pipelineId: String!, stackBy: String): JSON
   salesCardsFields: JSON


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose a cpSalesBoardDetail GraphQL query for retrieving a single sales board for the client portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new query capability to retrieve individual sales board details in the client portal, allowing users to fetch specific board information by ID.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->