### PR TITLE
fix: allow core app admins to read OAuth clients

### DIFF
--- a/backend/core-api/src/meta/permissions.ts
+++ b/backend/core-api/src/meta/permissions.ts
@@ -752,7 +752,7 @@ export const permissions: IPermissionConfig = {
         {
           plugin: 'core',
           module: 'apps',
-          actions: ['appsManage'],
+          actions: ['appsRead', 'appsManage'],
           scope: 'all',
         },
         {

--- a/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
+++ b/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
@@ -27,13 +27,27 @@ const buildOAuthClientQuery = (searchValue?: string) => {
   return query;
 };
 
+const checkOAuthClientReadPermission = async (
+  checkPermission: IContext['checkPermission'],
+) => {
+  try {
+    await checkPermission('appsRead');
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== 'Permission required') {
+      throw error;
+    }
+
+    await checkPermission('appsManage');
+  }
+};
+
 export const oauthClientAppQueries = {
   async oauthClientApps(
     _parent: undefined,
     { searchValue, page = 1, perPage = 20 }: any,
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.find(buildOAuthClientQuery(searchValue))
       .skip((page - 1) * perPage)
@@ -46,7 +60,7 @@ export const oauthClientAppQueries = {
     { searchValue }: { searchValue?: string },
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.countDocuments(
       buildOAuthClientQuery(searchValue),
@@ -58,7 +72,7 @@ export const oauthClientAppQueries = {
     { _id }: { _id: string },
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.findOne({ _id });
   },


### PR DESCRIPTION
## Summary
- Add appsRead to the Core modules admin default permission group
- Allow OAuth client read queries for users with appsManage so app admins can list OAuth clients

## Why
Users with Core modules admin had appsManage but OAuth client list queries required appsRead, causing Permission required errors.

## Verification
- git diff --check
- NODE_OPTIONS=--max-old-space-size=4096 pnpm nx build core-api

## Summary by Sourcery

Allow app administrators to read OAuth clients using either appsRead or appsManage permissions and align default Core admin permissions accordingly.

Bug Fixes:
- Permit OAuth client read queries for users with appsManage when appsRead is not granted by falling back to appsManage permission.

Enhancements:
- Add appsRead to the Core apps admin default permission group to keep permissions consistent for OAuth client access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admin role permissions to include read access for OAuth client apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->