### PR TITLE
fix: department edit form not loading data 

### DIFF
--- a/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
+++ b/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
@@ -17,6 +17,7 @@ export const DepartmentTypes = `
         userCount: Int
         userIds: [String]
         workhours:JSON
+        status: String
     }
 
     type DepartmentsListResponse {


### PR DESCRIPTION
Add missing status field to Department GraphQL type. The field was used in the frontend query but not declared in the schema, causing a 400 error and empty edit form.

## Summary by Sourcery

Bug Fixes:
- Expose the status field on the Department GraphQL type to prevent 400 errors when loading the department edit form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Departments now include a status field for improved tracking and visibility of departmental information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->