### PR TITLE
feat: add CMS menu reordering

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -207,8 +207,8 @@ export function CustomFields() {
       </CustomFieldsHeader>
       <div className="flex overflow-hidden flex-auto">
         <CmsSidebar />
-        <div className="flex overflow-hidden flex-col flex-auto w-full">
-          <div className="flex-auto">
+        <div className="flex min-h-0 overflow-hidden flex-col flex-auto w-full">
+          <div className="min-h-0 flex-auto overflow-y-auto">
             <div className="p-6">
               <div className="max-w-4xl mx-auto">
                 {/* Table Header */}

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -12,15 +12,19 @@ import { ICustomFieldGroup } from '../types/customFieldTypes';
 const compareByLabel = (
   a: { _id?: string; label?: string; code?: string },
   b: { _id?: string; label?: string; code?: string },
-) =>
-  (a.label || a.code || a._id || '').localeCompare(
-    b.label || b.code || b._id || '',
-    undefined,
-    {
-      numeric: true,
-      sensitivity: 'base',
-    },
-  );
+) => {
+  const aValue = a.label || a.code || a._id || '';
+  const bValue = b.label || b.code || b._id || '';
+
+  if (!aValue && !bValue) return 0;
+  if (!aValue) return 1;
+  if (!bValue) return -1;
+
+  return aValue.localeCompare(bValue, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+};
 
 export const useCustomFieldGroups = (websiteId?: string) => {
   const { data, loading, refetch } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation } from '@apollo/client';
 import { toast } from 'erxes-ui';
+import { useMemo } from 'react';
 import { CMS_CUSTOM_FIELD_GROUPS } from '../graphql/queries';
 import {
   CMS_CUSTOM_FIELD_GROUP_ADD,
@@ -8,11 +9,35 @@ import {
 } from '../graphql/mutations';
 import { ICustomFieldGroup } from '../types/customFieldTypes';
 
+const compareByLabel = (
+  a: { _id?: string; label?: string; code?: string },
+  b: { _id?: string; label?: string; code?: string },
+) =>
+  (a.label || a.code || a._id || '').localeCompare(
+    b.label || b.code || b._id || '',
+    undefined,
+    {
+      numeric: true,
+      sensitivity: 'base',
+    },
+  );
+
 export const useCustomFieldGroups = (websiteId?: string) => {
   const { data, loading, refetch } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {
     variables: { clientPortalId: websiteId },
     skip: !websiteId,
   });
+
+  const groups = useMemo(
+    () =>
+      ((data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[])
+        .map((group) => ({
+          ...group,
+          fields: [...(group.fields || [])].sort(compareByLabel),
+        }))
+        .sort(compareByLabel),
+    [data?.cmsCustomFieldGroupList?.list],
+  );
 
   const [addGroup] = useMutation(CMS_CUSTOM_FIELD_GROUP_ADD, {
     onCompleted: () => {
@@ -57,7 +82,7 @@ export const useCustomFieldGroups = (websiteId?: string) => {
   });
 
   return {
-    groups: (data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[],
+    groups,
     loading,
     refetch,
     addGroup,

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -20,7 +20,7 @@ const compareByLabel = (
   if (!aValue) return 1;
   if (!bValue) return -1;
 
-  return aValue.localeCompare(bValue, undefined, {
+  return aValue.localeCompare(bValue, 'en', {
     numeric: true,
     sensitivity: 'base',
   });

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
@@ -72,7 +72,6 @@ export const CMS_MENU_ADD = gql`
       label
       contentType
       contentTypeId
-      type
       linkType
       kind
       icon
@@ -92,7 +91,6 @@ export const CMS_MENU_EDIT = gql`
       label
       contentType
       contentTypeId
-      type
       linkType
       kind
       icon
@@ -792,6 +790,7 @@ export const CMS_MENU_LIST = gql`
     $limit: Int
     $cursor: String
     $direction: CURSOR_DIRECTION
+    $orderBy: JSON
   ) {
     cmsMenuList(
       clientPortalId: $clientPortalId
@@ -800,13 +799,13 @@ export const CMS_MENU_LIST = gql`
       limit: $limit
       cursor: $cursor
       direction: $direction
+      orderBy: $orderBy
     ) {
       _id
       parentId
       label
       contentType
       contentTypeId
-      type
       linkType
       kind
       icon

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusColumn.tsx
@@ -13,6 +13,7 @@ import {
   IconArticle,
   IconEdit,
   IconTrash,
+  IconGripVertical,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useConfirm } from 'erxes-ui/hooks/use-confirm';
@@ -129,6 +130,16 @@ export const useMenusColumns = (
   const { isMissing } = useIsTranslationMissing();
 
   return [
+    {
+      id: 'drag',
+      header: () => <span className="sr-only">Reorder</span>,
+      cell: () => (
+        <div className="flex h-full items-center justify-center text-muted-foreground">
+          <IconGripVertical size={16} />
+        </div>
+      ),
+      size: 36,
+    },
     {
       id: 'more',
       header: () => <span className="sr-only">More</span>,

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardSensor,
   closestCenter,
   type DragEndEvent,
+  type DragStartEvent,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -38,6 +39,7 @@ interface MenuItem {
   parentId?: string;
   order?: number;
   depth?: number;
+  path?: string[];
   [key: string]: unknown;
 }
 
@@ -48,6 +50,18 @@ interface MenusRecordTableProps {
 }
 
 const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
+
+const DragTransformContext = React.createContext<{
+  activeId: string | null;
+  transform: string | null;
+  transition: string | null;
+  setTransform: (transform: string | null, transition: string | null) => void;
+}>({
+  activeId: null,
+  transform: null,
+  transition: null,
+  setTransform: () => {},
+});
 
 const applySiblingOrder = (
   menus: MenuItem[],
@@ -86,6 +100,13 @@ const SortableMenuRow = React.forwardRef<
     id: original?._id,
   });
 
+  const {
+    activeId,
+    transform: sharedTransform,
+    transition: sharedTransition,
+    setTransform,
+  } = React.useContext(DragTransformContext);
+
   const setRowRef = useCallback(
     (node: HTMLTableRowElement | null) => {
       setNodeRef(node);
@@ -100,6 +121,29 @@ const SortableMenuRow = React.forwardRef<
     [ref, setNodeRef],
   );
 
+  const isDescendant = useMemo(() => {
+    if (!activeId || !original?.path) return false;
+    return original.path.includes(activeId);
+  }, [activeId, original?.path]);
+
+  useEffect(() => {
+    if (isDragging) {
+      setTransform(CSS.Transform.toString(transform), transition || null);
+    }
+  }, [isDragging, transform, transition, setTransform]);
+
+  const effectiveTransform = isDragging
+    ? CSS.Transform.toString(transform)
+    : isDescendant
+      ? sharedTransform
+      : CSS.Transform.toString(transform);
+
+  const effectiveTransition = isDragging
+    ? transition
+    : isDescendant
+      ? sharedTransition
+      : transition;
+
   return (
     <RecordTable.Row
       {...props}
@@ -110,12 +154,13 @@ const SortableMenuRow = React.forwardRef<
       className={cn(
         'cursor-grab active:cursor-grabbing',
         isDragging && 'relative z-10 opacity-60',
+        isDescendant && 'relative z-10 opacity-80',
         className,
       )}
       style={{
         ...style,
-        transform: CSS.Transform.toString(transform),
-        transition,
+        transform: effectiveTransform,
+        transition: effectiveTransition,
       }}
     />
   );
@@ -139,6 +184,12 @@ export const MenusRecordTable = ({
   const language = useAtomValue(cmsLanguageAtom);
   const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
   const [reorderingCount, setReorderingCount] = useState(0);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeTransform, setActiveTransform] = useState<{
+    transform: string | null;
+    transition: string | null;
+  }>({ transform: null, transition: null });
+
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
   const isMountedRef = useRef(true);
@@ -175,6 +226,10 @@ export const MenusRecordTable = ({
     refetch();
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  };
+
   /**
    * Handles the end of a drag operation.
    * Optimistically updates the UI and enqueues the server mutations
@@ -182,6 +237,9 @@ export const MenusRecordTable = ({
    */
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
+      setActiveId(null);
+      setActiveTransform({ transform: null, transition: null });
+
       if (!over || active.id === over.id) {
         return;
       }
@@ -282,27 +340,43 @@ export const MenusRecordTable = ({
       id="cms-menus-dnd"
       sensors={sensors}
       collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={() => {
+        setActiveId(null);
+        setActiveTransform({ transform: null, transition: null });
+      }}
     >
-      <RecordTable.Provider
-        columns={columns}
-        data={orderedMenus}
-        className="h-full m-3 pb-1"
-        stickyColumns={['drag', 'more', 'checkbox', 'label']}
+      <DragTransformContext.Provider
+        value={{
+          activeId,
+          transform: activeTransform.transform,
+          transition: activeTransform.transition,
+          setTransform: (transform, transition) => {
+            setActiveTransform({ transform, transition });
+          },
+        }}
       >
-        <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
-          <RecordTable.Scroll>
-            <RecordTable>
-              <RecordTable.Header />
-              <RecordTable.Body>
-                {loading && <RecordTable.RowSkeleton rows={10} />}
-                <RecordTable.RowList Row={SortableMenuRow} />
-              </RecordTable.Body>
-            </RecordTable>
-          </RecordTable.Scroll>
-        </SortableContext>
-        <MenusCommandBar onBulkDelete={handleBulkDelete} />
-      </RecordTable.Provider>
+        <RecordTable.Provider
+          columns={columns}
+          data={orderedMenus}
+          className="h-full m-3 pb-1"
+          stickyColumns={['drag', 'more', 'checkbox', 'label']}
+        >
+          <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
+            <RecordTable.Scroll>
+              <RecordTable>
+                <RecordTable.Header />
+                <RecordTable.Body>
+                  {loading && <RecordTable.RowSkeleton rows={10} />}
+                  <RecordTable.RowList Row={SortableMenuRow} />
+                </RecordTable.Body>
+              </RecordTable>
+            </RecordTable.Scroll>
+          </SortableContext>
+          <MenusCommandBar onBulkDelete={handleBulkDelete} />
+        </RecordTable.Provider>
+      </DragTransformContext.Provider>
     </DndContext>
   );
 };

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -63,7 +63,7 @@ const applySiblingOrder = (
   const updatedMenus = menus.map((menu) => {
     const order = orderById.get(menu._id);
 
-    return order !== undefined ? { ...menu, order } : menu;
+    return order === undefined ? menu : { ...menu, order };
   });
 
   return buildFlatTree(updatedMenus, locale);

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -53,9 +53,11 @@ const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
 
 const DragTransformContext = React.createContext<{
   activeId: string | null;
+  activeParentId: string | null;
   containerRef: React.RefObject<HTMLDivElement | null>;
 }>({
   activeId: null,
+  activeParentId: null,
   containerRef: { current: null },
 });
 
@@ -81,89 +83,102 @@ const applySiblingOrder = (
   return buildFlatTree(updatedMenus, locale);
 };
 
-const SortableMenuRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.ComponentProps<typeof RecordTable.Row>
->(({ className, original, style, ...props }, ref) => {
-  const {
-    attributes,
-    isDragging,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({
-    id: original?._id,
-  });
+const SortableMenuRow = React.memo(
+  React.forwardRef<
+    HTMLTableRowElement,
+    React.ComponentProps<typeof RecordTable.Row>
+  >(({ className, original, style, ...props }, ref) => {
+    const { activeId, activeParentId, containerRef } = React.useContext(
+      DragTransformContext,
+    );
 
-  const { activeId, containerRef } = React.useContext(DragTransformContext);
+    const isDraggingItem = activeId === original?._id;
+    const isSibling =
+      activeId &&
+      !isDraggingItem &&
+      (getParentKey(original) || 'root') === activeParentId;
 
-  const setRowRef = useCallback(
-    (node: HTMLTableRowElement | null) => {
-      setNodeRef(node);
+    const {
+      attributes,
+      isDragging,
+      listeners,
+      setNodeRef,
+      transform,
+      transition,
+    } = useSortable({
+      id: original?._id,
+      // Disable sortable logic for items that don't need to move (non-siblings)
+      // This is the primary performance win.
+      disabled: activeId ? !isDraggingItem && !isSibling : false,
+    });
 
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLTableRowElement | null>).current =
-          node;
+    const setRowRef = useCallback(
+      (node: HTMLTableRowElement | null) => {
+        setNodeRef(node);
+
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLTableRowElement | null>).current =
+            node;
+        }
+      },
+      [ref, setNodeRef],
+    );
+
+    const isDescendant = useMemo(() => {
+      if (!activeId || !original?.path) return false;
+      return original.path.includes(activeId);
+    }, [activeId, original?.path]);
+
+    useEffect(() => {
+      if (isDragging && containerRef.current) {
+        const container = containerRef.current;
+        const tStr = CSS.Transform.toString(transform) || 'none';
+        container.style.setProperty('--drag-transform', tStr);
+        container.style.setProperty('--drag-transition', transition || 'none');
+
+        return () => {
+          container.style.removeProperty('--drag-transform');
+          container.style.removeProperty('--drag-transition');
+        };
       }
-    },
-    [ref, setNodeRef],
-  );
+    }, [isDragging, transform, transition, containerRef]);
 
-  const isDescendant = useMemo(() => {
-    if (!activeId || !original?.path) return false;
-    return original.path.includes(activeId);
-  }, [activeId, original?.path]);
+    const effectiveTransform = isDragging
+      ? CSS.Transform.toString(transform)
+      : isDescendant
+        ? 'var(--drag-transform)'
+        : CSS.Transform.toString(transform);
 
-  useEffect(() => {
-    if (isDragging && containerRef.current) {
-      const container = containerRef.current;
-      const tStr = CSS.Transform.toString(transform) || 'none';
-      container.style.setProperty('--drag-transform', tStr);
-      container.style.setProperty('--drag-transition', transition || 'none');
+    const effectiveTransition = isDragging
+      ? transition
+      : isDescendant
+        ? 'var(--drag-transition)'
+        : transition;
 
-      return () => {
-        container.style.removeProperty('--drag-transform');
-        container.style.removeProperty('--drag-transition');
-      };
-    }
-  }, [isDragging, transform, transition, containerRef]);
-
-  const effectiveTransform = isDragging
-    ? CSS.Transform.toString(transform)
-    : isDescendant
-      ? 'var(--drag-transform)'
-      : CSS.Transform.toString(transform);
-
-  const effectiveTransition = isDragging
-    ? transition
-    : isDescendant
-      ? 'var(--drag-transition)'
-      : transition;
-
-  return (
-    <RecordTable.Row
-      {...props}
-      {...attributes}
-      {...listeners}
-      ref={setRowRef}
-      original={original}
-      className={cn(
-        'cursor-grab active:cursor-grabbing',
-        isDragging && 'relative z-10 opacity-60',
-        isDescendant && 'relative z-10 opacity-80',
-        className,
-      )}
-      style={{
-        ...style,
-        transform: effectiveTransform,
-        transition: effectiveTransition,
-      }}
-    />
-  );
-});
+    return (
+      <RecordTable.Row
+        {...props}
+        {...attributes}
+        {...listeners}
+        ref={setRowRef}
+        original={original}
+        className={cn(
+          'cursor-grab active:cursor-grabbing will-change-transform',
+          isDragging && 'relative z-10 opacity-60',
+          isDescendant && 'relative z-10 opacity-80',
+          className,
+        )}
+        style={{
+          ...style,
+          transform: effectiveTransform,
+          transition: effectiveTransition,
+        }}
+      />
+    );
+  }),
+);
 
 SortableMenuRow.displayName = 'SortableMenuRow';
 
@@ -184,6 +199,7 @@ export const MenusRecordTable = ({
   const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
   const [reorderingCount, setReorderingCount] = useState(0);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeParentId, setActiveParentId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
@@ -205,10 +221,13 @@ export const MenusRecordTable = ({
     };
   }, []);
 
-  const pointerSensor = useSensor(PointerSensor, pointerSensorOptions);
+  const mouseSensor = useSensor(PointerSensor, pointerSensorOptions);
   const keyboardSensor = useSensor(KeyboardSensor, keyboardSensorOptions);
 
-  const sensors = useSensors(pointerSensor, keyboardSensor);
+  const sensors = useMemo(() => [mouseSensor, keyboardSensor], [
+    mouseSensor,
+    keyboardSensor,
+  ]);
 
   const menuIds = useMemo(
     () => orderedMenus.map((menu) => menu._id),
@@ -223,7 +242,9 @@ export const MenusRecordTable = ({
   };
 
   const handleDragStart = (event: DragStartEvent) => {
+    const activeMenu = orderedMenus.find((m) => m._id === event.active.id);
     setActiveId(event.active.id as string);
+    setActiveParentId(getParentKey(activeMenu) || 'root');
   };
 
   /**
@@ -234,6 +255,7 @@ export const MenusRecordTable = ({
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
       setActiveId(null);
+      setActiveParentId(null);
 
       if (!over || active.id === over.id) {
         return;
@@ -339,11 +361,13 @@ export const MenusRecordTable = ({
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
         setActiveId(null);
+        setActiveParentId(null);
       }}
     >
       <DragTransformContext.Provider
         value={{
           activeId,
+          activeParentId,
           containerRef,
         }}
       >

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -1,9 +1,38 @@
-import { RecordTable } from 'erxes-ui';
+import { RecordTable, cn, toast } from 'erxes-ui';
 import { useMutation } from '@apollo/client';
+import {
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
-import { CMS_MENU_REMOVE } from '../../graphql/queries';
+import { CMS_MENU_EDIT, CMS_MENU_REMOVE } from '../../graphql/queries';
+import { buildFlatTree } from '../menuUtils';
+
+interface MenuItem {
+  _id: string;
+  label: string;
+  parentId?: string;
+  order?: number;
+  depth?: number;
+  [key: string]: unknown;
+}
 
 interface MenusRecordTableProps {
   clientPortalId: string;
@@ -11,13 +40,111 @@ interface MenusRecordTableProps {
   onEdit: (menu: any) => void;
 }
 
+const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
+
+const applySiblingOrder = (menus: MenuItem[], siblings: MenuItem[]) => {
+  const orderById = new Map(
+    siblings.map((menu, index) => [menu._id, index + 1]),
+  );
+
+  const updatedMenus = menus.map((menu) => {
+    const order = orderById.get(menu._id);
+
+    return order ? { ...menu, order } : menu;
+  });
+
+  return buildFlatTree(updatedMenus);
+};
+
+type SortableMenuRowProps = React.ComponentProps<typeof RecordTable.Row> & {
+  disabled?: boolean;
+};
+
+const SortableMenuRow = React.forwardRef<
+  HTMLTableRowElement,
+  SortableMenuRowProps
+>(({ className, disabled, original, style, ...props }, ref) => {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    id: original?._id,
+    disabled: disabled || !original?._id,
+  });
+
+  const setRowRef = useCallback(
+    (node: HTMLTableRowElement | null) => {
+      setNodeRef(node);
+
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLTableRowElement | null>).current =
+          node;
+      }
+    },
+    [ref, setNodeRef],
+  );
+
+  return (
+    <RecordTable.Row
+      {...props}
+      {...attributes}
+      {...listeners}
+      ref={setRowRef}
+      original={original}
+      className={cn(
+        'cursor-grab active:cursor-grabbing',
+        isDragging && 'relative z-10 opacity-60',
+        disabled && 'cursor-default',
+        className,
+      )}
+      style={{
+        ...style,
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+    />
+  );
+});
+
+SortableMenuRow.displayName = 'SortableMenuRow';
+
 export const MenusRecordTable = ({
   clientPortalId,
   kind,
   onEdit,
 }: MenusRecordTableProps) => {
   const { menus, loading, refetch } = useMenus({ clientPortalId, kind });
+  const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
+  const [isReordering, setIsReordering] = useState(false);
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
+  const [editMenu] = useMutation(CMS_MENU_EDIT);
+
+  useEffect(() => {
+    setOrderedMenus(menus);
+  }, [menus]);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const menuIds = useMemo(
+    () => orderedMenus.map((menu) => menu._id),
+    [orderedMenus],
+  );
 
   const handleBulkDelete = async (ids: string[]) => {
     for (const id of ids) {
@@ -26,24 +153,99 @@ export const MenusRecordTable = ({
     refetch();
   };
 
+  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id || isReordering) {
+      return;
+    }
+
+    const activeMenu = orderedMenus.find((menu) => menu._id === active.id);
+    const overMenu = orderedMenus.find((menu) => menu._id === over.id);
+
+    if (!activeMenu || !overMenu) {
+      return;
+    }
+
+    const parentId = getParentKey(activeMenu);
+
+    if (parentId !== getParentKey(overMenu)) {
+      toast({
+        description: 'Menus can only be reordered within the same level.',
+      });
+      return;
+    }
+
+    const siblings = orderedMenus.filter(
+      (menu) => getParentKey(menu) === parentId,
+    );
+    const oldIndex = siblings.findIndex((menu) => menu._id === active.id);
+    const newIndex = siblings.findIndex((menu) => menu._id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+      return;
+    }
+
+    const previousMenus = orderedMenus;
+    const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
+    const nextMenus = applySiblingOrder(orderedMenus, reorderedSiblings);
+
+    setOrderedMenus(nextMenus);
+    setIsReordering(true);
+
+    try {
+      await Promise.all(
+        reorderedSiblings.map((menu, index) =>
+          editMenu({
+            variables: {
+              _id: menu._id,
+              input: { order: index + 1 },
+            },
+          }),
+        ),
+      );
+      await refetch();
+    } catch (error) {
+      setOrderedMenus(previousMenus);
+      toast({
+        description:
+          error instanceof Error ? error.message : 'Failed to reorder menus.',
+      });
+    } finally {
+      setIsReordering(false);
+    }
+  };
+
   const columns = useMenusColumns(onEdit, refetch);
+  const SortableRow = useCallback(
+    (props: React.ComponentProps<typeof RecordTable.Row>) => (
+      <SortableMenuRow {...props} disabled={isReordering} />
+    ),
+    [isReordering],
+  );
 
   return (
     <RecordTable.Provider
       columns={columns}
-      data={menus}
+      data={orderedMenus}
       className="h-full m-3 pb-1"
-      stickyColumns={['more', 'checkbox', 'label']}
+      stickyColumns={['drag', 'more', 'checkbox', 'label']}
     >
-      <RecordTable.Scroll>
-        <RecordTable>
-          <RecordTable.Header />
-          <RecordTable.Body>
-            {loading && <RecordTable.RowSkeleton rows={10} />}
-            <RecordTable.RowList />
-          </RecordTable.Body>
-        </RecordTable>
-      </RecordTable.Scroll>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
+          <RecordTable.Scroll>
+            <RecordTable>
+              <RecordTable.Header />
+              <RecordTable.Body>
+                {loading && <RecordTable.RowSkeleton rows={10} />}
+                <RecordTable.RowList Row={SortableRow} />
+              </RecordTable.Body>
+            </RecordTable>
+          </RecordTable.Scroll>
+        </SortableContext>
+      </DndContext>
       <MenusCommandBar onBulkDelete={handleBulkDelete} />
     </RecordTable.Provider>
   );

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -63,7 +63,11 @@ const applySiblingOrder = (
   const updatedMenus = menus.map((menu) => {
     const order = orderById.get(menu._id);
 
-    return order === undefined ? menu : { ...menu, order };
+    if (typeof order === 'number') {
+      return { ...menu, order };
+    }
+
+    return menu;
   });
 
   return buildFlatTree(updatedMenus, locale);

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -205,6 +205,16 @@ export const MenusRecordTable = ({
       }
 
       const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
+      
+      // Calculate changes: only update items whose order actually changed
+      const changes = reorderedSiblings
+        .map((menu, index) => ({
+          _id: menu._id,
+          newOrder: index + 1,
+          oldOrder: menu.order
+        }))
+        .filter(change => change.newOrder !== change.oldOrder);
+
       const nextMenus = applySiblingOrder(
         orderedMenus,
         reorderedSiblings,
@@ -217,11 +227,11 @@ export const MenusRecordTable = ({
 
       try {
         await Promise.all(
-          reorderedSiblings.map((menu, index) =>
+          changes.map((change) =>
             editMenu({
               variables: {
-                _id: menu._id,
-                input: { order: index + 1 },
+                _id: change._id,
+                input: { order: change.newOrder },
               },
             }),
           ),

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -23,7 +23,7 @@ import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
 import { CMS_MENU_EDIT, CMS_MENU_REMOVE } from '../../graphql/queries';
-import { buildFlatTree } from '../menuUtils';
+import { buildFlatTree } from '@/cms/menus/menuUtils';
 
 interface MenuItem {
   _id: string;

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -142,6 +142,9 @@ export const MenusRecordTable = ({
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
   const isMountedRef = useRef(true);
+  
+  // Queue to serialize mutations per parent to prevent race conditions
+  const mutationQueueRef = useRef<Record<string, Promise<any>>>({});
 
   useEffect(() => {
     if (reorderingCount === 0) {
@@ -172,6 +175,11 @@ export const MenusRecordTable = ({
     refetch();
   };
 
+  /**
+   * Handles the end of a drag operation.
+   * Optimistically updates the UI and enqueues the server mutations
+   * to be processed sequentially per parent level.
+   */
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
       if (!over || active.id === over.id) {
@@ -185,9 +193,9 @@ export const MenusRecordTable = ({
         return;
       }
 
-      const parentId = getParentKey(activeMenu);
+      const parentId = getParentKey(activeMenu) || 'root';
 
-      if (parentId !== getParentKey(overMenu)) {
+      if (parentId !== (getParentKey(overMenu) || 'root')) {
         toast({
           description: 'Menus can only be reordered within the same level.',
         });
@@ -195,7 +203,7 @@ export const MenusRecordTable = ({
       }
 
       const siblings = orderedMenus.filter(
-        (menu) => getParentKey(menu) === parentId,
+        (menu) => (getParentKey(menu) || 'root') === parentId,
       );
       const oldIndex = siblings.findIndex((menu) => menu._id === active.id);
       const newIndex = siblings.findIndex((menu) => menu._id === over.id);
@@ -206,7 +214,7 @@ export const MenusRecordTable = ({
 
       const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
       
-      // Calculate changes: only update items whose order actually changed
+      // Only update items whose order actually changed
       const changes = reorderedSiblings
         .map((menu, index) => ({
           _id: menu._id,
@@ -225,37 +233,44 @@ export const MenusRecordTable = ({
       setOrderedMenus(nextMenus);
       setReorderingCount((prev) => prev + 1);
 
-      try {
-        await Promise.all(
-          changes.map((change) =>
-            editMenu({
-              variables: {
-                _id: change._id,
-                input: { order: change.newOrder },
-              },
-            }),
-          ),
-        );
-        // Wait for refetch to complete to ensure server state is captured
-        await refetch();
-      } catch (error) {
-        if (isMountedRef.current) {
-          toast({
-            description:
-              error instanceof Error
-                ? error.message
-                : 'Failed to reorder menus.',
-          });
-          // Revert on error if no other reorders are pending
-          if (reorderingCount === 1) {
-            setOrderedMenus(menus);
+      // Serialize mutations for this parent level
+      const currentQueue = mutationQueueRef.current[parentId] || Promise.resolve();
+      
+      const nextMutation = currentQueue.then(async () => {
+        try {
+          await Promise.all(
+            changes.map((change) =>
+              editMenu({
+                variables: {
+                  _id: change._id,
+                  input: { order: change.newOrder },
+                },
+              }),
+            ),
+          );
+          await refetch();
+        } catch (error) {
+          if (isMountedRef.current) {
+            toast({
+              description:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to reorder menus.',
+            });
+            // Revert on error if this was the last pending reorder for this parent
+            setOrderedMenus((current) => {
+              // If we've already moved on to more reorders, don't revert to stale data
+              return reorderingCount === 1 ? menus : current;
+            });
+          }
+        } finally {
+          if (isMountedRef.current) {
+            setReorderingCount((prev) => Math.max(0, prev - 1));
           }
         }
-      } finally {
-        if (isMountedRef.current) {
-          setReorderingCount((prev) => Math.max(0, prev - 1));
-        }
-      }
+      });
+
+      mutationQueueRef.current[parentId] = nextMutation;
     },
     [orderedMenus, language, editMenu, refetch, menus, reorderingCount],
   );

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -184,7 +184,6 @@ export const MenusRecordTable = ({
       return;
     }
 
-    const previousMenus = orderedMenus;
     const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
     const nextMenus = applySiblingOrder(orderedMenus, reorderedSiblings);
 
@@ -202,15 +201,17 @@ export const MenusRecordTable = ({
           }),
         ),
       );
-      await refetch();
     } catch (error) {
-      setOrderedMenus(previousMenus);
       toast({
         description:
           error instanceof Error ? error.message : 'Failed to reorder menus.',
       });
     } finally {
-      setIsReordering(false);
+      try {
+        await refetch();
+      } finally {
+        setIsReordering(false);
+      }
     }
   };
 

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -4,14 +4,12 @@ import {
   DndContext,
   PointerSensor,
   KeyboardSensor,
-  closestCenter,
   rectIntersection,
   DragOverlay,
   defaultDropAnimationSideEffects,
   type DragEndEvent,
   type DragStartEvent,
   useSensor,
-  useSensors,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -29,7 +27,6 @@ import React, {
   useState,
 } from 'react';
 import { useAtomValue } from 'jotai';
-import { flexRender } from '@tanstack/react-table';
 import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
@@ -138,65 +135,73 @@ const SortableMenuRow = React.memo(
       activeParentId: string | null;
       isDraggingAny: boolean;
     }
-  >(({ className, original, style, activeId, activeParentId, isDraggingAny, ...props }, ref) => {
-    const isDraggingItem = activeId === original?._id;
-    const isDescendant = activeId && original?.path?.includes(activeId);
-    
-    // Siblings of the dragging item are the only ones allowed to move
-    const isSibling =
-      activeId &&
-      !isDraggingItem &&
-      (getParentKey(original) || 'root') === activeParentId;
-
-    const {
-      attributes,
-      isDragging,
-      listeners,
-      setNodeRef,
-      transform,
-      transition,
-    } = useSortable({
-      id: original?._id,
-      disabled: activeId ? !isDraggingItem && !isSibling : false,
-    });
-
-    const setRowRef = useCallback(
-      (node: HTMLTableRowElement | null) => {
-        setNodeRef(node);
-
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          (ref as React.MutableRefObject<HTMLTableRowElement | null>).current =
-            node;
-        }
+  >(
+    (
+      {
+        className,
+        original,
+        style,
+        activeId,
+        activeParentId,
+        isDraggingAny,
+        ...props
       },
-      [ref, setNodeRef],
-    );
+      ref,
+    ) => {
+      const isDraggingItem = activeId === original?._id;
+      const isDescendant = activeId && original?.path?.includes(activeId);
 
-    // Completely hide the row and its children in the table while they are in the overlay
-    const isHidden = isDraggingItem || isDescendant;
+      // Siblings of the dragging item are the only ones allowed to move
+      const isSibling =
+        activeId &&
+        !isDraggingItem &&
+        (getParentKey(original) || 'root') === activeParentId;
 
-    return (
-      <RecordTable.Row
-        {...props}
-        {...attributes}
-        {...listeners}
-        ref={setRowRef}
-        original={original}
-        className={cn(
-          'cursor-grab active:cursor-grabbing will-change-transform transition-opacity',
-          isHidden && 'opacity-0 pointer-events-none', // Hidden placeholder
-          className,
-        )}
-        style={{
-          ...style,
-          transform: CSS.Translate.toString(transform),
-          transition,
-        }}
-      />
-    );
-  }),
+      const { attributes, listeners, setNodeRef, transform, transition } =
+        useSortable({
+          id: original?._id,
+          disabled: activeId ? !isDraggingItem && !isSibling : false,
+        });
+
+      const setRowRef = useCallback(
+        (node: HTMLTableRowElement | null) => {
+          setNodeRef(node);
+
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref) {
+            (
+              ref as React.MutableRefObject<HTMLTableRowElement | null>
+            ).current = node;
+          }
+        },
+        [ref, setNodeRef],
+      );
+
+      // Completely hide the row and its children in the table while they are in the overlay
+      const isHidden = isDraggingItem || isDescendant;
+
+      return (
+        <RecordTable.Row
+          {...props}
+          {...attributes}
+          {...listeners}
+          ref={setRowRef}
+          original={original}
+          className={cn(
+            'cursor-grab active:cursor-grabbing will-change-transform transition-opacity',
+            isHidden && 'opacity-0 pointer-events-none', // Hidden placeholder
+            className,
+          )}
+          style={{
+            ...style,
+            transform: CSS.Translate.toString(transform),
+            transition,
+          }}
+        />
+      );
+    },
+  ),
 );
 
 SortableMenuRow.displayName = 'SortableMenuRow';
@@ -223,7 +228,7 @@ export const MenusRecordTable = ({
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
   const isMountedRef = useRef(true);
-  
+
   // Queue to serialize mutations per parent to prevent race conditions
   const mutationQueueRef = useRef<Record<string, Promise<any>>>({});
 
@@ -242,10 +247,10 @@ export const MenusRecordTable = ({
   const mouseSensor = useSensor(PointerSensor, pointerSensorOptions);
   const keyboardSensor = useSensor(KeyboardSensor, keyboardSensorOptions);
 
-  const sensors = useMemo(() => [mouseSensor, keyboardSensor], [
-    mouseSensor,
-    keyboardSensor,
-  ]);
+  const sensors = useMemo(
+    () => [mouseSensor, keyboardSensor],
+    [mouseSensor, keyboardSensor],
+  );
 
   const menuIds = useMemo(
     () => orderedMenus.map((menu) => menu._id),
@@ -259,7 +264,9 @@ export const MenusRecordTable = ({
 
   const activeSubtree = useMemo(() => {
     if (!activeId) return [];
-    return orderedMenus.filter((m) => m._id === activeId || m.path?.includes(activeId));
+    return orderedMenus.filter(
+      (m) => m._id === activeId || m.path?.includes(activeId),
+    );
   }, [activeId, orderedMenus]);
 
   const handleBulkDelete = async (ids: string[]) => {
@@ -311,14 +318,14 @@ export const MenusRecordTable = ({
       }
 
       const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
-      
+
       const changes = reorderedSiblings
         .map((menu, index) => ({
           _id: menu._id,
           newOrder: index + 1,
-          oldOrder: menu.order
+          oldOrder: menu.order,
         }))
-        .filter(change => change.newOrder !== change.oldOrder);
+        .filter((change) => change.newOrder !== change.oldOrder);
 
       const nextMenus = applySiblingOrder(
         orderedMenus,
@@ -330,7 +337,7 @@ export const MenusRecordTable = ({
       setReorderingCount((prev) => prev + 1);
 
       const currentQueue = mutationQueueRef.current[pId] || Promise.resolve();
-      
+
       const nextMutation = currentQueue.then(async () => {
         try {
           await Promise.all(
@@ -347,9 +354,14 @@ export const MenusRecordTable = ({
         } catch (error) {
           if (isMountedRef.current) {
             toast({
-              description: error instanceof Error ? error.message : 'Failed to reorder menus.',
+              description:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to reorder menus.',
             });
-            setOrderedMenus((current) => (reorderingCount === 1 ? menus : current));
+            setOrderedMenus((current) =>
+              reorderingCount === 1 ? menus : current,
+            );
           }
         } finally {
           if (isMountedRef.current) {
@@ -366,14 +378,17 @@ export const MenusRecordTable = ({
   const columns = useMenusColumns(onEdit, refetch);
 
   // Custom Row component for RecordTable to pass extra props
-  const CustomRow = useCallback((props: any) => (
-    <SortableMenuRow 
-      {...props} 
-      activeId={activeId} 
-      activeParentId={activeParentId}
-      isDraggingAny={!!activeId}
-    />
-  ), [activeId, activeParentId]);
+  const CustomRow = useCallback(
+    (props: any) => (
+      <SortableMenuRow
+        {...props}
+        activeId={activeId}
+        activeParentId={activeParentId}
+        isDraggingAny={!!activeId}
+      />
+    ),
+    [activeId, activeParentId],
+  );
 
   return (
     <DndContext
@@ -393,10 +408,7 @@ export const MenusRecordTable = ({
         className="h-full m-3 pb-1"
         stickyColumns={['drag', 'more', 'checkbox', 'label']}
       >
-        <SortableContext
-          items={menuIds}
-          strategy={verticalListSortingStrategy}
-        >
+        <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
           <RecordTable.Scroll>
             <RecordTable>
               <RecordTable.Header />

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -5,6 +5,9 @@ import {
   PointerSensor,
   KeyboardSensor,
   closestCenter,
+  rectIntersection,
+  DragOverlay,
+  defaultDropAnimationSideEffects,
   type DragEndEvent,
   type DragStartEvent,
   useSensor,
@@ -26,6 +29,7 @@ import React, {
   useState,
 } from 'react';
 import { useAtomValue } from 'jotai';
+import { flexRender } from '@tanstack/react-table';
 import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
@@ -51,16 +55,6 @@ interface MenusRecordTableProps {
 
 const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
 
-const DragTransformContext = React.createContext<{
-  activeId: string | null;
-  activeParentId: string | null;
-  containerRef: React.RefObject<HTMLDivElement | null>;
-}>({
-  activeId: null,
-  activeParentId: null,
-  containerRef: { current: null },
-});
-
 const applySiblingOrder = (
   menus: MenuItem[],
   siblings: MenuItem[],
@@ -83,16 +77,72 @@ const applySiblingOrder = (
   return buildFlatTree(updatedMenus, locale);
 };
 
+const dropAnimation = {
+  sideEffects: defaultDropAnimationSideEffects({
+    styles: {
+      active: {
+        opacity: '0.5',
+      },
+    },
+  }),
+};
+
+// Static row for DragOverlay
+const StaticMenuRow = ({
+  menu,
+  columns,
+  isOverlay = false,
+}: {
+  menu: MenuItem;
+  columns: any[];
+  isOverlay?: boolean;
+}) => {
+  return (
+    <div
+      className={cn(
+        'flex items-center h-cell border-b bg-background',
+        isOverlay && 'opacity-40 border-none',
+      )}
+    >
+      {columns.map((column) => (
+        <div
+          key={column.id}
+          style={{ width: column.size, minWidth: column.size }}
+          className="px-2 overflow-hidden text-ellipsis whitespace-nowrap"
+        >
+          {column.cell ? (
+            <div className="flex h-full items-center">
+              {/* Simplified rendering for overlay to keep it fast */}
+              {column.id === 'label' ? (
+                <span className="text-sm font-medium">
+                  {'-'.repeat(menu.depth || 0) + ' ' + menu.label}
+                </span>
+              ) : column.id === 'drag' ? (
+                <div className="flex h-full items-center justify-center text-muted-foreground">
+                  <div className="w-4 h-4" />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const SortableMenuRow = React.memo(
   React.forwardRef<
     HTMLTableRowElement,
-    React.ComponentProps<typeof RecordTable.Row>
-  >(({ className, original, style, ...props }, ref) => {
-    const { activeId, activeParentId, containerRef } = React.useContext(
-      DragTransformContext,
-    );
-
+    React.ComponentProps<typeof RecordTable.Row> & {
+      activeId: string | null;
+      activeParentId: string | null;
+      isDraggingAny: boolean;
+    }
+  >(({ className, original, style, activeId, activeParentId, isDraggingAny, ...props }, ref) => {
     const isDraggingItem = activeId === original?._id;
+    const isDescendant = activeId && original?.path?.includes(activeId);
+    
+    // Siblings of the dragging item are the only ones allowed to move
     const isSibling =
       activeId &&
       !isDraggingItem &&
@@ -107,8 +157,6 @@ const SortableMenuRow = React.memo(
       transition,
     } = useSortable({
       id: original?._id,
-      // Disable sortable logic for items that don't need to move (non-siblings)
-      // This is the primary performance win.
       disabled: activeId ? !isDraggingItem && !isSibling : false,
     });
 
@@ -126,36 +174,8 @@ const SortableMenuRow = React.memo(
       [ref, setNodeRef],
     );
 
-    const isDescendant = useMemo(() => {
-      if (!activeId || !original?.path) return false;
-      return original.path.includes(activeId);
-    }, [activeId, original?.path]);
-
-    useEffect(() => {
-      if (isDragging && containerRef.current) {
-        const container = containerRef.current;
-        const tStr = CSS.Transform.toString(transform) || 'none';
-        container.style.setProperty('--drag-transform', tStr);
-        container.style.setProperty('--drag-transition', transition || 'none');
-
-        return () => {
-          container.style.removeProperty('--drag-transform');
-          container.style.removeProperty('--drag-transition');
-        };
-      }
-    }, [isDragging, transform, transition, containerRef]);
-
-    const effectiveTransform = isDragging
-      ? CSS.Transform.toString(transform)
-      : isDescendant
-        ? 'var(--drag-transform)'
-        : CSS.Transform.toString(transform);
-
-    const effectiveTransition = isDragging
-      ? transition
-      : isDescendant
-        ? 'var(--drag-transition)'
-        : transition;
+    // Completely hide the row and its children in the table while they are in the overlay
+    const isHidden = isDraggingItem || isDescendant;
 
     return (
       <RecordTable.Row
@@ -165,15 +185,14 @@ const SortableMenuRow = React.memo(
         ref={setRowRef}
         original={original}
         className={cn(
-          'cursor-grab active:cursor-grabbing will-change-transform',
-          isDragging && 'relative z-10 opacity-60',
-          isDescendant && 'relative z-10 opacity-80',
+          'cursor-grab active:cursor-grabbing will-change-transform transition-opacity',
+          isHidden && 'opacity-0 pointer-events-none', // Hidden placeholder
           className,
         )}
         style={{
           ...style,
-          transform: effectiveTransform,
-          transition: effectiveTransition,
+          transform: CSS.Translate.toString(transform),
+          transition,
         }}
       />
     );
@@ -200,7 +219,6 @@ export const MenusRecordTable = ({
   const [reorderingCount, setReorderingCount] = useState(0);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [activeParentId, setActiveParentId] = useState<string | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
@@ -234,6 +252,16 @@ export const MenusRecordTable = ({
     [orderedMenus],
   );
 
+  const activeMenu = useMemo(
+    () => (activeId ? orderedMenus.find((m) => m._id === activeId) : null),
+    [activeId, orderedMenus],
+  );
+
+  const activeSubtree = useMemo(() => {
+    if (!activeId) return [];
+    return orderedMenus.filter((m) => m._id === activeId || m.path?.includes(activeId));
+  }, [activeId, orderedMenus]);
+
   const handleBulkDelete = async (ids: string[]) => {
     for (const id of ids) {
       await removeMenu({ variables: { _id: id } });
@@ -242,16 +270,11 @@ export const MenusRecordTable = ({
   };
 
   const handleDragStart = (event: DragStartEvent) => {
-    const activeMenu = orderedMenus.find((m) => m._id === event.active.id);
+    const item = orderedMenus.find((m) => m._id === event.active.id);
     setActiveId(event.active.id as string);
-    setActiveParentId(getParentKey(activeMenu) || 'root');
+    setActiveParentId(getParentKey(item) || 'root');
   };
 
-  /**
-   * Handles the end of a drag operation.
-   * Optimistically updates the UI and enqueues the server mutations
-   * to be processed sequentially per parent level.
-   */
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
       setActiveId(null);
@@ -261,16 +284,16 @@ export const MenusRecordTable = ({
         return;
       }
 
-      const activeMenu = orderedMenus.find((menu) => menu._id === active.id);
-      const overMenu = orderedMenus.find((menu) => menu._id === over.id);
+      const aMenu = orderedMenus.find((menu) => menu._id === active.id);
+      const oMenu = orderedMenus.find((menu) => menu._id === over.id);
 
-      if (!activeMenu || !overMenu) {
+      if (!aMenu || !oMenu) {
         return;
       }
 
-      const parentId = getParentKey(activeMenu) || 'root';
+      const pId = getParentKey(aMenu) || 'root';
 
-      if (parentId !== (getParentKey(overMenu) || 'root')) {
+      if (pId !== (getParentKey(oMenu) || 'root')) {
         toast({
           description: 'Menus can only be reordered within the same level.',
         });
@@ -278,7 +301,7 @@ export const MenusRecordTable = ({
       }
 
       const siblings = orderedMenus.filter(
-        (menu) => (getParentKey(menu) || 'root') === parentId,
+        (menu) => (getParentKey(menu) || 'root') === pId,
       );
       const oldIndex = siblings.findIndex((menu) => menu._id === active.id);
       const newIndex = siblings.findIndex((menu) => menu._id === over.id);
@@ -289,7 +312,6 @@ export const MenusRecordTable = ({
 
       const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
       
-      // Only update items whose order actually changed
       const changes = reorderedSiblings
         .map((menu, index) => ({
           _id: menu._id,
@@ -304,12 +326,10 @@ export const MenusRecordTable = ({
         language || 'en',
       );
 
-      // Optimistic update
       setOrderedMenus(nextMenus);
       setReorderingCount((prev) => prev + 1);
 
-      // Serialize mutations for this parent level
-      const currentQueue = mutationQueueRef.current[parentId] || Promise.resolve();
+      const currentQueue = mutationQueueRef.current[pId] || Promise.resolve();
       
       const nextMutation = currentQueue.then(async () => {
         try {
@@ -327,16 +347,9 @@ export const MenusRecordTable = ({
         } catch (error) {
           if (isMountedRef.current) {
             toast({
-              description:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to reorder menus.',
+              description: error instanceof Error ? error.message : 'Failed to reorder menus.',
             });
-            // Revert on error if this was the last pending reorder for this parent
-            setOrderedMenus((current) => {
-              // If we've already moved on to more reorders, don't revert to stale data
-              return reorderingCount === 1 ? menus : current;
-            });
+            setOrderedMenus((current) => (reorderingCount === 1 ? menus : current));
           }
         } finally {
           if (isMountedRef.current) {
@@ -345,18 +358,28 @@ export const MenusRecordTable = ({
         }
       });
 
-      mutationQueueRef.current[parentId] = nextMutation;
+      mutationQueueRef.current[pId] = nextMutation;
     },
     [orderedMenus, language, editMenu, refetch, menus, reorderingCount],
   );
 
   const columns = useMenusColumns(onEdit, refetch);
 
+  // Custom Row component for RecordTable to pass extra props
+  const CustomRow = useCallback((props: any) => (
+    <SortableMenuRow 
+      {...props} 
+      activeId={activeId} 
+      activeParentId={activeParentId}
+      isDraggingAny={!!activeId}
+    />
+  ), [activeId, activeParentId]);
+
   return (
     <DndContext
       id="cms-menus-dnd"
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={rectIntersection}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
@@ -364,38 +387,38 @@ export const MenusRecordTable = ({
         setActiveParentId(null);
       }}
     >
-      <DragTransformContext.Provider
-        value={{
-          activeId,
-          activeParentId,
-          containerRef,
-        }}
+      <RecordTable.Provider
+        columns={columns}
+        data={orderedMenus}
+        className="h-full m-3 pb-1"
+        stickyColumns={['drag', 'more', 'checkbox', 'label']}
       >
-        <div ref={containerRef} className="h-full">
-          <RecordTable.Provider
-            columns={columns}
-            data={orderedMenus}
-            className="h-full m-3 pb-1"
-            stickyColumns={['drag', 'more', 'checkbox', 'label']}
-          >
-            <SortableContext
-              items={menuIds}
-              strategy={verticalListSortingStrategy}
-            >
-              <RecordTable.Scroll>
-                <RecordTable>
-                  <RecordTable.Header />
-                  <RecordTable.Body>
-                    {loading && <RecordTable.RowSkeleton rows={10} />}
-                    <RecordTable.RowList Row={SortableMenuRow} />
-                  </RecordTable.Body>
-                </RecordTable>
-              </RecordTable.Scroll>
-            </SortableContext>
-            <MenusCommandBar onBulkDelete={handleBulkDelete} />
-          </RecordTable.Provider>
-        </div>
-      </DragTransformContext.Provider>
+        <SortableContext
+          items={menuIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <RecordTable.Scroll>
+            <RecordTable>
+              <RecordTable.Header />
+              <RecordTable.Body>
+                {loading && <RecordTable.RowSkeleton rows={10} />}
+                <RecordTable.RowList Row={CustomRow} />
+              </RecordTable.Body>
+            </RecordTable>
+          </RecordTable.Scroll>
+        </SortableContext>
+        <MenusCommandBar onBulkDelete={handleBulkDelete} />
+      </RecordTable.Provider>
+
+      <DragOverlay dropAnimation={dropAnimation}>
+        {activeId && activeMenu ? (
+          <div className="flex flex-col rounded-md overflow-hidden shadow-2xl ring-1 ring-primary/5">
+            {activeSubtree.map((m) => (
+              <StaticMenuRow key={m._id} menu={m} columns={columns} isOverlay />
+            ))}
+          </div>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 };

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -19,11 +19,13 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAtomValue } from 'jotai';
 import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
 import { CMS_MENU_EDIT, CMS_MENU_REMOVE } from '../../graphql/queries';
 import { buildFlatTree } from '@/cms/menus/menuUtils';
+import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 
 interface MenuItem {
   _id: string;
@@ -42,7 +44,11 @@ interface MenusRecordTableProps {
 
 const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
 
-const applySiblingOrder = (menus: MenuItem[], siblings: MenuItem[]) => {
+const applySiblingOrder = (
+  menus: MenuItem[],
+  siblings: MenuItem[],
+  locale?: string,
+) => {
   const orderById = new Map(
     siblings.map((menu, index) => [menu._id, index + 1]),
   );
@@ -53,7 +59,7 @@ const applySiblingOrder = (menus: MenuItem[], siblings: MenuItem[]) => {
     return order ? { ...menu, order } : menu;
   });
 
-  return buildFlatTree(updatedMenus);
+  return buildFlatTree(updatedMenus, locale);
 };
 
 type SortableMenuRowProps = React.ComponentProps<typeof RecordTable.Row> & {
@@ -120,6 +126,7 @@ export const MenusRecordTable = ({
   onEdit,
 }: MenusRecordTableProps) => {
   const { menus, loading, refetch } = useMenus({ clientPortalId, kind });
+  const language = useAtomValue(cmsLanguageAtom);
   const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
   const [isReordering, setIsReordering] = useState(false);
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
@@ -185,7 +192,11 @@ export const MenusRecordTable = ({
     }
 
     const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
-    const nextMenus = applySiblingOrder(orderedMenus, reorderedSiblings);
+    const nextMenus = applySiblingOrder(
+      orderedMenus,
+      reorderedSiblings,
+      language || 'en',
+    );
 
     setOrderedMenus(nextMenus);
     setIsReordering(true);

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -18,7 +18,13 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useAtomValue } from 'jotai';
 import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
@@ -43,6 +49,7 @@ interface MenusRecordTableProps {
 }
 
 const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
+const SortableRowDisabledContext = React.createContext(false);
 
 const applySiblingOrder = (
   menus: MenuItem[],
@@ -56,7 +63,7 @@ const applySiblingOrder = (
   const updatedMenus = menus.map((menu) => {
     const order = orderById.get(menu._id);
 
-    return order ? { ...menu, order } : menu;
+    return order !== undefined ? { ...menu, order } : menu;
   });
 
   return buildFlatTree(updatedMenus, locale);
@@ -120,6 +127,16 @@ const SortableMenuRow = React.forwardRef<
 
 SortableMenuRow.displayName = 'SortableMenuRow';
 
+const SortableMenuRowWithContext = (
+  props: React.ComponentProps<typeof RecordTable.Row>,
+) => {
+  const disabled = React.useContext(SortableRowDisabledContext);
+
+  return <SortableMenuRow {...props} disabled={disabled} />;
+};
+
+SortableMenuRowWithContext.displayName = 'SortableMenuRowWithContext';
+
 export const MenusRecordTable = ({
   clientPortalId,
   kind,
@@ -131,10 +148,17 @@ export const MenusRecordTable = ({
   const [isReordering, setIsReordering] = useState(false);
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
     setOrderedMenus(menus);
   }, [menus]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -213,26 +237,24 @@ export const MenusRecordTable = ({
         ),
       );
     } catch (error) {
-      toast({
-        description:
-          error instanceof Error ? error.message : 'Failed to reorder menus.',
-      });
+      if (isMountedRef.current) {
+        toast({
+          description:
+            error instanceof Error ? error.message : 'Failed to reorder menus.',
+        });
+      }
     } finally {
       try {
         await refetch();
       } finally {
-        setIsReordering(false);
+        if (isMountedRef.current) {
+          setIsReordering(false);
+        }
       }
     }
   };
 
   const columns = useMenusColumns(onEdit, refetch);
-  const SortableRow = useCallback(
-    (props: React.ComponentProps<typeof RecordTable.Row>) => (
-      <SortableMenuRow {...props} disabled={isReordering} />
-    ),
-    [isReordering],
-  );
 
   return (
     <RecordTable.Provider
@@ -246,17 +268,22 @@ export const MenusRecordTable = ({
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
       >
-        <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
-          <RecordTable.Scroll>
-            <RecordTable>
-              <RecordTable.Header />
-              <RecordTable.Body>
-                {loading && <RecordTable.RowSkeleton rows={10} />}
-                <RecordTable.RowList Row={SortableRow} />
-              </RecordTable.Body>
-            </RecordTable>
-          </RecordTable.Scroll>
-        </SortableContext>
+        <SortableRowDisabledContext.Provider value={isReordering}>
+          <SortableContext
+            items={menuIds}
+            strategy={verticalListSortingStrategy}
+          >
+            <RecordTable.Scroll>
+              <RecordTable>
+                <RecordTable.Header />
+                <RecordTable.Body>
+                  {loading && <RecordTable.RowSkeleton rows={10} />}
+                  <RecordTable.RowList Row={SortableMenuRowWithContext} />
+                </RecordTable.Body>
+              </RecordTable>
+            </RecordTable.Scroll>
+          </SortableContext>
+        </SortableRowDisabledContext.Provider>
       </DndContext>
       <MenusCommandBar onBulkDelete={handleBulkDelete} />
     </RecordTable.Provider>

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -2,9 +2,8 @@ import { RecordTable, cn, toast } from 'erxes-ui';
 import { useMutation } from '@apollo/client';
 import {
   DndContext,
+  PointerSensor,
   KeyboardSensor,
-  MouseSensor,
-  TouchSensor,
   closestCenter,
   type DragEndEvent,
   useSensor,
@@ -49,7 +48,6 @@ interface MenusRecordTableProps {
 }
 
 const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
-const SortableRowDisabledContext = React.createContext(false);
 
 const applySiblingOrder = (
   menus: MenuItem[],
@@ -73,14 +71,10 @@ const applySiblingOrder = (
   return buildFlatTree(updatedMenus, locale);
 };
 
-type SortableMenuRowProps = React.ComponentProps<typeof RecordTable.Row> & {
-  disabled?: boolean;
-};
-
 const SortableMenuRow = React.forwardRef<
   HTMLTableRowElement,
-  SortableMenuRowProps
->(({ className, disabled, original, style, ...props }, ref) => {
+  React.ComponentProps<typeof RecordTable.Row>
+>(({ className, original, style, ...props }, ref) => {
   const {
     attributes,
     isDragging,
@@ -90,7 +84,6 @@ const SortableMenuRow = React.forwardRef<
     transition,
   } = useSortable({
     id: original?._id,
-    disabled: disabled || !original?._id,
   });
 
   const setRowRef = useCallback(
@@ -117,7 +110,6 @@ const SortableMenuRow = React.forwardRef<
       className={cn(
         'cursor-grab active:cursor-grabbing',
         isDragging && 'relative z-10 opacity-60',
-        disabled && 'cursor-default',
         className,
       )}
       style={{
@@ -131,15 +123,12 @@ const SortableMenuRow = React.forwardRef<
 
 SortableMenuRow.displayName = 'SortableMenuRow';
 
-const SortableMenuRowWithContext = (
-  props: React.ComponentProps<typeof RecordTable.Row>,
-) => {
-  const disabled = React.useContext(SortableRowDisabledContext);
-
-  return <SortableMenuRow {...props} disabled={disabled} />;
+const pointerSensorOptions = {
+  activationConstraint: { distance: 8 },
 };
-
-SortableMenuRowWithContext.displayName = 'SortableMenuRowWithContext';
+const keyboardSensorOptions = {
+  coordinateGetter: sortableKeyboardCoordinates,
+};
 
 export const MenusRecordTable = ({
   clientPortalId,
@@ -149,14 +138,16 @@ export const MenusRecordTable = ({
   const { menus, loading, refetch } = useMenus({ clientPortalId, kind });
   const language = useAtomValue(cmsLanguageAtom);
   const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
-  const [isReordering, setIsReordering] = useState(false);
+  const [reorderingCount, setReorderingCount] = useState(0);
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
-    setOrderedMenus(menus);
-  }, [menus]);
+    if (reorderingCount === 0) {
+      setOrderedMenus(menus);
+    }
+  }, [menus, reorderingCount]);
 
   useEffect(() => {
     return () => {
@@ -164,17 +155,10 @@ export const MenusRecordTable = ({
     };
   }, []);
 
-  const sensors = useSensors(
-    useSensor(MouseSensor, {
-      activationConstraint: { distance: 8 },
-    }),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 150, tolerance: 5 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
+  const pointerSensor = useSensor(PointerSensor, pointerSensorOptions);
+  const keyboardSensor = useSensor(KeyboardSensor, keyboardSensorOptions);
+
+  const sensors = useSensors(pointerSensor, keyboardSensor);
 
   const menuIds = useMemo(
     () => orderedMenus.map((menu) => menu._id),
@@ -188,108 +172,112 @@ export const MenusRecordTable = ({
     refetch();
   };
 
-  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id || isReordering) {
-      return;
-    }
-
-    const activeMenu = orderedMenus.find((menu) => menu._id === active.id);
-    const overMenu = orderedMenus.find((menu) => menu._id === over.id);
-
-    if (!activeMenu || !overMenu) {
-      return;
-    }
-
-    const parentId = getParentKey(activeMenu);
-
-    if (parentId !== getParentKey(overMenu)) {
-      toast({
-        description: 'Menus can only be reordered within the same level.',
-      });
-      return;
-    }
-
-    const siblings = orderedMenus.filter(
-      (menu) => getParentKey(menu) === parentId,
-    );
-    const oldIndex = siblings.findIndex((menu) => menu._id === active.id);
-    const newIndex = siblings.findIndex((menu) => menu._id === over.id);
-
-    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
-      return;
-    }
-
-    const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
-    const nextMenus = applySiblingOrder(
-      orderedMenus,
-      reorderedSiblings,
-      language || 'en',
-    );
-
-    setOrderedMenus(nextMenus);
-    setIsReordering(true);
-
-    try {
-      await Promise.all(
-        reorderedSiblings.map((menu, index) =>
-          editMenu({
-            variables: {
-              _id: menu._id,
-              input: { order: index + 1 },
-            },
-          }),
-        ),
-      );
-    } catch (error) {
-      if (isMountedRef.current) {
-        toast({
-          description:
-            error instanceof Error ? error.message : 'Failed to reorder menus.',
-        });
+  const handleDragEnd = useCallback(
+    async ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) {
+        return;
       }
-    } finally {
+
+      const activeMenu = orderedMenus.find((menu) => menu._id === active.id);
+      const overMenu = orderedMenus.find((menu) => menu._id === over.id);
+
+      if (!activeMenu || !overMenu) {
+        return;
+      }
+
+      const parentId = getParentKey(activeMenu);
+
+      if (parentId !== getParentKey(overMenu)) {
+        toast({
+          description: 'Menus can only be reordered within the same level.',
+        });
+        return;
+      }
+
+      const siblings = orderedMenus.filter(
+        (menu) => getParentKey(menu) === parentId,
+      );
+      const oldIndex = siblings.findIndex((menu) => menu._id === active.id);
+      const newIndex = siblings.findIndex((menu) => menu._id === over.id);
+
+      if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+        return;
+      }
+
+      const reorderedSiblings = arrayMove(siblings, oldIndex, newIndex);
+      const nextMenus = applySiblingOrder(
+        orderedMenus,
+        reorderedSiblings,
+        language || 'en',
+      );
+
+      // Optimistic update
+      setOrderedMenus(nextMenus);
+      setReorderingCount((prev) => prev + 1);
+
       try {
+        await Promise.all(
+          reorderedSiblings.map((menu, index) =>
+            editMenu({
+              variables: {
+                _id: menu._id,
+                input: { order: index + 1 },
+              },
+            }),
+          ),
+        );
+        // Wait for refetch to complete to ensure server state is captured
         await refetch();
+      } catch (error) {
+        if (isMountedRef.current) {
+          toast({
+            description:
+              error instanceof Error
+                ? error.message
+                : 'Failed to reorder menus.',
+          });
+          // Revert on error if no other reorders are pending
+          if (reorderingCount === 1) {
+            setOrderedMenus(menus);
+          }
+        }
       } finally {
         if (isMountedRef.current) {
-          setIsReordering(false);
+          setReorderingCount((prev) => Math.max(0, prev - 1));
         }
       }
-    }
-  };
+    },
+    [orderedMenus, language, editMenu, refetch, menus, reorderingCount],
+  );
 
   const columns = useMenusColumns(onEdit, refetch);
 
   return (
-    <RecordTable.Provider
-      columns={columns}
-      data={orderedMenus}
-      className="h-full m-3 pb-1"
-      stickyColumns={['drag', 'more', 'checkbox', 'label']}
+    <DndContext
+      id="cms-menus-dnd"
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
     >
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
+      <RecordTable.Provider
+        columns={columns}
+        data={orderedMenus}
+        className="h-full m-3 pb-1"
+        stickyColumns={['drag', 'more', 'checkbox', 'label']}
       >
-        <SortableRowDisabledContext.Provider value={isReordering}>
-          <SortableContext
-            items={menuIds}
-            strategy={verticalListSortingStrategy}
-          >
-            <RecordTable.Scroll>
-              <RecordTable>
-                <RecordTable.Header />
-                <RecordTable.Body>
-                  {loading && <RecordTable.RowSkeleton rows={10} />}
-                  <RecordTable.RowList Row={SortableMenuRowWithContext} />
-                </RecordTable.Body>
-              </RecordTable>
-            </RecordTable.Scroll>
-          </SortableContext>
-        </SortableRowDisabledContext.Provider>
-      </DndContext>
-      <MenusCommandBar onBulkDelete={handleBulkDelete} />
-    </RecordTable.Provider>
+        <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
+          <RecordTable.Scroll>
+            <RecordTable>
+              <RecordTable.Header />
+              <RecordTable.Body>
+                {loading && <RecordTable.RowSkeleton rows={10} />}
+                <RecordTable.RowList Row={SortableMenuRow} />
+              </RecordTable.Body>
+            </RecordTable>
+          </RecordTable.Scroll>
+        </SortableContext>
+        <MenusCommandBar onBulkDelete={handleBulkDelete} />
+      </RecordTable.Provider>
+    </DndContext>
   );
 };

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -53,14 +53,10 @@ const getParentKey = (menu?: MenuItem) => menu?.parentId || null;
 
 const DragTransformContext = React.createContext<{
   activeId: string | null;
-  transform: string | null;
-  transition: string | null;
-  setTransform: (transform: string | null, transition: string | null) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
 }>({
   activeId: null,
-  transform: null,
-  transition: null,
-  setTransform: () => {},
+  containerRef: { current: null },
 });
 
 const applySiblingOrder = (
@@ -100,12 +96,7 @@ const SortableMenuRow = React.forwardRef<
     id: original?._id,
   });
 
-  const {
-    activeId,
-    transform: sharedTransform,
-    transition: sharedTransition,
-    setTransform,
-  } = React.useContext(DragTransformContext);
+  const { activeId, containerRef } = React.useContext(DragTransformContext);
 
   const setRowRef = useCallback(
     (node: HTMLTableRowElement | null) => {
@@ -127,21 +118,29 @@ const SortableMenuRow = React.forwardRef<
   }, [activeId, original?.path]);
 
   useEffect(() => {
-    if (isDragging) {
-      setTransform(CSS.Transform.toString(transform), transition || null);
+    if (isDragging && containerRef.current) {
+      const container = containerRef.current;
+      const tStr = CSS.Transform.toString(transform) || 'none';
+      container.style.setProperty('--drag-transform', tStr);
+      container.style.setProperty('--drag-transition', transition || 'none');
+
+      return () => {
+        container.style.removeProperty('--drag-transform');
+        container.style.removeProperty('--drag-transition');
+      };
     }
-  }, [isDragging, transform, transition, setTransform]);
+  }, [isDragging, transform, transition, containerRef]);
 
   const effectiveTransform = isDragging
     ? CSS.Transform.toString(transform)
     : isDescendant
-      ? sharedTransform
+      ? 'var(--drag-transform)'
       : CSS.Transform.toString(transform);
 
   const effectiveTransition = isDragging
     ? transition
     : isDescendant
-      ? sharedTransition
+      ? 'var(--drag-transition)'
       : transition;
 
   return (
@@ -185,10 +184,7 @@ export const MenusRecordTable = ({
   const [orderedMenus, setOrderedMenus] = useState<MenuItem[]>(menus);
   const [reorderingCount, setReorderingCount] = useState(0);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [activeTransform, setActiveTransform] = useState<{
-    transform: string | null;
-    transition: string | null;
-  }>({ transform: null, transition: null });
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const [removeMenu] = useMutation(CMS_MENU_REMOVE);
   const [editMenu] = useMutation(CMS_MENU_EDIT);
@@ -238,7 +234,6 @@ export const MenusRecordTable = ({
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
       setActiveId(null);
-      setActiveTransform({ transform: null, transition: null });
 
       if (!over || active.id === over.id) {
         return;
@@ -344,38 +339,38 @@ export const MenusRecordTable = ({
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
         setActiveId(null);
-        setActiveTransform({ transform: null, transition: null });
       }}
     >
       <DragTransformContext.Provider
         value={{
           activeId,
-          transform: activeTransform.transform,
-          transition: activeTransform.transition,
-          setTransform: (transform, transition) => {
-            setActiveTransform({ transform, transition });
-          },
+          containerRef,
         }}
       >
-        <RecordTable.Provider
-          columns={columns}
-          data={orderedMenus}
-          className="h-full m-3 pb-1"
-          stickyColumns={['drag', 'more', 'checkbox', 'label']}
-        >
-          <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
-            <RecordTable.Scroll>
-              <RecordTable>
-                <RecordTable.Header />
-                <RecordTable.Body>
-                  {loading && <RecordTable.RowSkeleton rows={10} />}
-                  <RecordTable.RowList Row={SortableMenuRow} />
-                </RecordTable.Body>
-              </RecordTable>
-            </RecordTable.Scroll>
-          </SortableContext>
-          <MenusCommandBar onBulkDelete={handleBulkDelete} />
-        </RecordTable.Provider>
+        <div ref={containerRef} className="h-full">
+          <RecordTable.Provider
+            columns={columns}
+            data={orderedMenus}
+            className="h-full m-3 pb-1"
+            stickyColumns={['drag', 'more', 'checkbox', 'label']}
+          >
+            <SortableContext
+              items={menuIds}
+              strategy={verticalListSortingStrategy}
+            >
+              <RecordTable.Scroll>
+                <RecordTable>
+                  <RecordTable.Header />
+                  <RecordTable.Body>
+                    {loading && <RecordTable.RowSkeleton rows={10} />}
+                    <RecordTable.RowList Row={SortableMenuRow} />
+                  </RecordTable.Body>
+                </RecordTable>
+              </RecordTable.Scroll>
+            </SortableContext>
+            <MenusCommandBar onBulkDelete={handleBulkDelete} />
+          </RecordTable.Provider>
+        </div>
       </DragTransformContext.Provider>
     </DndContext>
   );

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -10,6 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
   useSensor,
+  useSensors,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -31,7 +32,7 @@ import { useMenusColumns } from './MenusColumn';
 import { MenusCommandBar } from './menus-command-bar/MenusCommandBar';
 import { useMenus } from '../hooks/useMenus';
 import { CMS_MENU_EDIT, CMS_MENU_REMOVE } from '../../graphql/queries';
-import { buildFlatTree } from '@/cms/menus/menuUtils';
+import { buildFlatTree, getDepthPrefix } from '@/cms/menus/menuUtils';
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 
 interface MenuItem {
@@ -112,7 +113,7 @@ const StaticMenuRow = ({
               {/* Simplified rendering for overlay to keep it fast */}
               {column.id === 'label' ? (
                 <span className="text-sm font-medium">
-                  {'-'.repeat(menu.depth || 0) + ' ' + menu.label}
+                  {getDepthPrefix(menu.depth || 0) + menu.label}
                 </span>
               ) : column.id === 'drag' ? (
                 <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -213,6 +214,10 @@ const keyboardSensorOptions = {
   coordinateGetter: sortableKeyboardCoordinates,
 };
 
+/**
+ * A high-performance record table for managing CMS menus with drag-and-drop reordering.
+ * Uses @dnd-kit for fluid subtree dragging and serialized mutations to prevent race conditions.
+ */
 export const MenusRecordTable = ({
   clientPortalId,
   kind,
@@ -231,8 +236,11 @@ export const MenusRecordTable = ({
 
   // Queue to serialize mutations per parent to prevent race conditions
   const mutationQueueRef = useRef<Record<string, Promise<any>>>({});
+  // Ref to avoid stale closure issues in async handlers
+  const reorderingCountRef = useRef(reorderingCount);
 
   useEffect(() => {
+    reorderingCountRef.current = reorderingCount;
     if (reorderingCount === 0) {
       setOrderedMenus(menus);
     }
@@ -241,16 +249,15 @@ export const MenusRecordTable = ({
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
+      // Clean up mutation queue on unmount
+      mutationQueueRef.current = {};
     };
   }, []);
 
-  const mouseSensor = useSensor(PointerSensor, pointerSensorOptions);
+  const pointerSensor = useSensor(PointerSensor, pointerSensorOptions);
   const keyboardSensor = useSensor(KeyboardSensor, keyboardSensorOptions);
 
-  const sensors = useMemo(
-    () => [mouseSensor, keyboardSensor],
-    [mouseSensor, keyboardSensor],
-  );
+  const sensors = useSensors(pointerSensor, keyboardSensor);
 
   const menuIds = useMemo(
     () => orderedMenus.map((menu) => menu._id),
@@ -276,11 +283,14 @@ export const MenusRecordTable = ({
     refetch();
   };
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const item = orderedMenus.find((m) => m._id === event.active.id);
-    setActiveId(event.active.id as string);
-    setActiveParentId(getParentKey(item) || 'root');
-  };
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const item = orderedMenus.find((m) => m._id === event.active.id);
+      setActiveId(event.active.id as string);
+      setActiveParentId(getParentKey(item) || 'root');
+    },
+    [orderedMenus],
+  );
 
   const handleDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
@@ -338,41 +348,49 @@ export const MenusRecordTable = ({
 
       const currentQueue = mutationQueueRef.current[pId] || Promise.resolve();
 
-      const nextMutation = currentQueue.then(async () => {
-        try {
-          await Promise.all(
-            changes.map((change) =>
-              editMenu({
-                variables: {
-                  _id: change._id,
-                  input: { order: change.newOrder },
-                },
-              }),
-            ),
-          );
-          await refetch();
-        } catch (error) {
-          if (isMountedRef.current) {
-            toast({
-              description:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to reorder menus.',
-            });
-            setOrderedMenus((current) =>
-              reorderingCount === 1 ? menus : current,
+      const nextMutation = currentQueue
+        .then(async () => {
+          try {
+            await Promise.all(
+              changes.map((change) =>
+                editMenu({
+                  variables: {
+                    _id: change._id,
+                    input: { order: change.newOrder },
+                  },
+                }),
+              ),
             );
+            await refetch();
+          } catch (error) {
+            if (isMountedRef.current) {
+              toast({
+                description:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to reorder menus.',
+              });
+              // Use ref value to check if this was the last pending operation
+              if (reorderingCountRef.current === 1) {
+                setOrderedMenus(menus);
+              }
+            }
+          } finally {
+            if (isMountedRef.current) {
+              setReorderingCount((prev) => Math.max(0, prev - 1));
+            }
           }
-        } finally {
-          if (isMountedRef.current) {
-            setReorderingCount((prev) => Math.max(0, prev - 1));
+        })
+        .finally(() => {
+          // Clean up completed promise from queue
+          if (mutationQueueRef.current[pId] === nextMutation) {
+            delete mutationQueueRef.current[pId];
           }
-        }
-      });
+        });
 
       mutationQueueRef.current[pId] = nextMutation;
     },
-    [orderedMenus, language, editMenu, refetch, menus, reorderingCount],
+    [orderedMenus, language, editMenu, refetch, menus],
   );
 
   const columns = useMenusColumns(onEdit, refetch);

--- a/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenuDrawer.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenuDrawer.ts
@@ -155,7 +155,10 @@ export function useMenuDrawer({ isOpen, onClose, onSuccess, clientPortalId, menu
     (m: RawMenuItem) => m._id !== menu?._id,
   );
 
-  const parentOptions = buildFlatTree(rawMenus).map((item) => ({
+  const parentOptions = buildFlatTree(
+    rawMenus,
+    selectedLanguage || cmsLanguage || defaultLanguage || 'en',
+  ).map((item) => ({
     _id: item._id,
     label: getDepthPrefix(item.depth) + item.label,
   }));

--- a/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenus.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenus.ts
@@ -32,8 +32,8 @@ export const useMenus = ({
   });
 
   const menus = useMemo(
-    () => buildFlatTree(data?.cmsMenuList || []),
-    [data?.cmsMenuList],
+    () => buildFlatTree(data?.cmsMenuList || [], language || 'en'),
+    [data?.cmsMenuList, language],
   );
 
   return { menus, totalCount: menus.length, loading, error, refetch };

--- a/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenus.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/hooks/useMenus.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { CMS_MENU_LIST } from '../../graphql/queries';
 import { cmsLanguageAtom } from '../../shared/states/cmsLanguageState';
@@ -13,13 +14,27 @@ export const useMenus = ({
 }) => {
   const language = useAtomValue(cmsLanguageAtom);
 
+  const variables = useMemo(
+    () => ({
+      clientPortalId,
+      limit: 100,
+      kind,
+      language,
+      orderBy: { order: 1 },
+    }),
+    [clientPortalId, kind, language],
+  );
+
   const { data, loading, error, refetch } = useQuery(CMS_MENU_LIST, {
-    variables: { clientPortalId, limit: 50, kind, language },
+    variables,
     skip: !clientPortalId,
     fetchPolicy: 'network-only',
   });
 
-  const menus = buildFlatTree(data?.cmsMenuList || []);
+  const menus = useMemo(
+    () => buildFlatTree(data?.cmsMenuList || []),
+    [data?.cmsMenuList],
+  );
 
   return { menus, totalCount: menus.length, loading, error, refetch };
 };

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -6,6 +6,11 @@ export type RawMenuItem = {
   [key: string]: unknown;
 };
 
+/**
+ * Compares two menu items for sorting purposes.
+ * Prioritizes the 'order' field, then falls back to locale-aware label comparison.
+ * Items without an order are placed at the end.
+ */
 function compareMenuItems<T extends RawMenuItem>(
   a: T,
   b: T,
@@ -18,12 +23,16 @@ function compareMenuItems<T extends RawMenuItem>(
     return aOrder - bOrder;
   }
 
-  return a.label.localeCompare(b.label, locale || 'en', {
+  return a.label.localeCompare(b.label, locale, {
     numeric: true,
     sensitivity: 'base',
   });
 }
 
+/**
+ * Transforms a flat list of menu items into a sorted flat tree structure.
+ * Each item is enriched with its depth and the path of ancestor IDs.
+ */
 export function buildFlatTree<T extends RawMenuItem>(
   items: T[],
   locale = 'en',
@@ -46,6 +55,9 @@ export function buildFlatTree<T extends RawMenuItem>(
   return result;
 }
 
+/**
+ * Generates a visual indentation prefix based on the nesting depth.
+ */
 export function getDepthPrefix(depth: number): string {
   if (depth <= 0) return '';
   return '-'.repeat(depth) + ' ';

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -2,8 +2,23 @@ export type RawMenuItem = {
   _id: string;
   label: string;
   parentId?: string;
+  order?: number;
   [key: string]: unknown;
 };
+
+function compareMenuItems<T extends RawMenuItem>(a: T, b: T): number {
+  const aOrder = a.order ?? Number.MAX_SAFE_INTEGER;
+  const bOrder = b.order ?? Number.MAX_SAFE_INTEGER;
+
+  if (aOrder !== bOrder) {
+    return aOrder - bOrder;
+  }
+
+  return a.label.localeCompare(b.label, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
 
 export function buildFlatTree<T extends RawMenuItem>(
   items: T[],
@@ -12,12 +27,7 @@ export function buildFlatTree<T extends RawMenuItem>(
   const addChildren = (parentId: string | null, depth: number) => {
     items
       .filter((item) => (item.parentId || null) === parentId)
-      .sort((a, b) =>
-        a.label.localeCompare(b.label, undefined, {
-          numeric: true,
-          sensitivity: 'base',
-        }),
-      )
+      .sort(compareMenuItems)
       .forEach((item) => {
         result.push({ ...item, depth });
         addChildren(item._id, depth + 1);

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -27,18 +27,22 @@ function compareMenuItems<T extends RawMenuItem>(
 export function buildFlatTree<T extends RawMenuItem>(
   items: T[],
   locale = 'en',
-): (T & { depth: number })[] {
-  const result: (T & { depth: number })[] = [];
-  const addChildren = (parentId: string | null, depth: number) => {
+): (T & { depth: number; path: string[] })[] {
+  const result: (T & { depth: number; path: string[] })[] = [];
+  const addChildren = (
+    parentId: string | null,
+    depth: number,
+    path: string[],
+  ) => {
     items
       .filter((item) => (item.parentId || null) === parentId)
       .sort((a, b) => compareMenuItems(a, b, locale))
       .forEach((item) => {
-        result.push({ ...item, depth });
-        addChildren(item._id, depth + 1);
+        result.push({ ...item, depth, path });
+        addChildren(item._id, depth + 1, [...path, item._id]);
       });
   };
-  addChildren(null, 0);
+  addChildren(null, 0, []);
   return result;
 }
 

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -14,7 +14,7 @@ function compareMenuItems<T extends RawMenuItem>(a: T, b: T): number {
     return aOrder - bOrder;
   }
 
-  return a.label.localeCompare(b.label, undefined, {
+  return a.label.localeCompare(b.label, 'en', {
     numeric: true,
     sensitivity: 'base',
   });

--- a/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/menuUtils.ts
@@ -6,7 +6,11 @@ export type RawMenuItem = {
   [key: string]: unknown;
 };
 
-function compareMenuItems<T extends RawMenuItem>(a: T, b: T): number {
+function compareMenuItems<T extends RawMenuItem>(
+  a: T,
+  b: T,
+  locale = 'en',
+): number {
   const aOrder = a.order ?? Number.MAX_SAFE_INTEGER;
   const bOrder = b.order ?? Number.MAX_SAFE_INTEGER;
 
@@ -14,7 +18,7 @@ function compareMenuItems<T extends RawMenuItem>(a: T, b: T): number {
     return aOrder - bOrder;
   }
 
-  return a.label.localeCompare(b.label, 'en', {
+  return a.label.localeCompare(b.label, locale || 'en', {
     numeric: true,
     sensitivity: 'base',
   });
@@ -22,12 +26,13 @@ function compareMenuItems<T extends RawMenuItem>(a: T, b: T): number {
 
 export function buildFlatTree<T extends RawMenuItem>(
   items: T[],
+  locale = 'en',
 ): (T & { depth: number })[] {
   const result: (T & { depth: number })[] = [];
   const addChildren = (parentId: string | null, depth: number) => {
     items
       .filter((item) => (item.parentId || null) === parentId)
-      .sort(compareMenuItems)
+      .sort((a, b) => compareMenuItems(a, b, locale))
       .forEach((item) => {
         result.push({ ...item, depth });
         addChildren(item._id, depth + 1);


### PR DESCRIPTION
## Summary
- add drag-and-drop ordering for CMS menus using existing menu order persistence
- make CMS custom fields page scrollable and deterministic in listing order
- remove unsupported MenuItem.type selections from CMS menu operations

## Validation
- pnpm nx build content_ui --skip-nx-cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering for menu items with grip handles and inline feedback.

* **Improvements**
  * Stable, order- and label-aware sorting for menus and custom fields.
  * Menu list supports explicit ordering for predictable views.
  * Improved scrolling and layout for custom fields.
  * Memoization and other performance optimizations for snappier lists.
  * Reorder validation and error feedback to prevent invalid moves.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->