### PR TITLE
fix: restrict export button to users with exportsManage permission

### DIFF
--- a/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
+++ b/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
@@ -67,13 +67,15 @@ export const CustomersCommandBar = () => {
           </>
         </Can>
         <Separator.Inline />
-        <Export
-          pluginName="core"
-          moduleName="contacts"
-          collectionName="customers"
-          buttonVariant="secondary"
-          ids={customerIds}
-        />
+        <Can action="exportsManage">
+          <Export
+            pluginName="core"
+            moduleName="contacts"
+            collectionName="customers"
+            buttonVariant="secondary"
+            ids={customerIds}
+          />
+        </Can>
         {isOs && (
           <Can action="contactsUpdate">
             <>

--- a/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
+++ b/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
@@ -66,16 +66,14 @@ export const CustomersCommandBar = () => {
             />
           </>
         </Can>
-        <Can action="exportsManage">
-          <Separator.Inline />
-          <Export
-            pluginName="core"
-            moduleName="contacts"
-            collectionName="customers"
-            buttonVariant="secondary"
-            ids={customerIds}
-          />
-        </Can>
+        <Separator.Inline />
+        <Export
+          pluginName="core"
+          moduleName="contacts"
+          collectionName="customers"
+          buttonVariant="secondary"
+          ids={customerIds}
+        />
         {isOs && (
           <Can action="contactsUpdate">
             <>

--- a/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
+++ b/frontend/core-ui/src/modules/contacts/customers/components/customers-command-bar/CustomersCommandBar.tsx
@@ -66,8 +66,8 @@ export const CustomersCommandBar = () => {
             />
           </>
         </Can>
-        <Separator.Inline />
         <Can action="exportsManage">
+          <Separator.Inline />
           <Export
             pluginName="core"
             moduleName="contacts"

--- a/frontend/core-ui/src/pages/contacts/CustomersIndexPage.tsx
+++ b/frontend/core-ui/src/pages/contacts/CustomersIndexPage.tsx
@@ -2,7 +2,7 @@ import { CustomersHeader } from '@/contacts/customers/components/CustomersHeader
 import { CustomersRecordTable } from '@/contacts/customers/components/CustomersRecordTable';
 import { CustomersFilter } from '@/contacts/customers/components/CustomersFilter';
 import { PageContainer, PageSubHeader } from 'erxes-ui';
-import { Import } from 'ui-modules';
+import { Can, Import } from 'ui-modules';
 import { Export } from 'ui-modules/modules/import-export/components/epxort/Export';
 import { useCustomersVariables } from '@/contacts/customers/hooks/useCustomers';
 import { CustomerDetail } from '@/contacts/customers/customer-detail/components/CustomerDetail';
@@ -20,17 +20,21 @@ export const CustomersIndexPage = () => {
       <CustomersHeader />
       <PageSubHeader>
         <CustomersFilter />
-        <Import
-          pluginName="core"
-          moduleName="contacts"
-          collectionName="customers"
-        />
-        <Export
-          pluginName="core"
-          moduleName="contacts"
-          collectionName="customers"
-          getFilters={getFilters}
-        />
+        <Can action="importsManage">
+          <Import
+            pluginName="core"
+            moduleName="contacts"
+            collectionName="customers"
+          />
+        </Can>
+        <Can action="exportsManage">
+          <Export
+            pluginName="core"
+            moduleName="contacts"
+            collectionName="customers"
+            getFilters={getFilters}
+          />
+        </Can>
       </PageSubHeader>
       <CustomersRecordTable />
       <CustomerDetail />


### PR DESCRIPTION
Wrap Export button in Can component to check exportsManage permission. Previously any user could see and use the export button regardless of permissions.

## Summary by Sourcery

Bug Fixes:
- Hide and block access to the customers export button for users lacking the exportsManage permission by gating it behind the permission check component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based access control for import and export operations. Users now require specific permissions to access these features on the customers page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->