### PR TITLE
Loyalty widget

### DIFF
--- a/frontend/plugins/accounting_ui/src/modules/settings/permission-settings/components/PermissionsCommandBar.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/settings/permission-settings/components/PermissionsCommandBar.tsx
@@ -28,6 +28,7 @@ export const PermissionsCommandbar = () => {
 };
 
 const PermissionsBulkEditor = ({ selected }: { selected: IPermission[] }) => {
+  const { table } = RecordTable.useRecordTable();
   const { editPermissionsBulk, loading } = usePermissionEdit();
   const [level, setLevel] = useState<string>('');
   const [read, setRead] = useState<string | undefined>();
@@ -46,7 +47,13 @@ const PermissionsBulkEditor = ({ selected }: { selected: IPermission[] }) => {
       if (!Number.isNaN(n)) changes.level = n;
     }
     if (!Object.keys(changes).length) return;
-    editPermissionsBulk(selected, changes);
+    const promise = editPermissionsBulk(selected, changes);
+    Promise.resolve(promise).then(() => {
+      table.resetRowSelection();
+      setLevel('');
+      setRead(undefined);
+      setWrite(undefined);
+    });
   };
 
   const canSave =

--- a/frontend/plugins/loyalty_ui/module-federation.config.ts
+++ b/frontend/plugins/loyalty_ui/module-federation.config.ts
@@ -20,6 +20,7 @@ const config: ModuleFederationConfig = {
     './loyaltySettings': './src/LoyaltySettings.tsx',
     './loyaltySettingsNavigation': './src/LoyaltySettingsNavigation.tsx',
     './widgets': './src/widgets/Widgets.tsx',
+    './relationWidget': './src/widgets/Widgets.tsx',
   },
 
   shared: (libraryName, defaultConfig) => {

--- a/frontend/plugins/loyalty_ui/src/config.tsx
+++ b/frontend/plugins/loyalty_ui/src/config.tsx
@@ -33,4 +33,12 @@ export const CONFIG: IUIConfig = {
       path: 'loyalty',
     },
   ],
+  widgets: {
+    relationWidgets: [
+      {
+        name: 'loyalty',
+        icon: IconAward,
+      },
+    ],
+  },
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/GiveScoreModal.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/GiveScoreModal.tsx
@@ -6,12 +6,7 @@ import { useMutation } from '@apollo/client';
 import { CHANGE_SCORE_MUTATION } from '../graphql/mutations';
 import { SelectOwnerTypeFormItem } from './selects/SelectOwnerType';
 import { SelectScoreCampaignFormItem } from './selects/SelectScoreCampaign';
-import { SelectScoreCustomerFormItem } from './selects/SelectCustomer';
-import {
-  SelectCompanyFormItem,
-  SelectUserFormItem,
-  SelectClientPortalUserFormItem,
-} from './selects/SelectOwnerById';
+import { SelectOwnerByType } from './selects/SelectOwnerByType';
 import { ChooseDealSheet } from './ChooseDealSheet';
 
 type TargetType = 'sales' | 'pos' | null;
@@ -139,81 +134,22 @@ export const GiveScoreModal = ({
                 )}
               />
 
-              {ownerType === 'customer' && (
-                <Form.Field
-                  control={form.control}
-                  name="ownerId"
-                  rules={{ required: 'Owner is required' }}
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Owner *</Form.Label>
-                      <SelectScoreCustomerFormItem
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="Choose customer"
-                      />
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-              )}
-
-              {ownerType === 'company' && (
-                <Form.Field
-                  control={form.control}
-                  name="ownerId"
-                  rules={{ required: 'Owner is required' }}
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Owner *</Form.Label>
-                      <SelectCompanyFormItem
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="Choose company"
-                      />
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-              )}
-
-              {ownerType === 'user' && (
-                <Form.Field
-                  control={form.control}
-                  name="ownerId"
-                  rules={{ required: 'Owner is required' }}
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Owner *</Form.Label>
-                      <SelectUserFormItem
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="Choose team member"
-                      />
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-              )}
-
-              {ownerType === 'cpUser' && (
-                <Form.Field
-                  control={form.control}
-                  name="ownerId"
-                  rules={{ required: 'Owner is required' }}
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Owner *</Form.Label>
-                      <SelectClientPortalUserFormItem
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="Choose client portal user"
-                      />
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-              )}
+              <Form.Field
+                control={form.control}
+                name="ownerId"
+                rules={{ required: 'Owner is required' }}
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Owner *</Form.Label>
+                    <SelectOwnerByType
+                      ownerType={ownerType}
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                    <Form.Message />
+                  </Form.Item>
+                )}
+              />
 
               {ownerId && (
                 <div className="flex flex-col gap-2 w-full">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/ScoreFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/ScoreFilter.tsx
@@ -27,6 +27,7 @@ import {
   SelectOwnerTypeFilterBar,
 } from './selects/SelectOwnerType';
 import {
+  SelectScoreCustomerFilterItem,
   SelectScoreCustomerFilterView,
   SelectScoreCustomerFilterBar,
 } from './selects/SelectCustomer';
@@ -91,6 +92,7 @@ const ScoreFilterPopover = () => {
               <Command.List className="p-1">
                 <SelectScoreCampaignFilterItem />
                 <SelectOwnerTypeFilterItem />
+                <SelectScoreCustomerFilterItem />
                 <SelectScoreActionFilterItem />
                 <Filter.Item value="scoreBoardId">
                   <IconLabel />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/ScoreSummaryWidget.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/ScoreSummaryWidget.tsx
@@ -1,107 +1,135 @@
 import {
-  IconCaretRightFilled,
   IconChartHistogram,
-  IconCircleFilled,
+  IconTrendingUp,
+  IconTrendingDown,
+  IconCoins,
+  IconCaretRightFilled,
 } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useQuery } from '@apollo/client';
-import { Button, cn, Collapsible, SideMenu } from 'erxes-ui';
+import {
+  Button,
+  Card,
+  Collapsible,
+  ScrollArea,
+  Separator,
+  SideMenu,
+  Spinner,
+} from 'erxes-ui';
 import { SCORE_LOG_STATISTICS_QUERY } from '../graphql/queries';
 
-const COLORS = [
-  'text-blue-600',
-  'text-green-500',
-  'text-purple-500',
-  'text-red-500',
-  'text-yellow-500',
-  'text-orange-500',
-  'text-pink-500',
-];
+type ScoreStats = {
+  totalPointEarned?: number;
+  totalPointBalance?: number;
+  totalPointRedeemed?: number;
+  redemptionRate?: number;
+  activeLoyaltyMembers?: number;
+  monthlyActiveUsers?: number;
+  mostRedeemedProductCategory?: string;
+};
 
-export const ScoreSummaryWidget = () => {
+const useScoreStats = (ownerId?: string, ownerType?: string) => {
   const { data, loading } = useQuery(SCORE_LOG_STATISTICS_QUERY, {
     fetchPolicy: 'cache-and-network',
+    variables: { ownerId, ownerType },
   });
+  return { stats: (data?.scoreLogStatistics || {}) as ScoreStats, loading };
+};
 
-  const stats = data?.scoreLogStatistics || {};
+const ScoreStatCards = ({
+  stats,
+  loading,
+}: {
+  stats: ScoreStats;
+  loading: boolean;
+}) => {
+  if (loading) return <Spinner containerClassName="py-10" />;
 
-  const SUMMARY_ITEMS = [
-    {
-      key: 'totalPointEarned',
-      label: 'Total Point Earned',
-      value: stats.totalPointEarned ?? '-',
-    },
-    {
-      key: 'totalPointBalance',
-      label: 'Points Balance',
-      value: stats.totalPointBalance ?? '-',
-    },
-    {
-      key: 'mostRedeemedProductCategory',
-      label: 'Top Redeemed Product Catalog',
-      value: stats.mostRedeemedProductCategory ?? '-',
-    },
-    {
-      key: 'redemptionRate',
-      label: 'Redemption Rates',
-      value:
-        stats.redemptionRate == null
-          ? '-'
-          : `${Number(stats.redemptionRate).toFixed(1)}%`,
-    },
-    {
-      key: 'activeLoyaltyMembers',
-      label: 'Active Loyalty Members',
-      value: stats.activeLoyaltyMembers ?? '-',
-    },
-    {
-      key: 'monthlyActiveUsers',
-      label: 'Monthly Active Users',
-      value: stats.monthlyActiveUsers ?? '-',
-    },
-    {
-      key: 'totalPointRedeemed',
-      label: 'Total Point Redeemed',
-      value: stats.totalPointRedeemed ?? '-',
-    },
-  ];
+  const earned = stats.totalPointEarned ?? 0;
+  const balance = stats.totalPointBalance ?? 0;
+  const redeemed = stats.totalPointRedeemed ?? 0;
+  const redemptionRate = stats.redemptionRate;
 
   return (
-    <SideMenu defaultValue="">
-      <SideMenu.Content value="score-summary">
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        <StatCard
+          icon={<IconTrendingUp className="size-4 text-green-500" />}
+          label="Total Earned"
+          value={Number(earned).toLocaleString()}
+        />
+        <StatCard
+          icon={<IconCoins className="size-4 text-blue-500" />}
+          label="Points Balance"
+          value={Number(balance).toLocaleString()}
+        />
+        <StatCard
+          icon={<IconTrendingDown className="size-4 text-red-400" />}
+          label="Total Redeemed"
+          value={Number(redeemed).toLocaleString()}
+        />
+      </div>
+      <Separator />
+      <div className="flex flex-col gap-2">
+        <SecondaryRow
+          label="Redemption Rate"
+          value={
+            redemptionRate == null
+              ? '—'
+              : `${Number(redemptionRate).toFixed(1)}%`
+          }
+        />
+        <SecondaryRow
+          label="Active Loyalty Members"
+          value={stats.activeLoyaltyMembers ?? '—'}
+        />
+        <SecondaryRow
+          label="Monthly Active Users"
+          value={stats.monthlyActiveUsers ?? '—'}
+        />
+        {stats.mostRedeemedProductCategory && (
+          <SecondaryRow
+            label="Top Redeemed Category"
+            value={stats.mostRedeemedProductCategory}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ScoreSummaryPanelContent = () => {
+  const { stats, loading } = useScoreStats();
+
+  return (
+    <div className="p-4">
+      <Collapsible className="group/collapsible-menu" defaultOpen>
+        <Collapsible.Trigger asChild>
+          <Button
+            variant="secondary"
+            className="w-min text-accent-foreground justify-start text-left mb-3"
+            size="sm"
+          >
+            <IconCaretRightFilled className="transition-transform group-data-[state=open]/collapsible-menu:rotate-90" />
+            Summary
+          </Button>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <ScoreStatCards stats={stats} loading={loading} />
+        </Collapsible.Content>
+      </Collapsible>
+    </div>
+  );
+};
+
+export const ScoreSummaryPanel = () => {
+  const [open, setOpen] = useState('');
+
+  return (
+    <SideMenu value={open} onValueChange={setOpen}>
+      <SideMenu.Content value="score-summary" className="data-[state=active]:w-96">
         <SideMenu.Header Icon={IconChartHistogram} label="Score Summary" />
-        <div className="p-4 border-b">
-          <Collapsible className="group/collapsible-menu" defaultOpen>
-            <Collapsible.Trigger asChild>
-              <Button
-                variant="secondary"
-                className="w-min text-accent-foreground justify-start text-left"
-                size="sm"
-              >
-                <IconCaretRightFilled className="transition-transform group-data-[state=open]/collapsible-menu:rotate-90" />
-                Summary
-              </Button>
-            </Collapsible.Trigger>
-            <Collapsible.Content>
-              <div className="flex flex-col gap-4 items-start w-full my-4">
-                {SUMMARY_ITEMS.map(({ key, label, value }, index) => (
-                  <div key={key} className="flex items-center gap-1">
-                    <div className="flex items-center gap-2">
-                      <IconCircleFilled
-                        className={cn('size-2', COLORS[index % COLORS.length])}
-                      />
-                      <p className="text-xs font-medium text-muted-foreground">
-                        {label}:
-                      </p>
-                    </div>
-                    <p className="text-xs font-medium">
-                      {loading ? '...' : value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </Collapsible.Content>
-          </Collapsible>
-        </div>
+        {open === 'score-summary' && <ScoreSummaryPanelContent />}
       </SideMenu.Content>
       <SideMenu.Sidebar>
         <SideMenu.Trigger
@@ -113,3 +141,64 @@ export const ScoreSummaryWidget = () => {
     </SideMenu>
   );
 };
+
+export const ScoreSummaryWidget = ({
+  ownerId,
+  ownerType,
+}: {
+  ownerId?: string;
+  ownerType?: string;
+}) => {
+  const { data, loading } = useQuery(SCORE_LOG_STATISTICS_QUERY, {
+    fetchPolicy: 'cache-and-network',
+    variables: { ownerId, ownerType },
+    skip: !ownerId,
+  });
+  const stats = (data?.scoreLogStatistics || {}) as ScoreStats;
+
+  return (
+    <>
+      <div className="h-11 px-4 flex items-center gap-2 flex-none bg-background">
+        <IconChartHistogram className="size-4 text-muted-foreground" />
+        <span className="font-medium text-primary">Score Summary</span>
+      </div>
+      <Separator />
+      <ScrollArea className="flex-auto">
+        <div className="p-4">
+          <ScoreStatCards stats={stats} loading={loading} />
+        </div>
+      </ScrollArea>
+    </>
+  );
+};
+
+const StatCard = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+}) => (
+  <Card className="bg-background px-4 py-3 flex items-center justify-between">
+    <div className="flex items-center gap-2">
+      {icon}
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+    <span className="text-sm font-bold">{value}</span>
+  </Card>
+);
+
+const SecondaryRow = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) => (
+  <div className="flex items-center justify-between px-1">
+    <span className="text-xs text-muted-foreground">{label}</span>
+    <span className="text-xs font-semibold">{value}</span>
+  </div>
+);

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
@@ -33,6 +33,33 @@ const GET_CUSTOMERS_SIMPLE = gql`
   }
 `;
 
+const GET_COMPANIES_SIMPLE = gql`
+  query ScoreCompaniesSimpleFilter($searchValue: String, $limit: Int) {
+    companies(searchValue: $searchValue, limit: $limit) {
+      list {
+        _id
+        primaryName
+        primaryEmail
+        primaryPhone
+      }
+    }
+  }
+`;
+
+const GET_USERS_SIMPLE = gql`
+  query ScoreUsersSimpleFilter($searchValue: String, $isActive: Boolean) {
+    allUsers(searchValue: $searchValue, isActive: $isActive) {
+      _id
+      email
+      details {
+        fullName
+        firstName
+        lastName
+      }
+    }
+  }
+`;
+
 interface CustomerOption {
   value: string;
   label: string;
@@ -55,6 +82,7 @@ const getCustomerLabel = (c: {
 const useCustomerOptions = (searchValue?: string) => {
   const { data, loading } = useQuery(GET_CUSTOMERS_SIMPLE, {
     variables: { limit: 50, searchValue },
+    fetchPolicy: 'cache-first',
   });
 
   const options = useMemo<CustomerOption[]>(
@@ -75,13 +103,90 @@ const useCustomerOptions = (searchValue?: string) => {
   return { options, loading };
 };
 
+const useOwnerOptions = (ownerType: string, search: string) => {
+  const customerQuery = useQuery(GET_CUSTOMERS_SIMPLE, {
+    variables: { limit: 50, searchValue: search || undefined },
+    skip: ownerType !== 'customer',
+    fetchPolicy: 'cache-first',
+  });
+
+  const companyQuery = useQuery(GET_COMPANIES_SIMPLE, {
+    variables: { limit: 50, searchValue: search || undefined },
+    skip: ownerType !== 'company',
+    fetchPolicy: 'cache-first',
+  });
+
+  const userQuery = useQuery(GET_USERS_SIMPLE, {
+    variables: { searchValue: search || undefined, isActive: true },
+    skip: ownerType !== 'user',
+    fetchPolicy: 'cache-first',
+  });
+
+  const options = useMemo<CustomerOption[]>(() => {
+    if (ownerType === 'customer') {
+      return (customerQuery.data?.customers?.list || []).map(
+        (c: {
+          _id: string;
+          firstName?: string;
+          middleName?: string;
+          lastName?: string;
+          primaryEmail?: string;
+          primaryPhone?: string;
+        }) => ({ value: c._id, label: getCustomerLabel(c) }),
+      );
+    }
+    if (ownerType === 'company') {
+      return (companyQuery.data?.companies?.list || []).map(
+        (c: {
+          _id: string;
+          primaryName?: string;
+          primaryEmail?: string;
+          primaryPhone?: string;
+        }) => ({
+          value: c._id,
+          label: c.primaryName || c.primaryEmail || c.primaryPhone || 'Unnamed',
+        }),
+      );
+    }
+    if (ownerType === 'user') {
+      return (userQuery.data?.allUsers || []).map(
+        (u: {
+          _id: string;
+          email?: string;
+          details?: {
+            fullName?: string;
+            firstName?: string;
+            lastName?: string;
+          };
+        }) => ({
+          value: u._id,
+          label:
+            u.details?.fullName ||
+            [u.details?.firstName, u.details?.lastName]
+              .filter(Boolean)
+              .join(' ') ||
+            u.email ||
+            'Unnamed',
+        }),
+      );
+    }
+    return [];
+  }, [ownerType, customerQuery.data, companyQuery.data, userQuery.data]);
+
+  const loading =
+    customerQuery.loading || companyQuery.loading || userQuery.loading;
+
+  return { options, loading };
+};
+
 interface SelectScoreCustomerContextType {
   value: string;
-  onValueChange: (val: string) => void;
+  onValueChange: (val: string, label?: string) => void;
   options: CustomerOption[];
   loading: boolean;
   search: string;
   setSearch: (s: string) => void;
+  ownerType: string;
 }
 
 const SelectScoreCustomerContext =
@@ -99,19 +204,21 @@ const useSelectScoreCustomerContext = () => {
 export const SelectScoreCustomerProvider = ({
   value,
   onValueChange,
+  ownerType = 'customer',
   children,
 }: {
   value: string;
-  onValueChange: (val: string) => void;
+  onValueChange: (val: string, label?: string) => void;
+  ownerType?: string;
   children: React.ReactNode;
 }) => {
   const [search, setSearch] = useState('');
   const { options, loading } = useCustomerOptions(search);
 
   const handleChange = useCallback(
-    (val: string) => {
+    (val: string, label?: string) => {
       if (!val) return;
-      onValueChange(val);
+      onValueChange(val, label);
     },
     [onValueChange],
   );
@@ -124,8 +231,51 @@ export const SelectScoreCustomerProvider = ({
       loading,
       search,
       setSearch,
+      ownerType,
     }),
-    [value, handleChange, options, loading, search],
+    [value, handleChange, options, loading, search, ownerType],
+  );
+
+  return (
+    <SelectScoreCustomerContext.Provider value={ctx}>
+      {children}
+    </SelectScoreCustomerContext.Provider>
+  );
+};
+
+const SelectOwnerProvider = ({
+  value,
+  onValueChange,
+  ownerType,
+  children,
+}: {
+  value: string;
+  onValueChange: (val: string, label?: string) => void;
+  ownerType: string;
+  children: React.ReactNode;
+}) => {
+  const [search, setSearch] = useState('');
+  const { options, loading } = useOwnerOptions(ownerType, search);
+
+  const handleChange = useCallback(
+    (val: string, label?: string) => {
+      if (!val) return;
+      onValueChange(val, label);
+    },
+    [onValueChange],
+  );
+
+  const ctx = useMemo(
+    () => ({
+      value: value || '',
+      onValueChange: handleChange,
+      options,
+      loading,
+      search,
+      setSearch,
+      ownerType,
+    }),
+    [value, handleChange, options, loading, search, ownerType],
   );
 
   return (
@@ -179,7 +329,51 @@ const SelectScoreCustomerContent = () => {
           <Command.Item
             key={opt.value}
             value={opt.value}
-            onSelect={() => onValueChange(opt.value)}
+            onSelect={() => onValueChange(opt.value, opt.label)}
+          >
+            <span className="font-medium">{opt.label}</span>
+            <Combobox.Check checked={value === opt.value} />
+          </Command.Item>
+        ))}
+      </Command.List>
+    </Command>
+  );
+};
+
+const SelectOwnerContent = () => {
+  const {
+    value,
+    onValueChange,
+    options,
+    loading,
+    search,
+    setSearch,
+    ownerType,
+  } = useSelectScoreCustomerContext();
+
+  const placeholder =
+    ownerType === 'company'
+      ? 'Search companies...'
+      : ownerType === 'user'
+      ? 'Search team members...'
+      : 'Search customers...';
+
+  return (
+    <Command shouldFilter={false}>
+      <Command.Input
+        value={search}
+        onValueChange={setSearch}
+        placeholder={placeholder}
+      />
+      <Command.Empty>
+        {loading ? 'Loading...' : 'No results found'}
+      </Command.Empty>
+      <Command.List>
+        {options.map((opt) => (
+          <Command.Item
+            key={opt.value}
+            value={opt.value}
+            onSelect={() => onValueChange(opt.value, opt.label)}
           >
             <span className="font-medium">{opt.label}</span>
             <Combobox.Check checked={value === opt.value} />
@@ -193,7 +387,7 @@ const SelectScoreCustomerContent = () => {
 export const SelectScoreCustomerFilterItem = () => (
   <Filter.Item value="scoreOwnerId">
     <IconUser />
-    Customer
+    Owner
   </Filter.Item>
 );
 
@@ -203,34 +397,66 @@ export const SelectScoreCustomerFilterView = ({
   queryKey?: string;
 }) => {
   const [value, setValue] = useQueryState<string>(queryKey);
+  const [ownerType] = useQueryState<string>('scoreOwnerType');
   const { resetFilterState } = useFilterContext();
 
   return (
     <Filter.View filterKey={queryKey}>
-      <SelectScoreCustomerProvider
+      <SelectOwnerProvider
+        ownerType={ownerType || 'customer'}
         value={value || ''}
         onValueChange={(val) => {
           setValue(val);
           resetFilterState();
         }}
       >
-        <SelectScoreCustomerContent />
-      </SelectScoreCustomerProvider>
+        <SelectOwnerContent />
+      </SelectOwnerProvider>
     </Filter.View>
+  );
+};
+
+const SelectOwnerBarButton = ({
+  filterKey,
+  barLabel,
+}: {
+  filterKey: string;
+  barLabel: string;
+}) => {
+  const { value, options } = useSelectScoreCustomerContext();
+  const selectedOption = options.find((o) => o.value === value);
+
+  return (
+    <Filter.BarButton filterKey={filterKey}>
+      {value && selectedOption ? (
+        <span className="font-medium text-sm">{selectedOption.label}</span>
+      ) : (
+        <span className="text-accent-foreground/80">Select {barLabel}</span>
+      )}
+    </Filter.BarButton>
   );
 };
 
 export const SelectScoreCustomerFilterBar = () => {
   const [value, setValue] = useQueryState<string>('scoreOwnerId');
+  const [ownerType] = useQueryState<string>('scoreOwnerType');
   const [open, setOpen] = useState(false);
+
+  const barLabel =
+    ownerType === 'company'
+      ? 'Company'
+      : ownerType === 'user'
+      ? 'Team Member'
+      : 'Customer';
 
   return (
     <Filter.BarItem queryKey="scoreOwnerId">
       <Filter.BarName>
         <IconUser />
-        Customer
+        {barLabel}
       </Filter.BarName>
-      <SelectScoreCustomerProvider
+      <SelectOwnerProvider
+        ownerType={ownerType || 'customer'}
         value={value || ''}
         onValueChange={(val) => {
           setValue(val || null);
@@ -239,15 +465,16 @@ export const SelectScoreCustomerFilterBar = () => {
       >
         <Popover open={open} onOpenChange={setOpen}>
           <Popover.Trigger asChild>
-            <Filter.BarButton filterKey="scoreOwnerId">
-              <SelectScoreCustomerValue />
-            </Filter.BarButton>
+            <SelectOwnerBarButton
+              filterKey="scoreOwnerId"
+              barLabel={barLabel}
+            />
           </Popover.Trigger>
           <Combobox.Content>
-            <SelectScoreCustomerContent />
+            <SelectOwnerContent />
           </Combobox.Content>
         </Popover>
-      </SelectScoreCustomerProvider>
+      </SelectOwnerProvider>
     </Filter.BarItem>
   );
 };
@@ -259,7 +486,7 @@ export const SelectScoreCustomerFormItem = ({
   className,
 }: {
   value: string;
-  onValueChange: (val: string) => void;
+  onValueChange: (val: string, label?: string) => void;
   placeholder?: string;
   className?: string;
 }) => {
@@ -268,8 +495,8 @@ export const SelectScoreCustomerFormItem = ({
   return (
     <SelectScoreCustomerProvider
       value={value}
-      onValueChange={(val) => {
-        onValueChange(val);
+      onValueChange={(val, label) => {
+        onValueChange(val, label);
         setOpen(false);
       }}
     >
@@ -294,7 +521,7 @@ const SelectScoreCustomerRoot = ({
   className,
 }: {
   value: string;
-  onValueChange?: (val: string) => void;
+  onValueChange?: (val: string, label?: string) => void;
   placeholder?: string;
   className?: string;
 }) => {
@@ -303,8 +530,8 @@ const SelectScoreCustomerRoot = ({
   return (
     <SelectScoreCustomerProvider
       value={value}
-      onValueChange={(val) => {
-        onValueChange?.(val);
+      onValueChange={(val, label) => {
+        onValueChange?.(val, label);
         setOpen(false);
       }}
     >

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
@@ -94,7 +94,7 @@ const useOwnerOptions = (ownerType: string, search: string) => {
 
   const userQuery = useQuery(GET_USERS_SIMPLE, {
     variables: { searchValue: search || undefined, isActive: true },
-    skip: ownerType !== 'user',
+    skip: ownerType !== 'user' || !search,
     fetchPolicy: 'cache-first',
   });
 

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
@@ -258,6 +258,18 @@ const SelectScoreCustomerValue = ({
   );
 };
 
+const getOwnerSearchPlaceholder = (ownerType: string) => {
+  if (ownerType === 'company') return 'Search companies...';
+  if (ownerType === 'user') return 'Search team members...';
+  return 'Search customers...';
+};
+
+const getOwnerBarLabel = (ownerType: string) => {
+  if (ownerType === 'company') return 'Company';
+  if (ownerType === 'user') return 'Team Member';
+  return 'Customer';
+};
+
 const SelectOwnerContent = () => {
   const {
     value,
@@ -269,12 +281,7 @@ const SelectOwnerContent = () => {
     ownerType,
   } = useSelectScoreCustomerContext();
 
-  const placeholder =
-    ownerType === 'company'
-      ? 'Search companies...'
-      : ownerType === 'user'
-      ? 'Search team members...'
-      : 'Search customers...';
+  const placeholder = getOwnerSearchPlaceholder(ownerType);
 
   return (
     <Command shouldFilter={false}>
@@ -360,12 +367,7 @@ export const SelectScoreCustomerFilterBar = () => {
   const [ownerType] = useQueryState<string>('scoreOwnerType');
   const [open, setOpen] = useState(false);
 
-  const barLabel =
-    ownerType === 'company'
-      ? 'Company'
-      : ownerType === 'user'
-      ? 'Team Member'
-      : 'Customer';
+  const barLabel = getOwnerBarLabel(ownerType || 'customer');
 
   return (
     <Filter.BarItem queryKey="scoreOwnerId">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectCustomer.tsx
@@ -79,30 +79,6 @@ const getCustomerLabel = (c: {
   return name || c.primaryEmail || c.primaryPhone || 'Unnamed';
 };
 
-const useCustomerOptions = (searchValue?: string) => {
-  const { data, loading } = useQuery(GET_CUSTOMERS_SIMPLE, {
-    variables: { limit: 50, searchValue },
-    fetchPolicy: 'cache-first',
-  });
-
-  const options = useMemo<CustomerOption[]>(
-    () =>
-      (data?.customers?.list || []).map(
-        (c: {
-          _id: string;
-          firstName?: string;
-          middleName?: string;
-          lastName?: string;
-          primaryEmail?: string;
-          primaryPhone?: string;
-        }) => ({ value: c._id, label: getCustomerLabel(c) }),
-      ),
-    [data?.customers?.list],
-  );
-
-  return { options, loading };
-};
-
 const useOwnerOptions = (ownerType: string, search: string) => {
   const customerQuery = useQuery(GET_CUSTOMERS_SIMPLE, {
     variables: { limit: 50, searchValue: search || undefined },
@@ -201,7 +177,7 @@ const useSelectScoreCustomerContext = () => {
   return ctx;
 };
 
-export const SelectScoreCustomerProvider = ({
+const SelectOwnerProvider = ({
   value,
   onValueChange,
   ownerType = 'customer',
@@ -210,48 +186,6 @@ export const SelectScoreCustomerProvider = ({
   value: string;
   onValueChange: (val: string, label?: string) => void;
   ownerType?: string;
-  children: React.ReactNode;
-}) => {
-  const [search, setSearch] = useState('');
-  const { options, loading } = useCustomerOptions(search);
-
-  const handleChange = useCallback(
-    (val: string, label?: string) => {
-      if (!val) return;
-      onValueChange(val, label);
-    },
-    [onValueChange],
-  );
-
-  const ctx = useMemo(
-    () => ({
-      value: value || '',
-      onValueChange: handleChange,
-      options,
-      loading,
-      search,
-      setSearch,
-      ownerType,
-    }),
-    [value, handleChange, options, loading, search, ownerType],
-  );
-
-  return (
-    <SelectScoreCustomerContext.Provider value={ctx}>
-      {children}
-    </SelectScoreCustomerContext.Provider>
-  );
-};
-
-const SelectOwnerProvider = ({
-  value,
-  onValueChange,
-  ownerType,
-  children,
-}: {
-  value: string;
-  onValueChange: (val: string, label?: string) => void;
-  ownerType: string;
   children: React.ReactNode;
 }) => {
   const [search, setSearch] = useState('');
@@ -285,6 +219,20 @@ const SelectOwnerProvider = ({
   );
 };
 
+export const SelectScoreCustomerProvider = ({
+  value,
+  onValueChange,
+  children,
+}: {
+  value: string;
+  onValueChange: (val: string, label?: string) => void;
+  children: React.ReactNode;
+}) => (
+  <SelectOwnerProvider value={value} onValueChange={onValueChange} ownerType="customer">
+    {children}
+  </SelectOwnerProvider>
+);
+
 const SelectScoreCustomerValue = ({
   placeholder,
   className,
@@ -307,36 +255,6 @@ const SelectScoreCustomerValue = ({
     <div className="flex items-center gap-2">
       <p className={cn('font-medium text-sm', className)}>{selected.label}</p>
     </div>
-  );
-};
-
-const SelectScoreCustomerContent = () => {
-  const { value, onValueChange, options, loading, search, setSearch } =
-    useSelectScoreCustomerContext();
-
-  return (
-    <Command shouldFilter={false}>
-      <Command.Input
-        value={search}
-        onValueChange={setSearch}
-        placeholder="Search customers..."
-      />
-      <Command.Empty>
-        {loading ? 'Loading...' : 'No customers found'}
-      </Command.Empty>
-      <Command.List>
-        {options.map((opt) => (
-          <Command.Item
-            key={opt.value}
-            value={opt.value}
-            onSelect={() => onValueChange(opt.value, opt.label)}
-          >
-            <span className="font-medium">{opt.label}</span>
-            <Combobox.Check checked={value === opt.value} />
-          </Command.Item>
-        ))}
-      </Command.List>
-    </Command>
   );
 };
 
@@ -493,8 +411,9 @@ export const SelectScoreCustomerFormItem = ({
   const [open, setOpen] = useState(false);
 
   return (
-    <SelectScoreCustomerProvider
+    <SelectOwnerProvider
       value={value}
+      ownerType="customer"
       onValueChange={(val, label) => {
         onValueChange(val, label);
         setOpen(false);
@@ -507,10 +426,10 @@ export const SelectScoreCustomerFormItem = ({
           </Combobox.Trigger>
         </Form.Control>
         <Combobox.Content>
-          <SelectScoreCustomerContent />
+          <SelectOwnerContent />
         </Combobox.Content>
       </Popover>
-    </SelectScoreCustomerProvider>
+    </SelectOwnerProvider>
   );
 };
 
@@ -528,8 +447,9 @@ const SelectScoreCustomerRoot = ({
   const [open, setOpen] = useState(false);
 
   return (
-    <SelectScoreCustomerProvider
+    <SelectOwnerProvider
       value={value}
+      ownerType="customer"
       onValueChange={(val, label) => {
         onValueChange?.(val, label);
         setOpen(false);
@@ -540,17 +460,17 @@ const SelectScoreCustomerRoot = ({
           <SelectScoreCustomerValue placeholder={placeholder} />
         </Combobox.Trigger>
         <Combobox.Content>
-          <SelectScoreCustomerContent />
+          <SelectOwnerContent />
         </Combobox.Content>
       </Popover>
-    </SelectScoreCustomerProvider>
+    </SelectOwnerProvider>
   );
 };
 
 export const SelectScoreCustomer = Object.assign(SelectScoreCustomerRoot, {
   Provider: SelectScoreCustomerProvider,
   Value: SelectScoreCustomerValue,
-  Content: SelectScoreCustomerContent,
+  Content: SelectOwnerContent,
   FilterItem: SelectScoreCustomerFilterItem,
   FilterView: SelectScoreCustomerFilterView,
   FilterBar: SelectScoreCustomerFilterBar,

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectOwnerByType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/score/components/selects/SelectOwnerByType.tsx
@@ -1,0 +1,66 @@
+import { SelectScoreCustomerFormItem } from './SelectCustomer';
+import {
+  SelectCompanyFormItem,
+  SelectUserFormItem,
+  SelectClientPortalUserFormItem,
+} from './SelectOwnerById';
+
+type Props = {
+  ownerType: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+};
+
+const PLACEHOLDERS: Record<string, string> = {
+  customer: 'Choose customer',
+  company: 'Choose company',
+  user: 'Choose team member',
+  cpUser: 'Choose client portal user',
+};
+
+export const SelectOwnerByType = ({
+  ownerType,
+  value,
+  onValueChange,
+  placeholder,
+}: Props) => {
+  const resolvedPlaceholder = placeholder || PLACEHOLDERS[ownerType];
+
+  switch (ownerType) {
+    case 'customer':
+      return (
+        <SelectScoreCustomerFormItem
+          value={value}
+          onValueChange={onValueChange}
+          placeholder={resolvedPlaceholder}
+        />
+      );
+    case 'company':
+      return (
+        <SelectCompanyFormItem
+          value={value}
+          onValueChange={onValueChange}
+          placeholder={resolvedPlaceholder}
+        />
+      );
+    case 'user':
+      return (
+        <SelectUserFormItem
+          value={value}
+          onValueChange={onValueChange}
+          placeholder={resolvedPlaceholder}
+        />
+      );
+    case 'cpUser':
+      return (
+        <SelectClientPortalUserFormItem
+          value={value}
+          onValueChange={onValueChange}
+          placeholder={resolvedPlaceholder}
+        />
+      );
+    default:
+      return null;
+  }
+};

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreMoreColumn.tsx
@@ -1,5 +1,5 @@
 import { ApolloError, useMutation } from '@apollo/client';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconEdit, IconTrash, IconChartHistogram } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import {
   Button,
@@ -11,6 +11,7 @@ import {
   useQueryState,
   useToast,
 } from 'erxes-ui';
+import { useNavigate } from 'react-router';
 import { LOYALTY_SCORE_ROW_REMOVE } from '../graphql/mutations/loyaltyScoreRowsRemove';
 import { useLoyaltyScoreEdit } from '../hooks/useLoyaltyScoreEdit';
 import { IScore } from '../types/loyaltyScoreTypes';
@@ -28,6 +29,11 @@ export const ScoreMoreColumnCell = ({
   });
   const { confirm } = useConfirm();
   const { toast } = useToast();
+  const navigate = useNavigate();
+
+  const handleSeeScores = () => {
+    navigate(`/loyalty/scores?scoreCampaignId=${_id}`);
+  };
 
   const handleEdit = (scoreId: string) => {
     setEditScoreId(scoreId);
@@ -71,6 +77,9 @@ export const ScoreMoreColumnCell = ({
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
               <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="see-scores" onSelect={handleSeeScores}>
+              <IconChartHistogram /> See scores
             </Command.Item>
             <Command.Item asChild>
               <Button

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/ScorePage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/ScorePage.tsx
@@ -1,16 +1,30 @@
 import { useEffect } from 'react';
-import { PageSubHeader } from 'erxes-ui';
+import { Button, PageSubHeader } from 'erxes-ui';
+import { Link } from 'react-router';
+import { IconSettings } from '@tabler/icons-react';
 import { useLoyaltyHeaderAction } from '~/modules/loyalties/components/LoyaltyHeaderActionContext';
 import { ScoreFilter } from '../../modules/loyalties/score/components/ScoreFilter';
 import { ScoreRecordTable } from '../../modules/loyalties/score/components/ScoreRecordTable';
 import { GiveScoreModal } from '../../modules/loyalties/score/components/GiveScoreModal';
-import { ScoreSummaryWidget } from '../../modules/loyalties/score/components/ScoreSummaryWidget';
+import { ScoreSummaryPanel } from '../../modules/loyalties/score/components/ScoreSummaryWidget';
+
+const ScoreHeaderActions = () => (
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" asChild>
+      <Link to="/settings/loyalty/config/score">
+        <IconSettings className="size-4" />
+        Go to settings
+      </Link>
+    </Button>
+    <GiveScoreModal />
+  </div>
+);
 
 export const ScorePage = () => {
   const { setAction } = useLoyaltyHeaderAction();
 
   useEffect(() => {
-    setAction(<GiveScoreModal />);
+    setAction(<ScoreHeaderActions />);
     return () => setAction(null);
   }, [setAction]);
 
@@ -22,7 +36,7 @@ export const ScorePage = () => {
         </PageSubHeader>
         <ScoreRecordTable />
       </div>
-      <ScoreSummaryWidget />
+      <ScoreSummaryPanel />
     </div>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/widgets/Widgets.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/Widgets.tsx
@@ -1,13 +1,21 @@
+import { IRelationWidgetProps } from 'ui-modules';
+import { ScoreSummaryWidget } from '../modules/loyalties/score/components/ScoreSummaryWidget';
+
+const CONTENT_TYPE_TO_OWNER_TYPE: Record<string, string> = {
+  'core:customer': 'customer',
+  'core:company': 'company',
+  'core:user': 'user',
+};
+
 export const Widgets = ({
-  module,
   contentId,
   contentType,
-}: {
-  module: any;
-  contentId: string;
-  contentType: string;
-}) => {
-  return <div>pricing Widget</div>;
+}: IRelationWidgetProps) => {
+  const ownerType = CONTENT_TYPE_TO_OWNER_TYPE[contentType] || contentType;
+
+  return (
+    <ScoreSummaryWidget ownerId={contentId} ownerType={ownerType} />
+  );
 };
 
 export default Widgets;


### PR DESCRIPTION
## Summary by Sourcery

Introduce a loyalty score summary widget and panel that can be used both on the main scores page and as a relation widget, with owner-aware filtering and improved statistics presentation.

New Features:
- Add owner-aware score summary widget that shows key loyalty statistics for a given customer, company, or user.
- Expose a score summary side panel on the scores page with collapsible detailed statistics.
- Register a loyalty relation widget and wire it to the score summary widget for entity pages.
- Allow navigating from a score campaign configuration row directly to the filtered scores list.

Bug Fixes:
- Reset selection and bulk edit form state after applying permission bulk edits in accounting permission settings.

Enhancements:
- Extend score owner selection to support customers, companies, and users with context-aware search and labels.
- Refine score statistics UI into card-based layout with loading states and secondary metric rows.
- Update score page header actions to include a shortcut to loyalty score settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned score summary as stats-driven cards inside a collapsible panel
  * Embeddable relation widget to surface the score summary

* **Improvements**
  * Header actions updated to surface settings and give-score controls
  * Owner selector unified and now supports companies and team members as well as customers
  * Added “See scores” action to campaign more-menu

* **Bug Fixes**
  * Row selection now clears after successful bulk permission updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->