### PR TITLE
fix: cp password change

### DIFF
--- a/backend/core-api/src/modules/clientportal/graphql/resolvers/mutations/cpUser/user.ts
+++ b/backend/core-api/src/modules/clientportal/graphql/resolvers/mutations/cpUser/user.ts
@@ -20,7 +20,9 @@ import type {
   ConfirmChangeEmailParams,
   RequestChangePhoneParams,
   ConfirmChangePhoneParams,
+  ChangePasswordParams,
 } from '@/clientportal/types/cpUserParams';
+import { validatePassword } from '@/clientportal/services/helpers/validators';
 
 export const userMutations: Record<string, Resolver<any, any, IContext>> = {
   async clientPortalUserEdit(
@@ -286,5 +288,39 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
 
     await models.CPUser.removeUser(cpUser._id, models);
     return { _id: cpUser._id };
+  },
+
+  async clientPortalUserChangePassword(
+    _root: unknown,
+    { currentPassword, newPassword }: ChangePasswordParams,
+    { models, cpUser }: IContext,
+  ) {
+    if (!cpUser) {
+      throw new AuthenticationError('User not authenticated');
+    }
+
+    const user = await getCPUserByIdOrThrow(cpUser._id, models);
+
+    if (!user.password) {
+      throw new ValidationError('No password set for this account');
+    }
+
+    const isMatch = await models.CPUser.comparePassword(
+      currentPassword,
+      user.password,
+    );
+    if (!isMatch) {
+      throw new ValidationError('Current password is incorrect');
+    }
+
+    validatePassword(newPassword);
+
+    const hashedPassword = await models.CPUser.generatePassword(newPassword);
+    await models.CPUser.updateOne(
+      { _id: cpUser._id },
+      { $set: { password: hashedPassword }, $unset: { actionCode: '' } },
+    );
+
+    return getCPUserByIdOrThrow(cpUser._id, models);
   },
 };

--- a/backend/core-api/src/modules/clientportal/graphql/schemas/cpUser.ts
+++ b/backend/core-api/src/modules/clientportal/graphql/schemas/cpUser.ts
@@ -234,6 +234,7 @@ export const mutations = `
   clientPortalUserRequestChangePhone(newPhone: String!): String
   clientPortalUserConfirmChangePhone(code: String!): CPUser
   clientPortalUserDelete: CPUserRemoveResponse
+  clientPortalUserChangePassword(currentPassword: String!, newPassword: String!): CPUser
 `;
 
 export const queries = `

--- a/backend/core-api/src/modules/clientportal/types/cpUserParams.ts
+++ b/backend/core-api/src/modules/clientportal/types/cpUserParams.ts
@@ -111,6 +111,11 @@ export interface CpUsersSetPasswordParams {
   newPassword: string;
 }
 
+export interface ChangePasswordParams {
+  currentPassword: string;
+  newPassword: string;
+}
+
 export interface RequestChangeEmailParams {
   newEmail: string;
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a client portal GraphQL mutation to allow authenticated users to change their own password with validation.

New Features:
- Introduce a clientPortalUserChangePassword GraphQL mutation that updates a CP user's password after verifying the current password and validating the new one.

Enhancements:
- Define a ChangePasswordParams type for client portal password change input and wire it into the GraphQL schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now change their password in the client portal. The feature requires verification of the current password before allowing a new one to be set, with built-in validation for password strength and security requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erxes/erxes/pull/7822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->