### PR TITLE
feat(operation): add filtered export for tasks and projects

### DIFF
--- a/backend/erxes-api-shared/src/core-modules/import-export/utils/exportBatchProcess.ts
+++ b/backend/erxes-api-shared/src/core-modules/import-export/utils/exportBatchProcess.ts
@@ -357,7 +357,11 @@ export const createExportBatchProcessor = (
           selectedFields.includes(h.key),
         )
         .map((h: { label: string; key: string }) => h.label);
-      const headerKeys = selectedFields;
+      const headerKeys = exportHeaders
+        .filter((h: { label: string; key: string }) =>
+          selectedFields.includes(h.key),
+        )
+        .map((h: { label: string; key: string }) => h.key);
 
       const tempWorkspace = await createImportExportTempWorkspace({
         kind: 'export',

--- a/backend/plugins/operation_api/src/main.ts
+++ b/backend/plugins/operation_api/src/main.ts
@@ -7,6 +7,14 @@ import { generateModels } from './connectionResolvers';
 import * as trpc from './trpc/init-trpc';
 import { permissions } from './meta/permissions';
 import { notifications } from './meta/notifications';
+import {
+  createCoreModuleProducerHandler,
+  TImportExportProducers,
+  TGetExportDataInput,
+  TGetExportHeadersInput,
+} from 'erxes-api-shared/core-modules';
+import { taskExportHandlers } from './modules/task/meta/import-export/export/exportHandlers';
+import { projectExportHandlers } from './modules/project/meta/import-export/export/exportHandlers';
 
 export const router: Router = Router();
 
@@ -45,6 +53,41 @@ startPlugin({
   },
 
   expressRouter: router,
+
+  importExport: {
+    export: {
+      types: [
+        {
+          label: 'Task',
+          contentType: 'operation:task.tasks',
+        },
+        {
+          label: 'Project',
+          contentType: 'operation:project.projects',
+        },
+      ],
+      getExportHeaders: createCoreModuleProducerHandler({
+        moduleName: 'importExport',
+        modules: {
+          tasks: taskExportHandlers,
+          projects: projectExportHandlers,
+        },
+        methodName: TImportExportProducers.GET_EXPORT_HEADERS,
+        extractModuleName: (input: any) => input.collectionName || 'tasks',
+        generateModels,
+      }),
+      getExportData: createCoreModuleProducerHandler({
+        moduleName: 'importExport',
+        modules: {
+          tasks: taskExportHandlers,
+          projects: projectExportHandlers,
+        },
+        methodName: TImportExportProducers.GET_EXPORT_DATA,
+        extractModuleName: (input: any) => input.collectionName || 'tasks',
+        generateModels,
+      }),
+    },
+  },
 
   meta: {
     permissions,

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/buildProjectExportRow.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/buildProjectExportRow.ts
@@ -25,7 +25,10 @@ export const cleanDescription = (description: any) => {
   if (typeof description === 'string' && (description.startsWith('[') || description.startsWith('{'))) {
     try {
       const parsed = JSON.parse(description);
-      if (Array.isArray(parsed)) {
+      const isArray = Array.isArray(parsed);
+      const isObject = typeof parsed === 'object' && parsed !== null;
+      if (isArray || isObject) {
+        const blocks = isArray ? parsed : [parsed];
         const extractText = (content: any[]): string => {
           if (!Array.isArray(content)) return '';
           return content
@@ -52,7 +55,7 @@ export const cleanDescription = (description: any) => {
           return text;
         };
 
-        return parsed.map(processBlock).filter(Boolean).join('\n');
+        return blocks.map(processBlock).filter(Boolean).join('\n');
       }
     } catch {
       // ignore

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/buildProjectExportRow.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/buildProjectExportRow.ts
@@ -1,0 +1,151 @@
+import { IProjectDocument } from '../../../@types/project';
+
+export const defaultProjectFieldFormatter = (value: any) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.join('; ');
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+
+  return String(value);
+};
+
+export const cleanDescription = (description: any) => {
+  if (!description) return '';
+  if (typeof description === 'string' && (description.startsWith('[') || description.startsWith('{'))) {
+    try {
+      const parsed = JSON.parse(description);
+      if (Array.isArray(parsed)) {
+        const extractText = (content: any[]): string => {
+          if (!Array.isArray(content)) return '';
+          return content
+            .map((item) => {
+              if (item.type === 'link') {
+                return extractText(item.content || []);
+              }
+              return item.text || '';
+            })
+            .join('');
+        };
+
+        const processBlock = (block: any): string => {
+          let text = '';
+          if (block.content) {
+            text += extractText(block.content);
+          }
+          if (block.children && Array.isArray(block.children)) {
+            const childrenText = block.children.map(processBlock).filter(Boolean).join('\n');
+            if (childrenText) {
+              text += '\n' + childrenText;
+            }
+          }
+          return text;
+        };
+
+        return parsed.map(processBlock).filter(Boolean).join('\n');
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return String(description);
+};
+
+const getDeepValue = (obj: any, path: string) => {
+  if (!path.includes('.')) return obj?.[path];
+  return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+};
+
+export const buildProjectExportRow = (
+  project: IProjectDocument,
+  selectedFields?: string[],
+  maps?: {
+    statusMap?: Map<string, string>;
+    teamMap?: Map<string, string>;
+    leadMap?: Map<string, string>;
+    membersMap?: Map<string, string>;
+    creatorMap?: Map<string, string>;
+    tagMap?: Map<string, string>;
+  },
+  formatter = defaultProjectFieldFormatter,
+): Record<string, any> => {
+  const formatValue = formatter || defaultProjectFieldFormatter;
+
+  const {
+    statusMap,
+    teamMap,
+    leadMap,
+    membersMap,
+    creatorMap,
+    tagMap,
+  } = maps || {};
+
+  const formatTeams = (teamIds?: any[]) => {
+    if (!teamIds || !teamIds.length) return '';
+    return teamIds.map(id => teamMap?.get(String(id)) || String(id)).join(', ');
+  };
+
+  const formatMembers = (memberIds?: any[]) => {
+    if (!memberIds || !memberIds.length) return '';
+    return memberIds.map(id => membersMap?.get(String(id)) || String(id)).join(', ');
+  };
+
+  const formatTags = (tagIds?: any[]) => {
+    if (!tagIds || !tagIds.length) return '';
+    return tagIds.map(id => tagMap?.get(String(id)) || String(id)).join(', ');
+  };
+
+  const allFields: Record<string, any> = {
+    _id: formatValue(project._id),
+    name: formatValue(project.name),
+    description: formatValue(cleanDescription(project.description)),
+    status: formatValue(statusMap?.get(String(project.status)) || project.status),
+    priority: formatValue(project.priority),
+    teams: formatValue(formatTeams(project.teamIds)),
+    tags: formatValue(formatTags(project.tagIds)),
+    startDate: formatValue(project.startDate ? new Date(project.startDate) : ''),
+    targetDate: formatValue(project.targetDate ? new Date(project.targetDate) : ''),
+    lead: formatValue(leadMap?.get(String(project.leadId)) || project.leadId),
+    members: formatValue(formatMembers(project.memberIds)),
+    createdBy: formatValue(creatorMap?.get(String(project.createdBy)) || project.createdBy),
+    createdAt: formatValue(project.createdAt ? new Date(project.createdAt) : ''),
+  };
+
+  if (selectedFields?.length) {
+    const result: Record<string, any> = { _id: String(project._id || '') };
+
+    for (const key of selectedFields) {
+      if (key === 'description') {
+        result[key] = formatValue(cleanDescription(project.description));
+      } else if (key === 'status') {
+        result[key] = formatValue(statusMap?.get(String(project.status)) || project.status);
+      } else if (key === 'teams') {
+        result[key] = formatValue(formatTeams(project.teamIds));
+      } else if (key === 'tags') {
+        result[key] = formatValue(formatTags(project.tagIds));
+      } else if (key === 'lead') {
+        result[key] = formatValue(leadMap?.get(String(project.leadId)) || project.leadId);
+      } else if (key === 'members') {
+        result[key] = formatValue(formatMembers(project.memberIds));
+      } else if (key === 'createdBy') {
+        result[key] = formatValue(creatorMap?.get(String(project.createdBy)) || project.createdBy);
+      } else {
+        result[key] = formatValue(getDeepValue(project, key));
+      }
+    }
+
+    return result;
+  }
+
+  return allFields;
+};

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/exportHandlers.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/exportHandlers.ts
@@ -1,0 +1,32 @@
+import {
+  TExportHandlers,
+  IImportExportContext,
+} from 'erxes-api-shared/core-modules';
+import { getProjectExportHeaders } from './getProjectExportHeaders';
+import { getProjectExportData } from './getProjectExportData';
+
+const projectExportMap: Record<string, any> = {
+  projects: {
+    getExportHeaders: getProjectExportHeaders,
+    getExportData: getProjectExportData,
+  },
+};
+
+export const projectExportHandlers: TExportHandlers = {
+  getExportHeaders: async (data: any, ctx: IImportExportContext) => {
+    const { collectionName } = data;
+    const handler = projectExportMap[collectionName]?.getExportHeaders;
+    if (!handler) {
+      throw new Error(`Export headers handler not found for ${collectionName}`);
+    }
+    return handler(data, ctx);
+  },
+  getExportData: async (args: any, ctx: IImportExportContext) => {
+    const { collectionName } = args;
+    const handler = projectExportMap[collectionName]?.getExportData;
+    if (!handler) {
+      throw new Error(`Export handler not found for ${collectionName}`);
+    }
+    return handler(args, ctx);
+  },
+};

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportData.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportData.ts
@@ -1,0 +1,225 @@
+import {
+  GetExportData,
+  IImportExportContext,
+  buildExportCursorQuery,
+  normalizeExportLimit,
+} from 'erxes-api-shared/core-modules';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { IModels } from '~/connectionResolvers';
+import { buildProjectExportRow } from './buildProjectExportRow';
+import { escapeRegExp } from 'erxes-api-shared/utils';
+import { STATUS_TYPES } from '@/status/constants/types';
+import { IProjectDocument, IProjectFilter } from '../../../@types/project';
+import mongoose, { FilterQuery } from 'mongoose';
+
+interface IUser {
+  _id: string;
+  username?: string;
+  email?: string;
+  details?: {
+    fullName?: string;
+    firstName?: string;
+    lastName?: string;
+  };
+}
+
+export async function getProjectExportData(
+  data: GetExportData & {
+    search?: string;
+    filters?: IProjectFilter;
+  },
+  { subdomain, models }: IImportExportContext<IModels>,
+): Promise<Record<string, any>[]> {
+  const { cursor, limit, ids, selectedFields, filters } = data;
+  const effectiveLimit = normalizeExportLimit(limit, 100);
+
+  if (!models) {
+    throw new Error('Models not available in context');
+  }
+
+  const { Project, Team, TeamMember } = models;
+
+  const filter = { ...data, ...(filters || {}) };
+
+  const query: FilterQuery<IProjectDocument> = {};
+
+  if (filter._ids && filter._ids.length) {
+    query._id = { $in: filter._ids };
+  }
+
+  if (filter.name) {
+    query.name = { $regex: filter.name, $options: 'i' };
+  } else if (filter.search?.trim()) {
+    const sv = escapeRegExp(filter.search.trim());
+    const re = new RegExp(sv, 'i');
+    query.$or = [{ name: re }, { description: re }];
+  }
+
+  if (filter.status) {
+    query.status = filter.status;
+  }
+
+  if (filter.priority) {
+    query.priority = filter.priority;
+  }
+
+  if (filter.startDate) {
+    query.startDate = { $gte: new Date(filter.startDate) };
+  }
+
+  if (filter.targetDate) {
+    query.targetDate = { $gte: new Date(filter.targetDate) };
+  }
+
+  if (filter.leadId) {
+    query.leadId = filter.leadId;
+  }
+
+  if (filter.memberIds && filter.memberIds.length > 0) {
+    query.memberIds = { $in: filter.memberIds };
+  }
+
+  if (filter.memberId) {
+    query.$or = [
+      { memberIds: { $in: [filter.memberId] } },
+      { leadId: filter.memberId },
+    ];
+  }
+
+  if (filter.tagIds && filter.tagIds.length > 0) {
+    query.tagIds = { $in: filter.tagIds };
+  }
+
+  if (filter.teamIds && filter.teamIds.length > 0) {
+    query.teamIds = { $in: filter.teamIds };
+  }
+
+  if (
+    (filter.teamIds && filter.teamIds.length <= 0 && filter.userId) ||
+    (!filter.teamIds && !filter.memberId && filter.userId)
+  ) {
+    const teamIds = await TeamMember.find({
+      memberId: filter.userId,
+    }).distinct('teamId');
+
+    if (filter.userId) {
+      query.$or = [
+        { teamIds: { $in: teamIds } },
+        { leadId: filter.userId },
+        { memberIds: filter.userId },
+      ];
+    } else {
+      query.teamIds = { $in: teamIds };
+    }
+  }
+
+  if (filter.active) {
+    const statusFilter = {
+      $nin: [STATUS_TYPES.CANCELLED, STATUS_TYPES.COMPLETED],
+    };
+
+    if (filter.taskId) {
+      const task = await models.Task.findOne({
+        _id: filter.taskId,
+      });
+
+      if (task?.projectId) {
+        query.$or = [{ status: statusFilter }, { _id: task.projectId }];
+      } else {
+        query.status = statusFilter;
+      }
+    } else {
+      query.status = statusFilter;
+    }
+  }
+
+  const { query: exportQuery, isIdsMode } = buildExportCursorQuery({
+    baseQuery: query as Record<string, any>,
+    cursor,
+    ids,
+    limit: effectiveLimit,
+  });
+
+  if (isIdsMode && (exportQuery._id as any)?.$in?.length === 0) {
+    return [];
+  }
+
+  const projects = await Project.find(exportQuery)
+    .sort({ _id: 1 })
+    .limit(effectiveLimit)
+    .lean();
+
+  const teamIds = new Set<string>();
+  const userIds = new Set<string>();
+  const tagIds = new Set<string>();
+
+  for (const p of projects) {
+    if (p.teamIds) {
+      p.teamIds.forEach(id => teamIds.add(String(id)));
+    }
+    if (p.tagIds) {
+      p.tagIds.forEach(id => tagIds.add(String(id)));
+    }
+    if (p.leadId) userIds.add(String(p.leadId));
+    if (p.memberIds) {
+      p.memberIds.forEach(id => userIds.add(String(id)));
+    }
+    if (p.createdBy) userIds.add(String(p.createdBy));
+  }
+
+  const [teams, users, tags] = await Promise.all([
+    teamIds.size ? Team.find({ _id: { $in: Array.from(teamIds) } }).select('_id name').lean() : [],
+    userIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'users',
+          action: 'find',
+          input: { query: { _id: { $in: Array.from(userIds) } } },
+        })
+      : [],
+    tagIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'tags',
+          action: 'find',
+          input: { query: { _id: { $in: Array.from(tagIds) } } },
+        })
+      : [],
+  ]);
+
+  const statusMap = new Map<string, string>([
+    [String(STATUS_TYPES.BACKLOG), 'Backlog'],
+    [String(STATUS_TYPES.UNSTARTED), 'Todo'],
+    [String(STATUS_TYPES.STARTED), 'In progress'],
+    [String(STATUS_TYPES.COMPLETED), 'Done'],
+    [String(STATUS_TYPES.CANCELLED), 'Cancelled'],
+    [String(STATUS_TYPES.TRIAGE), 'Triage'],
+  ]);
+
+  const teamMap = new Map<string, string>();
+  (teams || []).forEach((t: { _id: string | mongoose.Types.ObjectId; name?: string }) => teamMap.set(String(t._id), t.name || ''));
+
+  const userMap = new Map<string, string>();
+  (users || []).forEach((u: IUser) => {
+    const name = u.details?.fullName || `${u.details?.firstName || ''} ${u.details?.lastName || ''}`.trim() || u.username || u.email || '';
+    userMap.set(String(u._id), name);
+  });
+
+  const tagMap = new Map<string, string>();
+  (tags || []).forEach((t: { _id: string; name?: string }) => tagMap.set(String(t._id), t.name || ''));
+
+  return projects.map((p: any) =>
+    buildProjectExportRow(p, selectedFields, {
+      statusMap,
+      teamMap,
+      leadMap: userMap,
+      membersMap: userMap,
+      creatorMap: userMap,
+      tagMap,
+    }),
+  );
+}

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportData.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportData.ts
@@ -42,17 +42,18 @@ export async function getProjectExportData(
   const filter = { ...data, ...(filters || {}) };
 
   const query: FilterQuery<IProjectDocument> = {};
+  const andFilters: any[] = [];
 
   if (filter._ids && filter._ids.length) {
     query._id = { $in: filter._ids };
   }
 
   if (filter.name) {
-    query.name = { $regex: filter.name, $options: 'i' };
+    query.name = { $regex: escapeRegExp(filter.name), $options: 'i' };
   } else if (filter.search?.trim()) {
     const sv = escapeRegExp(filter.search.trim());
     const re = new RegExp(sv, 'i');
-    query.$or = [{ name: re }, { description: re }];
+    andFilters.push({ $or: [{ name: re }, { description: re }] });
   }
 
   if (filter.status) {
@@ -80,10 +81,12 @@ export async function getProjectExportData(
   }
 
   if (filter.memberId) {
-    query.$or = [
-      { memberIds: { $in: [filter.memberId] } },
-      { leadId: filter.memberId },
-    ];
+    andFilters.push({
+      $or: [
+        { memberIds: { $in: [filter.memberId] } },
+        { leadId: filter.memberId },
+      ],
+    });
   }
 
   if (filter.tagIds && filter.tagIds.length > 0) {
@@ -103,11 +106,13 @@ export async function getProjectExportData(
     }).distinct('teamId');
 
     if (filter.userId) {
-      query.$or = [
-        { teamIds: { $in: teamIds } },
-        { leadId: filter.userId },
-        { memberIds: filter.userId },
-      ];
+      andFilters.push({
+        $or: [
+          { teamIds: { $in: teamIds } },
+          { leadId: filter.userId },
+          { memberIds: filter.userId },
+        ],
+      });
     } else {
       query.teamIds = { $in: teamIds };
     }
@@ -124,13 +129,19 @@ export async function getProjectExportData(
       });
 
       if (task?.projectId) {
-        query.$or = [{ status: statusFilter }, { _id: task.projectId }];
+        andFilters.push({
+          $or: [{ status: statusFilter }, { _id: task.projectId }],
+        });
       } else {
         query.status = statusFilter;
       }
     } else {
       query.status = statusFilter;
     }
+  }
+
+  if (andFilters.length > 0) {
+    query.$and = andFilters;
   }
 
   const { query: exportQuery, isIdsMode } = buildExportCursorQuery({

--- a/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportHeaders.ts
+++ b/backend/plugins/operation_api/src/modules/project/meta/import-export/export/getProjectExportHeaders.ts
@@ -1,0 +1,24 @@
+import {
+    ImportHeaderDefinition,
+    IImportExportContext,
+  } from 'erxes-api-shared/core-modules';
+  
+  export async function getProjectExportHeaders(
+    _data: any,
+    _ctx: IImportExportContext,
+  ): Promise<ImportHeaderDefinition[]> {
+    return [
+      { label: 'Name', key: 'name', isDefault: true },
+      { label: 'Description', key: 'description' },
+      { label: 'Status', key: 'status' },
+      { label: 'Priority', key: 'priority' },
+      { label: 'Teams', key: 'teams' },
+      { label: 'Tags', key: 'tags' },
+      { label: 'Start Date', key: 'startDate' },
+      { label: 'Target Date', key: 'targetDate' },
+      { label: 'Lead', key: 'lead' },
+      { label: 'Members', key: 'members' },
+      { label: 'Created By', key: 'createdBy' },
+      { label: 'Created At', key: 'createdAt' },
+    ];
+  }

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
@@ -80,6 +80,8 @@ export const buildTaskExportRow = (
     assigneeMap?: Map<string, string>;
     creatorMap?: Map<string, string>;
     teamMap?: Map<string, string>;
+    tagMap?: Map<string, string>;
+    labelMap?: Map<string, string>;
   },
   formatter = defaultTaskFieldFormatter,
 ): Record<string, any> => {
@@ -93,7 +95,19 @@ export const buildTaskExportRow = (
     assigneeMap,
     creatorMap,
     teamMap,
+    tagMap,
+    labelMap,
   } = maps || {};
+
+  const formatTags = (tagIds?: any[]) => {
+    if (!tagIds || !tagIds.length) return '';
+    return tagIds.map((id) => tagMap?.get(String(id)) || String(id)).join(', ');
+  };
+
+  const formatLabels = (labelIds?: any[]) => {
+    if (!labelIds || !labelIds.length) return '';
+    return labelIds.map((id) => labelMap?.get(String(id)) || String(id)).join(', ');
+  };
 
   const allFields: Record<string, any> = {
     _id: formatValue(task._id),
@@ -103,8 +117,8 @@ export const buildTaskExportRow = (
     status: formatValue(statusMap?.get(String(task.status)) || task.status),
     team: formatValue(teamMap?.get(String(task.teamId)) || task.teamId),
     priority: formatValue(task.priority),
-    labels: formatValue(task.labelIds),
-    tags: formatValue(task.tagIds),
+    labels: formatValue(formatLabels(task.labelIds)),
+    tags: formatValue(formatTags(task.tagIds)),
     assignee: formatValue(assigneeMap?.get(String(task.assigneeId)) || task.assigneeId),
     createdBy: formatValue(creatorMap?.get(String(task.createdBy)) || task.createdBy),
     
@@ -129,6 +143,8 @@ export const buildTaskExportRow = (
       if (key === 'description') result[key] = formatValue(cleanDescription(task.description));
       else if (key === 'status') result[key] = formatValue(statusMap?.get(String(task.status)) || task.status);
       else if (key === 'team') result[key] = formatValue(teamMap?.get(String(task.teamId)) || task.teamId);
+      else if (key === 'labels') result[key] = formatValue(formatLabels(task.labelIds));
+      else if (key === 'tags') result[key] = formatValue(formatTags(task.tagIds));
       else if (key === 'assignee') result[key] = formatValue(assigneeMap?.get(String(task.assigneeId)) || task.assigneeId);
       else if (key === 'createdBy') result[key] = formatValue(creatorMap?.get(String(task.createdBy)) || task.createdBy);
       else if (key === 'project') result[key] = formatValue(projectMap?.get(String(task.projectId)) || task.projectId);

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
@@ -1,0 +1,141 @@
+import { ITaskDocument } from '../../../@types/task';
+
+export const defaultTaskFieldFormatter = (value: any) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.join('; ');
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+
+  return String(value);
+};
+
+export const cleanDescription = (description: any) => {
+  if (!description) return '';
+  if (typeof description === 'string' && (description.startsWith('[') || description.startsWith('{'))) {
+    try {
+      const parsed = JSON.parse(description);
+      if (Array.isArray(parsed)) {
+        const extractText = (content: any[]): string => {
+          if (!Array.isArray(content)) return '';
+          return content
+            .map((item) => {
+              if (item.type === 'link') {
+                return extractText(item.content || []);
+              }
+              return item.text || '';
+            })
+            .join('');
+        };
+
+        const processBlock = (block: any): string => {
+          let text = '';
+          if (block.content) {
+            text += extractText(block.content);
+          }
+          if (block.children && Array.isArray(block.children)) {
+            const childrenText = block.children.map(processBlock).filter(Boolean).join('\n');
+            if (childrenText) {
+              text += '\n' + childrenText;
+            }
+          }
+          return text;
+        };
+
+        return parsed.map(processBlock).filter(Boolean).join('\n');
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return String(description);
+};
+
+const getDeepValue = (obj: any, path: string) => {
+  if (!path.includes('.')) return obj?.[path];
+  return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+};
+
+export const buildTaskExportRow = (
+  task: ITaskDocument & { number?: number },
+  selectedFields?: string[],
+  maps?: {
+    statusMap?: Map<string, string>;
+    projectMap?: Map<string, string>;
+    cycleMap?: Map<string, string>;
+    milestoneMap?: Map<string, string>;
+    assigneeMap?: Map<string, string>;
+    creatorMap?: Map<string, string>;
+    teamMap?: Map<string, string>;
+  },
+  formatter = defaultTaskFieldFormatter,
+): Record<string, any> => {
+  const formatValue = formatter || defaultTaskFieldFormatter;
+
+  const {
+    statusMap,
+    projectMap,
+    cycleMap,
+    milestoneMap,
+    assigneeMap,
+    creatorMap,
+    teamMap,
+  } = maps || {};
+
+  const allFields: Record<string, any> = {
+    _id: formatValue(task._id),
+    name: formatValue(task.name),
+    description: formatValue(cleanDescription(task.description)),
+    
+    status: formatValue(statusMap?.get(String(task.status)) || task.status),
+    team: formatValue(teamMap?.get(String(task.teamId)) || task.teamId),
+    priority: formatValue(task.priority),
+    labels: formatValue(task.labelIds),
+    tags: formatValue(task.tagIds),
+    assignee: formatValue(assigneeMap?.get(String(task.assigneeId)) || task.assigneeId),
+    createdBy: formatValue(creatorMap?.get(String(task.createdBy)) || task.createdBy),
+    
+    startDate: formatValue(task.startDate ? new Date(task.startDate) : ''),
+    targetDate: formatValue(task.targetDate ? new Date(task.targetDate) : ''),
+    
+    cycle: formatValue(cycleMap?.get(String(task.cycleId)) || task.cycleId),
+    project: formatValue(projectMap?.get(String(task.projectId)) || task.projectId),
+    milestone: formatValue(milestoneMap?.get(String(task.milestoneId)) || task.milestoneId),
+    
+    estimatePoint: formatValue(task.estimatePoint),
+    statusChangedDate: formatValue(task.statusChangedDate ? new Date(task.statusChangedDate) : ''),
+    number: formatValue(task.number),
+    statusType: formatValue(task.statusType),
+    createdAt: formatValue(task.createdAt ? new Date(task.createdAt) : ''),
+  };
+
+  if (selectedFields?.length) {
+    const result: Record<string, any> = { _id: String(task._id || '') };
+
+    for (const key of selectedFields) {
+      if (key === 'description') result[key] = formatValue(cleanDescription(task.description));
+      else if (key === 'status') result[key] = formatValue(statusMap?.get(String(task.status)) || task.status);
+      else if (key === 'team') result[key] = formatValue(teamMap?.get(String(task.teamId)) || task.teamId);
+      else if (key === 'assignee') result[key] = formatValue(assigneeMap?.get(String(task.assigneeId)) || task.assigneeId);
+      else if (key === 'createdBy') result[key] = formatValue(creatorMap?.get(String(task.createdBy)) || task.createdBy);
+      else if (key === 'project') result[key] = formatValue(projectMap?.get(String(task.projectId)) || task.projectId);
+      else if (key === 'cycle') result[key] = formatValue(cycleMap?.get(String(task.cycleId)) || task.cycleId);
+      else if (key === 'milestone') result[key] = formatValue(milestoneMap?.get(String(task.milestoneId)) || task.milestoneId);
+      else result[key] = formatValue(getDeepValue(task, key));
+    }
+
+    return result;
+  }
+
+  return allFields;
+};

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/buildTaskExportRow.ts
@@ -25,7 +25,10 @@ export const cleanDescription = (description: any) => {
   if (typeof description === 'string' && (description.startsWith('[') || description.startsWith('{'))) {
     try {
       const parsed = JSON.parse(description);
-      if (Array.isArray(parsed)) {
+      const isArray = Array.isArray(parsed);
+      const isObject = typeof parsed === 'object' && parsed !== null;
+      if (isArray || isObject) {
+        const blocks = isArray ? parsed : [parsed];
         const extractText = (content: any[]): string => {
           if (!Array.isArray(content)) return '';
           return content
@@ -52,7 +55,7 @@ export const cleanDescription = (description: any) => {
           return text;
         };
 
-        return parsed.map(processBlock).filter(Boolean).join('\n');
+        return blocks.map(processBlock).filter(Boolean).join('\n');
       }
     } catch {
       // ignore

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/exportHandlers.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/exportHandlers.ts
@@ -1,0 +1,32 @@
+import {
+  TExportHandlers,
+  IImportExportContext,
+} from 'erxes-api-shared/core-modules';
+import { getTaskExportHeaders } from './getTaskExportHeaders';
+import { getTaskExportData } from './getTaskExportData';
+
+const taskExportMap: Record<string, any> = {
+  tasks: {
+    getExportHeaders: getTaskExportHeaders,
+    getExportData: getTaskExportData,
+  },
+};
+
+export const taskExportHandlers: TExportHandlers = {
+  getExportHeaders: async (data: any, ctx: IImportExportContext) => {
+    const { collectionName } = data;
+    const handler = taskExportMap[collectionName]?.getExportHeaders;
+    if (!handler) {
+      throw new Error(`Export headers handler not found for ${collectionName}`);
+    }
+    return handler(data, ctx);
+  },
+  getExportData: async (args: any, ctx: IImportExportContext) => {
+    const { collectionName } = args;
+    const handler = taskExportMap[collectionName]?.getExportData;
+    if (!handler) {
+      throw new Error(`Export handler not found for ${collectionName}`);
+    }
+    return handler(args, ctx);
+  },
+};

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
@@ -74,7 +74,7 @@ export async function getTaskExportData(
   const query: FilterQuery<ITaskDocument> = {};
 
   if (filter.name) {
-    query.name = { $regex: filter.name, $options: 'i' };
+    query.name = { $regex: escapeRegExp(filter.name), $options: 'i' };
   } else if (filter.search?.trim()) {
     const sv = escapeRegExp(filter.search.trim());
     const re = new RegExp(sv, 'i');
@@ -155,6 +155,9 @@ export async function getTaskExportData(
           teamId: filter.teamId,
           endDate: { $lt: now },
         }).distinct('_id');
+        if (pastCycles.length === 0) {
+          return [];
+        }
         query.cycleId = { $in: pastCycles } as any;
         break;
       }
@@ -166,6 +169,8 @@ export async function getTaskExportData(
         }).sort({ endDate: -1 });
         if (previousCycle) {
           query.cycleId = previousCycle._id;
+        } else {
+          return [];
         }
         break;
       }
@@ -178,6 +183,8 @@ export async function getTaskExportData(
         });
         if (currentCycle) {
           query.cycleId = currentCycle._id;
+        } else {
+          return [];
         }
         break;
       }
@@ -189,6 +196,8 @@ export async function getTaskExportData(
         }).sort({ startDate: 1 });
         if (upcomingCycle) {
           query.cycleId = upcomingCycle._id;
+        } else {
+          return [];
         }
         break;
       }
@@ -198,6 +207,9 @@ export async function getTaskExportData(
           teamId: filter.teamId,
           startDate: { $gt: now },
         }).distinct('_id');
+        if (futureCycles.length === 0) {
+          return [];
+        }
         query.cycleId = { $in: futureCycles } as any;
         break;
       }

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
@@ -1,0 +1,415 @@
+import {
+  GetExportData,
+  IImportExportContext,
+  buildExportCursorQuery,
+  normalizeExportLimit,
+} from 'erxes-api-shared/core-modules';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { IModels } from '~/connectionResolvers';
+import { buildTaskExportRow } from './buildTaskExportRow';
+import { escapeRegExp } from 'erxes-api-shared/utils';
+import { STATUS_TYPES } from '@/status/constants/types';
+import { ITaskDocument, ITaskFilter } from '../../../@types/task';
+import mongoose, { FilterQuery } from 'mongoose';
+
+interface IUser {
+  _id: string;
+  username?: string;
+  email?: string;
+  details?: {
+    fullName?: string;
+    firstName?: string;
+    lastName?: string;
+  };
+}
+
+const handleDateFilter = (
+  filterQuery: FilterQuery<ITaskDocument>,
+  fieldName: string,
+  value: string | Date,
+) => {
+  if (value === 'no-date') {
+    filterQuery[fieldName] = { $exists: false };
+    return;
+  }
+
+  if (value === 'in-past') {
+    filterQuery[fieldName] = { $lt: new Date() };
+    return;
+  }
+
+  const stringValue = value instanceof Date ? value.toISOString() : value;
+
+  filterQuery[fieldName] = { $lte: new Date(stringValue) };
+};
+
+export async function getTaskExportData(
+  data: GetExportData & {
+    search?: string;
+    projectId?: string;
+    cycleId?: string;
+    milestone?: string;
+    status?: string;
+    assigneeId?: string;
+    priority?: string;
+    teamId?: string;
+    startDate?: string;
+    endDate?: string;
+    filters?: ITaskFilter;
+  },
+  { subdomain, models }: IImportExportContext<IModels>,
+): Promise<Record<string, any>[]> {
+  const { cursor, limit, ids, selectedFields, filters } = data;
+  const effectiveLimit = normalizeExportLimit(limit, 100);
+
+  if (!models) {
+    throw new Error('Models not available in context');
+  }
+
+  const { Task, Team, Status, Project, Milestone, Cycle } = models;
+
+  // Merge direct query parameters and nested filters
+  const filter = { ...data, ...(filters || {}) };
+
+  const query: FilterQuery<ITaskDocument> = {};
+
+  if (filter.name) {
+    query.name = { $regex: filter.name, $options: 'i' };
+  } else if (filter.search?.trim()) {
+    const sv = escapeRegExp(filter.search.trim());
+    const re = new RegExp(sv, 'i');
+    query.$or = [{ name: re }, { description: re }];
+  }
+
+  if (filter.status) {
+    query.status = filter.status;
+  }
+  if (filter.statusType) {
+    query.statusType = filter.statusType;
+  }
+
+  if (filter.priority !== undefined && filter.priority !== '') {
+    query.priority = Number(filter.priority);
+  }
+
+  if (filter.startDate) {
+    handleDateFilter(query, 'startDate', filter.startDate);
+  }
+
+  if (filter.targetDate) {
+    handleDateFilter(query, 'targetDate', filter.targetDate);
+  }
+
+  if (filter.createdDate) {
+    handleDateFilter(query, 'createdAt', filter.createdDate);
+  } else if (filter.startDate || filter.endDate) {
+    const createdAtQuery: Record<string, Date> = {};
+    if (filter.startDate) {
+      createdAtQuery.$gte = new Date(filter.startDate);
+    }
+    if (filter.endDate) {
+      createdAtQuery.$lte = new Date(filter.endDate);
+    }
+    query.createdAt = createdAtQuery;
+  }
+
+  if (filter.updatedDate) {
+    handleDateFilter(query, 'updatedAt', filter.updatedDate);
+  }
+
+  if (filter.completedDate) {
+    query.statusType = STATUS_TYPES.COMPLETED;
+    handleDateFilter(query, 'statusChangedDate', filter.completedDate);
+  }
+
+  if (filter.teamId) {
+    query.teamId = filter.teamId;
+  }
+
+  if (filter.createdBy) {
+    query.createdBy = filter.createdBy;
+  }
+
+  if (filter.assigneeId) {
+    if (filter.assigneeId === 'no-assignee') {
+      query.assigneeId = { $exists: false } as any;
+    } else {
+      query.assigneeId = filter.assigneeId;
+    }
+  }
+
+  if (filter.cycleId) {
+    query.cycleId = filter.cycleId;
+  }
+
+  if (filter.cycleFilter && filter.teamId) {
+    const now = new Date();
+
+    switch (filter.cycleFilter) {
+      case 'noCycle':
+        query.cycleId = null;
+        break;
+
+      case 'anyPastCycle': {
+        const pastCycles = await models.Cycle.find({
+          teamId: filter.teamId,
+          endDate: { $lt: now },
+        }).distinct('_id');
+        query.cycleId = { $in: pastCycles } as any;
+        break;
+      }
+
+      case 'previousCycle': {
+        const previousCycle = await models.Cycle.findOne({
+          teamId: filter.teamId,
+          endDate: { $lt: now },
+        }).sort({ endDate: -1 });
+        if (previousCycle) {
+          query.cycleId = previousCycle._id;
+        }
+        break;
+      }
+
+      case 'currentCycle': {
+        const currentCycle = await models.Cycle.findOne({
+          teamId: filter.teamId,
+          startDate: { $lte: now },
+          endDate: { $gte: now },
+        });
+        if (currentCycle) {
+          query.cycleId = currentCycle._id;
+        }
+        break;
+      }
+
+      case 'upcomingCycle': {
+        const upcomingCycle = await models.Cycle.findOne({
+          teamId: filter.teamId,
+          startDate: { $gt: now },
+        }).sort({ startDate: 1 });
+        if (upcomingCycle) {
+          query.cycleId = upcomingCycle._id;
+        }
+        break;
+      }
+
+      case 'anyFutureCycle': {
+        const futureCycles = await models.Cycle.find({
+          teamId: filter.teamId,
+          startDate: { $gt: now },
+        }).distinct('_id');
+        query.cycleId = { $in: futureCycles } as any;
+        break;
+      }
+    }
+  }
+
+  if (filter.projectId) {
+    if (filter.projectId === 'no-project') {
+      query.projectId = { $exists: false } as any;
+    } else {
+      query.projectId = filter.projectId;
+    }
+  }
+
+  if (
+    filter.projectStatus ||
+    filter.projectPriority ||
+    filter.projectLeadId ||
+    filter.projectMilestoneName
+  ) {
+    let projectIds: string[] = [];
+
+    if (filter.projectMilestoneName) {
+      const matchingMilestones = await models.Milestone.find({
+        name: { $regex: filter.projectMilestoneName, $options: 'i' },
+      }).distinct('projectId');
+
+      if (matchingMilestones.length === 0) {
+        return [];
+      }
+
+      projectIds = matchingMilestones;
+    }
+
+    if (
+      filter.projectStatus ||
+      filter.projectPriority ||
+      filter.projectLeadId
+    ) {
+      const projectFilter: FilterQuery<any> = {};
+
+      if (filter.projectStatus) {
+        projectFilter.status = filter.projectStatus;
+      }
+
+      if (filter.projectPriority) {
+        projectFilter.priority = filter.projectPriority;
+      }
+
+      if (filter.projectLeadId) {
+        projectFilter.leadId = filter.projectLeadId;
+      }
+
+      if (projectIds.length > 0) {
+        projectFilter._id = { $in: projectIds };
+      }
+
+      const matchingProjects =
+        await models.Project.find(projectFilter).distinct('_id');
+
+      if (matchingProjects.length === 0) {
+        return [];
+      }
+
+      projectIds = matchingProjects;
+    }
+
+    if (projectIds.length > 0) {
+      if (query.projectId) {
+        if (!projectIds.includes(query.projectId as string)) {
+          return [];
+        }
+      } else {
+        query.projectId = { $in: projectIds } as any;
+      }
+    }
+  }
+
+  if (filter.milestoneId) {
+    query.milestoneId = filter.milestoneId;
+  } else if (filter.milestone) {
+    query.milestoneId = filter.milestone;
+  }
+
+  if (filter.estimatePoint) {
+    query.estimatePoint = filter.estimatePoint;
+  }
+
+  if (filter.tagIds && filter.tagIds.length > 0) {
+    query.tagIds = { $in: filter.tagIds } as any;
+  }
+
+  if (filter.labelIds && filter.labelIds.length > 0) {
+    query.labelIds = { $in: filter.labelIds } as any;
+  }
+
+  if (
+    filter.teamId &&
+    filter.projectId &&
+    filter.projectId !== 'no-project'
+  ) {
+    delete query.teamId;
+  }
+
+  if (
+    filter.userId &&
+    !filter.teamId &&
+    !filter.assigneeId &&
+    !filter.projectId
+  ) {
+    query.assigneeId = filter.userId;
+  }
+
+  const { query: exportQuery, isIdsMode } = buildExportCursorQuery({
+    baseQuery: query as Record<string, any>,
+    cursor,
+    ids,
+    limit: effectiveLimit,
+  });
+
+  if (isIdsMode && (exportQuery._id as any)?.$in?.length === 0) {
+    return [];
+  }
+
+  const tasks = await Task.find(exportQuery)
+    .sort({ _id: 1 })
+    .limit(effectiveLimit)
+    .lean();
+
+  const statusIds = new Set<string>();
+  const teamIds = new Set<string>();
+  const projectIds = new Set<string>();
+  const milestoneIds = new Set<string>();
+  const cycleIds = new Set<string>();
+  const assigneeIds = new Set<string>();
+  const creatorIds = new Set<string>();
+
+  for (const t of tasks) {
+    if (t.status) statusIds.add(String(t.status));
+    if (t.teamId) teamIds.add(String(t.teamId));
+    if (t.projectId) projectIds.add(String(t.projectId));
+    if (t.milestoneId) milestoneIds.add(String(t.milestoneId));
+    if (t.cycleId) cycleIds.add(String(t.cycleId));
+    if (t.assigneeId) assigneeIds.add(String(t.assigneeId));
+    if (t.createdBy) creatorIds.add(String(t.createdBy));
+  }
+
+  const [statuses, teams, projects, milestones, cycles, users, creators] = await Promise.all([
+    statusIds.size ? Status.find({ _id: { $in: Array.from(statusIds) } }).select('_id name').lean() : [],
+    teamIds.size ? Team.find({ _id: { $in: Array.from(teamIds) } }).select('_id name').lean() : [],
+    projectIds.size ? Project.find({ _id: { $in: Array.from(projectIds) } }).select('_id name').lean() : [],
+    milestoneIds.size ? Milestone.find({ _id: { $in: Array.from(milestoneIds) } }).select('_id name').lean() : [],
+    cycleIds.size ? Cycle.find({ _id: { $in: Array.from(cycleIds) } }).select('_id name').lean() : [],
+    
+    assigneeIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'users',
+          action: 'find',
+          input: { query: { _id: { $in: Array.from(assigneeIds) } } },
+        })
+      : [],
+    creatorIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'users',
+          action: 'find',
+          input: { query: { _id: { $in: Array.from(creatorIds) } } },
+        })
+      : [],
+  ]);
+
+  const statusMap = new Map<string, string>();
+  (statuses || []).forEach((s: { _id: string | mongoose.Types.ObjectId; name?: string }) => statusMap.set(String(s._id), s.name || ''));
+
+  const teamMap = new Map<string, string>();
+  (teams || []).forEach((t: { _id: string | mongoose.Types.ObjectId; name?: string }) => teamMap.set(String(t._id), t.name || ''));
+
+  const projectMap = new Map<string, string>();
+  (projects || []).forEach((p: { _id: string | mongoose.Types.ObjectId; name?: string }) => projectMap.set(String(p._id), p.name || ''));
+
+  const milestoneMap = new Map<string, string>();
+  (milestones || []).forEach((m: { _id: string | mongoose.Types.ObjectId; name?: string }) => milestoneMap.set(String(m._id), m.name || ''));
+
+  const cycleMap = new Map<string, string>();
+  (cycles || []).forEach((c: { _id: string | mongoose.Types.ObjectId; name?: string }) => cycleMap.set(String(c._id), c.name || ''));
+
+  const assigneeMap = new Map<string, string>();
+  (users || []).forEach((u: IUser) => {
+    const name = u.details?.fullName || `${u.details?.firstName || ''} ${u.details?.lastName || ''}`.trim() || u.username || u.email || '';
+    assigneeMap.set(String(u._id), name);
+  });
+
+  const creatorMap = new Map<string, string>();
+  (creators || []).forEach((c: IUser) => {
+    const name = c.details?.fullName || `${c.details?.firstName || ''} ${c.details?.lastName || ''}`.trim() || c.username || c.email || '';
+    creatorMap.set(String(c._id), name);
+  });
+
+  return tasks.map((t: any) =>
+    buildTaskExportRow(t, selectedFields, {
+      statusMap,
+      projectMap,
+      cycleMap,
+      milestoneMap,
+      assigneeMap,
+      creatorMap,
+      teamMap,
+    }),
+  );
+}

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
@@ -337,6 +337,7 @@ export async function getTaskExportData(
   const cycleIds = new Set<string>();
   const assigneeIds = new Set<string>();
   const creatorIds = new Set<string>();
+  const tagIds = new Set<string>();
 
   for (const t of tasks) {
     if (t.status) statusIds.add(String(t.status));
@@ -346,9 +347,12 @@ export async function getTaskExportData(
     if (t.cycleId) cycleIds.add(String(t.cycleId));
     if (t.assigneeId) assigneeIds.add(String(t.assigneeId));
     if (t.createdBy) creatorIds.add(String(t.createdBy));
+    if (t.tagIds) {
+      t.tagIds.forEach((id) => tagIds.add(String(id)));
+    }
   }
 
-  const [statuses, teams, projects, milestones, cycles, users, creators] = await Promise.all([
+  const [statuses, teams, projects, milestones, cycles, users, creators, tags] = await Promise.all([
     statusIds.size ? Status.find({ _id: { $in: Array.from(statusIds) } }).select('_id name').lean() : [],
     teamIds.size ? Team.find({ _id: { $in: Array.from(teamIds) } }).select('_id name').lean() : [],
     projectIds.size ? Project.find({ _id: { $in: Array.from(projectIds) } }).select('_id name').lean() : [],
@@ -373,6 +377,16 @@ export async function getTaskExportData(
           module: 'users',
           action: 'find',
           input: { query: { _id: { $in: Array.from(creatorIds) } } },
+        })
+      : [],
+    tagIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          method: 'query',
+          module: 'tags',
+          action: 'find',
+          input: { query: { _id: { $in: Array.from(tagIds) } } },
         })
       : [],
   ]);
@@ -404,6 +418,9 @@ export async function getTaskExportData(
     creatorMap.set(String(c._id), name);
   });
 
+  const tagMap = new Map<string, string>();
+  (tags || []).forEach((t: { _id: string; name?: string }) => tagMap.set(String(t._id), t.name || ''));
+
   return tasks.map((t: any) =>
     buildTaskExportRow(t, selectedFields, {
       statusMap,
@@ -413,6 +430,7 @@ export async function getTaskExportData(
       assigneeMap,
       creatorMap,
       teamMap,
+      tagMap,
     }),
   );
 }

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
@@ -102,15 +102,6 @@ export async function getTaskExportData(
 
   if (filter.createdDate) {
     handleDateFilter(query, 'createdAt', filter.createdDate);
-  } else if (filter.startDate || filter.endDate) {
-    const createdAtQuery: Record<string, Date> = {};
-    if (filter.startDate) {
-      createdAtQuery.$gte = new Date(filter.startDate);
-    }
-    if (filter.endDate) {
-      createdAtQuery.$lte = new Date(filter.endDate);
-    }
-    query.createdAt = createdAtQuery;
   }
 
   if (filter.updatedDate) {

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportData.ts
@@ -338,6 +338,7 @@ export async function getTaskExportData(
   const assigneeIds = new Set<string>();
   const creatorIds = new Set<string>();
   const tagIds = new Set<string>();
+  const labelIds = new Set<string>();
 
   for (const t of tasks) {
     if (t.status) statusIds.add(String(t.status));
@@ -350,9 +351,12 @@ export async function getTaskExportData(
     if (t.tagIds) {
       t.tagIds.forEach((id) => tagIds.add(String(id)));
     }
+    if (t.labelIds) {
+      t.labelIds.forEach((id) => labelIds.add(String(id)));
+    }
   }
 
-  const [statuses, teams, projects, milestones, cycles, users, creators, tags] = await Promise.all([
+  const [statuses, teams, projects, milestones, cycles, users, creators, tags, labels] = await Promise.all([
     statusIds.size ? Status.find({ _id: { $in: Array.from(statusIds) } }).select('_id name').lean() : [],
     teamIds.size ? Team.find({ _id: { $in: Array.from(teamIds) } }).select('_id name').lean() : [],
     projectIds.size ? Project.find({ _id: { $in: Array.from(projectIds) } }).select('_id name').lean() : [],
@@ -389,6 +393,16 @@ export async function getTaskExportData(
           input: { query: { _id: { $in: Array.from(tagIds) } } },
         })
       : [],
+    labelIds.size
+      ? sendTRPCMessage({
+          subdomain,
+          pluginName: 'sales',
+          method: 'query',
+          module: 'pipelineLabel',
+          action: 'find',
+          input: { _id: { $in: Array.from(labelIds) } },
+        })
+      : [],
   ]);
 
   const statusMap = new Map<string, string>();
@@ -421,6 +435,9 @@ export async function getTaskExportData(
   const tagMap = new Map<string, string>();
   (tags || []).forEach((t: { _id: string; name?: string }) => tagMap.set(String(t._id), t.name || ''));
 
+  const labelMap = new Map<string, string>();
+  (labels || []).forEach((l: { _id: string; name?: string }) => labelMap.set(String(l._id), l.name || ''));
+
   return tasks.map((t: any) =>
     buildTaskExportRow(t, selectedFields, {
       statusMap,
@@ -431,6 +448,7 @@ export async function getTaskExportData(
       creatorMap,
       teamMap,
       tagMap,
+      labelMap,
     }),
   );
 }

--- a/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportHeaders.ts
+++ b/backend/plugins/operation_api/src/modules/task/meta/import-export/export/getTaskExportHeaders.ts
@@ -1,0 +1,32 @@
+import {
+    ImportHeaderDefinition,
+    IImportExportContext,
+  } from 'erxes-api-shared/core-modules';
+  
+  export async function getTaskExportHeaders(
+    _data: any,
+    _ctx: IImportExportContext,
+  ): Promise<ImportHeaderDefinition[]> {
+    return [
+      { label: 'Name', key: 'name', isDefault: true },
+      { label: 'Description', key: 'description' },
+      { label: 'Status', key: 'status' },
+      { label: 'Team', key: 'team' },
+      { label: 'Priority', key: 'priority' },
+      { label: 'Labels', key: 'labels' },
+      { label: 'Tags', key: 'tags' },
+      { label: 'Assignee', key: 'assignee' },
+      { label: 'Created By', key: 'createdBy' },
+      { label: 'Start Date', key: 'startDate' },
+      { label: 'Target Date', key: 'targetDate' },
+      { label: 'Cycle', key: 'cycle' },
+      { label: 'Project', key: 'project' },
+      { label: 'Milestone', key: 'milestone' },
+      { label: 'Estimate Point', key: 'estimatePoint' },
+      { label: 'Status Changed Date', key: 'statusChangedDate' },
+      { label: 'Number', key: 'number' },
+      { label: 'Status Type', key: 'statusType' },
+      { label: 'Created At', key: 'createdAt' },
+    ];
+  }
+  

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -352,6 +352,12 @@ export const dealTrpcRouter = t.router({
       return pipeline || {};
     }),
   },
+  pipelineLabel: {
+    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+      const { models } = ctx;
+      return await models.PipelineLabels.find(input).lean();
+    }),
+  },
 });
 
 export const fetchSegment = async (

--- a/frontend/plugins/operation_ui/src/modules/project/components/ProjectsRecordTable.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/components/ProjectsRecordTable.tsx
@@ -1,11 +1,11 @@
 import { projectsColumns } from '@/project/components/ProjectsColumn';
 import { RecordTable, PageSubHeader } from 'erxes-ui';
-import { useProjects } from '@/project/hooks/useGetProjects';
+import { useProjects, useProjectsVariables } from '@/project/hooks/useGetProjects';
 import { useGetCurrentUsersTeams } from '@/team/hooks/useGetCurrentUsersTeams';
 import { ProjectsFilter } from '@/project/components/ProjectsFilter';
 import { useParams } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import { currentUserState } from 'ui-modules';
+import { currentUserState, Export } from 'ui-modules';
 import { PROJECTS_CURSOR_SESSION_KEY } from '@/project/constants/ProjectSessionKey';
 import { ProjectsCommandBar } from './projects-command-bar/ProjectsCommandBar';
 
@@ -13,10 +13,10 @@ export const ProjectsRecordTable = () => {
   const { teamId } = useParams();
   const currentUser = useAtomValue(currentUserState);
 
-  const variables = {
+  const variables = useProjectsVariables({
     teamIds: teamId ? [teamId] : undefined,
     memberId: !teamId ? currentUser?._id : undefined,
-  };
+  });
 
   const { projects, handleFetchMore, pageInfo, loading } = useProjects({
     variables,
@@ -24,10 +24,21 @@ export const ProjectsRecordTable = () => {
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
   const { teams } = useGetCurrentUsersTeams();
 
+  const getFilters = () => {
+    const { cursor, limit, orderBy, direction, ...filters } = variables;
+    return filters;
+  };
+
   return (
     <div className="flex flex-col overflow-hidden h-full">
       <PageSubHeader>
         <ProjectsFilter />
+        <Export
+          pluginName="operation"
+          moduleName="project"
+          collectionName="projects"
+          getFilters={getFilters}
+        />
       </PageSubHeader>
       <RecordTable.Provider
         columns={projectsColumns(teams)}

--- a/frontend/plugins/operation_ui/src/modules/project/components/projects-command-bar/ProjectsCommandBar.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/components/projects-command-bar/ProjectsCommandBar.tsx
@@ -1,5 +1,6 @@
 import { IconRepeat } from '@tabler/icons-react';
 import { useParams } from 'react-router';
+import { Export } from 'ui-modules';
 import {
   Button,
   Command,
@@ -33,10 +34,20 @@ export const ProjectsCommandBar = () => {
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const [currentContent, setCurrentContent] = useState<string>('main');
   const { teamId } = useParams<{ teamId: string }>();
+  const projectIds = selectedRows.map((row) => row.original._id);
+
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>{selectedRows.length} selected</CommandBar.Value>
+        <Separator.Inline />
+        <Export
+          pluginName="operation"
+          moduleName="project"
+          collectionName="projects"
+          buttonVariant="secondary"
+          ids={projectIds}
+        />
         <Separator.Inline />
 
         <Popover

--- a/frontend/plugins/operation_ui/src/modules/task/components/TasksLayout.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TasksLayout.tsx
@@ -1,13 +1,28 @@
 import { PageSubHeader } from 'erxes-ui';
 import { TasksFilter } from '@/task/components/TasksFilter';
 import { TasksView, TasksViewControl } from '@/task/components/TasksView';
+import { Export } from 'ui-modules';
+import { useTasksVariables } from '@/task/hooks/useGetTasks';
 
 export const TasksLayout = () => {
+  const variables = useTasksVariables();
+
+  const getFilters = () => {
+    const { cursor, limit, orderBy, direction, ...filters } = variables;
+    return filters;
+  };
+
   return (
     <div className="flex flex-col overflow-hidden w-full h-full">
       <PageSubHeader>
         <TasksFilter />
         <TasksViewControl />
+        <Export
+          pluginName="operation"
+          moduleName="task"
+          collectionName="tasks"
+          getFilters={getFilters}
+        />
       </PageSubHeader>
       <TasksView />
     </div>

--- a/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksCommandBar.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksCommandBar.tsx
@@ -11,7 +11,7 @@ import {
 import { Row } from '@tanstack/table-core';
 import { ITask } from '@/task/types';
 import { IconRepeat, IconTrash } from '@tabler/icons-react';
-import { currentUserState } from 'ui-modules';
+import { currentUserState, Export } from 'ui-modules';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 import { useUpdateTask } from '@/task/hooks/useUpdateTask';
@@ -69,6 +69,14 @@ export const TasksCommandBar = () => {
         <CommandBar.Value>
           {selectedRows.length} selected
         </CommandBar.Value>
+        <Separator.Inline />
+        <Export
+          pluginName="operation"
+          moduleName="task"
+          collectionName="tasks"
+          buttonVariant="secondary"
+          ids={taskIds}
+        />
         <Separator.Inline />
         <Popover
           open={open}

--- a/frontend/plugins/operation_ui/src/pages/TasksPage.tsx
+++ b/frontend/plugins/operation_ui/src/pages/TasksPage.tsx
@@ -6,17 +6,24 @@ import { TasksSideWidget } from '@/task/components/detail/TasksSideWidget';
 import { TeamBreadCrumb } from '@/team/components/breadcrumb/TeamBreadCrumb';
 import { Breadcrumb, PageSubHeader, Separator } from 'erxes-ui';
 import { useLocation, useParams } from 'react-router-dom';
-import { Can, PageHeader } from 'ui-modules';
+import { Can, PageHeader, Export } from 'ui-modules';
+import { useTasksVariables } from '@/task/hooks/useGetTasks';
 
 export const TasksPage = () => {
   const { teamId } = useParams();
   const { pathname } = useLocation();
+  const variables = useTasksVariables();
 
   const basePath = teamId
     ? `/operation/team/${teamId}/tasks`
     : `/operation/tasks`;
 
   const isCreatedView = pathname === '/operation/tasks/created';
+
+  const getFilters = () => {
+    const { cursor, limit, orderBy, direction, ...filters } = variables;
+    return filters;
+  };
 
   return (
     <>
@@ -43,6 +50,12 @@ export const TasksPage = () => {
           <PageSubHeader>
             <TasksFilter />
             <TasksViewControl />
+            <Export
+              pluginName="operation"
+              moduleName="task"
+              collectionName="tasks"
+              getFilters={getFilters}
+            />
           </PageSubHeader>
           <TasksView isCreatedView={isCreatedView} />
         </div>
@@ -51,3 +64,4 @@ export const TasksPage = () => {
     </>
   );
 };
+


### PR DESCRIPTION
Team project & tasks filtered export

## Summary by Sourcery

Add filtered export capabilities for operation tasks and projects in both frontend and backend, including support for exporting selected items and respecting current filters.

New Features:
- Enable CSV export for tasks and projects from operation views, using current filter criteria or selected rows.
- Introduce backend export handlers and data/header builders for tasks and projects to power the new filtered exports.

Enhancements:
- Align export batch processing to derive header keys from the configured export headers instead of raw selected field names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project export: selectable fields, advanced filters, normalized formats, ID→label resolution, and rich-description cleaning
  * Task export: selectable fields, extensive filters (dates, cycles, projects, assignees, tags), normalized formats, and rich-description cleaning
  * Export UI added to project and task lists for row- and filter-based exports
  * Centralized export handlers and predefined export column definitions

* **Bug Fix**
  * Export column headers and values now align correctly when exporting selected fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->