### PR TITLE
feat(sales): add cpDealsEdit and cpDealsCreateProductsData

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -13,7 +13,7 @@ import {
   copyChecklists,
   subscriptionWrapper,
 } from '../utils';
-import { addDeal, changeDeal, editDeal } from './utils';
+import { addDeal, changeDeal, createProductsData, editDeal } from './utils';
 import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { Resolver } from 'erxes-api-shared/core-types';
 
@@ -227,93 +227,11 @@ export const dealMutations: Record<string, Resolver> = {
 
   async dealsCreateProductsData(
     _root,
-    {
-      processId,
-      dealId,
-      docs,
-    }: {
-      processId: string;
-      dealId: string;
-      docs: IProductData[];
-    },
-    { models, user, checkPermission }: IContext,
+    { processId, dealId, docs }: { processId: string; dealId: string; docs: IProductData[] },
+    { models, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
-    const deal = await models.Deals.getDeal(dealId);
-    const stage = await models.Stages.getStage(deal.stageId);
-
-    const oldDataIds = (deal.productsData || []).map((pd) => pd._id);
-
-    const { assignedUserIds, addedUserIds, removedUserIds } =
-      checkAssignedUserFromPData(
-        deal.assignedUserIds,
-        [
-          ...(deal.productsData || [])
-            .filter((pdata) => pdata.assignUserId)
-            .map((pdata) => pdata.assignUserId || ''),
-          ...docs
-            .filter((pdata) => pdata.assignUserId)
-            .map((pdata) => pdata.assignUserId || ''),
-        ],
-        deal.productsData,
-      );
-
-    for (const doc of docs) {
-      if (doc._id) {
-        const checkDup = (deal.productsData || []).find(
-          (pd) => pd._id === doc._id,
-        );
-        if (checkDup) {
-          throw new Error('Deals productData duplicated');
-        }
-      }
-    }
-
-    // undefenid or null then true
-    const tickUsed = !(stage.defaultTick === false);
-    const addDocs = (docs || []).map(
-      (doc) => ({ ...doc, tickUsed } as IProductData),
-    );
-    const productsData: IProductData[] = (deal.productsData || []).concat(
-      addDocs,
-    );
-
-    const updatedItem =
-      (await models.Deals.findOneAndUpdate(
-        { _id: dealId },
-        {
-          $set: {
-            productsData,
-            assignedUserIds,
-            ...(await getTotalAmounts(productsData)),
-          },
-        },
-        {
-          new: true,
-        },
-      )) || ({} as any);
-
-    const dataIds = (updatedItem.productsData || [])
-      .filter((pd) => !oldDataIds.includes(pd._id))
-      .map((pd) => pd._id);
-
-    graphqlPubsub.publish(`salesProductsDataChanged:${dealId}`, {
-      salesProductsDataChanged: {
-        _id: dealId,
-        processId,
-        action: 'create',
-        data: {
-          dataIds,
-          docs,
-          productsData,
-        },
-      },
-    });
-
-    return {
-      dataIds,
-      productsData,
-    };
+    return createProductsData({ models, processId, dealId, docs });
   },
 
   async dealsEditProductData(
@@ -405,92 +323,10 @@ export const dealMutations: Record<string, Resolver> = {
 
   async cpDealsCreateProductsData(
     _root,
-    {
-      processId,
-      dealId,
-      docs,
-    }: {
-      processId: string;
-      dealId: string;
-      docs: IProductData[];
-    },
-    { models, user }: IContext,
+    { processId, dealId, docs }: { processId: string; dealId: string; docs: IProductData[] },
+    { models }: IContext,
   ) {
-    const deal = await models.Deals.getDeal(dealId);
-    const stage = await models.Stages.getStage(deal.stageId);
-
-    const oldDataIds = (deal.productsData || []).map((pd) => pd._id);
-
-    const { assignedUserIds, addedUserIds, removedUserIds } =
-      checkAssignedUserFromPData(
-        deal.assignedUserIds,
-        [
-          ...(deal.productsData || [])
-            .filter((pdata) => pdata.assignUserId)
-            .map((pdata) => pdata.assignUserId || ''),
-          ...docs
-            .filter((pdata) => pdata.assignUserId)
-            .map((pdata) => pdata.assignUserId || ''),
-        ],
-        deal.productsData,
-      );
-
-    for (const doc of docs) {
-      if (doc._id) {
-        const checkDup = (deal.productsData || []).find(
-          (pd) => pd._id === doc._id,
-        );
-        if (checkDup) {
-          throw new Error('Deals productData duplicated');
-        }
-      }
-    }
-
-    // undefenid or null then true
-    const tickUsed = !(stage.defaultTick === false);
-    const addDocs = (docs || []).map(
-      (doc) => ({ ...doc, tickUsed } as IProductData),
-    );
-    const productsData: IProductData[] = (deal.productsData || []).concat(
-      addDocs,
-    );
-
-    const updatedItem =
-      (await models.Deals.findOneAndUpdate(
-        { _id: dealId },
-        {
-          $set: {
-            productsData,
-            assignedUserIds,
-            ...(await getTotalAmounts(productsData)),
-          },
-        },
-        {
-          new: true,
-        },
-      )) || ({} as any);
-
-    const dataIds = (updatedItem.productsData || [])
-      .filter((pd) => !oldDataIds.includes(pd._id))
-      .map((pd) => pd._id);
-
-    graphqlPubsub.publish(`salesProductsDataChanged:${dealId}`, {
-      salesProductsDataChanged: {
-        _id: dealId,
-        processId,
-        action: 'create',
-        data: {
-          dataIds,
-          docs,
-          productsData,
-        },
-      },
-    });
-
-    return {
-      dataIds,
-      productsData,
-    };
+    return createProductsData({ models, processId, dealId, docs });
   },
 
   async cpDealsEditProductData(

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -1,12 +1,13 @@
 import { canGroup } from 'erxes-api-shared/core-modules';
 import { IUserDocument } from 'erxes-api-shared/core-types';
-import { checkUserIds, sendTRPCMessage } from 'erxes-api-shared/utils';
+import { checkUserIds, graphqlPubsub, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
-import { IDeal } from '~/modules/sales/@types';
+import { IDeal, IProductData } from '~/modules/sales/@types';
 import {
   checkMovePermission,
   createRelations,
   getNewOrder,
+  getTotalAmounts,
   sendNotifications,
 } from '~/modules/sales/utils';
 import {
@@ -319,4 +320,80 @@ export const changeDeal = async (
   });
 
   return updatedItem;
+};
+
+export const createProductsData = async ({
+  models,
+  processId,
+  dealId,
+  docs,
+}: {
+  models: IModels;
+  processId: string;
+  dealId: string;
+  docs: IProductData[];
+}) => {
+  const deal = await models.Deals.getDeal(dealId);
+  const stage = await models.Stages.getStage(deal.stageId);
+
+  const oldDataIds = (deal.productsData || []).map((pd) => pd._id);
+
+  const { assignedUserIds } = checkAssignedUserFromPData(
+    deal.assignedUserIds,
+    [
+      ...(deal.productsData || [])
+        .filter((pdata) => pdata.assignUserId)
+        .map((pdata) => pdata.assignUserId || ''),
+      ...docs
+        .filter((pdata) => pdata.assignUserId)
+        .map((pdata) => pdata.assignUserId || ''),
+    ],
+    deal.productsData,
+  );
+
+  for (const doc of docs) {
+    if (doc._id) {
+      const checkDup = (deal.productsData || []).find((pd) => pd._id === doc._id);
+      if (checkDup) {
+        throw new Error('Deals productData duplicated');
+      }
+    }
+  }
+
+  // undefined or null then true
+  const tickUsed = !(stage.defaultTick === false);
+  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed } as IProductData));
+  const productsData: IProductData[] = (deal.productsData || []).concat(addDocs);
+
+  const updatedItem =
+    (await models.Deals.findOneAndUpdate(
+      { _id: dealId },
+      {
+        $set: {
+          productsData,
+          assignedUserIds,
+          ...(await getTotalAmounts(productsData)),
+        },
+      },
+      { new: true },
+    )) || ({} as any);
+
+  const dataIds = (updatedItem.productsData || [])
+    .filter((pd) => !oldDataIds.includes(pd._id))
+    .map((pd) => pd._id);
+
+  graphqlPubsub.publish(`salesProductsDataChanged:${dealId}`, {
+    salesProductsDataChanged: {
+      _id: dealId,
+      processId,
+      action: 'create',
+      data: {
+        dataIds,
+        docs,
+        productsData,
+      },
+    },
+  });
+
+  return { dataIds, productsData };
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
@@ -12,28 +12,32 @@ import { SelectDealPriority } from '@/deals/components/deal-selects/SelectDealPr
 import { IDeal } from '@/deals/types/deals';
 import { useDealsContext } from '@/deals/context/DealContext';
 
+const ARRAY_KEYS = new Set(['assignedUserIds', 'tagIds', 'branchIds', 'departmentIds']);
+
+const FormField = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="space-y-2">
+    <Label>{label}</Label>
+    {children}
+  </div>
+);
+
 export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
   const { editDeals } = useDealsContext();
-
   const descriptionRef = useRef<string | undefined>(undefined);
 
-  const handleDealFieldChange = useCallback(
+  const handleChange = useCallback(
     (key: string, value: string | string[] | undefined | null) => {
-      if (value === undefined || value === null) return;
-
-      const isArrayKey = [
-        'assignedUserIds',
-        'tagIds',
-        'branchIds',
-        'departmentIds',
-      ].includes(key);
-
-      const finalValue = isArrayKey && !Array.isArray(value) ? [value] : value;
-
+      if (value == null) return;
       editDeals({
         variables: {
           _id: deal._id,
-          [key]: finalValue,
+          [key]: ARRAY_KEYS.has(key) && !Array.isArray(value) ? [value] : value,
         },
       });
     },
@@ -55,8 +59,7 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
   return (
     <>
       <div className="grid grid-cols-2 gap-4 py-4">
-        <div className="space-y-2">
-          <Label>Due date</Label>
+        <FormField label="Due date">
           <div className="flex items-center">
             <DateSelectDeal
               value={startDate}
@@ -72,20 +75,16 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
               variant="button"
             />
           </div>
-        </div>
-        <div className="space-y-2">
-          <Label>Assigned to</Label>
+        </FormField>
+        <FormField label="Assigned to">
           <SelectMember
             value={assignedUserIds}
-            onValueChange={(value) =>
-              handleDealFieldChange('assignedUserIds', value)
-            }
+            onValueChange={(value) => handleChange('assignedUserIds', value)}
             className="text-foreground"
             mode="multiple"
           />
-        </div>
-        <div className="space-y-2">
-          <Label>Label</Label>
+        </FormField>
+        <FormField label="Label">
           <div className="flex flex-wrap items-center gap-1">
             <SelectLabels.FilterBar
               filterKey=""
@@ -105,55 +104,39 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
               </div>
             ))}
           </div>
-        </div>
-        <div className="flex-col space-y-2">
-          <Label>Priority</Label>
-          <div>
-            <SelectDealPriority
-              dealId={_id}
-              value={priority || ''}
-              variant="card"
-            />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <Label>Tags</Label>
+        </FormField>
+        <FormField label="Priority">
+          <SelectDealPriority dealId={_id} value={priority || ''} variant="card" />
+        </FormField>
+        <FormField label="Tags">
           <SelectTags
             tagType="sales:deal"
             mode="multiple"
             value={tagIds}
-            onValueChange={(value) => {
-              handleDealFieldChange('tagIds', value);
-            }}
+            onValueChange={(value) => handleChange('tagIds', value)}
           />
-        </div>
-        <div className="space-y-2">
-          <Label>Branches</Label>
+        </FormField>
+        <FormField label="Branches">
           <SelectBranches.ComboboxItem
             value={branchIds}
-            onValueChange={(value) => {
-              handleDealFieldChange('branchIds', value);
-            }}
+            onValueChange={(value) => handleChange('branchIds', value)}
             mode="multiple"
           />
-        </div>
-        <div className="space-y-2">
-          <Label>Departments</Label>
+        </FormField>
+        <FormField label="Departments">
           <SelectDepartments.ComboboxItem
             mode="multiple"
             value={departmentIds}
-            onValueChange={(value) => {
-              handleDealFieldChange('departmentIds', value);
-            }}
+            onValueChange={(value) => handleChange('departmentIds', value)}
           />
-        </div>
+        </FormField>
       </div>
       <div
         className="space-y-2"
         onBlur={(e) => {
           if (e.currentTarget.contains(e.relatedTarget as Node)) return;
           if (descriptionRef.current !== undefined) {
-            handleDealFieldChange('description', descriptionRef.current);
+            handleChange('description', descriptionRef.current);
           }
         }}
       >


### PR DESCRIPTION
## Summary by Sourcery

Extract shared deal products data creation logic into a reusable utility and wire both standard and CP deal mutations to use it, while simplifying sales deal form field handling in the UI.

Bug Fixes:
- Ensure sales deal field updates correctly normalize single values to arrays for specific keys, preventing inconsistent payloads.

Enhancements:
- Refactor dealsCreateProductsData and cpDealsCreateProductsData mutations to delegate to a common createProductsData helper.
- Introduce a reusable FormField wrapper and centralized array-key handling in SalesFormFields to reduce repetition and normalize field values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for deal product data handling, centralizing shared functionality for better maintainability.
  * Streamlined form field rendering in the deals interface, reducing redundant markup while preserving functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->