### PR TITLE
feat(content-ui): improve single CMS navigation

### DIFF
--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -53,8 +53,17 @@ export const ContentNavigation = () => {
       /> */}
       {onlyCms?.clientPortalId ? (
         <>
-          <Sidebar.MenuItem>
-            <Sidebar.MenuButton asChild isActive={isCmsActive} className="pr-14">
+          <Sidebar.MenuItem className="group/cms-menu">
+            <Sidebar.MenuButton
+              asChild
+              isActive={isCmsActive}
+              className={cn(
+                'pr-14',
+                isCmsActive
+                  ? 'group-hover/cms-menu:bg-primary/10'
+                  : 'group-hover/cms-menu:bg-accent',
+              )}
+            >
               <Link to={cmsPath}>
                 <IconFileText
                   className={cn(
@@ -68,7 +77,7 @@ export const ContentNavigation = () => {
             <div className="absolute inset-y-0 right-1 flex items-center gap-0.5">
               <Button
                 aria-label="Add CMS"
-                className="h-6 w-6 p-0 text-primary/70 hover:bg-primary/10 hover:text-primary"
+                className="h-6 w-6 p-0 text-primary/70 hover:bg-transparent hover:text-primary"
                 size="icon"
                 title="Add CMS"
                 type="button"
@@ -83,7 +92,7 @@ export const ContentNavigation = () => {
               </Button>
               <Button
                 aria-label="Manage CMS"
-                className="h-6 w-6 p-0 text-primary/70 hover:bg-primary/10 hover:text-primary"
+                className="h-6 w-6 p-0 text-primary/70 hover:bg-transparent hover:text-primary"
                 size="icon"
                 title="Manage CMS"
                 type="button"

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -1,7 +1,45 @@
-import { IconFileText, IconWorldPlus } from '@tabler/icons-react';
-import { NavigationMenuLinkItem } from 'erxes-ui';
+import { useQuery } from '@apollo/client';
+import { IconDots, IconFileText, IconWorldPlus } from '@tabler/icons-react';
+import { NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+import { WebsiteDrawer } from './cms/components/websites/WebsiteDrawer';
+import { CONTENT_CMS_LIST } from './cms/graphql/queries';
+
+type CmsWebsite = {
+  _id: string;
+  clientPortalId: string;
+  name: string;
+  description: string;
+  domain: string;
+  url: string;
+  kind?: string;
+  createdAt: string;
+  languages?: string[];
+  language?: string;
+  postUrlField?: '_id' | 'count' | 'slug';
+};
 
 export const ContentNavigation = () => {
+  const { pathname } = useLocation();
+  const [isWebsiteDrawerOpen, setIsWebsiteDrawerOpen] = useState(false);
+  const { data, refetch } = useQuery<{
+    contentCMSList: CmsWebsite[];
+  }>(CONTENT_CMS_LIST);
+
+  const cmsList = data?.contentCMSList || [];
+  const onlyCms = cmsList.length === 1 ? cmsList[0] : null;
+  const cmsPath = onlyCms?.clientPortalId
+    ? `/content/cms/${onlyCms.clientPortalId}/posts`
+    : '/content/cms';
+  const isCmsActive = pathname.startsWith('/content/cms');
+
+  const handleWebsiteUpdated = () => {
+    refetch();
+    setIsWebsiteDrawerOpen(false);
+  };
+
   return (
     <div>
       {/* <NavigationMenuLinkItem
@@ -9,11 +47,42 @@ export const ContentNavigation = () => {
         path="/content/knowledgebase"
         icon={IconLibraryPhoto}
       /> */}
-      <NavigationMenuLinkItem
-        name="CMS"
-        path="/content/cms"
-        icon={IconFileText}
-      />
+      {onlyCms ? (
+        <>
+          <Sidebar.MenuItem>
+            <Sidebar.MenuButton asChild isActive={isCmsActive}>
+              <Link to={cmsPath}>
+                <IconFileText />
+                <span className="capitalize">CMS</span>
+              </Link>
+            </Sidebar.MenuButton>
+            <Sidebar.MenuAction
+              aria-label="Manage CMS"
+              title="Manage CMS"
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setIsWebsiteDrawerOpen(true);
+              }}
+            >
+              <IconDots />
+            </Sidebar.MenuAction>
+          </Sidebar.MenuItem>
+          <WebsiteDrawer
+            isOpen={isWebsiteDrawerOpen}
+            onClose={() => setIsWebsiteDrawerOpen(false)}
+            onSuccess={handleWebsiteUpdated}
+            website={onlyCms}
+          />
+        </>
+      ) : (
+        <NavigationMenuLinkItem
+          name="CMS"
+          path="/content/cms"
+          icon={IconFileText}
+        />
+      )}
       <NavigationMenuLinkItem
         name="Web Builder"
         path="/content/web-builder"

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -5,7 +5,7 @@ import {
   IconPlus,
   IconWorldPlus,
 } from '@tabler/icons-react';
-import { NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
+import { Button, NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -67,38 +67,44 @@ export const ContentNavigation = () => {
       {onlyCms ? (
         <>
           <Sidebar.MenuItem>
-            <Sidebar.MenuButton asChild isActive={isCmsActive}>
+            <Sidebar.MenuButton asChild isActive={isCmsActive} className="pr-14">
               <Link to={cmsPath}>
                 <IconFileText />
                 <span className="capitalize">CMS</span>
               </Link>
             </Sidebar.MenuButton>
-            <Sidebar.MenuAction
-              aria-label="Add CMS"
-              className="right-7 top-0.5 h-6 w-6 rounded text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
-              title="Add CMS"
-              type="button"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                handleOpenWebsiteDrawer();
-              }}
-            >
-              <IconPlus className="h-4 w-4" />
-            </Sidebar.MenuAction>
-            <Sidebar.MenuAction
-              aria-label="Manage CMS"
-              className="right-1 top-0.5 h-6 w-6 rounded text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
-              title="Manage CMS"
-              type="button"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                handleOpenWebsiteDrawer(onlyCms);
-              }}
-            >
-              <IconDotsVertical className="h-4 w-4" />
-            </Sidebar.MenuAction>
+            <div className="absolute inset-y-0 right-1 flex items-center gap-0.5">
+              <Button
+                aria-label="Add CMS"
+                className="h-6 w-6 p-0 text-primary/70 hover:bg-primary/10 hover:text-primary"
+                size="icon"
+                title="Add CMS"
+                type="button"
+                variant="ghost"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleOpenWebsiteDrawer();
+                }}
+              >
+                <IconPlus className="h-4 w-4" />
+              </Button>
+              <Button
+                aria-label="Manage CMS"
+                className="h-6 w-6 p-0 text-primary/70 hover:bg-primary/10 hover:text-primary"
+                size="icon"
+                title="Manage CMS"
+                type="button"
+                variant="ghost"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleOpenWebsiteDrawer(onlyCms);
+                }}
+              >
+                <IconDotsVertical className="h-4 w-4" />
+              </Button>
+            </div>
           </Sidebar.MenuItem>
           <WebsiteDrawer
             isOpen={isWebsiteDrawerOpen}

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client';
 import {
   IconDotsVertical,
   IconFileText,
+  IconPlus,
   IconWorldPlus,
 } from '@tabler/icons-react';
 import { NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
@@ -28,6 +29,7 @@ type CmsWebsite = {
 export const ContentNavigation = () => {
   const { pathname } = useLocation();
   const [isWebsiteDrawerOpen, setIsWebsiteDrawerOpen] = useState(false);
+  const [editingWebsite, setEditingWebsite] = useState<CmsWebsite>();
   const { data, refetch } = useQuery<{
     contentCMSList: CmsWebsite[];
   }>(CONTENT_CMS_LIST);
@@ -42,6 +44,17 @@ export const ContentNavigation = () => {
   const handleWebsiteUpdated = () => {
     refetch();
     setIsWebsiteDrawerOpen(false);
+    setEditingWebsite(undefined);
+  };
+
+  const handleCloseWebsiteDrawer = () => {
+    setIsWebsiteDrawerOpen(false);
+    setEditingWebsite(undefined);
+  };
+
+  const handleOpenWebsiteDrawer = (website?: CmsWebsite) => {
+    setEditingWebsite(website);
+    setIsWebsiteDrawerOpen(true);
   };
 
   return (
@@ -61,24 +74,37 @@ export const ContentNavigation = () => {
               </Link>
             </Sidebar.MenuButton>
             <Sidebar.MenuAction
+              aria-label="Add CMS"
+              className="right-7 top-0.5 h-6 w-6 rounded text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
+              title="Add CMS"
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                handleOpenWebsiteDrawer();
+              }}
+            >
+              <IconPlus className="h-4 w-4" />
+            </Sidebar.MenuAction>
+            <Sidebar.MenuAction
               aria-label="Manage CMS"
-              className="right-1.5 top-1 h-5 w-5 rounded bg-transparent text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
+              className="right-1 top-0.5 h-6 w-6 rounded text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
               title="Manage CMS"
               type="button"
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                setIsWebsiteDrawerOpen(true);
+                handleOpenWebsiteDrawer(onlyCms);
               }}
             >
-              <IconDotsVertical />
+              <IconDotsVertical className="h-4 w-4" />
             </Sidebar.MenuAction>
           </Sidebar.MenuItem>
           <WebsiteDrawer
             isOpen={isWebsiteDrawerOpen}
-            onClose={() => setIsWebsiteDrawerOpen(false)}
+            onClose={handleCloseWebsiteDrawer}
             onSuccess={handleWebsiteUpdated}
-            website={onlyCms}
+            website={editingWebsite}
           />
         </>
       ) : (

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -11,27 +11,14 @@ import { Link, useLocation } from 'react-router-dom';
 
 import { WebsiteDrawer } from './cms/components/websites/WebsiteDrawer';
 import { CONTENT_CMS_LIST } from './cms/graphql/queries';
-
-type CmsWebsite = {
-  _id: string;
-  clientPortalId: string;
-  name: string;
-  description: string;
-  domain: string;
-  url: string;
-  kind?: string;
-  createdAt: string;
-  languages?: string[];
-  language?: string;
-  postUrlField?: '_id' | 'count' | 'slug';
-};
+import { IWebsite } from './cms/types';
 
 export const ContentNavigation = () => {
   const { pathname } = useLocation();
   const [isWebsiteDrawerOpen, setIsWebsiteDrawerOpen] = useState(false);
-  const [editingWebsite, setEditingWebsite] = useState<CmsWebsite>();
+  const [editingWebsite, setEditingWebsite] = useState<IWebsite>();
   const { data, refetch } = useQuery<{
-    contentCMSList: CmsWebsite[];
+    contentCMSList: IWebsite[];
   }>(CONTENT_CMS_LIST);
 
   const cmsList = data?.contentCMSList || [];
@@ -52,7 +39,7 @@ export const ContentNavigation = () => {
     setEditingWebsite(undefined);
   };
 
-  const handleOpenWebsiteDrawer = (website?: CmsWebsite) => {
+  const handleOpenWebsiteDrawer = (website?: IWebsite) => {
     setEditingWebsite(website);
     setIsWebsiteDrawerOpen(true);
   };
@@ -64,7 +51,7 @@ export const ContentNavigation = () => {
         path="/content/knowledgebase"
         icon={IconLibraryPhoto}
       /> */}
-      {onlyCms ? (
+      {onlyCms?.clientPortalId ? (
         <>
           <Sidebar.MenuItem>
             <Sidebar.MenuButton asChild isActive={isCmsActive} className="pr-14">

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -1,5 +1,9 @@
 import { useQuery } from '@apollo/client';
-import { IconDots, IconFileText, IconWorldPlus } from '@tabler/icons-react';
+import {
+  IconDotsVertical,
+  IconFileText,
+  IconWorldPlus,
+} from '@tabler/icons-react';
 import { NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -58,6 +62,7 @@ export const ContentNavigation = () => {
             </Sidebar.MenuButton>
             <Sidebar.MenuAction
               aria-label="Manage CMS"
+              className="right-1.5 top-1 h-5 w-5 rounded bg-transparent text-primary/70 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary/40"
               title="Manage CMS"
               type="button"
               onClick={(event) => {
@@ -66,7 +71,7 @@ export const ContentNavigation = () => {
                 setIsWebsiteDrawerOpen(true);
               }}
             >
-              <IconDots />
+              <IconDotsVertical />
             </Sidebar.MenuAction>
           </Sidebar.MenuItem>
           <WebsiteDrawer

--- a/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
+++ b/frontend/plugins/content_ui/src/modules/ContentNavigation.tsx
@@ -5,7 +5,7 @@ import {
   IconPlus,
   IconWorldPlus,
 } from '@tabler/icons-react';
-import { Button, NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
+import { Button, cn, NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -56,7 +56,12 @@ export const ContentNavigation = () => {
           <Sidebar.MenuItem>
             <Sidebar.MenuButton asChild isActive={isCmsActive} className="pr-14">
               <Link to={cmsPath}>
-                <IconFileText />
+                <IconFileText
+                  className={cn(
+                    'text-accent-foreground',
+                    isCmsActive && 'text-primary',
+                  )}
+                />
                 <span className="capitalize">CMS</span>
               </Link>
             </Sidebar.MenuButton>

--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -24,23 +24,10 @@ import {
   websiteFormSchema,
   WebsiteFormType,
 } from '../../constants/websiteFormSchema';
-
-interface Website {
-  _id: string;
-  name: string;
-  description: string;
-  domain: string;
-  url: string;
-  kind?: string;
-  clientPortalId: string;
-  createdAt: string;
-  languages?: string[];
-  language?: string;
-  postUrlField?: '_id' | 'count' | 'slug';
-}
+import { IWebsite } from '../../types';
 
 interface WebsiteDrawerProps {
-  website?: Website;
+  website?: IWebsite;
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: () => void;

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -566,7 +566,7 @@ export const SettingsForm = ({
           </Dialog.Header>
 
           <div className="space-y-5 bg-muted/40 p-6">
-            <div className="space-y-3">
+            <div className="space-y-2">
               <label
                 htmlFor={DELETE_NAME_CONFIRMATION_INPUT_ID}
                 className="block text-sm leading-5 text-muted-foreground"
@@ -586,7 +586,7 @@ export const SettingsForm = ({
               />
             </div>
 
-            <div className="space-y-3">
+            <div className="space-y-2">
               <label
                 htmlFor={DELETE_PHRASE_CONFIRMATION_INPUT_ID}
                 className="block text-sm leading-5 text-muted-foreground"

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -565,7 +565,7 @@ export const SettingsForm = ({
             </Dialog.Description>
           </Dialog.Header>
 
-          <div className="space-y-5 bg-muted/40 p-6">
+          <div className="space-y-5 p-6">
             <div className="space-y-2">
               <label
                 htmlFor={DELETE_NAME_CONFIRMATION_INPUT_ID}

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -566,10 +566,10 @@ export const SettingsForm = ({
           </Dialog.Header>
 
           <div className="space-y-5 bg-muted/40 p-6">
-            <div className="space-y-2">
+            <div className="space-y-3">
               <label
                 htmlFor={DELETE_NAME_CONFIRMATION_INPUT_ID}
-                className="text-sm text-muted-foreground"
+                className="block text-sm leading-5 text-muted-foreground"
               >
                 To confirm, type{' '}
                 <span className="font-semibold text-foreground">
@@ -586,10 +586,10 @@ export const SettingsForm = ({
               />
             </div>
 
-            <div className="space-y-2">
+            <div className="space-y-3">
               <label
                 htmlFor={DELETE_PHRASE_CONFIRMATION_INPUT_ID}
-                className="text-sm text-muted-foreground"
+                className="block text-sm leading-5 text-muted-foreground"
               >
                 To confirm, type{' '}
                 <span className="font-semibold text-foreground">

--- a/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tabler/icons-react';
 import { Button, Spinner, ToggleGroup } from 'erxes-ui';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { WebsiteDrawer } from '../components/websites/WebsiteDrawer';
 import { CONTENT_CMS_LIST } from '../graphql/queries';
 import { CmsLayout } from './CmsLayout';
@@ -33,39 +33,47 @@ const getThumbnailGradient = (color: string) => {
 
 interface Website {
   _id: string;
+  clientPortalId: string;
   name: string;
-  description?: string;
+  description: string;
   createdAt: string;
-  domain?: string;
-  url?: string;
+  domain: string;
+  url: string;
+  kind?: string;
+  languages?: string[];
+  language?: string;
+  postUrlField?: '_id' | 'count' | 'slug';
 }
 
 export function Cms() {
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<'list' | 'thumbnail'>('thumbnail');
   const [isWebsiteDrawerOpen, setIsWebsiteDrawerOpen] = useState(false);
-  const [editingWebsite, setEditingWebsite] = useState<any>(null);
-  const { data, loading, refetch } = useQuery(CONTENT_CMS_LIST);
+  const [editingWebsite, setEditingWebsite] = useState<Website>();
+  const { data, loading, refetch } = useQuery<{
+    contentCMSList: Website[];
+  }>(CONTENT_CMS_LIST);
   const cmsList = data?.contentCMSList || [];
   const displayWebsites: Website[] = cmsList;
+  const onlyCms = cmsList.length === 1 ? cmsList[0] : null;
 
   const handleWebsiteCreatedOrUpdated = () => {
     refetch();
     setIsWebsiteDrawerOpen(false);
-    setEditingWebsite(null);
+    setEditingWebsite(undefined);
   };
 
   const handleCloseWebsiteDrawer = () => {
     setIsWebsiteDrawerOpen(false);
-    setEditingWebsite(null);
+    setEditingWebsite(undefined);
   };
 
-  const handleEditWebsite = (website: any) => {
+  const handleEditWebsite = (website: Website) => {
     setEditingWebsite(website);
     setIsWebsiteDrawerOpen(true);
   };
 
-  const handleWebsiteClick = (website: any) => {
+  const handleWebsiteClick = (website: Website) => {
     navigate(`/content/cms/${website.clientPortalId}/posts`);
   };
 
@@ -85,6 +93,12 @@ export function Cms() {
       </Button>
     </div>
   );
+
+  if (!loading && onlyCms?.clientPortalId) {
+    return (
+      <Navigate to={`/content/cms/${onlyCms.clientPortalId}/posts`} replace />
+    );
+  }
 
   return (
     <CmsLayout

--- a/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { WebsiteDrawer } from '../components/websites/WebsiteDrawer';
 import { CONTENT_CMS_LIST } from '../graphql/queries';
+import { IWebsite } from '../types';
 import { CmsLayout } from './CmsLayout';
 import { EmptyState } from './EmptyState';
 
@@ -31,30 +32,16 @@ const getThumbnailGradient = (color: string) => {
   return gradients[color as keyof typeof gradients] || gradients.orange;
 };
 
-interface Website {
-  _id: string;
-  clientPortalId: string;
-  name: string;
-  description: string;
-  createdAt: string;
-  domain: string;
-  url: string;
-  kind?: string;
-  languages?: string[];
-  language?: string;
-  postUrlField?: '_id' | 'count' | 'slug';
-}
-
 export function Cms() {
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<'list' | 'thumbnail'>('thumbnail');
   const [isWebsiteDrawerOpen, setIsWebsiteDrawerOpen] = useState(false);
-  const [editingWebsite, setEditingWebsite] = useState<Website>();
+  const [editingWebsite, setEditingWebsite] = useState<IWebsite>();
   const { data, loading, refetch } = useQuery<{
-    contentCMSList: Website[];
+    contentCMSList: IWebsite[];
   }>(CONTENT_CMS_LIST);
   const cmsList = data?.contentCMSList || [];
-  const displayWebsites: Website[] = cmsList;
+  const displayWebsites: IWebsite[] = cmsList;
   const onlyCms = cmsList.length === 1 ? cmsList[0] : null;
 
   const handleWebsiteCreatedOrUpdated = () => {
@@ -68,12 +55,17 @@ export function Cms() {
     setEditingWebsite(undefined);
   };
 
-  const handleEditWebsite = (website: Website) => {
+  const handleEditWebsite = (website: IWebsite) => {
     setEditingWebsite(website);
     setIsWebsiteDrawerOpen(true);
   };
 
-  const handleWebsiteClick = (website: Website) => {
+  const handleWebsiteClick = (website: IWebsite) => {
+    if (!website.clientPortalId) {
+      navigate('/content/cms');
+      return;
+    }
+
     navigate(`/content/cms/${website.clientPortalId}/posts`);
   };
 

--- a/frontend/plugins/content_ui/src/modules/cms/types/index.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/types/index.ts
@@ -7,6 +7,7 @@ export interface IWebsite {
   description?: string;
   createdAt: string;
   domain?: string;
+  publicUrl?: string;
   url?: string;
   kind?: string;
   languages?: string[];

--- a/frontend/plugins/content_ui/src/modules/cms/types/index.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/types/index.ts
@@ -1,1 +1,15 @@
 export { IUser, ICategory, ITopic } from '../../shared/types';
+
+export interface IWebsite {
+  _id: string;
+  clientPortalId?: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  domain?: string;
+  url?: string;
+  kind?: string;
+  languages?: string[];
+  language?: string;
+  postUrlField?: '_id' | 'count' | 'slug';
+}


### PR DESCRIPTION
## Summary
- redirect the CMS index directly to posts when only one CMS exists
- add single-CMS navigation actions for quick create and manage
- keep the existing CMS listing layout when there are zero or multiple CMS entries

## Test
- pnpm nx build content_ui --configuration=development

## Summary by Sourcery

Improve CMS navigation behavior when only a single CMS instance exists and add quick access actions for managing CMS websites from the navigation sidebar.

New Features:
- Redirect the CMS index route directly to the posts view when there is exactly one CMS instance configured.
- Expose quick-create and manage actions for CMS websites from the sidebar navigation when a single CMS is present.

Enhancements:
- Type the CMS website query results and editing state more strictly in the CMS listing view and navigation module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CMS navigation now queries your sites and updates dynamically.
  * Single-site portals auto-redirect to that site's posts view.
  * Inline "Add" and "Manage" actions appear in the navigation for single-site portals.
  * The "Web Builder" navigation link remains available.
* **Bug Fixes**
  * Safer handling when a site lacks a portal ID to avoid broken links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->