### PR TITLE
fix(loyalty): use active status for published score campaigns

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/constants.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/constants.ts
@@ -6,7 +6,7 @@ export const SCORE_ACTION = {
 };
 
 export const SCORE_CAMPAIGN_STATUSES = {
-  PUBLISHED: 'published',
+  PUBLISHED: 'active',
   DRAFT: 'draft',
   ARCHIVED: 'archived',
 } as const;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct score campaign published status mapping to use the active status value instead of the outdated published value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated loyalty score campaign status constants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->