### PR TITLE
fix(frontline): fix integrationsGetUsedTypes returning empty array

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/integrations.ts
@@ -135,22 +135,13 @@ export const integrationQueries = {
    * Get used integration types
    */
   async integrationsGetUsedTypes(_root, _args, { models }: IContext) {
-    const usedTypes: Array<{ _id: string; name: string }> = [];
-
     try {
       const kindMap = await getIntegrationsKinds();
+      const usedKinds: string[] = await models.Integrations.distinct('kind');
 
-      for (const kind of Object.keys(kindMap)) {
-        if (
-          (await models.Integrations.findIntegrations({
-            kind,
-          }).countDocuments()) > 0
-        ) {
-          usedTypes.push({ _id: kind, name: kindMap[kind] });
-        }
-      }
-
-      return usedTypes;
+      return usedKinds
+        .filter((kind) => kindMap[kind])
+        .map((kind) => ({ _id: kind, name: kindMap[kind] }));
     } catch (error) {
       console.error('Error in integrationsGetUsedTypes:', error);
       throw new Error('Failed to fetch used integration types');


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure integrationsGetUsedTypes returns the list of used integration kinds by querying distinct kinds and mapping them to defined integration names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized integration type retrieval logic for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->