### PR TITLE
feat:cms_menu has types for web, cms

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/@types/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/@types/cms.ts
@@ -16,6 +16,8 @@ export const MENU_LINK_TYPES = [
   'TAG',
 ] as const;
 export type MenuLinkType = (typeof MENU_LINK_TYPES)[number];
+export const MENU_CONTENT_SOURCES = ['cms', 'web'] as const;
+export type MenuContentSource = (typeof MENU_CONTENT_SOURCES)[number];
 
 export interface IContentCMS {
   name: string;
@@ -75,6 +77,7 @@ export interface ICMSMenu {
   label: string;
   contentType?: string;
   contentTypeId?: string;
+  type?: MenuContentSource;
   linkType?: MenuLinkType;
   kind: string;
   icon?: string;
@@ -94,7 +97,8 @@ export interface IMenuLinkedContent {
 }
 
 export interface ICMSMenuDocument
-  extends Omit<Document, 'contentType'>, ICMSMenu {
+  extends Omit<Document, 'contentType'>,
+    ICMSMenu {
   _id: string;
   createdAt: Date;
   updatedAt: Date;

--- a/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
@@ -2,6 +2,7 @@ import {
   ICMSMenuDocument,
   ICMSPageDocument,
   IContentCMSDocument,
+  MENU_CONTENT_SOURCES,
   MENU_LINK_TYPES,
 } from '@/cms/@types/cms';
 import {
@@ -43,8 +44,9 @@ export const cmsMenuSchema = new mongoose.Schema<ICMSMenuDocument>(
     clientPortalId: { type: String, required: true },
     webId: { type: String, optional: true },
     label: { type: String, required: true },
-    contentType: { type: String },
-    contentTypeId: { type: String },
+    contentType: { type: String, optional: true },
+    contentTypeId: { type: String, optional: true },
+    type: { type: String, enum: MENU_CONTENT_SOURCES, optional: true },
     linkType: { type: String, enum: MENU_LINK_TYPES },
     kind: { type: String, required: true },
     icon: { type: String },

--- a/backend/plugins/content_api/src/modules/cms/db/models/Menu.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Menu.ts
@@ -7,6 +7,7 @@ import {
   ICMSMenu,
   ICMSMenuDocument,
   IMenuLinkedContent,
+  MenuContentSource,
   MenuLinkType,
 } from '@/cms/@types/cms';
 import { IModels } from '~/connectionResolvers';
@@ -86,7 +87,14 @@ export const loadMenuItemClass = (models: IModels) => {
         : CONTENT_TYPE_BY_LINK_TYPE[linkType || 'URL'];
     }
 
-    return CONTENT_TYPE_BY_LINK_TYPE[linkType || 'URL'];
+    return undefined;
+  };
+
+  const normalizeContentSource = (
+    value?: string | null,
+    fallback: MenuContentSource = 'cms',
+  ): MenuContentSource => {
+    return String(value || fallback).toLowerCase() === 'web' ? 'web' : 'cms';
   };
 
   const normalizeOpenInNewTab = (
@@ -128,6 +136,7 @@ export const loadMenuItemClass = (models: IModels) => {
     clientPortalId: string;
     linkType: MenuLinkType;
     contentTypeId?: string;
+    type?: MenuContentSource | string;
   }): Promise<ResolvedMenuContent | null> => {
     if (!menuItem.contentTypeId || !CONTENT_LINK_TYPES.has(menuItem.linkType)) {
       return null;
@@ -149,10 +158,17 @@ export const loadMenuItemClass = (models: IModels) => {
     }
 
     switch (menuItem.linkType) {
-      case 'PAGE':
-        return models.Pages.findOne(contentQuery)
+      case 'PAGE': {
+        const pageModel: any =
+          normalizeContentSource(menuItem.type) === 'web'
+            ? models.WebPages
+            : models.Pages;
+
+        return pageModel
+          .findOne(contentQuery)
           .select({ _id: 1, name: 1, slug: 1 })
           .lean();
+      }
       case 'POST':
         return models.Posts.findOne(contentQuery)
           .select({ _id: 1, title: 1, slug: 1, count: 1 })
@@ -185,6 +201,17 @@ export const loadMenuItemClass = (models: IModels) => {
     }
 
     return trimmedValue;
+  };
+
+  const getLinkedContentLabel = (
+    linkType: MenuLinkType,
+    type?: MenuContentSource,
+  ) => {
+    if (linkType === 'PAGE' && type === 'web') {
+      return 'web page';
+    }
+
+    return CONTENT_TYPE_BY_LINK_TYPE[linkType];
   };
 
   const buildLinkedContentSummary = (
@@ -243,7 +270,9 @@ export const loadMenuItemClass = (models: IModels) => {
     const explicitUrlProvided = hasOwn(doc, 'url');
     const linkType = normalizeLinkType(
       mergedDoc.linkType || mergedDoc.contentType,
-      normalizeLinkType(existingMenuItem?.linkType || existingMenuItem?.contentType),
+      normalizeLinkType(
+        existingMenuItem?.linkType || existingMenuItem?.contentType,
+      ),
     );
     const existingLinkType = normalizeLinkType(
       existingMenuItem?.linkType || existingMenuItem?.contentType,
@@ -253,7 +282,11 @@ export const loadMenuItemClass = (models: IModels) => {
       return mergedDoc.url;
     }
 
-    if (existingMenuItem?.url && existingLinkType === 'URL' && !explicitUrlProvided) {
+    if (
+      existingMenuItem?.url &&
+      existingLinkType === 'URL' &&
+      !explicitUrlProvided
+    ) {
       return existingMenuItem.url;
     }
 
@@ -292,6 +325,13 @@ export const loadMenuItemClass = (models: IModels) => {
       normalizeLinkType(existingDoc.linkType || existingDoc.contentType),
     );
     const contentType = normalizeContentType(mergedDoc.contentType, linkType);
+    const contentSource =
+      linkType === 'PAGE'
+        ? normalizeContentSource(
+            mergedDoc.type,
+            normalizeContentSource(existingDoc.type),
+          )
+        : undefined;
     const openInNewTab = normalizeOpenInNewTab(
       mergedDoc,
       normalizeOpenInNewTab(existingDoc, false),
@@ -301,24 +341,32 @@ export const loadMenuItemClass = (models: IModels) => {
       ...doc,
       clientPortalId: mergedDoc.clientPortalId,
       linkType,
-      contentType,
       openInNewTab,
       target: toLegacyTarget(openInNewTab),
     };
 
-    if (CONTENT_LINK_TYPES.has(linkType)) {
-      if (!mergedDoc.contentTypeId) {
-        throw new Error('contentTypeId is required for content links');
-      }
+    if (contentType) {
+      normalizedDoc.contentType = contentType;
+    } else {
+      normalizedDoc.contentType = undefined;
+    }
 
+    normalizedDoc.type = contentSource;
+
+    if (CONTENT_LINK_TYPES.has(linkType) && mergedDoc.contentTypeId) {
       const content = await resolveLinkedContent({
         clientPortalId: mergedDoc.clientPortalId,
         linkType,
         contentTypeId: mergedDoc.contentTypeId,
+        type: contentSource,
       });
 
       if (!content) {
-        throw new Error(`Linked ${contentType} not found`);
+        throw new Error(
+          'Linked ' +
+            getLinkedContentLabel(linkType, contentSource) +
+            ' not found',
+        );
       }
 
       normalizedDoc.contentTypeId = String(content._id);
@@ -344,7 +392,9 @@ export const loadMenuItemClass = (models: IModels) => {
 
   class MenuItems {
     public static getMenuItems = async (query: any) => {
-      const pages = await models.MenuItems.find(query).sort({ order: 1 }).lean();
+      const pages = await models.MenuItems.find(query)
+        .sort({ order: 1 })
+        .lean();
 
       return pages;
     };
@@ -379,17 +429,37 @@ export const loadMenuItemClass = (models: IModels) => {
 
       const normalizedDoc = await normalizeMenuInput(doc, existingMenuItem);
 
-      const updateDoc: any = { $set: normalizedDoc };
+      const updateDoc: any = {
+        $set: Object.fromEntries(
+          Object.entries(normalizedDoc).filter(
+            ([, value]) => value !== undefined,
+          ),
+        ),
+      };
 
-      if (normalizedDoc.linkType === 'URL') {
-        updateDoc.$unset = { contentTypeId: 1 };
+      if (
+        normalizedDoc.contentType === undefined ||
+        normalizedDoc.contentTypeId === undefined ||
+        normalizedDoc.type === undefined
+      ) {
+        updateDoc.$unset = {};
+
+        if (normalizedDoc.contentType === undefined) {
+          updateDoc.$unset.contentType = 1;
+        }
+
+        if (normalizedDoc.contentTypeId === undefined) {
+          updateDoc.$unset.contentTypeId = 1;
+        }
+
+        if (normalizedDoc.type === undefined) {
+          updateDoc.$unset.type = 1;
+        }
       }
 
-      const menu = await models.MenuItems.findOneAndUpdate(
-        { _id },
-        updateDoc,
-        { new: true },
-      );
+      const menu = await models.MenuItems.findOneAndUpdate({ _id }, updateDoc, {
+        new: true,
+      });
       return menu;
     };
 
@@ -407,18 +477,17 @@ export const loadMenuItemClass = (models: IModels) => {
       const linkType = normalizeLinkType(
         rawMenuItem.linkType || rawMenuItem.contentType,
       );
-      const contentType = normalizeContentType(rawMenuItem.contentType, linkType);
       const openInNewTab = normalizeOpenInNewTab(rawMenuItem, false);
       const content = await resolveLinkedContent({
         clientPortalId: rawMenuItem.clientPortalId,
         linkType,
         contentTypeId: rawMenuItem.contentTypeId,
+        type: rawMenuItem.type,
       });
 
       return {
         ...rawMenuItem,
         linkType,
-        contentType,
         openInNewTab,
         target: toLegacyTarget(openInNewTab),
         url: await buildComputedUrl(
@@ -429,7 +498,9 @@ export const loadMenuItemClass = (models: IModels) => {
           },
           content,
         ),
-        linkedContent: content ? buildLinkedContentSummary(linkType, content) : null,
+        linkedContent: content
+          ? buildLinkedContentSummary(linkType, content)
+          : null,
       };
     };
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/menu.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/menu.ts
@@ -25,6 +25,7 @@ export const types = `
     label: String
     contentType: String
     contentTypeId: String
+    type: String
     linkType: MenuLinkType
     kind: String
     icon: String
@@ -51,6 +52,7 @@ export const inputs = `
     label: String
     contentType: String
     contentTypeId: String
+    type: String
     linkType: MenuLinkType
     kind: String
     icon: String

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/orders.ts
@@ -162,9 +162,8 @@ const orderQueries: Record<string, Resolver<any, any, IContext>> = {
   async cpCurrentOrder(
     _root,
     params: ISearchParams,
-    { models, config, posUser }: IContext,
+    { models, config }: IContext,
   ) {
-
     return filterOrders(params, models, config);
   },
 
@@ -434,7 +433,7 @@ orderQueries.cpAddresses.wrapperConfig = {
   forClientPortal: true,
 };
 orderQueries.cpCurrentOrder.wrapperConfig = {
-  forClientPortal: true,
+  skipPermission: true,
 };
 orderQueries.cpFullOrders.wrapperConfig = {
   forClientPortal: true,

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
@@ -70,8 +70,10 @@ export const CMS_MENU_ADD = gql`
       _id
       parentId
       label
-      # contentType
-      # contentTypeID
+      contentType
+      contentTypeId
+      type
+      linkType
       kind
       icon
       url
@@ -88,8 +90,10 @@ export const CMS_MENU_EDIT = gql`
       _id
       parentId
       label
-      # contentType
-      # contentTypeID
+      contentType
+      contentTypeId
+      type
+      linkType
       kind
       icon
       url
@@ -775,6 +779,10 @@ export const CMS_MENU_LIST = gql`
       _id
       parentId
       label
+      contentType
+      contentTypeId
+      type
+      linkType
       kind
       icon
       url

--- a/frontend/plugins/content_ui/src/modules/cms/menus/types/menuDrawerTypes.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/types/menuDrawerTypes.ts
@@ -21,6 +21,10 @@ export interface MenuInput {
   clientPortalId: string;
   label: string;
   url: string;
+  contentType?: string;
+  contentTypeId?: string;
+  type?: 'cms' | 'web';
+  linkType?: string;
   kind: string;
   parentId?: string;
   target?: string;
@@ -32,6 +36,10 @@ export interface MenuRecord {
   _id: string;
   label: string;
   url?: string;
+  contentType?: string;
+  contentTypeId?: string;
+  type?: 'cms' | 'web';
+  linkType?: string;
   kind?: string;
   parentId?: string;
   target?: string;
@@ -51,6 +59,9 @@ export interface MenuFormData {
   kind: string;
   clientPortalId: string;
   parentId: string;
+  contentType?: string;
+  contentTypeId?: string;
+  type?: 'cms' | 'web';
   linkType: string;
   target: boolean;
 }


### PR DESCRIPTION
## Summary by Sourcery

Support distinguishing CMS menu items that link to web vs CMS pages, persist this source type across API, schema, and UI, and relax content-link requirements when no linked content is provided.

New Features:
- Add a menu content source type (cms or web) to CMS menu items and use it to resolve linked PAGE content from either CMS or Web page collections.
- Expose menu item content type, content ID, source type, and link type through GraphQL queries and UI types for creating, editing, and listing menus.

Bug Fixes:
- Ensure CMS menu schema marks contentType and contentTypeId as optional to align with conditional content-link behavior.

Enhancements:
- Normalize and store menu item content source independently of link type, and improve linked-content not-found error messages to reflect the specific content source.
- Adjust menu update logic to only set defined fields, explicitly unset cleared content-related fields, and avoid forcing content links when no contentTypeId is provided.
- Allow cpCurrentOrder to be resolved without client-portal permission checks while keeping other order queries unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu system can now distinguish between CMS and Web content sources.
  * Menu items include additional classification and metadata fields.

* **Updates**
  * GraphQL menu operations extended to retrieve new menu metadata fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->