### PR TITLE
fix(frontline): response template search via backend searchValue

### DIFF
--- a/backend/plugins/frontline_api/src/modules/response/graphql/responseTemplateQueries.ts
+++ b/backend/plugins/frontline_api/src/modules/response/graphql/responseTemplateQueries.ts
@@ -31,13 +31,14 @@ export const responseTemplateQueries = {
 
     { models }: IContext,
   ) {
-    const filterQuery: any = {
-      channelId: { $exists: true, $ne: null },
-    };
+    const filterQuery = generateFilter(filter);
+
+    filterQuery.channelId = { $exists: true, $ne: null };
 
     if (filter.channelId) {
       filterQuery.channelId = filter.channelId;
     }
+
     return await cursorPaginate<IResponseTemplateDocument>({
       model: models.ResponseTemplates,
       params: {

--- a/backend/plugins/frontline_api/src/modules/response/graphql/schema.ts
+++ b/backend/plugins/frontline_api/src/modules/response/graphql/schema.ts
@@ -16,6 +16,7 @@ input ResponseTemplatesFilter {
   content: String
   channelId: String
   files: [String]
+  searchValue: String
   ${GQL_CURSOR_PARAM_DEFS}
   }
   type ResponseTemplateList {

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ResponseTemplateSelector.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ResponseTemplateSelector.tsx
@@ -59,6 +59,7 @@ export const ResponseTemplateSelector: React.FC<
     variables: {
       filter: {
         channelId: selectedChannel === 'all' ? undefined : selectedChannel,
+        searchValue: debouncedSearch || undefined,
       },
     },
   });


### PR DESCRIPTION
## Problem
Response template search in chat input was unreliable. Customer service agents couldn't find templates because:
- Backend resolver ignored `searchValue` and returned only first 24 templates unconditionally
- Frontend searched client-side on those 24 items only — any template beyond page 1 was invisible

## Changes
- **Backend schema**: Add `searchValue: String` to `ResponseTemplatesFilter` GraphQL input
- **Backend resolver**: `responseTemplates` now uses existing `generateFilter()` with case-insensitive regex search on `name` and `content`
- **Frontend**: `ResponseTemplateSelector` passes `searchValue: debouncedSearch` to GraphQL query instead of filtering client-side

## Testing
- Seeded 10 test templates with varied names/content (including Mongolian `Хэрэглэгч үрих`)
- Verified `searchValue="refund"` returns matching templates from backend
- Inbox now shows 5 test conversations after fixing MongoDB ObjectId/string type mismatches

Fixes unreliable template search for customer service workflows.

## Summary by Sourcery

Improve backend and frontend response template search to return server-filtered results instead of unreliable client-side filtering.

Bug Fixes:
- Ensure response templates query applies server-side filtering, including channel constraints, when searching.
- Fix response template selector to send the search term to the backend instead of filtering only the first page of results.

Enhancements:
- Extend GraphQL ResponseTemplatesFilter input to include a generic search value field for template name/content searching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side search filtering for response templates to improve lookup performance and accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->