### PR TITLE
fix(frontline): remove 16-character limit on ticket status name

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/settings/schema/ticketStatus.ts
+++ b/frontend/plugins/frontline_ui/src/modules/settings/schema/ticketStatus.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const TICKET_STATUS_FORM_SCHEMA = z.object({
-  name: z.string().min(1).max(16, 'Name must be at most 16 characters long'),
+  name: z.string().min(1),
   description: z
     .string()
     .max(255, 'Description must be at most 255 characters long')


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow ticket status names longer than 16 characters by removing the maximum length validation from the form schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket status names can now exceed 16 characters, enabling more descriptive naming options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->