### PR TITLE
sales-fix 

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/utils.ts
@@ -1115,6 +1115,7 @@ export const sendNotifications = async (
 
   const notificationDoc = {
     createdUser: user,
+    fromUserId: user._id,
     title,
     contentType: 'sales:deal',
     contentTypeId: item._id,

--- a/frontend/plugins/sales_ui/module-federation.config.ts
+++ b/frontend/plugins/sales_ui/module-federation.config.ts
@@ -20,6 +20,7 @@ const config: ModuleFederationConfig = {
     './dealsSettings': './src/pages/SalesSettingsIndexPage.tsx',
     './salesSettings': './src/pages/SalesSettingsIndexPage.tsx',
     './Widgets': './src/widgets/Widgets.tsx',
+    './notificationWidget': './src/widgets/notifications/NotificationsWidgets.tsx',
     './relationWidget': './src/widgets/relation/RelationWidgets.tsx',
     './pos': './src/modules/pos/Main.tsx',
     './posSettings': './src/modules/pos/pos/Main.tsx',

--- a/frontend/plugins/sales_ui/src/components/CopyText.tsx
+++ b/frontend/plugins/sales_ui/src/components/CopyText.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { IconCheck } from '@tabler/icons-react';
+import { cn, Tooltip } from 'erxes-ui';
+
+interface CopyTextProps {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const CopyText = ({ value, children, className }: CopyTextProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Tooltip.Provider>
+      <Tooltip open={copied ? false : undefined}>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={cn(
+              'inline-flex items-center gap-1 transition-colors',
+              className,
+            )}
+          >
+            {copied ? (
+              <span className="flex items-center gap-1 text-success">
+                <IconCheck className="size-4 shrink-0" />
+                Copied!
+              </span>
+            ) : (
+              children
+            )}
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Click to copy</Tooltip.Content>
+      </Tooltip>
+    </Tooltip.Provider>
+  );
+};

--- a/frontend/plugins/sales_ui/src/components/CopyText.tsx
+++ b/frontend/plugins/sales_ui/src/components/CopyText.tsx
@@ -18,7 +18,7 @@ export const CopyText = ({ value, children, className }: CopyTextProps) => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      // setCopied(false);
+      // clipboard write failed (e.g. permissions denied) — leave copied false
     }
   };
 

--- a/frontend/plugins/sales_ui/src/components/CopyText.tsx
+++ b/frontend/plugins/sales_ui/src/components/CopyText.tsx
@@ -11,11 +11,15 @@ interface CopyTextProps {
 export const CopyText = ({ value, children, className }: CopyTextProps) => {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = (e: React.MouseEvent) => {
+  const handleCopy = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // setCopied(false);
+    }
   };
 
   return (

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
@@ -1,6 +1,7 @@
 import Labels from '@/deals/cards/components/detail/overview/label/Labels';
 import { ItemFooter } from '@/deals/cards/components/item/Footer';
 import { useDealsEdit } from '@/deals/cards/hooks/useDeals';
+import { CopyText } from '~/components/CopyText';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { DateSelectDeal } from '@/deals/components/deal-selects/DateSelectDeal';
 import { SelectDealPriority } from '@/deals/components/deal-selects/SelectDealPriority';
@@ -102,7 +103,6 @@ export const DealsBoardCard = memo(function DealsBoardCard({
     stage,
     tagIds,
   } = deal;
-
   const onCardClick = () => {
     setSalesItemId(_id);
     setActiveDealAtom(_id);
@@ -140,7 +140,11 @@ export const DealsBoardCard = memo(function DealsBoardCard({
           </div>
         )}
         <div className="flex flex-col gap-1">
-          <h5 className="font-semibold">{name}</h5>
+          <h5 className="font-semibold">
+            <CopyText value={name || ''} className="hover:opacity-70 text-left">
+              {name}
+            </CopyText>
+          </h5>
           {stage?.age !== undefined && stage.age < 0 && (
             <span className="px-2 rounded flex gap-1 bg-yellow-50 text-yellow-400 border-yellow-100 border">
               <IconAlertCircleFilled className="size-6 pt-2" />

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/item/Footer.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/item/Footer.tsx
@@ -1,6 +1,7 @@
 import { IUser } from 'ui-modules';
 import { IconCalendar, IconNumber } from '@tabler/icons-react';
 import { SelectAssigneeDeal } from '@/deals/components/deal-selects/SelectAssigneeDeal';
+import { CopyText } from '~/components/CopyText';
 import dayjs from 'dayjs';
 
 type Props = {
@@ -14,18 +15,17 @@ export const ItemFooter = ({ number, createdAt, assignedUsers = [], id }: Props)
   return (
     <div className="flex justify-between items-center p-2">
       <div className="flex items-center gap-1 text-gray-500 text-xs">
-        {number && (
-          <>
-            <IconNumber className="w-4 h-4" />
+        {number ? (
+          <CopyText value={number} className="text-inherit hover:text-foreground">
+            <IconNumber className="size-4 shrink-0" />
             <span>{number}</span>
+          </CopyText>
+        ) : (
+          <>
+            <IconCalendar className="w-4 h-4" />
+            <span>{dayjs(createdAt).format('MMM DD, YYYY')}</span>
           </>
-        ) || (
-            <>
-              <IconCalendar className="w-4 h-4" />
-              <span>{dayjs(createdAt).format('MMM DD, YYYY')}</span>
-            </>
-          )
-        }
+        )}
       </div>
       <SelectAssigneeDeal
         variant="card"

--- a/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
+++ b/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
@@ -33,10 +33,22 @@ const SalesDealNotificationContent = ({
   contentTypeId,
   fromUser,
 }: TNotification) => {
-  const { data, loading } = useQuery<{ dealDetail: IDeal }>(GET_DEAL_DETAIL, {
-    variables: { _id: contentTypeId || '' },
-    skip: !contentTypeId,
-  });
+  const { data, loading, error } = useQuery<{ dealDetail: IDeal }>(
+    GET_DEAL_DETAIL,
+    {
+      variables: { _id: contentTypeId || '' },
+      skip: !contentTypeId,
+    },
+  );
+
+  if (error) {
+    return (
+      <NotificationContentUnavailable
+        title="Failed to load deal"
+        description={error.message}
+      />
+    );
+  }
 
   if (!contentTypeId) {
     return (

--- a/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
+++ b/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
@@ -89,8 +89,8 @@ const SalesDealNotificationContent = ({
           </span>
         </div>
 
-        <p className="text-foreground">
-          {action || 'has updated deal'}{' '}
+        <p className="flex flex-wrap items-baseline justify-center gap-1 text-foreground">
+          <span>{action || 'has updated deal'}</span>
           {loading ? (
             <Skeleton className="inline-block w-24 h-4 align-middle" />
           ) : (

--- a/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
+++ b/frontend/plugins/sales_ui/src/widgets/notifications/NotificationsWidgets.tsx
@@ -1,0 +1,145 @@
+import { useQuery } from '@apollo/client';
+import {
+  IconBriefcase,
+  IconExternalLink,
+  IconInfoCircle,
+} from '@tabler/icons-react';
+import {
+  Avatar,
+  Button,
+  RelativeDateDisplay,
+  Skeleton,
+  readImage,
+} from 'erxes-ui';
+import { Link } from 'react-router-dom';
+import { IUser, TNotification } from 'ui-modules';
+
+import { GET_DEAL_DETAIL } from '@/deals/graphql/queries/DealsQueries';
+import { IDeal } from '@/deals/types/deals';
+
+const getUserDisplayName = (user?: IUser) =>
+  user?.details?.fullName || user?.email || 'Unknown user';
+
+const buildDealPath = (deal: IDeal) => {
+  const searchParams = new URLSearchParams({ salesItemId: deal._id });
+  if (deal.boardId) searchParams.set('boardId', deal.boardId);
+  if (deal.pipeline?._id) searchParams.set('pipelineId', deal.pipeline._id);
+  return `/sales/deals?${searchParams.toString()}`;
+};
+
+const SalesDealNotificationContent = ({
+  action,
+  createdAt,
+  contentTypeId,
+  fromUser,
+}: TNotification) => {
+  const { data, loading } = useQuery<{ dealDetail: IDeal }>(GET_DEAL_DETAIL, {
+    variables: { _id: contentTypeId || '' },
+    skip: !contentTypeId,
+  });
+
+  if (!contentTypeId) {
+    return (
+      <NotificationContentUnavailable
+        title="Notification content unavailable"
+        description="This sales notification is missing a linked deal."
+      />
+    );
+  }
+
+  const deal = data?.dealDetail;
+
+  return (
+    <div className="flex flex-col gap-4 w-full max-w-md mx-auto justify-center items-center min-h-screen text-muted-foreground">
+      <div className="size-36 bg-sidebar rounded-2xl border-2 border-dashed flex flex-col items-center justify-center">
+        <IconBriefcase
+          size={64}
+          className="text-accent-foreground"
+          stroke={1}
+        />
+      </div>
+
+      <p className="font-bold text-lg text-foreground">Deal</p>
+
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="flex items-center gap-2">
+          <Avatar className="size-6">
+            <Avatar.Image
+              src={readImage(fromUser?.details?.avatar || '')}
+              alt={getUserDisplayName(fromUser)}
+            />
+            <Avatar.Fallback className="rounded-lg text-xs">
+              {getUserDisplayName(fromUser)[0].toUpperCase()}
+            </Avatar.Fallback>
+          </Avatar>
+          <span className="font-semibold text-foreground">
+            {getUserDisplayName(fromUser)}
+          </span>
+        </div>
+
+        <p className="text-foreground">
+          {action || 'has updated deal'}{' '}
+          {loading ? (
+            <Skeleton className="inline-block w-24 h-4 align-middle" />
+          ) : (
+            <span className="font-bold text-foreground">
+              {deal?.name || ''}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {createdAt && (
+        <p className="text-sm text-accent-foreground">
+          <RelativeDateDisplay.Value value={createdAt} />
+        </p>
+      )}
+
+      {!loading && deal && (
+        <Button variant="secondary" asChild>
+          <Link to={buildDealPath(deal)}>
+            <IconExternalLink className="size-4" />
+            Open deal
+          </Link>
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const NotificationContentUnavailable = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <div className="flex max-w-sm flex-col items-center text-center">
+        <div className="mb-4 flex size-12 items-center justify-center rounded-2xl bg-accent text-muted-foreground">
+          <IconInfoCircle className="size-5" />
+        </div>
+        <h3 className="text-base font-medium text-foreground">{title}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+};
+
+const NotificationsWidgets = (props: TNotification) => {
+  const [, moduleName] = (props.contentType || '').replace(':', '.').split('.');
+
+  if (moduleName === 'deal') {
+    return <SalesDealNotificationContent {...props} />;
+  }
+
+  return (
+    <NotificationContentUnavailable
+      title="Notification content unavailable"
+      description="This sales notification does not have a linked detail view yet."
+    />
+  );
+};
+
+export default NotificationsWidgets;

--- a/frontend/plugins/sales_ui/src/widgets/relation/modules/DealWidgetCard.tsx
+++ b/frontend/plugins/sales_ui/src/widgets/relation/modules/DealWidgetCard.tsx
@@ -1,22 +1,69 @@
-import { Card, Separator } from 'erxes-ui';
+import { Badge, Card, Separator, Tooltip } from 'erxes-ui';
+import { IconBuildingSkyscraper, IconMapPin } from '@tabler/icons-react';
 
 import { DateSelectDeal } from '@/deals/components/deal-selects/DateSelectDeal';
+import { PriorityBadge } from '@/deals/components/deal-selects/PriorityInline';
 import { IDeal } from '@/deals/types/deals';
 import { ItemFooter } from '@/deals/cards/components/item/Footer';
 import Labels from '@/deals/cards/components/detail/overview/label/Labels';
+
+const PRIORITY_MAP: Record<string, number> = {
+  'No Priority': 0,
+  Minor: 1,
+  Medium: 2,
+  High: 3,
+  Critical: 4,
+};
+
+const OverflowItems = ({ items }: { items: { title: string }[] }) => {
+  const [first, ...rest] = items;
+  if (!rest.length) {
+    return (
+      <span className="font-medium text-foreground truncate min-w-0">
+        {first.title}
+      </span>
+    );
+  }
+  return (
+    <Tooltip.Provider>
+      <Tooltip>
+        <Tooltip.Trigger asChild>
+          <span className="flex items-center gap-1 min-w-0 cursor-default">
+            <span className="font-medium text-foreground truncate min-w-0">
+              {first.title}
+            </span>
+            <span className="shrink-0 text-muted-foreground">+{rest.length}</span>
+          </span>
+        </Tooltip.Trigger>
+        <Tooltip.Content>{items.map((i) => i.title).join(', ')}</Tooltip.Content>
+      </Tooltip>
+    </Tooltip.Provider>
+  );
+};
 
 export const DealWidgetCard = ({ deal }: { deal: IDeal }) => {
   const {
     startDate,
     closeDate,
     name,
+    number,
+    priority,
+    stage,
+    status,
     _id,
     createdAt,
     assignedUsers,
     labels,
     boardId,
     pipeline,
+    departments,
+    branches,
   } = deal || {};
+
+  const priorityNum = PRIORITY_MAP[priority || ''] ?? 0;
+  const isArchived = status === 'archived';
+  const hasDepartments = !!departments?.length;
+  const hasBranches = !!branches?.length;
 
   const onCardClick = () => {
     const dealUrl = `/sales/deals?boardId=${boardId}&pipelineId=${pipeline._id}&salesItemId=${_id}`;
@@ -51,12 +98,53 @@ export const DealWidgetCard = ({ deal }: { deal: IDeal }) => {
             <Labels labels={labels} type="toggle" />
           </div>
         )}
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1 min-w-0">
           <h5 className="font-semibold">{name}</h5>
+          {(priorityNum > 0 || stage?.name || isArchived || hasDepartments || hasBranches) && (
+            <div className="mt-1.5 grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-1.5 text-xs overflow-hidden">
+              {stage?.name && (
+                <>
+                  <span className="text-muted-foreground">Stage</span>
+                  <span className="font-medium text-foreground truncate min-w-0">{stage.name}</span>
+                </>
+              )}
+              {priorityNum > 0 && (
+                <>
+                  <span className="text-muted-foreground">Priority</span>
+                  <PriorityBadge priority={priorityNum} className="text-xs py-0 h-5 w-fit" />
+                </>
+              )}
+              {hasDepartments && (
+                <>
+                  <span className="flex items-center gap-1 text-muted-foreground shrink-0">
+                    <IconBuildingSkyscraper className="size-3.5 shrink-0" />
+                    Dept.
+                  </span>
+                  <OverflowItems items={departments} />
+                </>
+              )}
+              {hasBranches && (
+                <>
+                  <span className="flex items-center gap-1 text-muted-foreground shrink-0">
+                    <IconMapPin className="size-3.5 shrink-0" />
+                    Branch
+                  </span>
+                  <OverflowItems items={branches} />
+                </>
+              )}
+              {isArchived && (
+                <>
+                  <span className="text-muted-foreground">Status</span>
+                  <Badge variant="secondary" className="text-xs py-0 h-5 w-fit">Archived</Badge>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
       <Separator />
       <ItemFooter
+        number={number}
         createdAt={createdAt}
         assignedUsers={assignedUsers || []}
         id={_id}


### PR DESCRIPTION
add notification widget for sales deal updates

## Summary by Sourcery

Add a sales deal notification widget and include sender metadata in sales notifications.

New Features:
- Expose a sales notification widget in the sales UI to display deal update details and link to the relevant deal.

Enhancements:
- Include the originating user ID in sales notification documents to support richer notification displays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deal notifications now include explicit sender info and show associated deal details with an “Open deal” link
  * New notification widget renders deal-focused content and graceful fallbacks when linked details are missing
  * Added copy-to-clipboard controls for deal names and numbers
  * Deal widgets and cards now show extra metadata (stage, priority, departments, branches) and archived status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->