### PR TITLE
fix(posclient): escape regex meta-chars before wildcard substitution (alert #987)

### DIFF
--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
@@ -455,8 +455,8 @@ const productQueries = {
           // preserving the original semantics for the gated single-character
           // inputs.
           const escaped = escapeRegExp(str)
-            .replaceAll(String.raw`\*`, '.')
-            .replaceAll('_', '.');
+            .replace(/\\\*/g, '.')
+            .replace(/_/g, '.');
           return new RegExp(`^${escaped}.*`, 'igu');
         }
         return new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
@@ -446,15 +446,20 @@ const productQueries = {
 
     if (groupedSimilarity === 'config') {
       const getRegex = (str) => {
-        return ['*', '.', '_'].includes(str)
-          ? new RegExp(
-              `^${str
-                .replace(/\./g, '\\.')
-                .replace(/\*/g, '.')
-                .replace(/_/g, '.')}.*`,
-              'igu',
-            )
-          : new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
+        if (['*', '.', '_'].includes(str)) {
+          // First fully escape every regex meta-character (including
+          // backslashes) via the shared helper, then deliberately unescape
+          // the supported wildcards ('*' and '_' become '.', i.e. match any
+          // single character). This avoids the incomplete-sanitization
+          // pattern flagged by CodeQL js/incomplete-sanitization while
+          // preserving the original semantics for the gated single-character
+          // inputs.
+          const escaped = escapeRegExp(str)
+            .replaceAll(String.raw`\*`, '.')
+            .replaceAll('_', '.');
+          return new RegExp(`^${escaped}.*`, 'igu');
+        }
+        return new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
       };
 
       const similarityGroups = await models.ProductsConfigs.getConfig(


### PR DESCRIPTION
## Closes alert #987

- **Rule:** `js/incomplete-sanitization` (severity: high)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/987
- **File:** `backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts:451`

## Vulnerable code (before)

```ts
const getRegex = (str) => {
  return ['*', '.', '_'].includes(str)
    ? new RegExp(
        `^${str
          .replace(/\./g, '\\.')
          .replace(/\*/g, '.')
          .replace(/_/g, '.')}.*`,
        'igu',
      )
    : new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
};
```

The chained `.replace()` calls in the wildcard branch escape only `.` and substitute `*`/`_` — leaving backslashes and other regex meta-chars in user-controlled strings unescaped. CodeQL `js/incomplete-sanitization` (\"This does not escape backslash characters in the input.\").

Although in practice the call is gated by `['*', '.', '_'].includes(str)` so `str` can only be a single safe char, the sanitiser itself is unsound — the rule fires on the pattern regardless.

## Fix

Escape every regex meta-char via the shared `escapeRegExp` helper first, then deliberately rewrite only the supported wildcards (`*` and `_` → `.`). The `.` mask is already escaped so no further work needed.

```ts
if (['*', '.', '_'].includes(str)) {
  const escaped = escapeRegExp(str)
    .replaceAll(String.raw`\*`, '.')
    .replaceAll('_', '.');
  return new RegExp(`^${escaped}.*`, 'igu');
}
return new RegExp(`.*${escapeRegExp(str)}.*`, 'igu');
```

## Verification

- Hand-rolled `.replace()` chain replaced with `escapeRegExp` + targeted wildcard rewrite.
- Original semantics preserved for the gated single-character inputs.

## Notes

- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.
- Manual link to alert Development panel is required after merge (no public API exists for this).

## Summary by Sourcery

Bug Fixes:
- Ensure wildcard-based regex patterns in POS client product queries fully escape regex meta-characters before applying custom wildcard substitutions to satisfy CodeQL js/incomplete-sanitization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product search/similarity matching to more reliably handle special characters by better sanitization of inputs.
  * Restored and clarified support for single-character wildcards (e.g., '*' and '_') while preserving case-insensitive "contains" behavior for other inputs, reducing false matches and improving result accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->