### PR TITLE
fix(core-api): use precomputed regex map for wildcard masks (alert #952)

### DIFF
--- a/backend/core-api/src/modules/products/graphql/resolvers/mutations/config.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/mutations/config.ts
@@ -7,11 +7,11 @@ import { IContext } from '~/connectionResolvers';
  * mask keys never reach a hand-rolled chained .replace() that could leak
  * un-escaped backslashes into the constructed RegExp source.
  */
-const WILDCARD_REGEX: Record<string, RegExp> = {
-  '*': /^..*/giu,
-  '.': /^\..*/giu,
-  _: /^..*/giu,
-};
+const WILDCARD_REGEX = new Map<string, RegExp>([
+  ['*', /^..*/giu],
+  ['.', /^\..*/giu],
+  ['_', /^..*/giu],
+]);
 
 export const configMutations = {
   /**
@@ -48,7 +48,7 @@ export const configMutations = {
           const maskValue = value[mask];
 
           const codeRegex =
-            WILDCARD_REGEX[mask] ??
+            WILDCARD_REGEX.get(mask) ??
             new RegExp(`.*${escapeRegExp(mask)}.*`, 'igu');
 
           const fieldFilter = (maskValue.filterField || 'code').includes(

--- a/backend/core-api/src/modules/products/graphql/resolvers/mutations/config.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/mutations/config.ts
@@ -1,4 +1,17 @@
+import { escapeRegExp } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
+
+/**
+ * Precomputed wildcard regex map for single-character similarity masks.
+ * Mirrors the safe pattern used in queries/product.ts so that user-controlled
+ * mask keys never reach a hand-rolled chained .replace() that could leak
+ * un-escaped backslashes into the constructed RegExp source.
+ */
+const WILDCARD_REGEX: Record<string, RegExp> = {
+  '*': /^..*/giu,
+  '.': /^\..*/giu,
+  _: /^..*/giu,
+};
 
 export const configMutations = {
   /**
@@ -34,15 +47,9 @@ export const configMutations = {
         for (const mask of masks) {
           const maskValue = value[mask];
 
-          const codeRegex = ['*', '.', '_'].includes(mask)
-            ? new RegExp(
-                `^${mask
-                  .replace(/\./g, '\\.')
-                  .replace(/\*/g, '.')
-                  .replace(/_/g, '.')}.*`,
-                'igu',
-              )
-            : new RegExp(`.*${mask}.*`, 'igu');
+          const codeRegex =
+            WILDCARD_REGEX[mask] ??
+            new RegExp(`.*${escapeRegExp(mask)}.*`, 'igu');
 
           const fieldFilter = (maskValue.filterField || 'code').includes(
             'customFieldsData.',


### PR DESCRIPTION
## Closes alert #952

- **Rule:** `js/incomplete-sanitization` (severity: high)
- **Alert:** https://github.com/erxes/erxes/security/code-scanning/952
- **File:** `backend/core-api/src/modules/products/graphql/resolvers/mutations/config.ts:39`

## Vulnerable code (before)

```ts
const codeRegex = ['*', '.', '_'].includes(mask)
  ? new RegExp(
      `^${mask
        .replace(/\./g, '\\.')
        .replace(/\*/g, '.')
        .replace(/_/g, '.')}.*`,
      'igu',
    )
  : new RegExp(`.*${mask}.*`, 'igu');
```

`mask` originates from `Object.keys(value)` where `value` comes from the `productsConfigsUpdate` GraphQL mutation input — entirely user/admin controlled. The chained `.replace()` chain in the wildcard branch escapes only `.` and substitutes `*`/`_` — leaving backslashes and other regex meta-chars in user-controlled strings unescaped. The fallback branch (`new RegExp(\`.*\${mask}.*\`, 'igu')`) is worse — it interpolates `mask` directly with NO escaping.

CodeQL `js/incomplete-sanitization`: \"This does not escape backslash characters in the input.\"

## Fix

- For the three gated single-character masks (`*`, `.`, `_`), use a small precomputed `WILDCARD_REGEX` map. This mirrors the safe pattern already used by the sibling query resolver and removes the hand-rolled `.replace()` chain entirely.
- For arbitrary masks, fall back to `escapeRegExp` from `erxes-api-shared` before interpolating into the regex source.

```ts
const codeRegex =
  WILDCARD_REGEX[mask] ??
  new RegExp(`.*${escapeRegExp(mask)}.*`, 'igu');
```

## Verification

- The chained `.replace()` pattern is gone from this file.
- The unsanitised fallback branch is gone — every user-controlled `mask` now flows through `escapeRegExp` before reaching the `RegExp` constructor.
- Behaviour for the supported wildcards (`*`, `.`, `_`) is unchanged.

## Notes

- The alert will move to `fixed` after the next CodeQL re-scan of `main` post-merge.
- Manual link to alert Development panel is required after merge (no public API exists for this).

## Summary by Sourcery

Sanitize construction of product config code regular expressions to prevent unsafe use of user-controlled masks in RegExp patterns.

Bug Fixes:
- Ensure user-controlled mask values are safely escaped before interpolation into dynamically constructed regular expressions in product config mutations.

Enhancements:
- Reuse a precomputed wildcard regex map for common single-character masks to align mutation behavior with existing query resolver patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal improvement to how similarity masks are processed, making pattern handling safer and more consistent.

* **Chores**
  * Code cleanup and simplification in backend match/pattern logic.

* **Impact**
  * No user-visible changes; behavior and APIs remain the same.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->