### PR TITLE
loyalty-score-statistics

### DIFF
--- a/backend/plugins/loyalty_api/src/modules/score/utils.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/utils.ts
@@ -295,7 +295,7 @@ export const scoreActiveUsers = async ({ models }) => {
 };
 
 export const scorePoint = async ({ doc, models, filter }) => {
-  const { stageId, number } = doc;
+  const { stageId, pipelineId, boardId, number } = doc;
 
   const refundedTargetIds = await models.ScoreLogs.distinct('targetId', {
     action: 'refund',
@@ -303,7 +303,7 @@ export const scorePoint = async ({ doc, models, filter }) => {
 
   const filterAggregate: any[] = [];
 
-  if (stageId || number) {
+  if (stageId || pipelineId || boardId || number) {
     const lookup = [
       {
         $lookup: {
@@ -380,11 +380,11 @@ export const scorePoint = async ({ doc, models, filter }) => {
 };
 
 export const scoreProducts = async ({ doc, models, filter }) => {
-  const { stageId, number } = doc;
+  const { stageId, pipelineId, boardId, number } = doc;
 
   const filterAggregate: any[] = [];
 
-  if (stageId || number) {
+  if (stageId || pipelineId || boardId || number) {
     const lookup = [
       {
         $lookup: {

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreSummaryWidget.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreSummaryWidget.tsx
@@ -17,24 +17,7 @@ import {
   Spinner,
 } from 'erxes-ui';
 import { SCORE_LOG_STATISTICS_QUERY } from '../graphql/queries';
-
-type ScoreStats = {
-  totalPointEarned?: number;
-  totalPointBalance?: number;
-  totalPointRedeemed?: number;
-  redemptionRate?: number;
-  activeLoyaltyMembers?: number;
-  monthlyActiveUsers?: number;
-  mostRedeemedProductCategory?: string;
-};
-
-const useScoreStats = (ownerId?: string, ownerType?: string) => {
-  const { data, loading } = useQuery(SCORE_LOG_STATISTICS_QUERY, {
-    fetchPolicy: 'cache-and-network',
-    variables: { ownerId, ownerType },
-  });
-  return { stats: (data?.scoreLogStatistics || {}) as ScoreStats, loading };
-};
+import { ScoreStats, useScoreStatistics } from '../hooks/useScoreStatistics';
 
 const ScoreStatCards = ({
   stats,
@@ -99,7 +82,7 @@ const ScoreStatCards = ({
 };
 
 const ScoreSummaryPanelContent = () => {
-  const { stats, loading } = useScoreStats();
+  const { stats, loading } = useScoreStatistics();
 
   return (
     <div className="p-4">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/graphql/queries.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/graphql/queries.ts
@@ -82,8 +82,11 @@ export const SCORE_LOG_STATISTICS_QUERY = gql`
     $action: String
     $fromDate: String
     $toDate: String
+    $boardId: String
+    $pipelineId: String
     $stageId: String
     $number: String
+    $description: String
   ) {
     scoreLogStatistics(
       searchValue: $searchValue
@@ -94,8 +97,11 @@ export const SCORE_LOG_STATISTICS_QUERY = gql`
       action: $action
       fromDate: $fromDate
       toDate: $toDate
+      boardId: $boardId
+      pipelineId: $pipelineId
       stageId: $stageId
       number: $number
+      description: $description
     )
   }
 `;

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreFilters.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreFilters.ts
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { useMultiQueryState } from 'erxes-ui';
+import { parseDateRangeFromString } from 'erxes-ui/modules/filter/date-filter/utils/parseDateRangeFromString';
+
+/**
+ * Reads the score filters from the URL query state and builds the GraphQL
+ * variables shared by both the scores table (`useScoreList`) and the score
+ * statistics (`useScoreStatistics`), so the summary always reflects the same
+ * rows shown in the table.
+ */
+export const useScoreFilters = () => {
+  const [
+    {
+      scoreOwnerType,
+      scoreOwnerId,
+      scoreCampaignId,
+      scoreDate,
+      scoreAction,
+      scoreBoardId,
+      scorePipelineId,
+      scoreStageId,
+      number,
+      description,
+    },
+  ] = useMultiQueryState<{
+    scoreOwnerType: string;
+    scoreOwnerId: string;
+    scoreCampaignId: string;
+    scoreDate: string;
+    scoreAction: string;
+    scoreBoardId: string;
+    scorePipelineId: string;
+    scoreStageId: string;
+    number: string;
+    description: string;
+  }>([
+    'scoreOwnerType',
+    'scoreOwnerId',
+    'scoreCampaignId',
+    'scoreDate',
+    'scoreAction',
+    'scoreBoardId',
+    'scorePipelineId',
+    'scoreStageId',
+    'number',
+    'description',
+  ]);
+
+  const dateRange = parseDateRangeFromString(scoreDate);
+
+  return useMemo(
+    () => ({
+      ownerType: scoreOwnerType || undefined,
+      ownerId: scoreOwnerId || undefined,
+      campaignId: scoreCampaignId || undefined,
+      fromDate: dateRange?.from?.toISOString() || undefined,
+      toDate: dateRange?.to?.toISOString() || undefined,
+      action: scoreAction || undefined,
+      boardId: scoreBoardId || undefined,
+      pipelineId: scorePipelineId || undefined,
+      stageId: scoreStageId || undefined,
+      number: number != null && number !== '' ? String(number) : undefined,
+      description: description || undefined,
+    }),
+    [
+      scoreOwnerType,
+      scoreOwnerId,
+      scoreCampaignId,
+      dateRange?.from,
+      dateRange?.to,
+      scoreAction,
+      scoreBoardId,
+      scorePipelineId,
+      scoreStageId,
+      number,
+      description,
+    ],
+  );
+};

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreList.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreList.ts
@@ -73,7 +73,7 @@ export const useScoreList = () => {
       boardId: scoreBoardId || undefined,
       pipelineId: scorePipelineId || undefined,
       stageId: scoreStageId || undefined,
-      number: number || undefined,
+      number: number != null && number !== '' ? String(number) : undefined,
       description: description || undefined,
       limit: SCORE_PER_PAGE,
     }),

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreList.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreList.ts
@@ -7,11 +7,11 @@ import {
   useRecordTableCursor,
   validateFetchMore,
 } from 'erxes-ui';
-import { parseDateRangeFromString } from 'erxes-ui/modules/filter/date-filter/utils/parseDateRangeFromString';
 import { useSetAtom } from 'jotai';
 import { SCORE_LOGS_QUERY } from '../graphql/queries';
 import { IScoreLog } from '../types/score';
 import { scoreTotalCountAtom } from '../states/scoreCounts';
+import { useScoreFilters } from './useScoreFilters';
 
 const SCORE_PER_PAGE = 50;
 export const SCORE_LOG_CURSOR_SESSION_KEY = 'score_logs_cursor';
@@ -19,78 +19,19 @@ export const SCORE_LOG_CURSOR_SESSION_KEY = 'score_logs_cursor';
 export const useScoreList = () => {
   const setTotalCount = useSetAtom(scoreTotalCountAtom);
 
-  const [
-    {
-      scoreOwnerType,
-      scoreOwnerId,
-      scoreCampaignId,
-      scoreDate,
-      scoreOrderType,
-      scoreAction,
-      scoreBoardId,
-      scorePipelineId,
-      scoreStageId,
-      number,
-      description,
-    },
-  ] = useMultiQueryState<{
-    scoreOwnerType: string;
-    scoreOwnerId: string;
-    scoreCampaignId: string;
-    scoreDate: string;
-    scoreOrderType: string;
-    scoreAction: string;
-    scoreBoardId: string;
-    scorePipelineId: string;
-    scoreStageId: string;
-    number: string;
-    description: string;
-  }>([
-    'scoreOwnerType',
-    'scoreOwnerId',
-    'scoreCampaignId',
-    'scoreDate',
-    'scoreOrderType',
-    'scoreAction',
-    'scoreBoardId',
-    'scorePipelineId',
-    'scoreStageId',
-    'number',
-    'description',
-  ]);
+  const filters = useScoreFilters();
 
-  const dateRange = parseDateRangeFromString(scoreDate);
+  const [{ scoreOrderType }] = useMultiQueryState<{ scoreOrderType: string }>([
+    'scoreOrderType',
+  ]);
 
   const variables = useMemo(
     () => ({
-      ownerType: scoreOwnerType || undefined,
-      ownerId: scoreOwnerId || undefined,
-      campaignId: scoreCampaignId || undefined,
-      fromDate: dateRange?.from?.toISOString() || undefined,
-      toDate: dateRange?.to?.toISOString() || undefined,
+      ...filters,
       orderType: scoreOrderType || undefined,
-      action: scoreAction || undefined,
-      boardId: scoreBoardId || undefined,
-      pipelineId: scorePipelineId || undefined,
-      stageId: scoreStageId || undefined,
-      number: number != null && number !== '' ? String(number) : undefined,
-      description: description || undefined,
       limit: SCORE_PER_PAGE,
     }),
-    [
-      scoreOwnerType,
-      scoreOwnerId,
-      scoreCampaignId,
-      dateRange?.from,
-      dateRange?.to,
-      scoreOrderType,
-      scoreAction,
-      scoreBoardId,
-      scorePipelineId,
-      scoreStageId,
-      number,
-      description,
-    ],
+    [filters, scoreOrderType],
   );
 
   const { cursor } = useRecordTableCursor({

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreStatistics.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreStatistics.ts
@@ -1,0 +1,100 @@
+import { useQuery } from '@apollo/client';
+import { useMemo } from 'react';
+import { useMultiQueryState } from 'erxes-ui';
+import { parseDateRangeFromString } from 'erxes-ui/modules/filter/date-filter/utils/parseDateRangeFromString';
+import { SCORE_LOG_STATISTICS_QUERY } from '../graphql/queries';
+
+export type ScoreStats = {
+  totalPointEarned?: number;
+  totalPointBalance?: number;
+  totalPointRedeemed?: number;
+  redemptionRate?: number;
+  activeLoyaltyMembers?: number;
+  monthlyActiveUsers?: number;
+  mostRedeemedProductCategory?: string;
+};
+
+/**
+ * Reads the same URL filters used by the scores table (`useScoreList`) and runs
+ * the statistics query with them, so the Score Summary reflects exactly the
+ * filtered rows shown in the table instead of the whole collection.
+ */
+export const useScoreStatistics = () => {
+  const [
+    {
+      scoreOwnerType,
+      scoreOwnerId,
+      scoreCampaignId,
+      scoreDate,
+      scoreAction,
+      scoreBoardId,
+      scorePipelineId,
+      scoreStageId,
+      number,
+      description,
+    },
+  ] = useMultiQueryState<{
+    scoreOwnerType: string;
+    scoreOwnerId: string;
+    scoreCampaignId: string;
+    scoreDate: string;
+    scoreAction: string;
+    scoreBoardId: string;
+    scorePipelineId: string;
+    scoreStageId: string;
+    number: string;
+    description: string;
+  }>([
+    'scoreOwnerType',
+    'scoreOwnerId',
+    'scoreCampaignId',
+    'scoreDate',
+    'scoreAction',
+    'scoreBoardId',
+    'scorePipelineId',
+    'scoreStageId',
+    'number',
+    'description',
+  ]);
+
+  const dateRange = parseDateRangeFromString(scoreDate);
+
+  const variables = useMemo(
+    () => ({
+      ownerType: scoreOwnerType || undefined,
+      ownerId: scoreOwnerId || undefined,
+      campaignId: scoreCampaignId || undefined,
+      fromDate: dateRange?.from?.toISOString() || undefined,
+      toDate: dateRange?.to?.toISOString() || undefined,
+      action: scoreAction || undefined,
+      boardId: scoreBoardId || undefined,
+      pipelineId: scorePipelineId || undefined,
+      stageId: scoreStageId || undefined,
+      number: number != null && number !== '' ? String(number) : undefined,
+      description: description || undefined,
+    }),
+    [
+      scoreOwnerType,
+      scoreOwnerId,
+      scoreCampaignId,
+      dateRange?.from,
+      dateRange?.to,
+      scoreAction,
+      scoreBoardId,
+      scorePipelineId,
+      scoreStageId,
+      number,
+      description,
+    ],
+  );
+
+  const { data, loading } = useQuery(SCORE_LOG_STATISTICS_QUERY, {
+    fetchPolicy: 'cache-and-network',
+    variables,
+  });
+
+  return {
+    stats: (data?.scoreLogStatistics || {}) as ScoreStats,
+    loading,
+  };
+};

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreStatistics.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useScoreStatistics.ts
@@ -1,8 +1,6 @@
 import { useQuery } from '@apollo/client';
-import { useMemo } from 'react';
-import { useMultiQueryState } from 'erxes-ui';
-import { parseDateRangeFromString } from 'erxes-ui/modules/filter/date-filter/utils/parseDateRangeFromString';
 import { SCORE_LOG_STATISTICS_QUERY } from '../graphql/queries';
+import { useScoreFilters } from './useScoreFilters';
 
 export type ScoreStats = {
   totalPointEarned?: number;
@@ -15,78 +13,12 @@ export type ScoreStats = {
 };
 
 /**
- * Reads the same URL filters used by the scores table (`useScoreList`) and runs
- * the statistics query with them, so the Score Summary reflects exactly the
- * filtered rows shown in the table instead of the whole collection.
+ * Runs the statistics query with the same URL filters used by the scores table,
+ * so the Score Summary reflects exactly the filtered rows instead of the whole
+ * collection.
  */
 export const useScoreStatistics = () => {
-  const [
-    {
-      scoreOwnerType,
-      scoreOwnerId,
-      scoreCampaignId,
-      scoreDate,
-      scoreAction,
-      scoreBoardId,
-      scorePipelineId,
-      scoreStageId,
-      number,
-      description,
-    },
-  ] = useMultiQueryState<{
-    scoreOwnerType: string;
-    scoreOwnerId: string;
-    scoreCampaignId: string;
-    scoreDate: string;
-    scoreAction: string;
-    scoreBoardId: string;
-    scorePipelineId: string;
-    scoreStageId: string;
-    number: string;
-    description: string;
-  }>([
-    'scoreOwnerType',
-    'scoreOwnerId',
-    'scoreCampaignId',
-    'scoreDate',
-    'scoreAction',
-    'scoreBoardId',
-    'scorePipelineId',
-    'scoreStageId',
-    'number',
-    'description',
-  ]);
-
-  const dateRange = parseDateRangeFromString(scoreDate);
-
-  const variables = useMemo(
-    () => ({
-      ownerType: scoreOwnerType || undefined,
-      ownerId: scoreOwnerId || undefined,
-      campaignId: scoreCampaignId || undefined,
-      fromDate: dateRange?.from?.toISOString() || undefined,
-      toDate: dateRange?.to?.toISOString() || undefined,
-      action: scoreAction || undefined,
-      boardId: scoreBoardId || undefined,
-      pipelineId: scorePipelineId || undefined,
-      stageId: scoreStageId || undefined,
-      number: number != null && number !== '' ? String(number) : undefined,
-      description: description || undefined,
-    }),
-    [
-      scoreOwnerType,
-      scoreOwnerId,
-      scoreCampaignId,
-      dateRange?.from,
-      dateRange?.to,
-      scoreAction,
-      scoreBoardId,
-      scorePipelineId,
-      scoreStageId,
-      number,
-      description,
-    ],
-  );
+  const variables = useScoreFilters();
 
   const { data, loading } = useQuery(SCORE_LOG_STATISTICS_QUERY, {
     fetchPolicy: 'cache-and-network',


### PR DESCRIPTION
## Summary by Sourcery

Align loyalty score statistics with the score list filters and extend backend filtering capabilities for score-related analytics.

New Features:
- Introduce a reusable useScoreStatistics hook that derives filters from URL query state and fetches matching score statistics.

Bug Fixes:
- Ensure numeric score filters are consistently stringified before being sent in GraphQL queries to prevent type mismatches.

Enhancements:
- Update the score summary widget to consume the new statistics hook so its data matches the currently filtered score list.
- Extend score point and product aggregation utilities to support filtering by board and pipeline identifiers in addition to stage and number.
- Expand the scoreLogStatistics GraphQL query to accept board, pipeline, stage, number, and description filters for more granular statistics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support filtering loyalty scores by pipeline and board, plus improved date-range handling.
  * Added a shared score statistics hook for retrieving score metrics.

* **Refactor**
  * Simplified score list query variable construction and centralized filter logic.
  * Replaced local statistics logic with the shared hook to unify data fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->