### PR TITLE
fix(payment): simplify Quick QR setup to use merchant ID only, TEST PR, (DONT MERGE!)

### DIFF
--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/payments.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/payments.ts
@@ -28,6 +28,11 @@ function validatePaymentKind(kind: string) {
 async function handleQPaySetup(input: any) {
   if (input.kind !== 'qpayQuickqr') return;
 
+  // If merchantId is already provided, skip merchant creation
+  if (input.config?.merchantId) {
+    return;
+  }
+
   if (input.config?.type) {
     input.config.isCompany = input.config.type === 'company';
     delete input.config.type;
@@ -133,23 +138,28 @@ const mutations = {
 
     if (kind === 'qpayQuickqr') {
       try {
-        if (config?.type) {
-          config.isCompany = config.type === 'company';
-          delete config.type;
+        // Skip update if merchantId is directly provided
+        if (config?.merchantId) {
+          // Merchant already exists, just update the config
+        } else {
+          if (config?.type) {
+            config.isCompany = config.type === 'company';
+            delete config.type;
+          }
+
+          const api = new QPayQuickQrAPI(config);
+          const { isCompany } = config;
+
+          const response = isCompany
+            ? await api.updateCompany(config)
+            : await api.updateCustomer(config);
+
+          if (!response?.id) {
+            throw new Error('QPay update did not return merchant id');
+          }
+
+          config.merchantId = response.id;
         }
-
-        const api = new QPayQuickQrAPI(config);
-        const { isCompany } = config;
-
-        const response = isCompany
-          ? await api.updateCompany(config)
-          : await api.updateCustomer(config);
-
-        if (!response?.id) {
-          throw new Error('QPay update did not return merchant id');
-        }
-
-        config.merchantId = response.id;
       } catch (e: any) {
         throw new Error(extractErrorMessage(e));
       }

--- a/frontend/plugins/payment_ui/src/modules/payment/constants.ts
+++ b/frontend/plugins/payment_ui/src/modules/payment/constants.ts
@@ -26,9 +26,15 @@ export const PAYMENT_KINDS = {
   },
   [PaymentKind.QUICKQR]: {
     name: 'Qpay Quick QR',
-    description: 'Connect your bank account to Qpay',
+    description: 'Use your existing QPay merchant account with static QR code',
     active: true,
-    fields: [],
+    fields: [
+      {
+        key: 'merchantId',
+        label: 'QPay Merchant ID',
+        validation: { type: 'minLength', value: 1 },
+      },
+    ],
   },
   [PaymentKind.SOCIALPAY]: {
     name: 'Social Pay',

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentForm.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentForm.tsx
@@ -8,10 +8,7 @@ import { PAYMENT_KINDS } from '~/modules/payment/constants';
 import { usePaymentAdd } from '~/modules/payment/hooks/usePaymentAdd';
 import { usePaymentEdit } from '~/modules/payment/hooks/usePaymentEdit';
 import { IPayment, IPaymentDocument } from '~/modules/payment/types/Payment';
-import { PaymentKind } from '~/modules/payment/types/PaymentMethods';
 import { paymentKind } from '~/modules/payment/utils';
-import QuickQrForm from '~/modules/settings/payment/components/QuickQrForm';
-
 type Props = {
   payment: any;
   onCancel: () => void;
@@ -27,33 +24,6 @@ const baseSchema = z.object({
   status: z.enum(['active', 'inactive'], {
     required_error: 'Status is required',
   }),
-});
-
-const quickQrSchema = z.object({
-  kind: z.string().min(1, 'Payment method is required'),
-  name: z
-    .string()
-    .min(1, 'Name is required')
-    .max(100, 'Name must be less than 100 characters'),
-  status: z.enum(['active', 'inactive'], {
-    required_error: 'Status is required',
-  }),
-  type: z.string().min(1, 'Type is required'),
-  companyName: z.string().optional(),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-  registerNumber: z.string().optional(),
-  mccCode: z.string().optional(),
-  city: z.string().optional(),
-  district: z.string().min(1, 'District is required'),
-  businessName: z.string().min(1, 'Business name is required'),
-  address: z.string().min(1, 'Address is required'),
-  phone: z.string().min(1, 'Phone is required'),
-  email: z.string().min(1, 'Email is required'),
-  bankAccount: z.string().min(1, 'Bank account is required'),
-  bankCode: z.string().min(1, 'Bank code is required'),
-  ibanNumber: z.string().min(1, 'IBAN number is required'),
-  bankAccountName: z.string().min(1, 'Bank account name is required'),
 });
 
 // Dynamic schema generator based on payment kind
@@ -118,10 +88,6 @@ const createPaymentSchema = (selectedKind: string) => {
     }
   });
 
-  if (selectedKind === PaymentKind.QUICKQR) {
-    return quickQrSchema;
-  }
-
   return baseSchema.extend(dynamicFields);
 };
 
@@ -162,13 +128,8 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
       });
     }
 
-    if (selectedKind === PaymentKind.QUICKQR) {
-      defaultValues.type = 'person';
-      defaultValues.city = '11000';
-    }
-
     return defaultValues;
-  }, [payment, selectedKind]);
+  }, [payment]);
 
   // Initialize form with react-hook-form and zod resolver
   const form = useForm({
@@ -274,14 +235,6 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
   };
 
   const currentPaymentKind = paymentKind(selectedKind);
-
-  const renderQuickQr = () => {
-    if (selectedKind !== PaymentKind.QUICKQR) {
-      return null;
-    }
-
-    return <QuickQrForm payment={payment} form={form} Form={Form} />;
-  };
 
   return (
     <Form {...form}>
@@ -470,7 +423,6 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                 />
               ))}
 
-              {renderQuickQr()}
             </div>
           </ScrollArea>
         </Sheet.Content>


### PR DESCRIPTION
## Changes

### Problem
Quick QR setup was overly complex with 14+ fields requiring merchant registration via QPay API.

### Solution
Simplified to use existing QPay Merchant ID:
- **Frontend**: Replaced complex form with single "QPay Merchant ID" field
- **Backend**: Skip merchant creation API call when merchantId is provided
- Users can now simply paste their existing QPay Merchant ID

### Files Changed
- 
- 
- 

### How to Use
1. Select "Qpay Quick QR" as payment method
2. Enter your QPay Merchant ID (from QPay merchant dashboard)
3. Save

No more complex forms or username/password required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QuickQR payment option now supports entering an existing QPay merchant ID for faster setup without creating a new merchant account.

* **Refactor**
  * Streamlined payment form to use consistent validation and field handling across all payment types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->