### PR TITLE
loyalty-scores-detail-sheet

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreLog.ts
@@ -10,7 +10,6 @@ import {
 } from '@/score/constants';
 import { scoreLogSchema } from '@/score/db/definitions/scoreLog';
 import {
-  buildSignedScoreExpression,
   fixScoreNumber,
   getOwnerScoreValue,
   prepareScoreLogChange,
@@ -194,15 +193,11 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
     }
 
     public static async getScoreLogs(doc: IScoreLogParams) {
-      const { stageId, pipelineId, boardId, number, orderType } = doc;
+      const { stageId, pipelineId, boardId, number } = doc;
       const limit = Math.min(Math.max(Number(doc.limit) || 50, 1), 100);
       const direction = doc.direction === 'backward' ? 'backward' : 'forward';
-      const logsPerOwner = Math.min(
-        Math.max(Number(doc.logsPerOwner) || 5, 1),
-        100,
-      );
-      const orderBy: Record<string, SortOrder> =
-        orderType === 'createdAt' ? { createdAt: -1 } : { totalScore: -1 };
+
+      const orderBy: Record<string, SortOrder> = { createdAt: -1 };
 
       const sortFields = Object.keys(orderBy);
       const sortOrder = {
@@ -220,7 +215,7 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
       const filterAggregate: any[] = [];
 
       if (stageId || pipelineId || boardId || number) {
-        const lookup = [
+        filterAggregate.push(
           {
             $lookup: {
               from: 'deals',
@@ -232,55 +227,27 @@ export const loadScoreLogClass = (models: IModels, subdomain: string) => {
           {
             $unwind: '$target',
           },
-        ];
-
-        filterAggregate.push(...lookup);
+        );
       }
 
+      // Each score log is returned as an individual row (no per-owner
+      // grouping). A single person can therefore appear on multiple rows;
+      // their detail is derived on demand from these rows by owner.
       const basePipeline: any[] = [
         ...filterAggregate,
         {
           $match: { ...filter },
         },
-        {
-          $sort: { createdAt: -1, _id: -1 },
-        },
-        {
-          $addFields: {
-            signedScore: buildSignedScoreExpression(),
-          },
-        },
-        {
-          $group: {
-            _id: '$ownerId',
-            ownerType: { $first: '$ownerType' },
-            logs: { $push: '$$ROOT' },
-            createdAt: { $max: '$createdAt' },
-            totalScore: { $sum: '$signedScore' },
-          },
-        },
       ];
 
       const cursorMatch = doc.cursor
         ? buildCursorQuery(doc.cursor, orderBy, direction, {
-          createdAt: 'date',
-          totalScore: 'number',
-
-        })
+            createdAt: 'date',
+          })
         : null;
 
       const listPipeline: any[] = [
         ...basePipeline,
-        {
-          $project: {
-            _id: '$_id',
-            ownerId: '$_id',
-            ownerType: 1,
-            logs: { $slice: ['$logs', logsPerOwner] },
-            createdAt: 1,
-            totalScore: 1,
-          },
-        },
         ...(cursorMatch ? [{ $match: cursorMatch }] : []),
         { $sort: sortOrder },
         { $limit: limit + 1 },

--- a/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/customResolvers/scoreLogItem.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/graphql/resolvers/customResolvers/scoreLogItem.ts
@@ -28,7 +28,6 @@ export default {
     }
 
     const campaign = await models.ScoreCampaigns.findOne({ _id: campaignId }).lean();
-    console.log(lastOwner, campaign, 'ddd')
     if (campaign?.fieldId) {
       return lastOwner?.propertiesData?.[campaign?.fieldId]
     }

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
@@ -282,9 +282,9 @@ export const scoreLogColumns: ColumnDef<IScoreLog>[] = [
 // Columns for the per-person detail sheet: the same definitions as the main
 // list (so they stay in sync) minus the row actions and owner columns, which
 // are redundant when every row already belongs to the same person.
-const DETAIL_EXCLUDED_COLUMNS = ['more', 'ownerName', 'ownerType'];
+const DETAIL_EXCLUDED_COLUMNS = new Set(['more', 'ownerName', 'ownerType']);
 
 export const scoreDetailColumns: ColumnDef<IScoreLog>[] =
   scoreLogColumns.filter(
-    (column) => !DETAIL_EXCLUDED_COLUMNS.includes(column.id || ''),
+    (column) => !DETAIL_EXCLUDED_COLUMNS.has(column.id || ''),
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
@@ -13,7 +13,8 @@ import {
   IconTrophy,
   IconUser,
 } from '@tabler/icons-react';
-import { ColumnDef } from '@tanstack/table-core';
+import { ColumnDef, Row } from '@tanstack/table-core';
+import { useSetAtom } from 'jotai';
 import {
   Badge,
   fixNum,
@@ -23,8 +24,12 @@ import {
 } from 'erxes-ui';
 import { IScoreLog, IScoreOwner } from '../types/score';
 import { makeScoreMoreColumn } from './ScoreMoreColumn';
+import { scoreDetailRecordAtom } from '../states/scoreDetail';
 
-const getOwnerName = (owner?: IScoreOwner, ownerType?: string): string => {
+export const getOwnerName = (
+  owner?: IScoreOwner,
+  ownerType?: string,
+): string => {
   if (!owner) return '';
   if (ownerType === 'user') {
     return (
@@ -53,20 +58,30 @@ const formatDate = (dateStr?: string) => {
 
 const formatScore = (value?: number) => fixNum(value, 4).toLocaleString();
 
+const ScoreOwnerNameCell = ({ row }: { row: Row<IScoreLog> }) => {
+  const setDetailRecord = useSetAtom(scoreDetailRecordAtom);
+  const record = row.original;
+  const name = getOwnerName(record.owner, record.ownerType);
+
+  return (
+    <RecordTableInlineCell
+      className={record.ownerId ? 'cursor-pointer' : undefined}
+      onClick={() => {
+        if (record.ownerId) setDetailRecord(record);
+      }}
+    >
+      <TextOverflowTooltip value={name} />
+    </RecordTableInlineCell>
+  );
+};
+
 export const scoreLogColumns: ColumnDef<IScoreLog>[] = [
   makeScoreMoreColumn(),
   {
     id: 'ownerName',
     header: () => <RecordTable.InlineHead icon={IconUser} label="Owner Name" />,
     size: 180,
-    cell: ({ row }) => {
-      const name = getOwnerName(row.original.owner, row.original.ownerType);
-      return (
-        <RecordTableInlineCell>
-          <TextOverflowTooltip value={name} />
-        </RecordTableInlineCell>
-      );
-    },
+    cell: ({ row }) => <ScoreOwnerNameCell row={row} />,
   },
   {
     id: 'ownerType',
@@ -263,3 +278,13 @@ export const scoreLogColumns: ColumnDef<IScoreLog>[] = [
     ),
   },
 ];
+
+// Columns for the per-person detail sheet: the same definitions as the main
+// list (so they stay in sync) minus the row actions and owner columns, which
+// are redundant when every row already belongs to the same person.
+const DETAIL_EXCLUDED_COLUMNS = ['more', 'ownerName', 'ownerType'];
+
+export const scoreDetailColumns: ColumnDef<IScoreLog>[] =
+  scoreLogColumns.filter(
+    (column) => !DETAIL_EXCLUDED_COLUMNS.includes(column.id || ''),
+  );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
@@ -37,6 +37,46 @@ export const ScoreDetailSheet = ({
   const logs: IScoreLog[] = data?.scoreLogs?.list || [];
   const isTruncated = logs.length >= SCORE_DETAIL_LIMIT;
 
+  const renderBody = () => {
+    if (loading && logs.length === 0) {
+      return <Spinner containerClassName="py-10" />;
+    }
+
+    if (error) {
+      return (
+        <div className="flex items-center justify-center h-24 text-xs text-destructive">
+          {error.message || 'Failed to load score logs'}
+        </div>
+      );
+    }
+
+    if (logs.length === 0) {
+      return (
+        <div className="flex items-center justify-center h-24 text-xs text-muted-foreground">
+          No log records found
+        </div>
+      );
+    }
+
+    return (
+      <div className="rounded-md overflow-hidden">
+        <RecordTable.Provider columns={scoreDetailColumns} data={logs}>
+          <RecordTable>
+            <RecordTable.Header />
+            <RecordTable.Body>
+              <RecordTable.RowList />
+            </RecordTable.Body>
+          </RecordTable>
+        </RecordTable.Provider>
+        {isTruncated && (
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            Showing the latest {SCORE_DETAIL_LIMIT} entries.
+          </p>
+        )}
+      </div>
+    );
+  };
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View side="bottom" className="h-[70vh] p-0 flex flex-col">
@@ -53,33 +93,7 @@ export const ScoreDetailSheet = ({
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="flex-1 min-h-0 p-4 overflow-auto">
-          {loading && logs.length === 0 ? (
-            <Spinner containerClassName="py-10" />
-          ) : error ? (
-            <div className="flex items-center justify-center h-24 text-xs text-destructive">
-              {error.message || 'Failed to load score logs'}
-            </div>
-          ) : logs.length === 0 ? (
-            <div className="flex items-center justify-center h-24 text-xs text-muted-foreground">
-              No log records found
-            </div>
-          ) : (
-            <div className="rounded-md overflow-hidden">
-              <RecordTable.Provider columns={scoreDetailColumns} data={logs}>
-                <RecordTable>
-                  <RecordTable.Header />
-                  <RecordTable.Body>
-                    <RecordTable.RowList />
-                  </RecordTable.Body>
-                </RecordTable>
-              </RecordTable.Provider>
-              {isTruncated && (
-                <p className="mt-2 text-center text-xs text-muted-foreground">
-                  Showing the latest {SCORE_DETAIL_LIMIT} entries.
-                </p>
-              )}
-            </div>
-          )}
+          {renderBody()}
         </Sheet.Content>
       </Sheet.View>
     </Sheet>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
@@ -10,6 +10,8 @@ interface ScoreDetailSheetProps {
   record: IScoreLog | null;
 }
 
+const SCORE_DETAIL_LIMIT = 100;
+
 const formatScore = (value?: number) => fixNum(value, 4).toLocaleString();
 
 export const ScoreDetailSheet = ({
@@ -22,17 +24,18 @@ export const ScoreDetailSheet = ({
   // The detail is keyed by person: every score log row of the same owner opens
   // the same set of entries. We resolve them from the owner carried by the
   // selected (latest) score log, without a separate owner lookup.
-  const { data, loading } = useQuery(SCORE_LOGS_QUERY, {
+  const { data, loading, error } = useQuery(SCORE_LOGS_QUERY, {
     variables: {
       ownerId: record?.ownerId,
       ownerType: record?.ownerType,
-      limit: 100,
+      limit: SCORE_DETAIL_LIMIT,
     },
     skip: !open || !record?.ownerId,
     fetchPolicy: 'cache-and-network',
   });
 
   const logs: IScoreLog[] = data?.scoreLogs?.list || [];
+  const isTruncated = logs.length >= SCORE_DETAIL_LIMIT;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange} modal>
@@ -52,6 +55,10 @@ export const ScoreDetailSheet = ({
         <Sheet.Content className="flex-1 min-h-0 p-4 overflow-auto">
           {loading && logs.length === 0 ? (
             <Spinner containerClassName="py-10" />
+          ) : error ? (
+            <div className="flex items-center justify-center h-24 text-xs text-destructive">
+              {error.message || 'Failed to load score logs'}
+            </div>
           ) : logs.length === 0 ? (
             <div className="flex items-center justify-center h-24 text-xs text-muted-foreground">
               No log records found
@@ -66,6 +73,11 @@ export const ScoreDetailSheet = ({
                   </RecordTable.Body>
                 </RecordTable>
               </RecordTable.Provider>
+              {isTruncated && (
+                <p className="mt-2 text-center text-xs text-muted-foreground">
+                  Showing the latest {SCORE_DETAIL_LIMIT} entries.
+                </p>
+              )}
             </div>
           )}
         </Sheet.Content>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
@@ -1,0 +1,75 @@
+import { useQuery } from '@apollo/client';
+import { fixNum, RecordTable, Sheet, Spinner } from 'erxes-ui';
+import { SCORE_LOGS_QUERY } from '../graphql/queries';
+import { IScoreLog } from '../types/score';
+import { getOwnerName, scoreDetailColumns } from './ScoreColumns';
+
+interface ScoreDetailSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  record: IScoreLog | null;
+}
+
+const formatScore = (value?: number) => fixNum(value, 4).toLocaleString();
+
+export const ScoreDetailSheet = ({
+  open,
+  onOpenChange,
+  record,
+}: ScoreDetailSheetProps) => {
+  const ownerName = record ? getOwnerName(record.owner, record.ownerType) : '';
+
+  // The detail is keyed by person: every score log row of the same owner opens
+  // the same set of entries. We resolve them from the owner carried by the
+  // selected (latest) score log, without a separate owner lookup.
+  const { data, loading } = useQuery(SCORE_LOGS_QUERY, {
+    variables: {
+      ownerId: record?.ownerId,
+      ownerType: record?.ownerType,
+      limit: 100,
+    },
+    skip: !open || !record?.ownerId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const logs: IScoreLog[] = data?.scoreLogs?.list || [];
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange} modal>
+      <Sheet.View side="bottom" className="h-[70vh] p-0 flex flex-col">
+        <Sheet.Header className="border-b px-6 py-4 gap-3 shrink-0">
+          <div>
+            <Sheet.Title>{ownerName || '—'}</Sheet.Title>
+            <p className="text-xs text-muted-foreground mt-1 capitalize">
+              {record?.ownerType || ''} · Total Score:{' '}
+              <span className="font-semibold text-foreground">
+                {formatScore(record?.totalScore)}
+              </span>
+            </p>
+          </div>
+          <Sheet.Close />
+        </Sheet.Header>
+        <Sheet.Content className="flex-1 min-h-0 p-4 overflow-auto">
+          {loading && logs.length === 0 ? (
+            <Spinner containerClassName="py-10" />
+          ) : logs.length === 0 ? (
+            <div className="flex items-center justify-center h-24 text-xs text-muted-foreground">
+              No log records found
+            </div>
+          ) : (
+            <div className="rounded-md overflow-hidden">
+              <RecordTable.Provider columns={scoreDetailColumns} data={logs}>
+                <RecordTable>
+                  <RecordTable.Header />
+                  <RecordTable.Body>
+                    <RecordTable.RowList />
+                  </RecordTable.Body>
+                </RecordTable>
+              </RecordTable.Provider>
+            </div>
+          )}
+        </Sheet.Content>
+      </Sheet.View>
+    </Sheet>
+  );
+};

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreMoreColumn.tsx
@@ -1,8 +1,11 @@
 import { Cell } from '@tanstack/react-table';
+import { useState } from 'react';
+import { useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { Popover, Command, Combobox, RecordTable } from 'erxes-ui';
-import { IconExternalLink } from '@tabler/icons-react';
+import { IconExternalLink, IconListDetails } from '@tabler/icons-react';
 import { IScoreLog } from '../types/score';
+import { scoreDetailRecordAtom } from '../states/scoreDetail';
 
 export const getProfileUrl = (ownerId: string, ownerType: string): string => {
   switch (ownerType) {
@@ -26,22 +29,40 @@ export const ScoreMoreColumnCell = ({
   cell: Cell<IScoreLog, unknown>;
 }) => {
   const navigate = useNavigate();
+  const setDetailRecord = useSetAtom(scoreDetailRecordAtom);
   const record = cell.row.original;
   const { ownerId, ownerType } = record;
 
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
   const handleSeeProfile = () => {
     if (!ownerId || !ownerType) return;
+    setPopoverOpen(false);
     navigate(getProfileUrl(ownerId, ownerType));
   };
 
+  const handleSeeDetail = () => {
+    if (!ownerId) return;
+    setPopoverOpen(false);
+    setDetailRecord(record);
+  };
+
   return (
-    <Popover>
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <Popover.Trigger asChild>
         <RecordTable.MoreButton className="w-full h-full" />
       </Popover.Trigger>
       <Combobox.Content>
         <Command shouldFilter={false}>
           <Command.List>
+            <Command.Item
+              value="detail"
+              onSelect={handleSeeDetail}
+              disabled={!ownerId}
+            >
+              <IconListDetails size={14} />
+              Detail
+            </Command.Item>
             <Command.Item
               value="see-profile"
               onSelect={handleSeeProfile}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreRecordTable.tsx
@@ -1,3 +1,4 @@
+import { useAtom } from 'jotai';
 import { RecordTable, Spinner } from 'erxes-ui';
 import { IconStar } from '@tabler/icons-react';
 import { scoreLogColumns } from './ScoreColumns';
@@ -6,17 +7,21 @@ import {
   useScoreList,
 } from '../hooks/useScoreList';
 import { GiveScoreModal } from './GiveScoreModal';
+import { ScoreDetailSheet } from './ScoreDetailSheet';
+import { scoreDetailRecordAtom } from '../states/scoreDetail';
 
 export const ScoreRecordTable = () => {
   const { list, loading, handleFetchMore, pageInfo } = useScoreList();
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
+  const [detailRecord, setDetailRecord] = useAtom(scoreDetailRecordAtom);
 
   const columnsKey = scoreLogColumns.map((c) => c.id || '').join('|');
 
   if (loading && !list?.length) return <Spinner />;
 
   return (
-    <RecordTable.Provider
+    <>
+      <RecordTable.Provider
       key={columnsKey}
       columns={scoreLogColumns}
       data={list || []}
@@ -61,6 +66,14 @@ export const ScoreRecordTable = () => {
           </div>
         )}
       </RecordTable.CursorProvider>
-    </RecordTable.Provider>
+      </RecordTable.Provider>
+      <ScoreDetailSheet
+        open={!!detailRecord}
+        onOpenChange={(value) => {
+          if (!value) setDetailRecord(null);
+        }}
+        record={detailRecord}
+      />
+    </>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerById.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerById.tsx
@@ -1,39 +1,16 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { cn, Combobox, Command, Form, Popover } from 'erxes-ui';
 import { useQuery, gql } from '@apollo/client';
+
+// Customer / company / team-member owners use the shared `ui-modules` selects
+// (see SelectOwnerByType). Client portal users have no ready-made select there,
+// so the lightweight one below is kept for that owner type.
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SelectOption {
   value: string;
   label: string;
-}
-
-interface CustomerItem {
-  _id: string;
-  firstName?: string;
-  lastName?: string;
-  primaryEmail?: string;
-  primaryPhone?: string;
-}
-
-interface CompanyItem {
-  _id: string;
-  primaryName?: string;
-  primaryEmail?: string;
-  primaryPhone?: string;
-}
-
-interface UserDetails {
-  fullName?: string;
-  firstName?: string;
-  lastName?: string;
-}
-
-interface UserItem {
-  _id: string;
-  email?: string;
-  details?: UserDetails;
 }
 
 interface CpUserItem {
@@ -52,47 +29,6 @@ interface SelectOwnerFormItemProps {
 }
 
 // ─── Queries ──────────────────────────────────────────────────────────────────
-
-const GET_CUSTOMERS = gql`
-  query ScoreCustomersSimple($searchValue: String, $limit: Int) {
-    customers(searchValue: $searchValue, limit: $limit) {
-      list {
-        _id
-        firstName
-        lastName
-        primaryEmail
-        primaryPhone
-      }
-    }
-  }
-`;
-
-const GET_COMPANIES = gql`
-  query ScoreCompaniesSimple($searchValue: String, $limit: Int) {
-    companies(searchValue: $searchValue, limit: $limit) {
-      list {
-        _id
-        primaryName
-        primaryEmail
-        primaryPhone
-      }
-    }
-  }
-`;
-
-const GET_USERS = gql`
-  query ScoreUsersSimple($searchValue: String, $isActive: Boolean) {
-    allUsers(searchValue: $searchValue, isActive: $isActive) {
-      _id
-      email
-      details {
-        fullName
-        firstName
-        lastName
-      }
-    }
-  }
-`;
 
 const GET_CLIENT_PORTAL_USERS = gql`
   query ScoreClientPortalUsersSimple($filter: IClientPortalUserFilter) {
@@ -150,197 +86,6 @@ const SelectTrigger = ({
     )}
   </Combobox.Trigger>
 );
-
-// ─── Customer ──────────────────────────────────────────────────────────────────
-
-export const SelectCustomerFormItem = ({
-  value,
-  onValueChange,
-  placeholder = 'Choose customer',
-  className,
-}: SelectOwnerFormItemProps) => {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-
-  const { data, loading } = useQuery<{ customers: { list: CustomerItem[] } }>(
-    GET_CUSTOMERS,
-    { variables: { searchValue: search || undefined, limit: 50 } },
-  );
-
-  const options = useMemo<SelectOption[]>(
-    () =>
-      (data?.customers?.list || []).map((c) => ({
-        value: c._id,
-        label: c.firstName || c.primaryEmail || c.primaryPhone || 'Unnamed',
-      })),
-    [data?.customers?.list],
-  );
-
-  const selected = options.find((o) => o.value === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Form.Control>
-        <SelectTrigger
-          selected={selected}
-          placeholder={placeholder}
-          className={className}
-        />
-      </Form.Control>
-      <Combobox.Content>
-        <Command shouldFilter={false}>
-          <Command.Input
-            value={search}
-            onValueChange={setSearch}
-            placeholder="Search customers..."
-          />
-          <Command.Empty>
-            {loading ? 'Loading...' : 'No customers found'}
-          </Command.Empty>
-          <Command.List>
-            <OptionList
-              options={options}
-              value={value}
-              onSelect={(v) => {
-                onValueChange(v);
-                setOpen(false);
-              }}
-            />
-          </Command.List>
-        </Command>
-      </Combobox.Content>
-    </Popover>
-  );
-};
-
-// ─── Company ──────────────────────────────────────────────────────────────────
-
-export const SelectCompanyFormItem = ({
-  value,
-  onValueChange,
-  placeholder = 'Choose company',
-  className,
-}: SelectOwnerFormItemProps) => {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-
-  const { data, loading } = useQuery<{ companies: { list: CompanyItem[] } }>(
-    GET_COMPANIES,
-    { variables: { searchValue: search || undefined, limit: 50 } },
-  );
-
-  const options = useMemo<SelectOption[]>(
-    () =>
-      (data?.companies?.list || []).map((c) => ({
-        value: c._id,
-        label: c.primaryName || c.primaryEmail || c.primaryPhone || 'Unnamed',
-      })),
-    [data?.companies?.list],
-  );
-
-  const selected = options.find((o) => o.value === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Form.Control>
-        <SelectTrigger
-          selected={selected}
-          placeholder={placeholder}
-          className={className}
-        />
-      </Form.Control>
-      <Combobox.Content>
-        <Command shouldFilter={false}>
-          <Command.Input
-            value={search}
-            onValueChange={setSearch}
-            placeholder="Search companies..."
-          />
-          <Command.Empty>
-            {loading ? 'Loading...' : 'No companies found'}
-          </Command.Empty>
-          <Command.List>
-            <OptionList
-              options={options}
-              value={value}
-              onSelect={(v) => {
-                onValueChange(v);
-                setOpen(false);
-              }}
-            />
-          </Command.List>
-        </Command>
-      </Combobox.Content>
-    </Popover>
-  );
-};
-
-// ─── Team Member ──────────────────────────────────────────────────────────────
-
-export const SelectUserFormItem = ({
-  value,
-  onValueChange,
-  placeholder = 'Choose team member',
-  className,
-}: SelectOwnerFormItemProps) => {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-
-  const { data, loading } = useQuery<{ allUsers: UserItem[] }>(GET_USERS, {
-    variables: { searchValue: search || undefined, isActive: true },
-  });
-
-  const options = useMemo<SelectOption[]>(
-    () =>
-      (data?.allUsers || []).map((u) => ({
-        value: u._id,
-        label:
-          u.details?.fullName ||
-          [u.details?.firstName, u.details?.lastName]
-            .filter(Boolean)
-            .join(' ') ||
-          u.email ||
-          'Unnamed',
-      })),
-    [data?.allUsers],
-  );
-
-  const selected = options.find((o) => o.value === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Form.Control>
-        <SelectTrigger
-          selected={selected}
-          placeholder={placeholder}
-          className={className}
-        />
-      </Form.Control>
-      <Combobox.Content>
-        <Command shouldFilter={false}>
-          <Command.Input
-            value={search}
-            onValueChange={setSearch}
-            placeholder="Search team members..."
-          />
-          <Command.Empty>
-            {loading ? 'Loading...' : 'No team members found'}
-          </Command.Empty>
-          <Command.List>
-            <OptionList
-              options={options}
-              value={value}
-              onSelect={(v) => {
-                onValueChange(v);
-                setOpen(false);
-              }}
-            />
-          </Command.List>
-        </Command>
-      </Combobox.Content>
-    </Popover>
-  );
-};
 
 // ─── Client Portal User ───────────────────────────────────────────────────────
 

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
@@ -1,9 +1,5 @@
-import {
-  SelectCustomerFormItem,
-  SelectCompanyFormItem,
-  SelectUserFormItem,
-  SelectClientPortalUserFormItem,
-} from './SelectOwnerById';
+import { SelectCustomer, SelectCompany, SelectMember } from 'ui-modules';
+import { SelectClientPortalUserFormItem } from './SelectOwnerById';
 
 type Props = {
   ownerType: string;
@@ -26,30 +22,32 @@ export const SelectOwnerByType = ({
   placeholder,
 }: Props) => {
   const resolvedPlaceholder = placeholder || PLACEHOLDERS[ownerType];
+  const handleChange = (val: string | string[] | null) =>
+    onValueChange((Array.isArray(val) ? val[0] : val) || '');
 
   switch (ownerType) {
     case 'customer':
       return (
-        <SelectCustomerFormItem
+        <SelectCustomer
           value={value}
-          onValueChange={onValueChange}
-          placeholder={resolvedPlaceholder}
+          onValueChange={handleChange}
+          mode="single"
         />
       );
     case 'company':
       return (
-        <SelectCompanyFormItem
+        <SelectCompany
           value={value}
-          onValueChange={onValueChange}
-          placeholder={resolvedPlaceholder}
+          onValueChange={handleChange}
+          mode="single"
         />
       );
     case 'user':
       return (
-        <SelectUserFormItem
+        <SelectMember.FormItem
           value={value}
-          onValueChange={onValueChange}
-          placeholder={resolvedPlaceholder}
+          onValueChange={handleChange}
+          mode="single"
         />
       );
     case 'cpUser':

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
@@ -48,6 +48,7 @@ export const SelectOwnerByType = ({
           value={value}
           onValueChange={handleChange}
           mode="single"
+          placeholder={resolvedPlaceholder}
         />
       );
     case 'cpUser':

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/states/scoreDetail.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/states/scoreDetail.ts
@@ -1,0 +1,7 @@
+import { atom } from 'jotai';
+import { IScoreLog } from '../types/score';
+
+// The score log row whose per-person detail sheet is open (null when closed).
+// Kept at the table level so the row "Detail" action and the single sheet
+// instance share state without a component import cycle.
+export const scoreDetailRecordAtom = atom<IScoreLog | null>(null);

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
@@ -3,56 +3,9 @@ import { Button, Form, Sheet, Select } from 'erxes-ui';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAddSpin } from '../hooks/useAddSpin';
-import { SelectCustomer, SelectMember } from 'ui-modules';
-import { SelectCompany } from 'ui-modules/modules/contacts/components/SelectCompany';
-import { SelectClientPortalUserFormItem } from '../../scores/components/selects/SelectOwnerById';
+import { SelectOwnerByType } from '../../scores/components/selects/SelectOwnerByType';
 import { SelectSpinCampaign } from './selects/SelectSpinCampaign';
 import { SelectVoucherCampaign } from '../../vouchers/components/selects/SelectVoucherCampaign';
-
-const SpinOwnerSelect = ({
-  ownerType,
-  value,
-  onChange,
-}: {
-  ownerType: string;
-  value: string;
-  onChange: (val: string) => void;
-}) => {
-  if (ownerType === 'company') {
-    return (
-      <SelectCompany
-        value={value}
-        onValueChange={(val) => onChange(val as string)}
-        mode="single"
-      />
-    );
-  }
-  if (ownerType === 'user') {
-    return (
-      <SelectMember.FormItem
-        value={value}
-        onValueChange={(val) => onChange(val as string)}
-        mode="single"
-      />
-    );
-  }
-  if (ownerType === 'cpUser') {
-    return (
-      <SelectClientPortalUserFormItem
-        value={value}
-        onValueChange={onChange}
-        placeholder="Choose client portal user"
-      />
-    );
-  }
-  return (
-    <SelectCustomer
-      value={value}
-      onValueChange={(val) => onChange(val as string)}
-      mode="single"
-    />
-  );
-};
 
 interface SpinAddFormValues {
   campaignId: string;
@@ -172,10 +125,10 @@ export const SpinAddSheet = () => {
                   <Form.Item>
                     <Form.Label>Owner *</Form.Label>
                     <Form.Control>
-                      <SpinOwnerSelect
+                      <SelectOwnerByType
                         ownerType={ownerType}
                         value={field.value}
-                        onChange={field.onChange}
+                        onValueChange={field.onChange}
                       />
                     </Form.Control>
                     <Form.Message />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
@@ -20,7 +20,11 @@ const SpinOwnerSelect = ({
 }) => {
   if (ownerType === 'company') {
     return (
-      <SelectCompany value={value} onValueChange={onChange} mode="single" />
+      <SelectCompany
+        value={value}
+        onValueChange={(val) => onChange(val as string)}
+        mode="single"
+      />
     );
   }
   if (ownerType === 'user') {
@@ -42,7 +46,11 @@ const SpinOwnerSelect = ({
     );
   }
   return (
-    <SelectCustomer value={value} onValueChange={onChange} mode="single" />
+    <SelectCustomer
+      value={value}
+      onValueChange={(val) => onChange(val as string)}
+      mode="single"
+    />
   );
 };
 

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
@@ -20,7 +20,11 @@ const SpinOwnerSelect = ({
 }) => {
   if (ownerType === 'company') {
     return (
-      <SelectCompany value={value} onValueChange={onChange} mode="single" />
+      <SelectCompany
+        value={value}
+        onValueChange={(val) => onChange(val as string)}
+        mode="single"
+      />
     );
   }
   if (ownerType === 'user') {
@@ -42,7 +46,11 @@ const SpinOwnerSelect = ({
     );
   }
   return (
-    <SelectCustomer value={value} onValueChange={onChange} mode="single" />
+    <SelectCustomer
+      value={value}
+      onValueChange={(val) => onChange(val as string)}
+      mode="single"
+    />
   );
 };
 

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
@@ -2,57 +2,10 @@ import { Button, Form, Sheet, Select } from 'erxes-ui';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useEditSpin } from '../hooks/useEditSpin';
-import { SelectCustomer, SelectMember } from 'ui-modules';
-import { SelectCompany } from 'ui-modules/modules/contacts/components/SelectCompany';
-import { SelectClientPortalUserFormItem } from '../../scores/components/selects/SelectOwnerById';
+import { SelectOwnerByType } from '../../scores/components/selects/SelectOwnerByType';
 import { ISpin } from '../types/spin';
 import { SelectSpinCampaign } from './selects/SelectSpinCampaign';
 import { SelectVoucherCampaign } from '../../vouchers/components/selects/SelectVoucherCampaign';
-
-const SpinOwnerSelect = ({
-  ownerType,
-  value,
-  onChange,
-}: {
-  ownerType: string;
-  value: string;
-  onChange: (val: string) => void;
-}) => {
-  if (ownerType === 'company') {
-    return (
-      <SelectCompany
-        value={value}
-        onValueChange={(val) => onChange(val as string)}
-        mode="single"
-      />
-    );
-  }
-  if (ownerType === 'user') {
-    return (
-      <SelectMember.FormItem
-        value={value}
-        onValueChange={(val) => onChange(val as string)}
-        mode="single"
-      />
-    );
-  }
-  if (ownerType === 'cpUser') {
-    return (
-      <SelectClientPortalUserFormItem
-        value={value}
-        onValueChange={onChange}
-        placeholder="Choose client portal user"
-      />
-    );
-  }
-  return (
-    <SelectCustomer
-      value={value}
-      onValueChange={(val) => onChange(val as string)}
-      mode="single"
-    />
-  );
-};
 
 interface SpinEditFormValues {
   campaignId: string;
@@ -188,10 +141,10 @@ export const SpinEditSheet = ({
                   <Form.Item>
                     <Form.Label>Owner *</Form.Label>
                     <Form.Control>
-                      <SpinOwnerSelect
+                      <SelectOwnerByType
                         ownerType={ownerType}
                         value={field.value}
-                        onChange={field.onChange}
+                        onValueChange={field.onChange}
                       />
                     </Form.Control>
                     <Form.Message />


### PR DESCRIPTION
## Summary by Sourcery

Add a per-owner score detail sheet for loyalty scores and simplify backend score log retrieval to return individual log rows instead of grouped per owner.

New Features:
- Introduce a bottom sheet view showing detailed score logs for a selected owner from the loyalty scores table, accessible from row actions and owner name clicks.

Bug Fixes:
- Remove a stray console.log from the score log item resolver to avoid noisy server logs.

Enhancements:
- Reuse shared owner select components from ui-modules for customers, companies, and team members in loyalty score and spin flows, keeping the lightweight client portal user select locally.
- Expose reusable score owner name helpers and define a dedicated column set for the detail sheet that stays in sync with the main score list.
- Adjust score log ordering to consistently sort by creation time and simplify aggregation by removing per-owner grouping and per-owner log limits.
- Harden owner-select handlers in spin sheets and score owner selector to accommodate the shared select components' value types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-owner Score Detail sheet (accessible from a new "Detail" action) showing total and recent score entries.

* **Refactor**
  * Score list now returns individual log entries with consistent ordering.
  * Unified owner selection controls and streamlined owner-name/columns; detail UI wired to shared state.

* **Bug Fixes**
  * Removed an extraneous debug log during score total computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->