### PR TITLE
fix(content): move CMS deletion to settings with confirmation

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -16,7 +16,6 @@ import { GET_WEBSITES } from '../../graphql/queries';
 import {
   CONTENT_CREATE_CMS,
   CONTENT_UPDATE_CMS,
-  CONTENT_DELETE_CMS,
 } from '../../graphql/mutations';
 import { useClientPortals } from '../../hooks/useClientPortals';
 import { LANGUAGES } from '../../../../constants';
@@ -36,7 +35,6 @@ interface Website {
   createdAt: string;
   languages?: string[];
   language?: string;
-  postUrlField?: '_id' | 'count' | 'slug';
 }
 
 interface WebsiteDrawerProps {
@@ -45,19 +43,6 @@ interface WebsiteDrawerProps {
   onClose: () => void;
   onSuccess?: () => void;
 }
-
-const POST_URL_FIELD_OPTIONS = [
-  { value: '_id', label: 'Post ID' },
-  { value: 'count', label: 'Post Count' },
-  { value: 'slug', label: 'Post Slug' },
-] as const;
-
-const POST_URL_FIELD_EXAMPLES: Record<WebsiteFormType['postUrlField'], string> =
-  {
-    _id: 'fSY5zj2QmcnXUNSnF9sYo',
-    count: '1',
-    slug: 'my-first-post',
-  };
 
 export function WebsiteDrawer({
   website,
@@ -70,7 +55,6 @@ export function WebsiteDrawer({
   const {
     clientPortals,
     loading: clientPortalsLoading,
-    error: clientPortalsError,
     refetch: refetchClientPortals,
   } = useClientPortals({}, !isOpen);
 
@@ -84,26 +68,8 @@ export function WebsiteDrawer({
       kind: 'client',
       languages: [],
       language: '',
-      postUrlField: '_id',
     },
   });
-
-  const selectedClientPortalId = form.watch('kind');
-  const selectedPostUrlField = form.watch('postUrlField');
-  const selectedClientPortal = clientPortals.find(
-    (portal) => portal._id === selectedClientPortalId,
-  );
-  const rawDomain = selectedClientPortal?.domain || '';
-  const normalizedDomain = rawDomain
-    ? rawDomain.startsWith('http')
-      ? rawDomain
-      : `https://${rawDomain}`
-    : '';
-  const previewPathSegment =
-    POST_URL_FIELD_EXAMPLES[selectedPostUrlField || '_id'];
-  const previewUrl = normalizedDomain
-    ? `${normalizedDomain.replace(/\/+$/, '')}/${previewPathSegment}`
-    : `/${previewPathSegment}`;
 
   useEffect(() => {
     if (isOpen) {
@@ -118,7 +84,6 @@ export function WebsiteDrawer({
           kind: website.clientPortalId || '',
           languages: website.languages || [],
           language: website.language || '',
-          postUrlField: website.postUrlField || '_id',
         });
       } else {
         form.reset({
@@ -129,7 +94,6 @@ export function WebsiteDrawer({
           kind: 'client',
           languages: [],
           language: '',
-          postUrlField: '_id',
         });
       }
     }
@@ -210,33 +174,8 @@ export function WebsiteDrawer({
     },
   );
 
-  const [deleteCMS, { loading: removing }] = useMutation(CONTENT_DELETE_CMS, {
-    refetchQueries: [{ query: GET_WEBSITES }],
-    awaitRefetchQueries: true,
-    onCompleted: () => {
-      onClose();
-      form.reset();
-      toast({
-        title: 'Success',
-        description: 'CMS deleted successfully',
-        variant: 'default',
-      });
-      if (onSuccess) {
-        onSuccess();
-      }
-    },
-    onError: (error) => {
-      toast({
-        title: 'Error',
-        description: error.message || 'Failed to delete CMS. Please try again.',
-        variant: 'destructive',
-        duration: 5000,
-      });
-    },
-  });
-
   const onSubmit = (data: WebsiteFormType) => {
-    const { name, description, language, languages, postUrlField } = data;
+    const { name, description, language, languages } = data;
 
     if (isEditing && website?._id) {
       updateCMS({
@@ -248,7 +187,6 @@ export function WebsiteDrawer({
             language: language || undefined,
             languages: languages || [],
             clientPortalId: data.kind,
-            postUrlField,
           },
         },
       });
@@ -263,7 +201,6 @@ export function WebsiteDrawer({
           language: language || undefined,
           languages: languages || [],
           clientPortalId: data.kind,
-          postUrlField,
           content: 'hello',
         },
       },
@@ -354,38 +291,6 @@ export function WebsiteDrawer({
 
             <Form.Field
               control={form.control}
-              name="postUrlField"
-              render={({ field }) => (
-                <Form.Item>
-                  <Form.Label>Post URL Field</Form.Label>
-                  <Form.Control>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <Select.Trigger>
-                        <Select.Value placeholder="Select post URL field" />
-                      </Select.Trigger>
-                      <Select.Content>
-                        {POST_URL_FIELD_OPTIONS.map((option) => (
-                          <Select.Item key={option.value} value={option.value}>
-                            {option.label}
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select>
-                  </Form.Control>
-                  <p className="text-xs text-muted-foreground">
-                    Choose which post field the public website will use in post
-                    URLs.
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Preview: {previewUrl}
-                  </p>
-                  <Form.Message className="text-destructive" />
-                </Form.Item>
-              )}
-            />
-
-            <Form.Field
-              control={form.control}
               name="languages"
               render={({ field }) => (
                 <Form.Item>
@@ -462,28 +367,10 @@ export function WebsiteDrawer({
                     ? 'Saving...'
                     : 'Creating...'
                   : isEditing
-                    ? 'Save Changes'
-                    : 'Create CMS'}
+                  ? 'Save Changes'
+                  : 'Create CMS'}
               </Button>
 
-              {isEditing && (
-                <Button
-                  variant="destructive"
-                  type="button"
-                  onClick={async () => {
-                    if (website?._id) {
-                      try {
-                        await deleteCMS({ variables: { id: website._id } });
-                      } catch (error) {
-                        console.error('Error deleting CMS:', error);
-                      }
-                    }
-                  }}
-                  disabled={removing}
-                >
-                  {removing ? 'Deleting...' : 'Delete'}
-                </Button>
-              )}
               <Button onClick={onClose} variant="outline">
                 Cancel
               </Button>

--- a/frontend/plugins/content_ui/src/modules/cms/constants/websiteFormSchema.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/constants/websiteFormSchema.ts
@@ -8,7 +8,6 @@ export const websiteFormSchema = z.object({
   kind: z.string().min(1, 'Client Portal is required'),
   languages: z.array(z.string()).default([]),
   language: z.string().default(''),
-  postUrlField: z.enum(['_id', 'count', 'slug']).default('_id'),
 });
 
 export type WebsiteFormType = z.infer<typeof websiteFormSchema>;

--- a/frontend/plugins/content_ui/src/modules/cms/settings/Settings.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/Settings.tsx
@@ -8,9 +8,12 @@ export const Settings = () => {
   const {
     canSave,
     clientPortals,
+    cms,
+    isDeleting,
     isSaving,
     settings,
     updateSetting,
+    handleDelete,
     handleSave,
   } = useSettingsForm();
 
@@ -27,9 +30,12 @@ export const Settings = () => {
 
         <div className="min-w-0 flex-1 overflow-auto bg-muted/20">
           <SettingsForm
+            cms={cms}
+            isDeleting={isDeleting}
             settings={settings}
             clientPortals={clientPortals}
             updateSetting={updateSetting}
+            onDelete={handleDelete}
           />
         </div>
       </div>

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -40,6 +40,27 @@ const POST_URL_FIELD_OPTIONS = [
 ];
 
 const DELETE_CONFIRMATION_PHRASE = 'delete my project';
+const DELETE_NAME_CONFIRMATION_INPUT_ID = 'delete-name-confirmation';
+const DELETE_PHRASE_CONFIRMATION_INPUT_ID = 'delete-phrase-confirmation';
+
+const trimTrailingSlashes = (value: string) => {
+  let endIndex = value.length;
+
+  while (endIndex > 0 && value.charCodeAt(endIndex - 1) === 47) {
+    endIndex -= 1;
+  }
+
+  return value.slice(0, endIndex);
+};
+
+interface ISettingsFormProps {
+  cms?: CmsSettingsData;
+  isDeleting: boolean;
+  settings: SettingsFormState;
+  clientPortals: ClientPortalOption[];
+  updateSetting: UpdateSetting;
+  onDelete: () => Promise<void> | void;
+}
 
 export const SettingsForm = ({
   cms,
@@ -48,14 +69,7 @@ export const SettingsForm = ({
   clientPortals,
   updateSetting,
   onDelete,
-}: {
-  cms?: CmsSettingsData;
-  isDeleting: boolean;
-  settings: SettingsFormState;
-  clientPortals: ClientPortalOption[];
-  updateSetting: UpdateSetting;
-  onDelete: () => Promise<void> | void;
-}) => {
+}: ISettingsFormProps) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteNameConfirmation, setDeleteNameConfirmation] = useState('');
   const [deletePhraseConfirmation, setDeletePhraseConfirmation] = useState('');
@@ -76,13 +90,13 @@ export const SettingsForm = ({
       : `https://${rawPublicUrl}`
     : '';
   const previewUrl = normalizedPublicUrl
-    ? `${normalizedPublicUrl.replace(/\/+$/, '')}/${
+    ? `${trimTrailingSlashes(normalizedPublicUrl)}/${
         selectedPostUrlField.example
       }`
     : `/${selectedPostUrlField.example}`;
   const canDeleteCMS =
     Boolean(cms?._id) &&
-    deleteNameConfirmation === cmsName &&
+    deleteNameConfirmation.trim() === cmsName &&
     deletePhraseConfirmation === DELETE_CONFIRMATION_PHRASE &&
     !isDeleting;
 
@@ -551,13 +565,17 @@ export const SettingsForm = ({
 
           <div className="space-y-5 bg-muted/40 p-6">
             <div className="space-y-2">
-              <label className="text-sm text-muted-foreground">
+              <label
+                htmlFor={DELETE_NAME_CONFIRMATION_INPUT_ID}
+                className="text-sm text-muted-foreground"
+              >
                 To confirm, type{' '}
                 <span className="font-semibold text-foreground">
                   &quot;{cmsName}&quot;
                 </span>
               </label>
               <Input
+                id={DELETE_NAME_CONFIRMATION_INPUT_ID}
                 value={deleteNameConfirmation}
                 onChange={(event) =>
                   setDeleteNameConfirmation(event.target.value)
@@ -567,13 +585,17 @@ export const SettingsForm = ({
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm text-muted-foreground">
+              <label
+                htmlFor={DELETE_PHRASE_CONFIRMATION_INPUT_ID}
+                className="text-sm text-muted-foreground"
+              >
                 To confirm, type{' '}
                 <span className="font-semibold text-foreground">
                   &quot;{DELETE_CONFIRMATION_PHRASE}&quot;
                 </span>
               </label>
               <Input
+                id={DELETE_PHRASE_CONFIRMATION_INPUT_ID}
                 value={deletePhraseConfirmation}
                 onChange={(event) =>
                   setDeletePhraseConfirmation(event.target.value)

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -1,21 +1,26 @@
 import {
+  IconAlertTriangle,
   IconChartBar,
   IconCheck,
+  IconLink,
   IconPhoto,
+  IconTrash,
   IconWorld,
 } from '@tabler/icons-react';
 import {
   Badge,
+  Button,
+  Dialog,
   Input,
   type MultiSelectOption,
   MultipleSelector,
   Select,
-  // Switch,
   Textarea,
-  // ToggleGroup,
 } from 'erxes-ui';
+import { useState } from 'react';
 import { LANGUAGES } from '../../../../constants';
 import {
+  CmsSettingsData,
   ClientPortalOption,
   SettingsFormState,
   UpdateSetting,
@@ -28,17 +33,58 @@ import {
 import { SettingsSection } from './SettingsSection';
 import { Uploader } from './Uploader';
 
+const POST_URL_FIELD_OPTIONS = [
+  { value: '_id', label: 'Post ID', example: 'fSY5zj2QmcnXUNSnF9sYo' },
+  { value: 'count', label: 'Post Count', example: '1' },
+  { value: 'slug', label: 'Post Slug', example: 'my-first-post' },
+];
+
+const DELETE_CONFIRMATION_PHRASE = 'delete my project';
+
 export const SettingsForm = ({
+  cms,
+  isDeleting,
   settings,
   clientPortals,
   updateSetting,
+  onDelete,
 }: {
+  cms?: CmsSettingsData;
+  isDeleting: boolean;
   settings: SettingsFormState;
   clientPortals: ClientPortalOption[];
   updateSetting: UpdateSetting;
+  onDelete: () => Promise<void> | void;
 }) => {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteNameConfirmation, setDeleteNameConfirmation] = useState('');
+  const [deletePhraseConfirmation, setDeletePhraseConfirmation] = useState('');
+
   const getLanguageLabel = (language: string) =>
     LANGUAGES.find((option) => option.value === language)?.label || language;
+
+  const cmsName =
+    cms?.name?.trim() || settings.websiteName.trim() || 'this CMS';
+  const selectedPostUrlField =
+    POST_URL_FIELD_OPTIONS.find(
+      (option) => option.value === settings.postUrlField,
+    ) || POST_URL_FIELD_OPTIONS[0];
+  const rawPublicUrl = settings.publicUrl || settings.domain;
+  const normalizedPublicUrl = rawPublicUrl
+    ? rawPublicUrl.startsWith('http')
+      ? rawPublicUrl
+      : `https://${rawPublicUrl}`
+    : '';
+  const previewUrl = normalizedPublicUrl
+    ? `${normalizedPublicUrl.replace(/\/+$/, '')}/${
+        selectedPostUrlField.example
+      }`
+    : `/${selectedPostUrlField.example}`;
+  const canDeleteCMS =
+    Boolean(cms?._id) &&
+    deleteNameConfirmation === cmsName &&
+    deletePhraseConfirmation === DELETE_CONFIRMATION_PHRASE &&
+    !isDeleting;
 
   const selectedLanguageOptions = settings.languages.map((language) => ({
     value: language,
@@ -90,17 +136,22 @@ export const SettingsForm = ({
     updateSetting('metaKeywords', keywords);
   };
 
-  // const getPostUrlFieldLabel = (value: string) => {
-  //   if (value === '_id') {
-  //     return 'Post ID';
-  //   }
+  const handleDeleteDialogChange = (open: boolean) => {
+    setDeleteDialogOpen(open);
 
-  //   if (value === 'count') {
-  //     return 'Post count';
-  //   }
+    if (!open) {
+      setDeleteNameConfirmation('');
+      setDeletePhraseConfirmation('');
+    }
+  };
 
-  //   return 'Slug';
-  // };
+  const handleDelete = async () => {
+    if (!canDeleteCMS) {
+      return;
+    }
+
+    await onDelete();
+  };
 
   return (
     <div className="min-w-0 space-y-4 p-4">
@@ -357,94 +408,33 @@ export const SettingsForm = ({
         </Field>
       </SettingsSection>
 
-      {/* <SettingsSection id="content" title="Content">
-        <div className="grid gap-4 md:grid-cols-2">
-          <Field
-            label="Post URL Format (postUrlField)"
-            hint="How post URLs are generated."
+      <SettingsSection id="content" title="Content">
+        <Field
+          id="postUrlField"
+          label="Post URL Field"
+          hint="Choose which post field the public website will use in post URLs."
+        >
+          <Select
+            value={settings.postUrlField}
+            onValueChange={(value) => updateSetting('postUrlField', value)}
           >
-            <ToggleGroup
-              type="single"
-              variant="outline"
-              value={settings.postUrlField}
-              onValueChange={(value) =>
-                value && updateSetting('postUrlField', value)
-              }
-              className="justify-start"
-            >
-              {['slug', '_id', 'count'].map((value) => (
-                <ToggleGroup.Item
-                  key={value}
-                  value={value}
-                  className="h-7 px-3 text-xs"
-                >
-                  {getPostUrlFieldLabel(value)}
-                </ToggleGroup.Item>
+            <Select.Trigger id="postUrlField" className="bg-muted">
+              <Select.Value placeholder="Select post URL field" />
+            </Select.Trigger>
+            <Select.Content>
+              {POST_URL_FIELD_OPTIONS.map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
               ))}
-            </ToggleGroup>
-          </Field>
-
-          <Field
-            id="postsPerPage"
-            label="Posts Per Page"
-            hint="Pagination chunk size."
-          >
-            <Select
-              value={settings.postsPerPage}
-              onValueChange={(value) => updateSetting('postsPerPage', value)}
-            >
-              <Select.Trigger id="postsPerPage" className="bg-muted">
-                <Select.Value />
-              </Select.Trigger>
-              <Select.Content>
-                {['10', '20', '50'].map((value) => (
-                  <Select.Item key={value} value={value}>
-                    {value}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select>
-          </Field>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <Field label="Default Post Status">
-            <ToggleGroup
-              type="single"
-              variant="outline"
-              value={settings.defaultPostStatus}
-              onValueChange={(value) =>
-                value && updateSetting('defaultPostStatus', value)
-              }
-              className="justify-start"
-            >
-              <ToggleGroup.Item value="draft" className="h-7 px-3 text-xs">
-                Draft
-              </ToggleGroup.Item>
-              <ToggleGroup.Item value="published" className="h-7 px-3 text-xs">
-                Published
-              </ToggleGroup.Item>
-            </ToggleGroup>
-          </Field>
-
-          <Field label="Comments">
-            <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3">
-              <div>
-                <div className="text-sm font-medium">Allow comments</div>
-                <div className="text-xs text-muted-foreground">
-                  Enable comment threads on posts
-                </div>
-              </div>
-              <Switch
-                checked={settings.allowComments}
-                onCheckedChange={(checked) =>
-                  updateSetting('allowComments', checked)
-                }
-              />
-            </div>
-          </Field>
-        </div>
-      </SettingsSection> */}
+            </Select.Content>
+          </Select>
+          <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            <IconLink className="size-4 shrink-0" />
+            <span className="min-w-0 truncate">Preview: {previewUrl}</span>
+          </div>
+        </Field>
+      </SettingsSection>
 
       <SettingsSection id="languages" title="Languages">
         <Field label="Supported Languages">
@@ -514,6 +504,111 @@ export const SettingsForm = ({
           />
         </Field>
       </SettingsSection>
+
+      <SettingsSection
+        id="delete"
+        title="Delete CMS"
+        className="border-destructive/40"
+        contentClassName="p-0"
+      >
+        <div className="space-y-4 p-4">
+          <p className="text-sm text-muted-foreground">
+            Permanently delete this CMS and its settings. This action cannot be
+            undone.
+          </p>
+          <div className="rounded-md border bg-muted/30 p-3">
+            <div className="text-sm font-medium">{cmsName}</div>
+            <div className="text-xs text-muted-foreground">
+              {cms?.domain ||
+                cms?.publicUrl ||
+                settings.domain ||
+                settings.publicUrl ||
+                'No public URL set'}
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end border-t border-destructive/20 bg-destructive/10 p-4">
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={!cms?._id || isDeleting}
+            onClick={() => handleDeleteDialogChange(true)}
+          >
+            <IconTrash className="size-4" />
+            Delete CMS
+          </Button>
+        </div>
+      </SettingsSection>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={handleDeleteDialogChange}>
+        <Dialog.Content className="max-w-xl gap-0 overflow-hidden p-0">
+          <Dialog.Header className="border-b p-6">
+            <Dialog.Title>Delete CMS</Dialog.Title>
+            <Dialog.Description>
+              This will permanently delete the CMS and related settings.
+            </Dialog.Description>
+          </Dialog.Header>
+
+          <div className="space-y-5 bg-muted/40 p-6">
+            <div className="space-y-2">
+              <label className="text-sm text-muted-foreground">
+                To confirm, type{' '}
+                <span className="font-semibold text-foreground">
+                  &quot;{cmsName}&quot;
+                </span>
+              </label>
+              <Input
+                value={deleteNameConfirmation}
+                onChange={(event) =>
+                  setDeleteNameConfirmation(event.target.value)
+                }
+                autoFocus
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm text-muted-foreground">
+                To confirm, type{' '}
+                <span className="font-semibold text-foreground">
+                  &quot;{DELETE_CONFIRMATION_PHRASE}&quot;
+                </span>
+              </label>
+              <Input
+                value={deletePhraseConfirmation}
+                onChange={(event) =>
+                  setDeletePhraseConfirmation(event.target.value)
+                }
+              />
+            </div>
+          </div>
+
+          <div className="border-y border-destructive/20 p-4">
+            <div className="flex items-center gap-3 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              <IconAlertTriangle className="size-5 shrink-0" />
+              <span>Deleting {cmsName} cannot be undone.</span>
+            </div>
+          </div>
+
+          <Dialog.Footer className="flex-row items-center justify-between p-4 sm:justify-between sm:space-x-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleDeleteDialogChange(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!canDeleteCMS}
+              onClick={handleDelete}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete CMS'}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -43,15 +43,15 @@ const DELETE_CONFIRMATION_PHRASE = 'delete my project';
 const DELETE_NAME_CONFIRMATION_INPUT_ID = 'delete-name-confirmation';
 const DELETE_PHRASE_CONFIRMATION_INPUT_ID = 'delete-phrase-confirmation';
 
-const trimTrailingSlashes = (value: string) => {
+function trimTrailingSlashes(value: string): string {
   let endIndex = value.length;
 
-  while (endIndex > 0 && value.charCodeAt(endIndex - 1) === 47) {
+  while (endIndex > 0 && value[endIndex - 1] === '/') {
     endIndex -= 1;
   }
 
   return value.slice(0, endIndex);
-};
+}
 
 interface ISettingsFormProps {
   cms?: CmsSettingsData;
@@ -83,12 +83,14 @@ export const SettingsForm = ({
     POST_URL_FIELD_OPTIONS.find(
       (option) => option.value === settings.postUrlField,
     ) || POST_URL_FIELD_OPTIONS[0];
-  const rawPublicUrl = settings.publicUrl || settings.domain;
-  const normalizedPublicUrl = rawPublicUrl
-    ? rawPublicUrl.startsWith('http')
+  const rawPublicUrl = settings.publicUrl.trim() || settings.domain.trim();
+  let normalizedPublicUrl = '';
+
+  if (rawPublicUrl) {
+    normalizedPublicUrl = rawPublicUrl.startsWith('http')
       ? rawPublicUrl
-      : `https://${rawPublicUrl}`
-    : '';
+      : `https://${rawPublicUrl}`;
+  }
   const previewUrl = normalizedPublicUrl
     ? `${trimTrailingSlashes(normalizedPublicUrl)}/${
         selectedPostUrlField.example
@@ -523,7 +525,7 @@ export const SettingsForm = ({
         id="delete"
         title="Delete CMS"
         className="border-destructive/40"
-        contentClassName="p-0"
+        contentClassName="space-y-0 p-0"
       >
         <div className="space-y-4 p-4">
           <p className="text-sm text-muted-foreground">

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -99,7 +99,7 @@ export const SettingsForm = ({
   const canDeleteCMS =
     Boolean(cms?._id) &&
     deleteNameConfirmation.trim() === cmsName &&
-    deletePhraseConfirmation === DELETE_CONFIRMATION_PHRASE &&
+    deletePhraseConfirmation.trim() === DELETE_CONFIRMATION_PHRASE &&
     !isDeleting;
 
   const selectedLanguageOptions = settings.languages.map((language) => ({

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
@@ -1,5 +1,13 @@
-import { Card } from 'erxes-ui';
+import { Card, cn } from 'erxes-ui';
 import { PropsWithChildren, ReactNode } from 'react';
+
+interface ISettingsSectionProps {
+  id: string;
+  title: string;
+  badge?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
 
 export const SettingsSection = ({
   id,
@@ -8,16 +16,10 @@ export const SettingsSection = ({
   className = '',
   contentClassName,
   children,
-}: PropsWithChildren<{
-  id: string;
-  title: string;
-  badge?: ReactNode;
-  className?: string;
-  contentClassName?: string;
-}>) => (
+}: PropsWithChildren<ISettingsSectionProps>) => (
   <Card
     id={`cms-settings-${id}`}
-    className={`rounded-lg border shadow-none ${className}`}
+    className={cn('rounded-lg border shadow-none', className)}
   >
     <Card.Header className="flex flex-row items-center justify-between gap-3 space-y-0 border-b px-4 py-3">
       <Card.Title className="text-sm">{title}</Card.Title>

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
@@ -5,17 +5,26 @@ export const SettingsSection = ({
   id,
   title,
   badge,
+  className = '',
+  contentClassName,
   children,
 }: PropsWithChildren<{
   id: string;
   title: string;
   badge?: ReactNode;
+  className?: string;
+  contentClassName?: string;
 }>) => (
-  <Card id={`cms-settings-${id}`} className="rounded-lg border shadow-none">
+  <Card
+    id={`cms-settings-${id}`}
+    className={`rounded-lg border shadow-none ${className}`}
+  >
     <Card.Header className="flex flex-row items-center justify-between gap-3 space-y-0 border-b px-4 py-3">
       <Card.Title className="text-sm">{title}</Card.Title>
       {badge}
     </Card.Header>
-    <Card.Content className="space-y-4 p-4">{children}</Card.Content>
+    <Card.Content className={contentClassName || 'space-y-4 p-4'}>
+      {children}
+    </Card.Content>
   </Card>
 );

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx
@@ -25,7 +25,7 @@ export const SettingsSection = ({
       <Card.Title className="text-sm">{title}</Card.Title>
       {badge}
     </Card.Header>
-    <Card.Content className={contentClassName || 'space-y-4 p-4'}>
+    <Card.Content className={cn('space-y-4 p-4', contentClassName)}>
       {children}
     </Card.Content>
   </Card>

--- a/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
@@ -1,9 +1,10 @@
 import { NetworkStatus, useMutation, useQuery } from '@apollo/client';
 import { toast } from 'erxes-ui';
 import { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   CONTENT_CREATE_CMS,
+  CONTENT_DELETE_CMS,
   CONTENT_UPDATE_CMS,
 } from '../../graphql/mutations';
 import { CONTENT_CMS_LIST, GET_WEBSITES } from '../../graphql/queries';
@@ -18,6 +19,7 @@ import { buildPublicUrl } from '../utils/settingsHelpers';
 
 export const useSettingsForm = () => {
   const { websiteId } = useParams();
+  const navigate = useNavigate();
   const [hydratedSettingsKey, setHydratedSettingsKey] = useState<string>();
   const [settings, setSettings] = useState<SettingsFormState>(DEFAULT_SETTINGS);
   const mutationOptions = {
@@ -47,8 +49,7 @@ export const useSettingsForm = () => {
     websitesQuery.observable.getCurrentResult().partial !== true &&
     Array.isArray(websitesData?.getClientPortals?.list);
 
-  const settingsQueriesFetched =
-    cmsQueryFetched && websitesQueryFetched;
+  const settingsQueriesFetched = cmsQueryFetched && websitesQueryFetched;
 
   const [createCMS, { loading: creatingCMS }] = useMutation(
     CONTENT_CREATE_CMS,
@@ -56,6 +57,10 @@ export const useSettingsForm = () => {
   );
   const [updateCMS, { loading: updatingCMS }] = useMutation(
     CONTENT_UPDATE_CMS,
+    mutationOptions,
+  );
+  const [deleteCMS, { loading: deletingCMS }] = useMutation(
+    CONTENT_DELETE_CMS,
     mutationOptions,
   );
 
@@ -82,8 +87,8 @@ export const useSettingsForm = () => {
   const hydrationKey = cms?._id
     ? `${websiteId}:cms:${cms._id}`
     : clientPortal?._id
-      ? `${websiteId}:clientPortal:${clientPortal._id}`
-      : undefined;
+    ? `${websiteId}:clientPortal:${clientPortal._id}`
+    : undefined;
 
   useEffect(() => {
     if (
@@ -255,16 +260,54 @@ export const useSettingsForm = () => {
     }
   };
 
+  const handleDelete = async () => {
+    if (!cms?._id) {
+      toast({
+        title: 'CMS not deleted',
+        description: 'Save this CMS before trying to delete it.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      await deleteCMS({
+        variables: {
+          id: cms._id,
+        },
+      });
+
+      toast({
+        title: 'Success',
+        description: 'CMS deleted successfully.',
+      });
+      navigate('/content/cms');
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Failed to delete CMS. Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return {
     canSave:
       Boolean(websiteId) &&
       settingsQueriesFetched &&
       !creatingCMS &&
-      !updatingCMS,
+      !updatingCMS &&
+      !deletingCMS,
     clientPortals,
+    cms,
+    isDeleting: deletingCMS,
     isSaving: creatingCMS || updatingCMS,
     settings,
     updateSetting,
+    handleDelete,
     handleSave,
   };
 };

--- a/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
@@ -275,7 +275,7 @@ export const useSettingsForm = () => {
         variables: {
           id: cms._id,
         },
-        refetchQueries: [{ query: CONTENT_CMS_LIST }, { query: GET_WEBSITES }],
+        refetchQueries: [{ query: CONTENT_CMS_LIST }],
         awaitRefetchQueries: true,
       });
 

--- a/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
@@ -275,6 +275,8 @@ export const useSettingsForm = () => {
         variables: {
           id: cms._id,
         },
+        refetchQueries: [{ query: CONTENT_CMS_LIST }, { query: GET_WEBSITES }],
+        awaitRefetchQueries: true,
       });
 
       toast({


### PR DESCRIPTION
## Summary
- move CMS post URL field from the edit sheet into CMS settings
- remove direct CMS deletion from the edit sheet
- add a settings danger section with confirmation inputs before deletion

## Tests
- pnpm nx build content_ui
- pnpm exec eslint frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx frontend/plugins/content_ui/src/modules/cms/constants/websiteFormSchema.ts frontend/plugins/content_ui/src/modules/cms/settings/Settings.tsx frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsSection.tsx frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
- git diff --check

## Notes
- Full pnpm nx lint content_ui still fails on existing unrelated CMS lint errors.

## Summary by Sourcery

Move CMS post URL configuration and deletion controls from the website edit drawer into the CMS settings page, adding a safer deletion flow and improving settings UX.

New Features:
- Allow configuring the CMS post URL field from the settings page with a selectable field and preview URL.
- Add a dedicated "Delete CMS" danger section in settings with a confirmation dialog requiring name and phrase inputs before deletion.

Enhancements:
- Refine the CMS settings form and hook to own the CMS delete mutation and navigation after deletion, removing delete logic from the website drawer.
- Extend the generic SettingsSection component to support custom container and content styling via optional className props.
- Simplify the website drawer form schema and UI by removing the post URL field configuration from website creation and editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add CMS deletion workflow in Settings with confirmation and progress state
  * Add Content settings in Settings: choose post-URL field and live preview

* **Bug Fixes**
  * Remove Post URL Field from website setup UI, schema, and create/update submissions
  * Remove hardcoded default content value from create flow

* **Chores**
  * Expose additional styling/customization hooks for settings sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->