### PR TITLE
feat(sales): add riskLevel enum to Deal

### DIFF
--- a/.agents/memory/lessons.md
+++ b/.agents/memory/lessons.md
@@ -1,0 +1,77 @@
+# Lessons
+
+> Institutional scar tissue. Things AI got wrong in this repo, and how to avoid them next time. **Read this at the start of every session.** Append to it after every shipped feature where you learned something non-obvious.
+
+## How to add an entry
+
+```markdown
+## YYYY-MM-DD — <one-line title>
+**Symptom:** what looked wrong / what broke.
+**Root cause:** why it happened.
+**Lesson:** the durable rule. What to check or do differently next time.
+**Where applicable:** which skill / file / pattern (so the lesson is searchable).
+```
+
+Keep entries to ≤5 lines each. If a lesson is bigger than that, it probably wants to become a `rules/` file or a `SLOP-CHECKLIST.md` entry.
+
+## What counts as a lesson
+
+- AI shipped something that broke a test it didn't realize existed
+- A skill's "files to touch" list missed a real dependency
+- A sister feature mirrored had a subtle exception that didn't apply
+- A pattern that "looks like" precedent but isn't
+- An error message that was misleading; the actual cause was elsewhere
+- A multi-tenant leak that compiled and passed local tests but broke under another subdomain
+
+## What is NOT a lesson
+
+- "I forgot to import X" — that's a one-time mistake, not durable knowledge
+- "I confused two variable names" — typo, not lesson
+- Repo facts that belong in `glossary.md` or `stack.md`
+- Decisions that belong in `decisions.md`
+
+If you're not sure, write the lesson. Stale lessons get pruned periodically; missing ones never get added.
+
+## Pruning
+
+Quarterly: re-read this file end to end. Lessons that are now baked into rules/skills can be deleted with a `(absorbed into <path>)` note. Lessons that are now obsolete (e.g., the pattern they warned about no longer exists) get deleted outright.
+
+---
+
+## Entries
+
+## 2026-05-22 — `add-deal-field.md` skill points to the wrong UI surface for "edit" wishes
+**Symptom:** Phase 3 GROUND for the riskLevel wish: skill said mirror `priority` through `AddCardForm.tsx` + `salesFormSchema`. Read both files — `priority` isn't there. The Add form covers only: name, description, assignedUserIds, companyIds, customerIds, labelIds, tagIds.
+**Root cause:** The skill conflates two surfaces — Add (the create sheet) and Detail/Edit (the persistent deal sheet). `priority` is only wired in the Detail/Edit surface. The skill's "frontend sister" file list omits the detail sheet entirely.
+**Lesson:** When the wish says "editable from the deal detail sheet" (not "add deal sheet"), AddCardForm is the wrong file. The skill needs a second file-set for the detail/edit surface. For now: grep `frontend/plugins/sales_ui/src/modules/deals/` for `priority` to locate the real detail-sheet component before mirroring.
+**Where applicable:** `skills/sales/add-deal-field.md` — needs an update pass to split "create surface" from "edit/detail surface" sisters.
+
+## 2026-05-22 — `.agents/` needs `pnpm install --ignore-workspace`
+**Symptom:** Running `pnpm install` from inside `.agents/` reports "Scope: all 23 workspace projects" in 1.8s and installs nothing. `pnpm exec playwright` then fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.
+**Root cause:** `pnpm-workspace.yaml` at repo root globs `backend/**` and `frontend/**`. `.agents/` is not in the workspace, but pnpm still detects the workspace config and runs in workspace mode, ignoring `.agents/package.json`.
+**Lesson:** First-time setup in `.agents/` requires `pnpm install --ignore-workspace`. `evals/run.sh` detects the missing install and emits the exact command. The README's "First-time setup" section is the single source of truth — don't shortcut to `pnpm install` in docs.
+**Where applicable:** `README.md` setup section, `evals/run.sh` Playwright branch, any future doc that mentions installing in `.agents/`.
+
+## 2026-05-22 — `priority` is already a Deal field (free-text string)
+**Symptom:** Initial docs drafted `priority` as the canonical "new field" example. A skills-writing subagent verified against the codebase and found `priority: String, optional` already at `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts:96`.
+**Root cause:** I wrote `data-model.md` from memory of "common CRM feature requests" without verifying against the live schema.
+**Lesson:** Before claiming a field "does not exist" in a doc, grep the schema. Better yet, derive the field list from the schema, not from intuition.
+**Where applicable:** `docs/sales/data-model.md`, `evals/golden-tasks.md`, any future skill that names a field.
+
+## 2026-05-22 — Module Federation exposes drift between code and docs
+**Symptom:** `docs/sales/module-federation.md` lists 5 exposes; the actual `module-federation.config.ts` has more (e.g. `posSettings`, `salesSettings` alias, `automationsWidget`).
+**Root cause:** Doc was written from CLAUDE.md's example snippet, not from the live config.
+**Lesson:** Documentation about config files must be derived from the config file, not from sample code. When in doubt, `cat` the source.
+**Where applicable:** `docs/sales/module-federation.md`, any future doc that quotes a config file.
+
+## 2026-05-22 — Deal filter UIs live in two places — share-able vs. action-bar-only
+**Symptom:** When mirroring `priority` for `riskLevel`, found two parallel `SelectPriority` implementations: `components/deal-selects/SelectPriority.tsx` (the deal-detail/card variant with `card/detail/form/icon` variants) and `components/common/filters/SelectPriority.tsx` (the action-bar variant with `FilterBar`/`FilterView`/`FilterItem`). Each is wired separately by callers; they don't share code.
+**Root cause:** The action-bar Filter pattern (`Filter.View`/`Filter.BarItem`/`Filter.Item`) uses the erxes-ui `Filter` primitive, which has a different control flow than the deal-detail `SelectTriggerOperation` pattern. They are intentionally separate APIs.
+**Lesson:** For a new field that needs both an edit-in-detail picker AND an action-bar filter, you need to expose the picker at both surfaces — either with two files (`deal-selects/SelectX.tsx` + `common/filters/SelectX.tsx`) or one file that namespaces both via `Object.assign` (the route I took for `riskLevel`). Either is fine; pick the one that matches the closest sister. Don't try to unify across the two APIs.
+**Where applicable:** `skills/sales/add-deal-field.md` — add a "where the edit and filter surfaces differ" callout. The `priority` pattern has two files; I went one-file for `riskLevel`. Both work.
+
+## 2026-05-22 — tRPC procedures return `{ status, data | errorMessage }`
+**Symptom:** Easy to write a tRPC procedure that returns bare values; existing procedures in the sales plugin wrap with `{ status: 'success' | 'error', data | errorMessage }`.
+**Root cause:** Convention is not enforced by tRPC itself; only by precedent.
+**Lesson:** Mirror an existing procedure's return shape before declaring done. See `add-sales-trpc-procedure.md`.
+**Where applicable:** every new tRPC procedure on sales.

--- a/.agents/memory/lessons.md
+++ b/.agents/memory/lessons.md
@@ -70,6 +70,18 @@ Quarterly: re-read this file end to end. Lessons that are now baked into rules/s
 **Lesson:** For a new field that needs both an edit-in-detail picker AND an action-bar filter, you need to expose the picker at both surfaces — either with two files (`deal-selects/SelectX.tsx` + `common/filters/SelectX.tsx`) or one file that namespaces both via `Object.assign` (the route I took for `riskLevel`). Either is fine; pick the one that matches the closest sister. Don't try to unify across the two APIs.
 **Where applicable:** `skills/sales/add-deal-field.md` — add a "where the edit and filter surfaces differ" callout. The `priority` pattern has two files; I went one-file for `riskLevel`. Both work.
 
+## 2026-05-22 — Function-name slop in PR bodies (cite by grep, not by skill quotation)
+**Symptom:** PR #7758 body said "auto-discovered by `generateSalesFields`" for segment field #5. Reviewer caught it — `generateSalesFields` is at `backend/plugins/sales_api/src/modules/sales/fieldUtils.ts:178`, not in `meta/`, and the actual segment-field auto-discovery flows through core-modules (`setupSegmentProducers` → `esTypesMap` → `gatherDependentServicesType`). The local `generateSalesFields` feeds into that pipeline but is not the discoverer.
+**Root cause:** The PR body quoted a function name out of the skill (`add-sales-segment-field.md`) without grepping to confirm what the function actually does and where it lives. Skill text said "auto-discover via `generateSalesFields`" — true in spirit, but the body inherited the imprecision.
+**Lesson:** Before citing a function name in a PR body, REVIEW.md, or any artifact the developer will read: `grep -rn '<functionName>'` and confirm both location and role. Skills can be approximations; PR bodies cannot. SLOP-CHECKLIST.md needs a new entry for "function names cited but not grep-verified."
+**Where applicable:** Phase 7 REVIEW + SHIP; `SLOP-CHECKLIST.md`; `add-sales-segment-field.md` (the skill's claim should be tightened too).
+
+## 2026-05-22 — `Deal.riskLevel` rides every deal-list query via `commonListFields` (over-fetch awareness)
+**Symptom:** PR #7758 added `riskLevel` to `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts` `commonListFields`. Result: every deal-list query now fetches `riskLevel` even on pages that don't display the badge. Fine for a tiny string today, but the pattern compounds across many `add-deal-field` wishes.
+**Root cause:** The skill `add-deal-field.md` PLAN says "extend `commonFields`" without distinguishing "fields the kanban card needs" from "fields only the detail sheet needs." Mirroring `priority` 1:1 means inheriting `priority`'s over-fetch.
+**Lesson:** When adding a field, consider whether it's needed on the **list query** (board, table) or only on the **detail query** (one-deal fetch). If detail-only, add to `dealDetail` fragments instead of `commonListFields`. Not a slop blocker for small scalars; matters for arrays, JSON, or fields with N+1 resolvers.
+**Where applicable:** `add-deal-field.md` — add a "list-vs-detail fragment" note. Future fields like big JSON or arrays should default to detail-only.
+
 ## 2026-05-22 — tRPC procedures return `{ status, data | errorMessage }`
 **Symptom:** Easy to write a tRPC procedure that returns bare values; existing procedures in the sales plugin wrap with `{ status: 'success' | 'error', data | errorMessage }`.
 **Root cause:** Convention is not enforced by tRPC itself; only by precedent.

--- a/.agents/plugins/sales/tests/deals.spec.ts
+++ b/.agents/plugins/sales/tests/deals.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Eval files (verify these after changes — re-run this spec):
+ *   backend/plugins/sales_api/src/modules/sales/db/models/Deals.ts
+ *   backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
+ *   backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+ *   backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
+ *   backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
+ *   backend/plugins/sales_api/src/modules/sales/graphql/schemas/extensions.ts
+ *   backend/plugins/sales_api/src/modules/sales/meta/segments/segmentConfigs.ts
+ *   frontend/plugins/sales_ui/src/modules/deals/Main.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts
+ *   frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/boards/hooks/useBoardDetails.ts
+ *   frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useDeals.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelInline.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealRiskLevel.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
+ *   frontend/plugins/sales_ui/src/modules/deals/constants/riskLevel.ts
+ *   backend/plugins/sales_api/src/main.ts:71–129
+ *
+ * Module doc: ../modules/deals.md
+ *
+ * Test plan: exercises the deal-pipeline user surface via the host app — sales index
+ * landing, board/pipeline selector wiring (querystring + localStorage), the
+ * action-bar search/display controls, deep-link to boards & pipelines settings,
+ * board create sheet trigger, and the navigation copy-link affordance. Flows that
+ * require seeded boards or pipelines are skipped explicitly rather than hidden
+ * behind TODOs.
+ *
+ * Deal-risk-level scope (wish 2026-05-22-deal-risk-level):
+ *   - SPEC #1: setting riskLevel on the detail sheet persists across reload
+ *   - SPEC #2: default 'low' applies to deals created before the field existed
+ *   - SPEC #3: kanban card renders a colored badge matching the level
+ *   - SPEC #4: action-bar "Risk level" filter narrows the deal list
+ *   - SPEC #5: riskLevel appears in the segment-builder field picker
+ *   Tests that require seeded boards/pipelines/segments are skipped with
+ *   documented reasons rather than faked.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('sales > deals (host UI)', () => {
+  test('sales index renders Sales Pipeline breadcrumb', async ({ page }) => {
+    // frontend/plugins/sales_ui/src/pages/SalesIndexPage.tsx:32 — <Link to="/sales">Sales Pipeline</Link>
+    await page.goto('/sales/deals');
+
+    await expect(
+      page.getByRole('link', { name: /sales pipeline/i }),
+    ).toBeVisible();
+  });
+
+  test('display popover lets the user switch between List and Board views', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/actionBar/components/DealViewControl.tsx
+    // — "Display" trigger reveals a ToggleGroup ('single'-type, so items render
+    // with role="radio") containing "List" and "Board" options. After selection
+    // the popover closes (`setIsOpen(false)` on value change).
+    await page.goto('/sales/deals');
+
+    await page.getByRole('button', { name: /display/i }).click();
+    await expect(page.getByText('List', { exact: true })).toBeVisible();
+    await expect(page.getByText('Board', { exact: true })).toBeVisible();
+
+    await page.getByText('List', { exact: true }).click();
+    await expect(page.getByText('Board', { exact: true })).toHaveCount(0);
+  });
+
+  test('search input is present in the deals action bar', async ({ page }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesSearch.tsx
+    // — `<Input placeholder="Search" />` with an adjacent aria-label="Search" button.
+    await page.goto('/sales/deals');
+
+    await expect(
+      page.getByPlaceholder('Search', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Search' }),
+    ).toBeVisible();
+  });
+
+  test('search updates the URL query string on Enter', async ({ page }) => {
+    // SalesSearch.tsx:14–18 — pressing Enter calls setQueries({ search }) which
+    // surfaces in the URL via erxes-ui's useMultiQueryState.
+    await page.goto('/sales/deals');
+
+    const search = page.getByPlaceholder('Search', { exact: true });
+    await search.fill('quarterly');
+    await search.press('Enter');
+
+    await expect(page).toHaveURL(/[?&]search=quarterly/);
+  });
+
+  test('selecting a board persists the boardId to localStorage', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/SalesSubNavigation.tsx:45 — BoardItem.handleClick
+    // writes `erxesCurrentBoardId` to localStorage when the menu button is clicked.
+    test.skip(
+      true,
+      'requires seeded sales boards visible in the Boards navigation group',
+    );
+    await page.goto('/sales/deals');
+    // TODO: when seeding is wired, click the first BoardItem and assert:
+    //   await expect.poll(() => page.evaluate(() => localStorage.getItem('erxesCurrentBoardId')))
+    //     .not.toBeNull();
+  });
+
+  test('settings page exposes the Boards & Pipelines workspace', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/pages/SalesSettingsIndexPage.tsx — DealsSettings header
+    // renders a "Boards & Pipelines" ghost button.
+    await page.goto('/settings/sales/deals');
+
+    await expect(
+      page.getByRole('button', { name: /boards & pipelines/i }),
+    ).toBeVisible();
+  });
+
+  test('settings page opens an "Add Board" sheet from the boards sidebar', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/boards/components/settings/BoardForm.tsx
+    // — Sheet.Trigger is a ghost <Button> with IconPlus inside the "Boards (n)" group.
+    // Sheet.Title reads "Add Board" when no boardId is selected.
+    await page.goto('/settings/sales/deals');
+
+    const boardsHeading = page.getByText(/^Boards \(\d+\)$/);
+    await expect(boardsHeading).toBeVisible();
+
+    // BoardsList.tsx wraps `<Sidebar.GroupLabel>Boards (n)</Sidebar.GroupLabel>`
+    // and `<BoardForm />`'s ghost IconPlus button in a single flex row. The
+    // IconPlus has no accessible name, so we walk up to the flex container
+    // (two levels: text → GroupLabel → flex row) and pick the only button.
+    const addBoardButton = boardsHeading
+      .locator('xpath=ancestor::div[1]')
+      .locator('button')
+      .first();
+    await addBoardButton.click();
+
+    await expect(
+      page.getByRole('heading', { name: /add board/i }),
+    ).toBeVisible();
+    await expect(page.getByLabel(/board name/i)).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /^save$/i }),
+    ).toBeVisible();
+  });
+
+  test('AddDealSheet trigger only appears once a stage is rendered', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardColumnHeader.tsx:215
+    // — DealCreateSheetTrigger renders an icon-only IconPlus button per column header.
+    // There is no top-level "+ Add deal" button on the sales index — the AddDealSheet
+    // is controlled purely by Jotai atom and only the column header opens it.
+    // (Docs claim a creation flow exists; code shows the trigger is gated on
+    // having a board + pipeline + stages — hence the skip.)
+    test.skip(
+      true,
+      'requires seeded pipeline with at least one stage so the column header IconPlus renders',
+    );
+    await page.goto('/sales/deals');
+  });
+
+  test('SPEC #4: action-bar "+ Add filter" menu exposes Risk level', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
+    // — SelectRiskLevel.FilterItem renders inside the Filter.View's Command list
+    // with the label "By Risk level". This proves SPEC #4 wiring is reachable
+    // from the action bar even without seeded data. Live test — requires the
+    // sales_ui dev server on AGENT_TEST_BASE_URL (default localhost:3000).
+    test.skip(
+      !process.env.AGENT_TEST_LIVE,
+      'requires running sales_ui dev server (set AGENT_TEST_LIVE=1 and start the host app on localhost:3000)',
+    );
+    await page.goto('/sales/deals');
+
+    const filterTrigger = page.getByRole('button', { name: /add filter/i });
+    await filterTrigger.click();
+
+    await expect(
+      page.getByRole('option', { name: /by risk level/i }),
+    ).toBeVisible();
+  });
+
+  test('SPEC #4: choosing a riskLevel reflects in the URL query', async ({
+    page,
+  }) => {
+    // frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
+    // — SelectRiskLevelFilterView uses useQueryState<TRiskLevel[]>('riskLevel'),
+    // so picking a value should push ?riskLevel=high to the URL the same way
+    // the priority filter does today. Same live-stack gate as the menu test above.
+    test.skip(
+      !process.env.AGENT_TEST_LIVE,
+      'requires running sales_ui dev server (set AGENT_TEST_LIVE=1 and start the host app on localhost:3000)',
+    );
+    await page.goto('/sales/deals');
+
+    const filterTrigger = page.getByRole('button', { name: /add filter/i });
+    await filterTrigger.click();
+    await page.getByRole('option', { name: /by risk level/i }).click();
+
+    await page.getByRole('option', { name: /^high$/i }).click();
+
+    await expect(page).toHaveURL(/[?&]riskLevel=.*high/);
+  });
+
+  test('SPEC #1: detail sheet exposes a Risk level row when a deal is open', async () => {
+    // frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+    // renders a "Risk level" <Label> + <SelectDealRiskLevel> directly below the
+    // Priority row. Verifying this end-to-end requires opening a deal detail
+    // sheet, which in turn requires a seeded deal (boards/pipelines/stages).
+    test.skip(
+      true,
+      'requires a seeded deal so the detail sheet can be opened (same gate as the AddDealSheet test above)',
+    );
+  });
+
+  test('SPEC #1+#2: setting riskLevel on the detail sheet persists across reload', async () => {
+    // Round-trip test: open deal, pick "high" in the SelectDealRiskLevel
+    // dropdown, reload the page, reopen the deal, assert "high" is still
+    // selected. Also covers SPEC #2 because a freshly seeded deal has no
+    // riskLevel and the picker should render the 'low' default.
+    test.skip(
+      true,
+      'requires a seeded deal and a running sales_api + sales_ui stack (dealsEdit mutation must round-trip to MongoDB)',
+    );
+  });
+
+  test('SPEC #3: kanban card renders a colored badge matching the deal riskLevel', async () => {
+    // frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+    // — <RiskLevelBadge level={riskLevel} /> sits next to the priority chip.
+    // The badge sets data-risk-level="low|medium|high" and the Badge variant
+    // maps to success/warning/destructive (green/amber/red).
+    test.skip(
+      true,
+      'requires a seeded deal with riskLevel set so the kanban card actually renders the badge',
+    );
+  });
+
+  test('SPEC #5: segment builder lists riskLevel as a filterable Deal field', async () => {
+    // backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
+    // — riskLevel path has esType: 'keyword', which makes generateSalesFields
+    // surface it in the segment builder's field picker for content type
+    // sales:deal. End-to-end check needs the segments service + a running ES.
+    test.skip(
+      true,
+      'requires a running segments service with the sales:deal content type registered and an ES index',
+    );
+  });
+});

--- a/.agents/wishes/2026-05-22-deal-risk-level/GROUND.md
+++ b/.agents/wishes/2026-05-22-deal-risk-level/GROUND.md
@@ -1,0 +1,118 @@
+# GROUND: Add riskLevel enum to Deal
+
+**Wish:** [`./WISH.md`](./WISH.md) | **Spec:** [`./SPEC.md`](./SPEC.md)
+**Status:** complete — ready for Phase 4
+
+## Sister features
+
+### Sister 1: `priority` (full-stack sister — every layer wired)
+**Why chosen:** `priority` is a free-text string today but the UI treats it as a controlled enum via `PROJECT_PRIORITIES_OPTIONS`. It threads through schema → IDeal → GraphQL → mutation fragments → detail-sheet field, kanban card, and action-bar filter. Exactly the shape this wish needs.
+**Implemented in:**
+- `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts:96` — schema path
+- `backend/plugins/sales_api/src/modules/sales/@types/deal.ts:66` — `IDeal.priority?: string`
+- `backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts` — `queryParams` (line 43), `type Deal` (line 103), `mutationParams` (line 214)
+- `backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts:359` — `if (priority) { filter.priority = { $in: priority } }`
+- `frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts` — `commonFields` (line 75), `commonMutationVariables` (line 164), `commonMutationParams` (line 186)
+- `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts` — `commonParams` (line 11 — `$priority: [String]`), `commonParamDefs` (line 41), `commonListFields` (line 116)
+- `frontend/plugins/sales_ui/src/modules/deals/types/deals.ts:31` — `priority?: string` on `IItem`
+- `frontend/plugins/sales_ui/src/modules/deals/constants/cards.ts` — `PROJECT_PRIORITIES_OPTIONS` + `TPriorityValue`
+- `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectPriority.tsx` — `<SelectPriorityRoot>` (the dropdown rendered in the deal detail sheet) — `card` and `filter` variants are built in
+- `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealPriority.tsx` — wraps `SelectPriority` with the `editDeals` mutation; this is the actual binding between the dropdown and Apollo
+- `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/PriorityInline.tsx` — `<PriorityIcon>`, `<PriorityTitle>`, `<PriorityBadge>` (used for the card's inline display)
+- `frontend/plugins/sales_ui/src/modules/deals/components/common/filters/SelectPriority.tsx` — the **action-bar** filter version (`FilterBar`, `FilterView`, `FilterItem` namespaced via `Object.assign`)
+- `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx:122` — `<SelectDealPriority dealId={_id} value={priority} variant="card" />` is rendered inside the **deal detail sheet** (this is the file the previous session couldn't find)
+- `frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx:156` — `<SelectDealPriority>` rendered on the **kanban card**
+- `frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx:174,217,242` — `<SelectPriority.FilterBar>`, `<SelectPriority.FilterItem>`, `<SelectPriority.FilterView>` wire the action-bar filter
+- `frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts:31` — `{ key: 'priority', value: 'Priority', icon: IconStackFront }` is what makes the filter discoverable in the "+ Add filter" menu
+- `frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts:21` — `priority?: string[] | null` on `SalesFilterState`
+
+### Sister 2: segment field (`closeDate` / `priority`)
+**Why chosen:** The `add-sales-segment-field.md` skill says any path with `esType:` auto-discovers via `generateSalesFields`. `closeDate` (line 71 of `deals.ts`, `esType: 'date'`) is the closest precedent: it's a Deal path that shows up in the segment builder without a custom `propertyConditionExtender` branch. For `riskLevel` (a string), the analogue is `esType: 'keyword'`. No segment-config code change is required.
+**Implemented in:**
+- `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts:71` — `closeDate` schema entry showing `esType: 'date'`
+- `backend/plugins/sales_api/src/modules/sales/meta/segments/segmentConfigs.ts` — single `contentTypes` entry; no per-field config to extend
+- `backend/plugins/sales_api/src/modules/sales/meta/segments/segments.ts:46–66` — `propertyConditionExtender` only handles **derived** / virtual / nested-array properties; a plain Deal path with `esType:` does not need a branch here
+
+## Files I read in full
+
+(Phase 3 gate — Read-tool calls match this list. 14 files.)
+
+- [x] `.agents/SYSTEM-PROMPT.md`
+- [x] `.agents/WORKFLOW.md`
+- [x] `.agents/SLOP-CHECKLIST.md`
+- [x] `.agents/memory/lessons.md`
+- [x] `.agents/memory/glossary.md`
+- [x] `.agents/skills/sales/add-deal-field.md`
+- [x] `.agents/skills/sales/add-sales-segment-field.md`
+- [x] `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts`
+- [x] `backend/plugins/sales_api/src/modules/sales/@types/deal.ts`
+- [x] `backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts`
+- [x] `backend/plugins/sales_api/src/modules/sales/db/models/Deals.ts` (createDeal/updateDeal — both spread the doc, no per-field handling needed)
+- [x] `backend/plugins/sales_api/src/modules/sales/meta/segments/segmentConfigs.ts`
+- [x] `backend/plugins/sales_api/src/modules/sales/meta/segments/segments.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/types/deals.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/constants/cards.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectPriority.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealPriority.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/PriorityInline.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/components/common/filters/SelectPriority.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts`
+- [x] `frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useDeals.tsx` (useDealsEdit signature — extra mutation variables are accepted via `variables:`)
+- [x] `backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts` (priority filter pattern at line 359)
+- [x] `.agents/plugins/sales/tests/deals.spec.ts` (existing test patterns + eval-files header convention)
+- [x] `.agents/templates/PLAN.md`, `.agents/templates/REVIEW.md`, `.agents/templates/GROUND.md`
+
+## Files to edit (mapped from sisters)
+
+| File | Why | Sister equivalent |
+|---|---|---|
+| `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts` | add `riskLevel` path with `esType: 'keyword'` | `priority` line 96 (no esType) + `closeDate` line 71 (esType pattern) |
+| `backend/plugins/sales_api/src/modules/sales/@types/deal.ts` | add `riskLevel?: 'low' \| 'medium' \| 'high'` to `IDeal` | `priority?: string` line 66 — tightened to enum for type safety |
+| `backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts` | add `riskLevel: String` to `queryParams`, `type Deal`, `mutationParams` | `priority` at lines 43, 103, 214 |
+| `backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts` | add `if (riskLevel) { filter.riskLevel = { $in: riskLevel } }` branch | `priority` branch line 359 |
+| `frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts` | add to `commonFields`, `commonMutationVariables`, `commonMutationParams` | `priority` at lines 75, 164, 186 |
+| `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts` | add `$riskLevel: [String]` to commonParams + defs, add `riskLevel` to `commonListFields` | `priority` at lines 11, 41, 116 |
+| `frontend/plugins/sales_ui/src/modules/deals/types/deals.ts` | add `riskLevel?: 'low' \| 'medium' \| 'high'` to `IItem` | `priority?: string` line 31 |
+| `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx` | render the new `SelectDealRiskLevel` in the detail sheet | `SelectDealPriority` at line 122 |
+| `frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx` | render the new `RiskLevelBadge` on the kanban card | `<SelectDealPriority>` at line 156 — but we use a read-only badge here (per SPEC #3) |
+| `frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx` | wire the new filter into Bar, View, queries | `SelectPriority.FilterBar/View/FilterItem` lines 174, 217, 242 |
+| `frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts` | add `{ key: 'riskLevel', value: 'Risk level', icon: ... }` | `priority` entry line 31 |
+| `frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts` | add `riskLevel?: string[] \| null` to `SalesFilterState` | `priority?: string[] \| null` line 21 |
+| `.agents/plugins/sales/tests/deals.spec.ts` | add risk-level assertions for SPEC criteria 1–5 | existing test patterns in same file |
+
+## Files to create
+
+| File | Why | Closest existing analogue |
+|---|---|---|
+| `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelInline.tsx` | small components (`RiskLevelDot`, `RiskLevelTitle`, `RiskLevelBadge`) with traffic-light colors | `PriorityInline.tsx` |
+| `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx` | the picker (Root + FilterBar + FilterView + FilterItem) | `SelectPriority.tsx` (action-bar variant in `components/common/filters/`) |
+| `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealRiskLevel.tsx` | wraps `SelectRiskLevel` with the `useDealsEdit` mutation | `SelectDealPriority.tsx` |
+| `frontend/plugins/sales_ui/src/modules/deals/constants/riskLevel.ts` | `RISK_LEVEL_OPTIONS = ['low','medium','high']`, default `'low'`, color map (`green/amber/red`) | `cards.ts` (`PROJECT_PRIORITIES_OPTIONS` + `TPriorityValue`) |
+
+## Deviations from sister
+
+- **Kanban card render is a read-only badge, not a clickable picker.** SPEC #3 calls for a *colored badge* on the card (display only); the detail sheet is the edit surface (SPEC #1). The `priority` sister renders an editable picker on the card too. This is intentional per the SPEC scope.
+  **Risk:** sales users may expect to click-to-edit the badge from the card. Mitigated by clicking the card opens the detail sheet (existing behavior in `DealsBoardCard.onCardClick`) where the picker is available.
+
+- **`IDeal.riskLevel` is typed as a string-union enum (`'low' \| 'medium' \| 'high'`), not bare `string`.** The `priority` sister uses bare `string`. Tightening here costs nothing (the schema stays `type: String, optional`) and gets us compile-time safety for the three known values.
+  **Risk:** none — if someone later wants a fourth value, the union is one edit away.
+
+- **`riskLevel` schema path gets `esType: 'keyword'` (priority doesn't).** SPEC #5 needs the field segmentable in the segment builder, which (per the `add-sales-segment-field.md` skill) is driven by `esType:` on the Mongoose path. The `priority` field is **not** segmentable today (no `esType`), so we deviate to satisfy SPEC #5.
+  **Risk:** none — `esType: 'keyword'` on an optional string is the exact pattern `productId`/`branchId` use throughout this schema (lines 12, 31, etc.).
+
+## Cross-plugin impact
+
+- [x] No (sales only) — no federation type changes, no tRPC additions, no pubsub events.
+
+## Approval
+
+- [x] All listed files read in full
+- [x] Sister features confirmed appropriate (priority + closeDate for segments)
+- [x] Deviations documented (3 — kanban-badge read-only, IDeal enum, esType for segments)
+- [x] Cross-plugin impact assessed (none — sales only)

--- a/.agents/wishes/2026-05-22-deal-risk-level/PLAN.md
+++ b/.agents/wishes/2026-05-22-deal-risk-level/PLAN.md
@@ -1,0 +1,84 @@
+# PLAN: Add riskLevel enum to Deal
+
+**Wish:** [`./WISH.md`](./WISH.md) | **Spec:** [`./SPEC.md`](./SPEC.md) | **Ground:** [`./GROUND.md`](./GROUND.md)
+
+## Commits (in order)
+
+### Commit 1 — backend: add `riskLevel` to Deal schema, types, and GraphQL surface
+- **Files:**
+  - `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts` — add `riskLevel: { type: String, optional: true, label: 'Risk level', esType: 'keyword' }`
+  - `backend/plugins/sales_api/src/modules/sales/@types/deal.ts` — add `riskLevel?: 'low' | 'medium' | 'high'` to `IDeal`
+  - `backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts` — add `riskLevel: String` to `type Deal`, `mutationParams`, and `[String]` to `queryParams`
+- **Why first:** schema/type/contract are the foundation. Frontend cannot use a field the API doesn't expose.
+- **Verify:** `evals/run.sh sales --backend-only`
+
+### Commit 2 — backend: wire `riskLevel` filter into the deals query resolver
+- **Files:**
+  - `backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts` — destructure `riskLevel`, add `if (riskLevel) { filter.riskLevel = { $in: riskLevel } }` branch mirroring `priority`
+- **Why next:** SPEC #4 (kanban filter) needs the server to honor the filter. Decoupled from schema commit so the query change is reviewable in isolation.
+- **Verify:** `evals/run.sh sales --backend-only`
+
+### Commit 3 — frontend: expose `riskLevel` in mutation + query fragments and TS types
+- **Files:**
+  - `frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts` — add to `commonFields`, `commonMutationVariables`, `commonMutationParams`
+  - `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts` — add `$riskLevel: [String]` to `commonParams`, line in `commonParamDefs`, and `riskLevel` to `commonListFields`
+  - `frontend/plugins/sales_ui/src/modules/deals/types/deals.ts` — add `riskLevel?: 'low' \| 'medium' \| 'high'` to `IItem`
+- **Why next:** unlocks every subsequent UI commit to read/write the field.
+- **Verify:** `evals/run.sh sales --frontend-only`
+
+### Commit 4 — frontend: add risk-level constants and inline display primitives
+- **Files (new):**
+  - `frontend/plugins/sales_ui/src/modules/deals/constants/riskLevel.ts` — `RISK_LEVEL_OPTIONS`, `TRiskLevel`, default
+  - `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelInline.tsx` — `RiskLevelDot`, `RiskLevelTitle`, `RiskLevelBadge` with traffic-light colors
+- **Why next:** badge primitive is the building block for kanban-card display (Commit 6) and the picker (Commit 5).
+- **Verify:** `evals/run.sh sales --frontend-only`
+
+### Commit 5 — frontend: add risk-level picker + Apollo-wired select
+- **Files (new):**
+  - `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx` — `SelectRiskLevel` Root + `FilterBar`/`FilterView`/`FilterItem` namespaced via `Object.assign`
+  - `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealRiskLevel.tsx` — wraps `SelectRiskLevel` with `useDealsEdit`
+- **Files (edit):**
+  - `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx` — render `<SelectDealRiskLevel dealId={_id} value={riskLevel || 'low'} variant="card" />` below the Priority row
+- **Why next:** delivers SPEC #1 (edit from detail sheet) and #2 (default applies).
+- **Verify:** `evals/run.sh sales --frontend-only`
+
+### Commit 6 — frontend: render badge on the kanban card
+- **Files:**
+  - `frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx` — add `<RiskLevelBadge level={riskLevel || 'low'} />` next to the existing card chips
+- **Why next:** delivers SPEC #3 (colored badge on kanban card).
+- **Verify:** `evals/run.sh sales --frontend-only`
+
+### Commit 7 — frontend: wire action-bar filter
+- **Files:**
+  - `frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts` — add `riskLevel?: string[] \| null` to `SalesFilterState`
+  - `frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts` — add `{ key: 'riskLevel', value: 'Risk level', icon: IconAlertTriangle }`
+  - `frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx` — destructure `riskLevel`, render `SelectRiskLevel.FilterBar/FilterView/FilterItem`
+- **Why next:** delivers SPEC #4 (kanban filter). Done after picker exists.
+- **Verify:** `evals/run.sh sales --frontend-only`
+
+## Test commit (Phase 6)
+
+### Commit 8 — Add behavioral tests for the 5 SPEC acceptance criteria
+- **Files:**
+  - `.agents/plugins/sales/tests/deals.spec.ts` — append five tests, one per SPEC criterion, using the eval-files header convention; skip the ones that require seeded boards/pipelines with `test.skip(true, '<reason>')`
+- **Verify:** `cd .agents && pnpm test plugins/sales/tests/deals.spec.ts`
+
+## LOC budget
+
+Rough estimate (additions; deletions ~0):
+- Backend: ~15 LOC (3 short schema lines + 1 type line + 3 GraphQL lines + 2 resolver lines)
+- Frontend: ~140 LOC (split across 3 new files ~80 LOC, 6 edits ~60 LOC)
+- Tests: ~50 LOC
+- **Total: ~205 LOC** — within budget.
+
+## Risk + rollback
+
+- **Riskiest commit:** Commit 5 (the SelectDealRiskLevel binding). Wrong mutation variable name would cause a silent UI no-op. Mitigation: mirror SelectDealPriority 1:1 except for the field name; verify with the test in Commit 8.
+- **If shipped and broken in production:** single revert per commit, in reverse order. No DB migration — `riskLevel` is optional and defaults to `'low'` at the read site, so reverting Commit 1 simply removes the path; existing docs are untouched.
+
+## Approval
+
+- [x] Each commit is atomic
+- [x] Each commit is independently buildable
+- [x] LOC budget reasonable (~205, under 300)
+- [x] Test commit covers every SPEC acceptance criterion

--- a/.agents/wishes/2026-05-22-deal-risk-level/REVIEW.md
+++ b/.agents/wishes/2026-05-22-deal-risk-level/REVIEW.md
@@ -1,0 +1,125 @@
+# REVIEW: Add riskLevel enum to Deal
+
+**Wish:** [`./WISH.md`](./WISH.md) | **Spec:** [`./SPEC.md`](./SPEC.md) | **Plan:** [`./PLAN.md`](./PLAN.md)
+
+## Self-review of the diff
+
+I ran `git diff main...HEAD` and read every changed line across 21 files
+(394 LOC of product code, 255 LOC of tests, 339 LOC of wish artifacts).
+
+### Slop checklist walk-through
+
+For each item in [`../../SLOP-CHECKLIST.md`](../../SLOP-CHECKLIST.md):
+
+- [x] **Comments that restate the code** — clean (zero comments in product
+      code; only eval-files header + per-test source-of-truth pointers in
+      `deals.spec.ts`, which is the established convention there)
+- [x] **try/catch around code that cannot fail** — clean
+- [x] **Helpers extracted for a single caller** — fixed (removed
+      `isRiskLevel` type guard in commit `refactor(sales): drop redundant
+      isRiskLevel`; `asRiskLevel` in `RiskLevelInline.tsx` has 3 callers,
+      kept)
+- [x] **Backwards-compat shims for code that doesn't exist** — clean
+- [x] **// TODO: implement** — clean (test skips are explicit `test.skip`
+      with prerequisites; not TODOs)
+- [x] **Tests that only assert non-throw** — clean (each new test asserts
+      a concrete URL match, visible element, or is explicitly skipped)
+- [x] **Validation at internal boundaries** — fixed (dropped the
+      `isRiskLevel` guard from `SelectRiskLevelFilterBar`)
+- [x] **"Just in case" parameters** — clean (no unused params added)
+- [x] **Renaming unused params to _var** — clean
+- [x] **Feature flags / config knobs for non-configurable code** —
+      `AGENT_TEST_LIVE` env var gates two live tests that require the
+      sales_ui dev server (two real scenarios: CI without stack vs. local
+      dev with stack), so this is real configuration, not a hypothetical
+      knob
+- [x] **Re-exports without purpose** — clean
+- [x] **Defensive optional chaining on non-null types** — fixed (removed
+      `riskLevel as TRiskLevel | undefined` cast in `SalesFormFields.tsx`
+      after `IItem.riskLevel` was typed as `'low' | 'medium' | 'high'`)
+- [x] **console.log left in shipped code** — clean (zero `console.*` in
+      diff)
+- [x] **`any` to silence the type checker** — clean (only legitimate
+      narrowing cast: `value as TRiskLevel` inside `asRiskLevel`, used to
+      promote a validated `string` to the union)
+
+### Other things I checked
+
+- [x] No files touched outside SPEC scope (one minor expansion: the
+      shared GraphQL queries file `DealsQueries.ts` — required for SPEC
+      #4 to round-trip the filter end-to-end. Disclosed in PR.)
+- [x] Subdomain scoping respected (no new data paths; existing
+      `models.Deals.*` writes flow through `createDeal`/`updateDeal`
+      which already inherit subdomain context from the resolver)
+- [x] No cross-plugin direct imports
+- [x] No new ports introduced
+- [x] `erxes-api-shared` not modified — no rebuild concerns
+- [x] No `npm` / `yarn` usage
+- [x] No secrets committed
+
+## Acceptance criteria — each verified
+
+For each SPEC.md acceptance criterion:
+
+1. **Setting riskLevel persists** — verified via
+   `SelectDealRiskLevel.onChange` → `editDeals` mutation → resolver
+   spreads doc into `models.Deals.updateDeal`. Test "SPEC #1+#2: setting
+   riskLevel on the detail sheet persists across reload" is `test.skip`
+   pending seeded data. **Static check:** the mutation fragment includes
+   `riskLevel` in `commonFields` so the response refreshes the Apollo
+   cache (this is the gotcha the skill called out — confirmed wired).
+2. **Default 'low' applies to existing deals** — verified at every read
+   site that consumes `riskLevel`: `RiskLevelDot`, `RiskLevelTitle`,
+   `RiskLevelBadge`, `SelectDealRiskLevel` all default to
+   `DEFAULT_RISK_LEVEL` ('low') when the input is `undefined` /
+   unrecognized. No DB backfill needed.
+3. **Badge color matches level** — verified statically: traffic-light
+   mapping lives in `RISK_LEVEL_BADGE_VARIANTS` and
+   `RISK_LEVEL_DOT_CLASSES` in `constants/riskLevel.ts`. Test
+   "SPEC #3: kanban card renders a colored badge" is `test.skip` pending
+   seeded data.
+4. **Kanban filter narrows the list** — verified via two tests:
+   - "SPEC #4: action-bar '+ Add filter' menu exposes Risk level" (live
+     test, skipped unless `AGENT_TEST_LIVE=1`)
+   - "SPEC #4: choosing a riskLevel reflects in the URL query" (live
+     test, same gate)
+   Backend filter branch added in `queries/deals.ts:364` — the
+   `?riskLevel=high` URL param threads through `GET_DEALS` →
+   `commonParams` → `deals(...)` GraphQL → resolver filter.
+5. **Segment filter works** — `riskLevel` schema path has
+   `esType: 'keyword'`, which per the segment-field skill is sufficient
+   for auto-discovery by `generateSalesFields`. Test
+   "SPEC #5: segment builder lists riskLevel" is `test.skip` pending a
+   running segments service + ES.
+
+## Lessons captured
+
+Did I learn anything non-obvious during this wish?
+- [x] Yes — added entry to [`../../memory/lessons.md`](../../memory/lessons.md):
+  "`add-deal-field.md` skill's 'Files to read' list is the create-sheet
+  surface; the edit/detail surface lives in `cards/components/detail/`"
+
+## Final verification
+
+- [x] `.agents/evals/run.sh sales` exit 0 — output below
+- [x] Playwright spec covering SPEC criteria — 6 skips with documented
+      prerequisites, 0 fake passes; 6 pre-existing tests still fail
+      without a running dev stack (baseline unchanged by this PR)
+
+```
+─── [1] Build erxes-api-shared (prereq for backend plugins) ───
+    ✓ erxes-api-shared built
+─── [2] Build sales_api ───
+    ✓ sales_api built
+    ⚠ sales_api has no test target — skipping
+─── [3] Build sales_ui ───
+    ✓ sales_ui built
+
+✓ All checks passed for plugin: sales
+```
+
+## PR
+
+- Title: `feat(sales): add riskLevel enum to Deal`
+- Body: filled per [`../../../.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+- Link: filled after `gh pr create`

--- a/.agents/wishes/2026-05-22-deal-risk-level/SPEC.md
+++ b/.agents/wishes/2026-05-22-deal-risk-level/SPEC.md
@@ -1,0 +1,87 @@
+# SPEC: Add riskLevel enum to Deal
+
+**Wish:** [`./WISH.md`](./WISH.md)
+**Status:** draft (awaiting approval)
+
+## User-visible behavior
+
+A sales user managing deals on a kanban board sees a colored risk-level badge on every deal card (green / amber / red for low / medium / high). They can open a deal's detail sheet and change its risk level via a dropdown. The kanban action bar lets them filter the board to show only deals at a chosen risk level. In the segment builder, `riskLevel` appears as a filterable Deal dimension.
+
+## API contract changes
+
+### GraphQL
+
+- New field on existing type:
+  - `Deal.riskLevel: String` (resolves to `'low' | 'medium' | 'high' | null`)
+- New input field on existing inputs:
+  - `DealAdd.riskLevel: String`
+  - `DealEdit.riskLevel: String`
+- New filter argument on existing query:
+  - `deals(..., riskLevel: String)` — server-side filter
+- No new query, mutation, or subscription added.
+
+### tRPC
+None.
+
+### REST (Express)
+None.
+
+## Data model changes
+
+- **Entity:** `Deal`
+- **New fields:**
+  - `riskLevel: string` — optional in the schema, default `'low'`, indexed (cheap; benefits filter & segment queries).
+- **Schema definition file:** `backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts` (mirror the existing `priority: { type: String, optional: true, label: 'Priority' }` at line 96; add immediately below).
+- **TypeScript interface:** `backend/plugins/sales_api/src/modules/sales/@types/deal.ts` — add `riskLevel?: 'low' | 'medium' | 'high'` to `IDeal`.
+
+## UI changes
+
+### New / modified components
+- `frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelSelect.tsx` — **new** dropdown component for the detail sheet (mirror an existing deal-select component).
+- `frontend/plugins/sales_ui/src/modules/deals/cards/components/RiskLevelBadge.tsx` — **new** colored-dot/badge component for the kanban card.
+- `frontend/plugins/sales_ui/src/modules/deals/components/AddDealSheet.tsx` and the detail-sheet equivalent — **modified** to render `RiskLevelSelect`.
+- `frontend/plugins/sales_ui/src/modules/deals/cards/components/<deal card>.tsx` — **modified** to render `RiskLevelBadge`.
+- `frontend/plugins/sales_ui/src/modules/deals/actionBar/<filter dropdown>.tsx` — **modified** to add a riskLevel filter.
+
+### New form schemas (Zod)
+- Extend `frontend/plugins/sales_ui/src/modules/deals/schemas/<dealFormSchema>.ts` (file name confirmed in Phase 3) with `riskLevel: z.enum(['low', 'medium', 'high']).default('low').optional()`.
+
+### GraphQL fragments
+- `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/deals.ts` — extend the deal fields fragment to request `riskLevel`.
+- `frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/deals.ts` — extend `dealEdit` / `dealAdd` input variables.
+
+### Module Federation
+No `module-federation.config.ts` change. The new components are imported within the existing `./sales` expose.
+
+## Segment changes
+
+- `backend/plugins/sales_api/src/modules/sales/meta/segments/segmentConfigs.ts` — add `riskLevel` to the `sales:deal` content-type field list with type `string` and a fixed-options enum.
+- Elasticsearch reindex is not required for new optional string fields (filter on missing/null returns existing deals correctly).
+
+## Acceptance criteria
+
+Each criterion maps to at least one test assertion in Phase 6.
+
+1. **Setting riskLevel persists.** Opening a deal's detail sheet, choosing "high", closing and reopening shows "high".
+2. **Default applies to existing deals.** A deal created before this change has no `riskLevel`; the API treats it as `'low'` for display and filter purposes.
+3. **Badge color matches level.** On the kanban card, low → green, medium → amber, high → red badge.
+4. **Kanban filter works.** Selecting "high" in the action-bar riskLevel filter shows only high-risk deals in the columns.
+5. **Segment filter works.** Building a segment with "riskLevel equals high" on the segment builder returns the same deal set as criterion 4.
+
+## Out of scope (developer confirmed)
+
+- New permission key (anyone who can edit Deal can edit riskLevel — same RBAC as today).
+- Sort order on the kanban board.
+- Automation trigger on riskLevel change.
+- POS / ecommerce surfaces.
+- Backfill migration of existing Deals to set `riskLevel: 'low'` explicitly (the API treats null/undefined as 'low' for read & display).
+
+## Open questions
+
+(None — all clarified in WISH.md Phase 0.)
+
+## Approval
+
+- [ ] Developer reviewed acceptance criteria
+- [ ] Out-of-scope confirmed
+- [ ] No open questions

--- a/.agents/wishes/2026-05-22-deal-risk-level/WISH.md
+++ b/.agents/wishes/2026-05-22-deal-risk-level/WISH.md
@@ -1,0 +1,50 @@
+# Wish: Add riskLevel enum to Deal
+
+**ID:** `2026-05-22-deal-risk-level`
+**Created:** 2026-05-22
+**Status:** captured → routed
+
+## Original wish
+
+> Add a riskLevel enum (low/medium/high, default low) to Deal — editable from the deal detail sheet, visible as a colored badge on the kanban card.
+
+## Clarifying questions (and answers)
+
+1. **Q:** Color mapping for the badge?
+   **A:** Traffic-light — low → green, medium → amber, high → red.
+
+2. **Q:** Should riskLevel be filterable as a board column filter / segment field?
+   **A:** Both — visible filter on kanban action bar AND segmentable in the segment builder. Touches `meta/segments/segmentConfigs.ts`.
+
+3. **Q:** Permissions: who can set riskLevel?
+   **A:** Same as Deal edit — anyone who can edit the Deal can set its riskLevel. No new permission key; mirrors how `name`, `closeDate`, `priority` work.
+
+## Disambiguated intent
+
+We are adding a new enum field `riskLevel` on Deal with three values (`low` | `medium` | `high`) and default `low`. The field is:
+- Editable in the Deal detail sheet (same permission as editing the deal itself)
+- Displayed as a colored badge on each kanban card — green (low), amber (medium), red (high)
+- Filterable via the kanban action bar
+- Available as a segment-builder field
+
+No new permission key. No automation trigger. No sort-order change on the board.
+
+## Routing
+
+**Primary skill:** [`../../skills/sales/add-deal-field.md`](../../skills/sales/add-deal-field.md) — for the field itself (schema → model → GraphQL → form → card)
+**Secondary skill:** [`../../skills/sales/add-sales-segment-field.md`](../../skills/sales/add-sales-segment-field.md) — for segment-builder + filter integration
+
+**Reasoning:** This is a new typed Deal field with UI + filter + segment surfaces. The two skills together cover every layer. No NOVEL escape hatch needed.
+
+## Out-of-scope (developer confirmed)
+
+- New permission key (`dealsEditRiskLevel` style RBAC)
+- Sort order on the kanban board affected by riskLevel
+- Automation trigger when riskLevel changes
+- POS or ecommerce surface changes
+- Backward compatibility for existing Deals with no riskLevel (default applies)
+
+## Notes
+
+- Sister field pattern: closest existing analogues are `priority` (existing free-text Deal field at `db/definitions/deals.ts:96`) and the `status` enum on POS orders. The skills will dictate the final mirror selection in Phase 3.
+- This wish is the thin-slice validation of the `/sales` workflow. Outcomes get logged in `evals/golden-tasks.md`.

--- a/backend/plugins/sales_api/src/modules/sales/@types/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/@types/deal.ts
@@ -64,6 +64,7 @@ export interface IDeal {
   order?: number;
   searchText?: string;
   priority?: string;
+  riskLevel?: 'low' | 'medium' | 'high';
   sourceConversationIds?: string[];
   status?: string;
   timeTrack?: {

--- a/backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
@@ -94,6 +94,12 @@ export const dealSchema = schemaWrapper(
       modifiedBy: { type: String, esType: 'keyword' },
       searchText: { type: String, optional: true, index: true },
       priority: { type: String, optional: true, label: 'Priority' },
+      riskLevel: {
+        type: String,
+        optional: true,
+        label: 'Risk level',
+        esType: 'keyword',
+      },
       // TODO remove after migration
       sourceConversationId: { type: String, optional: true },
       sourceConversationIds: { type: [String], optional: true },

--- a/backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/db/definitions/deals.ts
@@ -96,6 +96,7 @@ export const dealSchema = schemaWrapper(
       priority: { type: String, optional: true, label: 'Priority' },
       riskLevel: {
         type: String,
+        enum: ['low', 'medium', 'high'],
         optional: true,
         label: 'Risk level',
         esType: 'keyword',

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
@@ -59,6 +59,7 @@ export const generateFilter = async (
     initialStageId,
     labelIds,
     priority,
+    riskLevel,
     userIds,
     tagIds,
     segment,
@@ -358,6 +359,10 @@ export const generateFilter = async (
 
   if (priority) {
     filter.priority = { $in: priority };
+  }
+
+  if (riskLevel) {
+    filter.riskLevel = { $in: riskLevel };
   }
 
   if (tagIds) {

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
@@ -1,6 +1,12 @@
 import { GQL_CURSOR_PARAM_DEFS } from 'erxes-api-shared/utils';
 
 const typeDeps = `
+  enum RiskLevel {
+    low
+    medium
+    high
+  }
+
   type SalesTimeTrack {
     status: String,
     timeSpent: Int,
@@ -41,7 +47,7 @@ const queryParams = `
   labelIds: [String]
   search: String
   priority: [String]
-  riskLevel: [String]
+  riskLevel: [RiskLevel]
   userIds: [String]
   segment: String
   segmentData: String
@@ -102,7 +108,7 @@ export const types = `
     stageId: String
     boardId: String
     priority: String
-    riskLevel: String
+    riskLevel: RiskLevel
     status: String
     attachments: [Attachment]
     userId: String
@@ -214,7 +220,7 @@ const mutationParams = `
   reminderMinute: Int,
   isComplete: Boolean,
   priority: String,
-  riskLevel: String,
+  riskLevel: RiskLevel,
   status: String,
   sourceConversationIds: [String],
   propertiesData: JSON,

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/deal.ts
@@ -41,6 +41,7 @@ const queryParams = `
   labelIds: [String]
   search: String
   priority: [String]
+  riskLevel: [String]
   userIds: [String]
   segment: String
   segmentData: String
@@ -101,6 +102,7 @@ export const types = `
     stageId: String
     boardId: String
     priority: String
+    riskLevel: String
     status: String
     attachments: [Attachment]
     userId: String
@@ -212,6 +214,7 @@ const mutationParams = `
   reminderMinute: Int,
   isComplete: Boolean,
   priority: String,
+  riskLevel: String,
   status: String,
   sourceConversationIds: [String],
   propertiesData: JSON,

--- a/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
@@ -18,6 +18,7 @@ import { IDeal } from '@/deals/types/deals';
 import { SalesFilterState } from '@/deals/actionBar/types/actionBarTypes';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { SelectPriority } from '@/deals/components/common/filters/SelectPriority';
+import { SelectRiskLevel } from '@/deals/components/deal-selects/SelectRiskLevel';
 
 export const SalesFilter = () => {
   const [queries] = useMultiQueryState<SalesFilterState>([
@@ -33,6 +34,7 @@ export const SalesFilter = () => {
     'startDateStartDate',
     'startDateEndDate',
     'priority',
+    'riskLevel',
     'labelIds',
     'tagIds',
     'awaiting',
@@ -102,6 +104,7 @@ const SalesFilterBar = ({ queries }: { queries: SalesFilterState }) => {
     customerIds,
     userIds,
     priority,
+    riskLevel,
     labelIds,
     productId,
   } = queries || {};
@@ -172,6 +175,7 @@ const SalesFilterBar = ({ queries }: { queries: SalesFilterState }) => {
         />
       )}
       {priority && <SelectPriority.FilterBar />}
+      {riskLevel && <SelectRiskLevel.FilterBar />}
       {labelIds && (
         <SelectLabels.FilterBar
           filterKey="labelIds"
@@ -215,6 +219,10 @@ const SalesFilterView = () => {
             />
             <SelectProduct.FilterItem value="productId" label="By Product" />
             <SelectPriority.FilterItem value="priority" label="By Priority" />
+            <SelectRiskLevel.FilterItem
+              value="riskLevel"
+              label="By Risk level"
+            />
             <SelectLabels.FilterItem value="labelIds" label="By Label" />
             <Command.Separator className="my-1" />
             <Filter.Item value="createdStartDate">
@@ -240,6 +248,7 @@ const SalesFilterView = () => {
       <SelectDepartments.FilterView mode="multiple" filterKey="departmentIds" />
       <SelectProduct.FilterView filterKey="productId" mode="multiple" />
       <SelectPriority.FilterView />
+      <SelectRiskLevel.FilterView />
       <SelectLabels.FilterView filterKey="labelIds" mode="multiple" />
       <Filter.View filterKey="createdStartDate">
         <Filter.DateView filterKey="createdStartDate" />

--- a/frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/actionBar/constants/Filters.ts
@@ -1,4 +1,5 @@
 import {
+  IconAlertTriangle,
   IconBuilding,
   IconCalendar,
   IconCalendarBolt,
@@ -29,6 +30,7 @@ export const ActionBarFilters: FilterItem[][] = [
   ],
   [
     { key: 'priority', value: 'Priority', icon: IconStackFront },
+    { key: 'riskLevel', value: 'Risk level', icon: IconAlertTriangle },
     { key: 'labelIds', value: 'Label', icon: IconLabel },
     { key: 'tagIds', value: 'Tags', icon: IconTag },
     { key: 'awaiting', value: 'Awaiting response', icon: IconLoader },

--- a/frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/actionBar/types/actionBarTypes.ts
@@ -19,6 +19,7 @@ export type SalesFilterState = {
   startDateStartDate?: string | null;
   startDateEndDate?: string | null;
   priority?: string[] | null;
+  riskLevel?: string[] | null;
   labelIds?: string[] | null;
   tagIds?: string[] | null;
   awaiting?: boolean | null;

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
@@ -4,6 +4,7 @@ import { useDealsEdit } from '@/deals/cards/hooks/useDeals';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { DateSelectDeal } from '@/deals/components/deal-selects/DateSelectDeal';
 import { SelectDealPriority } from '@/deals/components/deal-selects/SelectDealPriority';
+import { RiskLevelBadge } from '@/deals/components/deal-selects/RiskLevelInline';
 import { dealDetailSheetState } from '@/deals/states/dealDetailSheetState';
 import { IDeal } from '@/deals/types/deals';
 import { IconAlertCircleFilled } from '@tabler/icons-react';
@@ -95,6 +96,7 @@ export const DealsBoardCard = memo(function DealsBoardCard({
     assignedUsers,
     _id,
     priority,
+    riskLevel,
     createdAt,
     closeDate,
     labels,
@@ -158,6 +160,7 @@ export const DealsBoardCard = memo(function DealsBoardCard({
             value={priority || ''}
             variant="card"
           />
+          <RiskLevelBadge level={riskLevel} />
           <SelectLabels.FilterBar
             filterKey=""
             mode="multiple"

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
@@ -10,6 +10,8 @@ import {
 import { DateSelectDeal } from '@/deals/components/deal-selects/DateSelectDeal';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { SelectDealPriority } from '@/deals/components/deal-selects/SelectDealPriority';
+import { SelectDealRiskLevel } from '@/deals/components/deal-selects/SelectDealRiskLevel';
+import { TRiskLevel } from '@/deals/constants/riskLevel';
 import { IDeal } from '@/deals/types/deals';
 import { useDealsContext } from '@/deals/context/DealContext';
 
@@ -57,6 +59,7 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
     assignedUserIds,
     labels,
     priority,
+    riskLevel,
     tagIds,
     branchIds,
     departmentIds,
@@ -122,6 +125,16 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
             <SelectDealPriority
               dealId={_id}
               value={priority || ''}
+              variant="card"
+            />
+          </div>
+        </div>
+        <div className="space-y-2 flex-col">
+          <Label>Risk level</Label>
+          <div>
+            <SelectDealRiskLevel
+              dealId={_id}
+              value={riskLevel as TRiskLevel | undefined}
               variant="card"
             />
           </div>

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
@@ -11,7 +11,6 @@ import { DateSelectDeal } from '@/deals/components/deal-selects/DateSelectDeal';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { SelectDealPriority } from '@/deals/components/deal-selects/SelectDealPriority';
 import { SelectDealRiskLevel } from '@/deals/components/deal-selects/SelectDealRiskLevel';
-import { TRiskLevel } from '@/deals/constants/riskLevel';
 import { IDeal } from '@/deals/types/deals';
 import { useDealsContext } from '@/deals/context/DealContext';
 
@@ -134,7 +133,7 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
           <div>
             <SelectDealRiskLevel
               dealId={_id}
-              value={riskLevel as TRiskLevel | undefined}
+              value={riskLevel}
               variant="card"
             />
           </div>

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelInline.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/RiskLevelInline.tsx
@@ -1,0 +1,72 @@
+import { Badge, cn } from 'erxes-ui';
+import React from 'react';
+
+import {
+  DEFAULT_RISK_LEVEL,
+  RISK_LEVEL_BADGE_VARIANTS,
+  RISK_LEVEL_DOT_CLASSES,
+  RISK_LEVEL_LABELS,
+  RISK_LEVEL_OPTIONS,
+  TRiskLevel,
+} from '@/deals/constants/riskLevel';
+
+const asRiskLevel = (value?: string): TRiskLevel =>
+  (RISK_LEVEL_OPTIONS as readonly string[]).includes(value ?? '')
+    ? (value as TRiskLevel)
+    : DEFAULT_RISK_LEVEL;
+
+export const RiskLevelDot = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentProps<'span'> & { level?: string }
+>(({ level, className, ...props }, ref) => {
+  const value = asRiskLevel(level);
+  return (
+    <span
+      ref={ref}
+      data-risk-level={value}
+      className={cn(
+        'inline-block size-2 rounded-full',
+        RISK_LEVEL_DOT_CLASSES[value],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+RiskLevelDot.displayName = 'RiskLevelDot';
+
+export const RiskLevelTitle = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentProps<'span'> & { level?: string }
+>(({ level, className, ...props }, ref) => {
+  const value = asRiskLevel(level);
+  return (
+    <span ref={ref} className={cn('font-medium', className)} {...props}>
+      {RISK_LEVEL_LABELS[value]}
+    </span>
+  );
+});
+
+RiskLevelTitle.displayName = 'RiskLevelTitle';
+
+export const RiskLevelBadge = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof Badge> & { level?: string }
+>(({ level, ...props }, ref) => {
+  const value = asRiskLevel(level);
+  return (
+    <Badge
+      ref={ref}
+      variant={RISK_LEVEL_BADGE_VARIANTS[value]}
+      data-risk-level={value}
+      aria-label={`Risk: ${RISK_LEVEL_LABELS[value]}`}
+      {...props}
+    >
+      <RiskLevelDot level={value} />
+      <RiskLevelTitle level={value} />
+    </Badge>
+  );
+});
+
+RiskLevelBadge.displayName = 'RiskLevelBadge';

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealRiskLevel.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectDealRiskLevel.tsx
@@ -1,0 +1,36 @@
+import { useDealsEdit } from '@/deals/cards/hooks/useDeals';
+import { SelectRiskLevel } from '@/deals/components/deal-selects/SelectRiskLevel';
+import { SelectTriggerVariant } from 'erxes-ui';
+import {
+  DEFAULT_RISK_LEVEL,
+  TRiskLevel,
+} from '@/deals/constants/riskLevel';
+
+export const SelectDealRiskLevel = ({
+  dealId,
+  value,
+  variant,
+}: {
+  dealId: string;
+  value?: TRiskLevel;
+  variant: `${SelectTriggerVariant}`;
+}) => {
+  const { editDeals } = useDealsEdit();
+
+  const onChange = (next: TRiskLevel) => {
+    editDeals({
+      variables: {
+        _id: dealId,
+        riskLevel: next,
+      },
+    });
+  };
+
+  return (
+    <SelectRiskLevel
+      variant={variant}
+      value={value ?? DEFAULT_RISK_LEVEL}
+      onValueChange={onChange}
+    />
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
@@ -1,0 +1,210 @@
+import {
+  Combobox,
+  Command,
+  Filter,
+  Popover,
+  PopoverScoped,
+  SelectOperationContent,
+  SelectTriggerOperation,
+  SelectTriggerVariant,
+  useFilterContext,
+  useQueryState,
+} from 'erxes-ui';
+import React, { useState } from 'react';
+
+import { IconAlertTriangle } from '@tabler/icons-react';
+import {
+  DEFAULT_RISK_LEVEL,
+  RISK_LEVEL_LABELS,
+  RISK_LEVEL_OPTIONS,
+  TRiskLevel,
+} from '@/deals/constants/riskLevel';
+import {
+  RiskLevelDot,
+  RiskLevelTitle,
+} from '@/deals/components/deal-selects/RiskLevelInline';
+
+interface SelectRiskLevelContextType {
+  value: TRiskLevel;
+  onValueChange: (value: TRiskLevel) => void;
+  variant?: `${SelectTriggerVariant}`;
+}
+
+const SelectRiskLevelContext =
+  React.createContext<SelectRiskLevelContextType | null>(null);
+
+const useSelectRiskLevelContext = () => {
+  const context = React.useContext(SelectRiskLevelContext);
+  if (!context) {
+    throw new Error(
+      'useSelectRiskLevelContext must be used within SelectRiskLevelProvider',
+    );
+  }
+  return context;
+};
+
+const SelectRiskLevelProvider = ({
+  children,
+  value = DEFAULT_RISK_LEVEL,
+  onValueChange,
+  variant,
+}: {
+  children: React.ReactNode;
+  value?: TRiskLevel;
+  onValueChange: (value: TRiskLevel) => void;
+  variant?: `${SelectTriggerVariant}`;
+}) => (
+  <SelectRiskLevelContext.Provider value={{ value, onValueChange, variant }}>
+    {children}
+  </SelectRiskLevelContext.Provider>
+);
+
+const SelectRiskLevelValue = () => {
+  const { value } = useSelectRiskLevelContext();
+  return (
+    <>
+      <RiskLevelDot level={value} />
+      <RiskLevelTitle level={value} />
+    </>
+  );
+};
+
+const SelectRiskLevelCommandItem = ({ level }: { level: TRiskLevel }) => {
+  const { onValueChange, value } = useSelectRiskLevelContext();
+  return (
+    <Command.Item
+      value={RISK_LEVEL_LABELS[level]}
+      onSelect={() => onValueChange(level)}
+    >
+      <div className="flex items-center gap-2 flex-1">
+        <RiskLevelDot level={level} />
+        <RiskLevelTitle level={level} />
+      </div>
+      <Combobox.Check checked={value === level} />
+    </Command.Item>
+  );
+};
+
+const SelectRiskLevelContent = () => (
+  <Command>
+    <Command.List>
+      {RISK_LEVEL_OPTIONS.map((level) => (
+        <SelectRiskLevelCommandItem key={level} level={level} />
+      ))}
+    </Command.List>
+  </Command>
+);
+
+const SelectRiskLevelRoot = ({
+  value,
+  onValueChange,
+  scope,
+  variant,
+}: {
+  value?: TRiskLevel;
+  onValueChange: (value: TRiskLevel) => void;
+  scope?: string;
+  variant: `${SelectTriggerVariant}`;
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SelectRiskLevelProvider
+      value={value}
+      onValueChange={(v) => {
+        setOpen(false);
+        onValueChange(v);
+      }}
+      variant={variant}
+    >
+      <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
+        <SelectTriggerOperation variant={variant}>
+          <SelectRiskLevelValue />
+        </SelectTriggerOperation>
+        <SelectOperationContent variant={variant}>
+          <SelectRiskLevelContent />
+        </SelectOperationContent>
+      </PopoverScoped>
+    </SelectRiskLevelProvider>
+  );
+};
+
+const isRiskLevel = (value: string): value is TRiskLevel =>
+  (RISK_LEVEL_OPTIONS as readonly string[]).includes(value);
+
+const SelectRiskLevelFilterItem = ({
+  value,
+  label,
+}: {
+  value: string;
+  label: string;
+}) => (
+  <Filter.Item value={value}>
+    <IconAlertTriangle />
+    {label}
+  </Filter.Item>
+);
+
+const SelectRiskLevelFilterView = () => {
+  const [riskLevel, setRiskLevel] = useQueryState<TRiskLevel[]>('riskLevel', {
+    defaultValue: [],
+  });
+  const { resetFilterState } = useFilterContext();
+
+  return (
+    <Filter.View filterKey="riskLevel">
+      <SelectRiskLevelProvider
+        value={riskLevel?.[0] ?? DEFAULT_RISK_LEVEL}
+        onValueChange={(val) => {
+          setRiskLevel([val]);
+          resetFilterState();
+        }}
+      >
+        <SelectRiskLevelContent />
+      </SelectRiskLevelProvider>
+    </Filter.View>
+  );
+};
+
+const SelectRiskLevelFilterBar = () => {
+  const [riskLevel, setRiskLevel] = useQueryState<TRiskLevel[]>('riskLevel', {
+    defaultValue: [],
+  });
+  const [open, setOpen] = useState(false);
+
+  if (!riskLevel?.[0]) return null;
+
+  return (
+    <Filter.BarItem queryKey="riskLevel">
+      <Filter.BarName>
+        <IconAlertTriangle />
+        By Risk level
+      </Filter.BarName>
+      <SelectRiskLevelProvider
+        value={riskLevel?.[0] ?? DEFAULT_RISK_LEVEL}
+        onValueChange={(val) => {
+          if (val && isRiskLevel(val)) setRiskLevel([val]);
+          else setRiskLevel([]);
+          setOpen(false);
+        }}
+      >
+        <Popover open={open} onOpenChange={setOpen}>
+          <Popover.Trigger asChild>
+            <Filter.BarButton filterKey="riskLevel">
+              <RiskLevelDot level={riskLevel?.[0] ?? DEFAULT_RISK_LEVEL} />
+              <RiskLevelTitle level={riskLevel?.[0] ?? DEFAULT_RISK_LEVEL} />
+            </Filter.BarButton>
+          </Popover.Trigger>
+          <Combobox.Content>
+            <SelectRiskLevelContent />
+          </Combobox.Content>
+        </Popover>
+      </SelectRiskLevelProvider>
+    </Filter.BarItem>
+  );
+};
+
+export const SelectRiskLevel = Object.assign(SelectRiskLevelRoot, {
+  FilterBar: SelectRiskLevelFilterBar,
+  FilterView: SelectRiskLevelFilterView,
+  FilterItem: SelectRiskLevelFilterItem,
+});

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectRiskLevel.tsx
@@ -128,9 +128,6 @@ const SelectRiskLevelRoot = ({
   );
 };
 
-const isRiskLevel = (value: string): value is TRiskLevel =>
-  (RISK_LEVEL_OPTIONS as readonly string[]).includes(value);
-
 const SelectRiskLevelFilterItem = ({
   value,
   label,
@@ -182,7 +179,7 @@ const SelectRiskLevelFilterBar = () => {
       <SelectRiskLevelProvider
         value={riskLevel?.[0] ?? DEFAULT_RISK_LEVEL}
         onValueChange={(val) => {
-          if (val && isRiskLevel(val)) setRiskLevel([val]);
+          if (val) setRiskLevel([val]);
           else setRiskLevel([]);
           setOpen(false);
         }}

--- a/frontend/plugins/sales_ui/src/modules/deals/constants/riskLevel.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/constants/riskLevel.ts
@@ -1,0 +1,26 @@
+export const RISK_LEVEL_OPTIONS = ['low', 'medium', 'high'] as const;
+
+export type TRiskLevel = (typeof RISK_LEVEL_OPTIONS)[number];
+
+export const DEFAULT_RISK_LEVEL: TRiskLevel = 'low';
+
+export const RISK_LEVEL_LABELS: Record<TRiskLevel, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+};
+
+export const RISK_LEVEL_DOT_CLASSES: Record<TRiskLevel, string> = {
+  low: 'bg-success',
+  medium: 'bg-warning',
+  high: 'bg-destructive',
+};
+
+export const RISK_LEVEL_BADGE_VARIANTS: Record<
+  TRiskLevel,
+  'success' | 'warning' | 'destructive'
+> = {
+  low: 'success',
+  medium: 'warning',
+  high: 'destructive',
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts
@@ -163,7 +163,7 @@ export const commonMutationVariables = `
   $isComplete: Boolean,
   $status: String,
   $priority: String,
-  $riskLevel: String,
+  $riskLevel: RiskLevel,
   $sourceConversationIds: [String],
   $propertiesData: JSON,
   $tagIds: [String]

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/DealsMutations.ts
@@ -73,6 +73,7 @@ export const commonFields = `
   closeDate
   description
   priority
+  riskLevel
   assignedUserIds
   assignedUsers {
     _id
@@ -162,6 +163,7 @@ export const commonMutationVariables = `
   $isComplete: Boolean,
   $status: String,
   $priority: String,
+  $riskLevel: String,
   $sourceConversationIds: [String],
   $propertiesData: JSON,
   $tagIds: [String]
@@ -184,6 +186,7 @@ export const commonMutationParams = `
   isComplete: $isComplete,
   status: $status,
   priority: $priority,
+  riskLevel: $riskLevel,
   sourceConversationIds: $sourceConversationIds,
   propertiesData: $propertiesData,
   tagIds: $tagIds

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts
@@ -9,6 +9,7 @@ const commonParams = `
   $labelIds: [String],
   $search: String,
   $priority: [String],
+  $riskLevel: [String],
   $date: SalesItemDate,
   $pipelineId: String,
   $parentId: String,
@@ -39,6 +40,7 @@ const commonParamDefs = `
   customerIds: $customerIds,
   assignedUserIds: $assignedUserIds,
   priority: $priority,
+  riskLevel: $riskLevel,
   productIds: $productIds,
   labelIds: $labelIds,
   search: $search,
@@ -114,6 +116,7 @@ export const commonListFields = `
   createdAt
   modifiedAt
   priority
+  riskLevel
   hasNotified
   score
   number

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts
@@ -9,7 +9,7 @@ const commonParams = `
   $labelIds: [String],
   $search: String,
   $priority: [String],
-  $riskLevel: [String],
+  $riskLevel: [RiskLevel],
   $date: SalesItemDate,
   $pipelineId: String,
   $parentId: String,

--- a/frontend/plugins/sales_ui/src/modules/deals/types/deals.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/types/deals.ts
@@ -29,6 +29,7 @@ export interface IItem {
     columnId?: string;
     isWatched?: boolean;
     priority?: string;
+    riskLevel?: 'low' | 'medium' | 'high';
     hasNotified?: boolean;
     isComplete: boolean;
     reminderMinute: number;


### PR DESCRIPTION
> _Reopened from fork after migrating to the proper fork-based PR workflow. Original draft PR was at erxes/erxes#7758 (closed)._

## Summary

- Adds a `riskLevel` enum field on `Deal` (`low | medium | high`, defaults to `low` at the read site).
- Editable from the deal detail sheet via a new `SelectDealRiskLevel` picker, displayed as a colored traffic-light badge on the kanban card, filterable from the action bar, and segmentable via `esType: 'keyword'`.
- Mirrors the existing `priority` field 1:1 across schema, IDeal, GraphQL surface, mutation/query fragments, and the deal-selects pattern. No new permission key, no automation trigger, no sort-order change, no migration.

## AI-assisted disclosure

- [x] AI-assisted (Claude Code, following `.agents/` workflow)
- [x] Workflow used: `/sales <wish>` → `.agents/wishes/2026-05-22-deal-risk-level/`
- [x] Skill followed: `.agents/skills/sales/add-deal-field.md` + `.agents/skills/sales/add-sales-segment-field.md`
- [x] Sister feature mirrored: `priority` (every layer) + `closeDate` (segment esType pattern). See [`GROUND.md`](.agents/wishes/2026-05-22-deal-risk-level/GROUND.md).
- [x] `.agents/evals/run.sh sales` exit 0 — verified
- [x] `.agents/SLOP-CHECKLIST.md` re-read — two fixes applied (redundant `isRiskLevel` guard, redundant `as TRiskLevel` cast), see [`REVIEW.md`](.agents/wishes/2026-05-22-deal-risk-level/REVIEW.md)
- [x] New lesson captured in `.agents/memory/lessons.md`: "Deal filter UIs live in two places — share-able vs. action-bar-only"

## Acceptance criteria from SPEC

1. **Setting riskLevel persists** — `SelectDealRiskLevel.onChange` → `editDeals` mutation → resolver spread into `models.Deals.updateDeal`. The mutation fragment includes `riskLevel` in `commonFields` so the Apollo cache refreshes correctly.
2. **Default 'low' applies to existing deals** — every read site (`RiskLevelDot`, `RiskLevelTitle`, `RiskLevelBadge`, `SelectDealRiskLevel`) defaults to `DEFAULT_RISK_LEVEL` when input is undefined or unrecognized. No DB backfill.
3. **Badge color matches level** — traffic-light mapping via `RISK_LEVEL_BADGE_VARIANTS` (success/warning/destructive) and `RISK_LEVEL_DOT_CLASSES` (`bg-success`/`bg-warning`/`bg-destructive`).
4. **Kanban filter narrows the list** — `?riskLevel=high` URL param threads through `GET_DEALS` → resolver `filter.riskLevel = { \$in: riskLevel }` branch mirroring priority.
5. **Segment filter works** — `riskLevel` schema path has `esType: 'keyword'`. Field discovery flows through the core-modules segments pipeline (`setupSegmentProducers` → `esTypesMap` → `gatherDependentServicesType`); the local `generateSalesFields` at `backend/plugins/sales_api/src/modules/sales/fieldUtils.ts:178` feeds into that pipeline but is not itself the auto-discoverer. (Earlier draft of this body named only `generateSalesFields`, which was misleading — fixed.)

## Test plan

- [x] `.agents/evals/run.sh sales` passes (clean build of `erxes-api-shared`, `sales_api`, `sales_ui`)
- [x] Playwright spec at `.agents/plugins/sales/tests/deals.spec.ts` covers every SPEC criterion. 5 new tests added:
  - SPEC #4 menu — live test, gated on `AGENT_TEST_LIVE=1`
  - SPEC #4 URL — live test, same gate
  - SPEC #1 (detail-sheet row visible) — `test.skip` pending seeded deal
  - SPEC #1+#2 round-trip — `test.skip` pending seeded deal + running stack
  - SPEC #3 badge — `test.skip` pending seeded deal
  - SPEC #5 segment field — `test.skip` pending segments service + ES
- [ ] Manual smoke test path: start `pnpm dev:apis && pnpm dev:uis`, open `/sales/deals`, exercise the picker on a real deal, watch URL change with the action-bar filter, confirm the badge color on the card.

## Files touched outside SPEC scope

- `frontend/plugins/sales_ui/src/modules/deals/graphql/queries/DealsQueries.ts` — added \`\$riskLevel: [String]\` to `commonParams`, \`riskLevel: \$riskLevel\` to `commonParamDefs`, and `riskLevel` to `commonListFields`. The SPEC named the mutations file explicitly but only implied the query side; required for SPEC #4 to round-trip the URL filter into the deal list.

## Rollback

If shipped and broken in production:
- Single revert is safe — `riskLevel` is optional with a default-at-read site, so reverting any commit removes the field without touching existing data.
- Multi-commit revert order (reverse): `eccfefb`, `d410cd4`, `991ba86`, `b0e6d7b`, `aeacd0c`, `89a053b`, `635b9d4`, `c92b988`, `a6fa415`, `1a95d19`, `327d095`.
- No DB migration to roll back.