### PR TITLE
refactor(loyalty): migrate campaign points from customFieldsData to propertiesData

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -289,7 +289,6 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
-      // For earning (positive score) with a campaign, read from propertiesData
       if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -310,7 +309,6 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         throw new Error(`score are not enough`);
       }
 
-      // For negative scores (gift/spend), do NOT pass campaignId – update global score only
       const effectiveCampaignId =
         score > 0 && campaignId ? campaignId : undefined;
 
@@ -379,17 +377,14 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           );
         }
 
-        // Get current owner to preserve existing propertiesData
         const owner = await getLoyaltyOwner(subdomain, { ownerType, ownerId });
         const currentProperties = owner?.propertiesData || {};
 
-        // Update the specific campaign field
         const updatedProperties = {
           ...currentProperties,
           [campaign.fieldId]: newScore,
         };
 
-        // Replace propertiesData and remove the global score update
         modifier.$set['propertiesData'] = updatedProperties;
         delete modifier.$set.score;
       }

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -289,7 +289,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
-      // Read from propertiesData (flat object) for earning
+      // Read from propertiesData for earning
       if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -272,7 +272,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
       const owner = await getLoyaltyOwner(subdomain, { ownerType, ownerId });
 
       if (!owner) {
-        throw new Error(`not fount ${ownerType}`);
+        throw new Error(`not found ${ownerType}`);
       }
 
       if (targetId && serviceName) {
@@ -289,7 +289,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
-      // Only use campaign-specific balance for earning (positive score)
+      // For earning (positive score) with a campaign, read from propertiesData
       if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -299,11 +299,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           throw new Error('Campaign not found');
         }
 
-        const campaignScore =
-          (owner?.customFieldsData || []).find(
-            ({ field }) => field === campaign.fieldId,
-          )?.value || 0;
-
+        const campaignScore = owner.propertiesData?.[campaign.fieldId] || 0;
         ownerScore = campaignScore;
       }
 
@@ -327,7 +323,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
       });
 
       if (!response || !Object.keys(response || {})?.length) {
-        throw new Error('Something went wrong for give score');
+        throw new Error('Something went wrong while giving score');
       }
 
       return await models.ScoreLogs.create({
@@ -337,7 +333,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         createdAt: new Date(),
         description,
         createdBy,
-        campaignId: effectiveCampaignId, // log with the effective campaignId (or undefined)
+        campaignId: effectiveCampaignId,
         action: 'add',
         targetId,
         serviceName,
@@ -370,9 +366,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         });
 
       const modifier: any = { $set: { score: newScore } };
-      const selector: {
-        _id: string;
-      } = { _id: ownerId };
+      const selector: { _id: string } = { _id: ownerId };
 
       if (campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
@@ -385,49 +379,18 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           );
         }
 
-        const prepareCustomFieldsData = await sendTRPCMessage({
-          subdomain,
-          pluginName: 'core',
-          method: 'mutation',
-          module: 'fields',
-          action: 'prepareCustomFieldsData',
-          input: [{ field: campaign.fieldId, value: newScore }],
-          defaultValue: [],
-        });
-
-        if (!prepareCustomFieldsData[0]) {
-          throw new Error(
-            'Something went wrong when preparing score field data',
-          );
-        }
-
-        const prepareCustomFieldData: { field: string; value: number } =
-          prepareCustomFieldsData[0];
-
+        // Get current owner to preserve existing propertiesData
         const owner = await getLoyaltyOwner(subdomain, { ownerType, ownerId });
+        const currentProperties = owner?.propertiesData || {};
 
-        const { customFieldsData } = owner || {};
-        let updatedCustomFieldsData;
+        // Update the specific campaign field
+        const updatedProperties = {
+          ...currentProperties,
+          [campaign.fieldId]: newScore,
+        };
 
-        if (
-          !customFieldsData ||
-          !(customFieldsData || []).find(
-            ({ field }) => field === campaign.fieldId,
-          )
-        ) {
-          updatedCustomFieldsData = [
-            ...(customFieldsData || []),
-            prepareCustomFieldData,
-          ];
-        } else {
-          updatedCustomFieldsData = customFieldsData.map((customFieldData) =>
-            customFieldData.field === campaign.fieldId
-              ? { ...customFieldData, ...prepareCustomFieldData }
-              : customFieldData,
-          );
-        }
-
-        modifier.$set['customFieldsData'] = updatedCustomFieldsData || [];
+        // Replace propertiesData and remove the global score update
+        modifier.$set['propertiesData'] = updatedProperties;
         delete modifier.$set.score;
       }
 

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -289,6 +289,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
+      // Only for earning (positive score) with a campaign – read from customFieldsData array
       if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -298,7 +299,11 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           throw new Error('Campaign not found');
         }
 
-        const campaignScore = owner.propertiesData?.[campaign.fieldId] || 0;
+        const campaignScore =
+          (owner?.customFieldsData || []).find(
+            ({ field }) => field === campaign.fieldId,
+          )?.value || 0;
+
         ownerScore = campaignScore;
       }
 
@@ -309,6 +314,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         throw new Error(`score are not enough`);
       }
 
+      // For negative scores (gift/spend), do NOT pass campaignId – update global score only
       const effectiveCampaignId =
         score > 0 && campaignId ? campaignId : undefined;
 
@@ -366,6 +372,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
       const modifier: any = { $set: { score: newScore } };
       const selector: { _id: string } = { _id: ownerId };
 
+      // Original logic for updating customFieldsData (array) – kept unchanged
       if (campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -377,15 +384,49 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           );
         }
 
+        const prepareCustomFieldsData = await sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'mutation',
+          module: 'fields',
+          action: 'prepareCustomFieldsData',
+          input: [{ field: campaign.fieldId, value: newScore }],
+          defaultValue: [],
+        });
+
+        if (!prepareCustomFieldsData[0]) {
+          throw new Error(
+            'Something went wrong when preparing score field data',
+          );
+        }
+
+        const prepareCustomFieldData: { field: string; value: number } =
+          prepareCustomFieldsData[0];
+
         const owner = await getLoyaltyOwner(subdomain, { ownerType, ownerId });
-        const currentProperties = owner?.propertiesData || {};
 
-        const updatedProperties = {
-          ...currentProperties,
-          [campaign.fieldId]: newScore,
-        };
+        const { customFieldsData } = owner || {};
+        let updatedCustomFieldsData;
 
-        modifier.$set['propertiesData'] = updatedProperties;
+        if (
+          !customFieldsData ||
+          !(customFieldsData || []).find(
+            ({ field }) => field === campaign.fieldId,
+          )
+        ) {
+          updatedCustomFieldsData = [
+            ...(customFieldsData || []),
+            prepareCustomFieldData,
+          ];
+        } else {
+          updatedCustomFieldsData = customFieldsData.map((customFieldData) =>
+            customFieldData.field === campaign.fieldId
+              ? { ...customFieldData, ...prepareCustomFieldData }
+              : customFieldData,
+          );
+        }
+
+        modifier.$set['customFieldsData'] = updatedCustomFieldsData || [];
         delete modifier.$set.score;
       }
 

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -289,7 +289,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
-      // Only for earning (positive score) with a campaign – read from customFieldsData array
+      // Read from propertiesData (flat object) for earning
       if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -299,11 +299,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           throw new Error('Campaign not found');
         }
 
-        const campaignScore =
-          (owner?.customFieldsData || []).find(
-            ({ field }) => field === campaign.fieldId,
-          )?.value || 0;
-
+        const campaignScore = owner.propertiesData?.[campaign.fieldId] || 0;
         ownerScore = campaignScore;
       }
 
@@ -314,7 +310,6 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         throw new Error(`score are not enough`);
       }
 
-      // For negative scores (gift/spend), do NOT pass campaignId – update global score only
       const effectiveCampaignId =
         score > 0 && campaignId ? campaignId : undefined;
 
@@ -372,7 +367,6 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
       const modifier: any = { $set: { score: newScore } };
       const selector: { _id: string } = { _id: ownerId };
 
-      // Original logic for updating customFieldsData (array) – kept unchanged
       if (campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
@@ -384,6 +378,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           );
         }
 
+        // Keep the prepareCustomFieldsData block (for validation or side effects)
         const prepareCustomFieldsData = await sendTRPCMessage({
           subdomain,
           pluginName: 'core',
@@ -400,33 +395,16 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           );
         }
 
-        const prepareCustomFieldData: { field: string; value: number } =
-          prepareCustomFieldsData[0];
-
+        // Ignore the result – we will use propertiesData instead
         const owner = await getLoyaltyOwner(subdomain, { ownerType, ownerId });
+        const currentProperties = owner?.propertiesData || {};
 
-        const { customFieldsData } = owner || {};
-        let updatedCustomFieldsData;
+        const updatedProperties = {
+          ...currentProperties,
+          [campaign.fieldId]: newScore,
+        };
 
-        if (
-          !customFieldsData ||
-          !(customFieldsData || []).find(
-            ({ field }) => field === campaign.fieldId,
-          )
-        ) {
-          updatedCustomFieldsData = [
-            ...(customFieldsData || []),
-            prepareCustomFieldData,
-          ];
-        } else {
-          updatedCustomFieldsData = customFieldsData.map((customFieldData) =>
-            customFieldData.field === campaign.fieldId
-              ? { ...customFieldData, ...prepareCustomFieldData }
-              : customFieldData,
-          );
-        }
-
-        modifier.$set['customFieldsData'] = updatedCustomFieldsData || [];
+        modifier.$set['propertiesData'] = updatedProperties;
         delete modifier.$set.score;
       }
 

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -289,7 +289,8 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
 
       let ownerScore = owner.score;
 
-      if (campaignId) {
+      // Only use campaign-specific balance for earning (positive score)
+      if (score > 0 && campaignId) {
         const campaign = await models.ScoreCampaigns.findOne({
           _id: campaignId,
         });
@@ -313,12 +314,16 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         throw new Error(`score are not enough`);
       }
 
+      // For negative scores (gift/spend), do NOT pass campaignId – update global score only
+      const effectiveCampaignId =
+        score > 0 && campaignId ? campaignId : undefined;
+
       const response = await this.updateOwnerScore({
         subdomain,
         ownerId,
         ownerType,
         newScore,
-        campaignId,
+        campaignId: effectiveCampaignId,
       });
 
       if (!response || !Object.keys(response || {})?.length) {
@@ -332,7 +337,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
         createdAt: new Date(),
         description,
         createdBy,
-        campaignId,
+        campaignId: effectiveCampaignId, // log with the effective campaignId (or undefined)
         action: 'add',
         targetId,
         serviceName,


### PR DESCRIPTION
…gn custom fields

## Summary by Sourcery

Bug Fixes:
- Prevent negative score operations from incorrectly using or affecting campaign-specific score balances by routing them through the global score instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Campaign-specific balances now apply only for positive loyalty score increases; negative adjustments affect the global balance.
  * Score logs now record a campaign association only when a positive score change applies to a campaign.
  * Profile score updates and logged campaign association are now consistent.
  * Current campaign score is correctly read from the owner’s profile properties.
  * Improved error handling when score update operations return no result.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->