### PR TITLE
feat(core): add custom field import/export for core and tickets; add load more for frontline response templates; fix inbox image preview, 

### DIFF
--- a/backend/core-api/src/modules/contacts/meta/import-export/export/companies/buildCompanyExportRow.ts
+++ b/backend/core-api/src/modules/contacts/meta/import-export/export/companies/buildCompanyExportRow.ts
@@ -6,6 +6,11 @@ const getFieldValue = (
   tagMap?: Map<string, string>,
   formatValue = defaultContactFieldFormatter,
 ): string => {
+  if (key.startsWith('propertiesData.')) {
+    const fieldId = key.replace('propertiesData.', '');
+    return formatValue(company?.propertiesData?.[fieldId]);
+  }
+
   if (key === 'tagIds') {
     const tagNames = (company.tagIds || [])
       .map((id: string) => tagMap?.get(String(id)) || id)
@@ -63,7 +68,15 @@ export const buildCompanyExportRow = (
     updatedAt: formatValue(company.updatedAt ? new Date(company.updatedAt) : ''),
   };
 
-  // selectedFields mode (Field selection UI)
+  const propertiesData = company?.propertiesData;
+  if (propertiesData && typeof propertiesData === 'object') {
+    for (const [fieldId, value] of Object.entries(propertiesData)) {
+      if (value !== undefined && value !== null) {
+        allFields[`propertiesData.${fieldId}`] = formatValue(value);
+      }
+    }
+  }
+
   if (selectedFields && selectedFields.length > 0) {
     const result: Record<string, any> = { _id: String(company._id || '') };
     selectedFields.forEach((key) => {

--- a/backend/core-api/src/modules/contacts/meta/import-export/export/companies/getCompanyExportHeaders.ts
+++ b/backend/core-api/src/modules/contacts/meta/import-export/export/companies/getCompanyExportHeaders.ts
@@ -1,38 +1,35 @@
 import {
-    ImportHeaderDefinition,
-    IImportExportContext,
-  } from 'erxes-api-shared/core-modules';
-  
-  export async function getCompanyExportHeaders(
-    _data: any,
-    _ctx: IImportExportContext,
-  ): Promise<ImportHeaderDefinition[]> {
-    return [
-        { label: 'Name', key: 'primaryName', isDefault: true },
-        { label: 'Emails', key: 'primaryEmail', isDefault: true },
-        // { label: 'Emails', key: 'emails' },
-        { label: 'Phones', key: 'primaryPhone', isDefault: true },
-        // { label: 'Phones', key: 'phones' },
-      
-        { label: 'Website', key: 'website' },
-        { label: 'Industry', key: 'industry' },
-        { label: 'Size', key: 'size' },
-      
-        { label: 'Status', key: 'status' },
-        { label: 'Business Type', key: 'businessType' },
-      
-        { label: 'Description', key: 'description' },
-        { label: 'Employees', key: 'employees' },
-      
-        { label: 'Links', key: 'links' },
-      
-        { label: 'Tags', key: 'tagIds', isDefault: true },
-      
-        { label: 'Code', key: 'code' },
-        { label: 'Location', key: 'location' },
-      
-        { label: 'Created At', key: 'createdAt' },
-        { label: 'Updated At', key: 'updatedAt' },
-    ];
-  }
+  ImportHeaderDefinition,
+  IImportExportContext,
+} from 'erxes-api-shared/core-modules';
+import { IModels } from '~/connectionResolvers';
+import { getCustomPropertyHeaders } from '~/meta/import-export/utils';
+
+export async function getCompanyExportHeaders(
+  _data: any,
+  { models }: IImportExportContext<IModels>,
+): Promise<ImportHeaderDefinition[]> {
+  const systemFields: ImportHeaderDefinition[] = [
+    { label: 'Name', key: 'primaryName', isDefault: true },
+    { label: 'Emails', key: 'primaryEmail', isDefault: true },
+    { label: 'Phones', key: 'primaryPhone', isDefault: true },
+    { label: 'Website', key: 'website' },
+    { label: 'Industry', key: 'industry' },
+    { label: 'Size', key: 'size' },
+    { label: 'Status', key: 'status' },
+    { label: 'Business Type', key: 'businessType' },
+    { label: 'Description', key: 'description' },
+    { label: 'Employees', key: 'employees' },
+    { label: 'Links', key: 'links' },
+    { label: 'Tags', key: 'tagIds', isDefault: true },
+    { label: 'Code', key: 'code' },
+    { label: 'Location', key: 'location' },
+    { label: 'Created At', key: 'createdAt' },
+    { label: 'Updated At', key: 'updatedAt' },
+  ];
+
+  const customFields = await getCustomPropertyHeaders(models, 'core:company');
+
+  return [...systemFields, ...customFields];
+}
   

--- a/backend/core-api/src/modules/contacts/meta/import-export/export/companies/getCompanyExportHeaders.ts
+++ b/backend/core-api/src/modules/contacts/meta/import-export/export/companies/getCompanyExportHeaders.ts
@@ -28,8 +28,9 @@ export async function getCompanyExportHeaders(
     { label: 'Updated At', key: 'updatedAt' },
   ];
 
+  if (!models) return systemFields;
+
   const customFields = await getCustomPropertyHeaders(models, 'core:company');
 
   return [...systemFields, ...customFields];
 }
-  

--- a/backend/core-api/src/modules/contacts/meta/import-export/export/customers/buildCustomerExportRow.ts
+++ b/backend/core-api/src/modules/contacts/meta/import-export/export/customers/buildCustomerExportRow.ts
@@ -8,27 +8,25 @@ const getFieldValue = (
   tagMap?: Map<string, string>,
   formatValue = defaultContactFieldFormatter,
 ): string => {
-  const isCustomField = key.startsWith('customFieldsData.');
+  if (key.startsWith('propertiesData.')) {
+    const fieldId = key.replace('propertiesData.', '');
+    return formatValue((customer as any).propertiesData?.[fieldId]);
+  }
 
-  // Handle custom fields
-  if (isCustomField) {
+  if (key.startsWith('customFieldsData.')) {
     const fieldId = key.replace('customFieldsData.', '');
     const customFieldsData = customer.customFieldsData || [];
-    if (!!customFieldsData?.length) {
-      const customField = customFieldsData.find(
-        (cf) => getRealIdFromElk(cf.field || '') === fieldId,
+    if (customFieldsData?.length) {
+      const cf = customFieldsData.find(
+        (c) => getRealIdFromElk(c.field || '') === fieldId,
       );
-      return formatValue(customField?.value);
+      return formatValue(cf?.value);
     }
     return '';
   }
 
-  // Handle system fields
-  const value = (customer as any)[key];
-
-  // Handle tagIds specially to show tag names
   if (key === 'tagIds') {
-    if (!!customer.tagIds?.length) {
+    if (customer.tagIds?.length) {
       const tagNames = customer.tagIds
         .map((tagId: string) => tagMap?.get(String(tagId)) || tagId)
         .filter(Boolean);
@@ -37,7 +35,7 @@ const getFieldValue = (
     return '';
   }
 
-  return formatValue(value);
+  return formatValue((customer as any)[key]);
 };
 
 export const buildCustomerExportRow = (
@@ -75,8 +73,7 @@ export const buildCustomerExportRow = (
     customFieldsData = [],
   } = customer;
 
-  // Get tag names from tagIds
-  const tagNames = !!tagIds?.length
+  const tagNames = tagIds?.length
     ? tagIds
         .map((tagId: string) => tagMap?.get(String(tagId)) || tagId)
         .filter(Boolean)
@@ -110,19 +107,25 @@ export const buildCustomerExportRow = (
     updatedAt: formatValue(updatedAt ? new Date(updatedAt) : ''),
   };
 
-  // Add custom fields
-  if (!!customFieldsData?.length) {
+  if (customFieldsData?.length) {
     for (const { field, value } of customFieldsData) {
-      if (field && value) {
+      if (field && value !== undefined) {
         const fieldId = getRealIdFromElk(field || '');
         allFields[`customFieldsData.${fieldId}`] = formatValue(value);
       }
     }
   }
 
-  // If selectedFields provided, only return those fields
+  const propertiesData = (customer as any).propertiesData;
+  if (propertiesData && typeof propertiesData === 'object') {
+    for (const [fieldId, value] of Object.entries(propertiesData)) {
+      if (value !== undefined && value !== null) {
+        allFields[`propertiesData.${fieldId}`] = formatValue(value);
+      }
+    }
+  }
+
   if (selectedFields && selectedFields.length > 0) {
-    // Always include _id for cursor-based pagination; it is not exported
     const result: Record<string, any> = { _id: String(customer._id || '') };
     selectedFields.forEach((key) => {
       result[key] = getFieldValue(customer, key, tagMap, formatValue);

--- a/backend/core-api/src/modules/contacts/meta/import-export/export/customers/getCustomerExportHeaders.ts
+++ b/backend/core-api/src/modules/contacts/meta/import-export/export/customers/getCustomerExportHeaders.ts
@@ -2,46 +2,36 @@ import {
   ImportHeaderDefinition,
   IImportExportContext,
 } from 'erxes-api-shared/core-modules';
+import { IModels } from '~/connectionResolvers';
+import { getCustomPropertyHeaders } from '~/meta/import-export/utils';
 
 export async function getCustomerExportHeaders(
-  {},
-  {}: IImportExportContext,
+  _data: any,
+  { models }: IImportExportContext<IModels>,
 ): Promise<ImportHeaderDefinition[]> {
-  // System fields
   const systemFields: ImportHeaderDefinition[] = [
     { label: 'First Name', key: 'firstName', isDefault: true },
     { label: 'Last Name', key: 'lastName', isDefault: true },
-    {
-      label: 'Middle Name',
-      key: 'middleName',
-    },
+    { label: 'Middle Name', key: 'middleName' },
     { label: 'Email', key: 'primaryEmail', isDefault: true },
     { label: 'Phone', key: 'primaryPhone', isDefault: true },
     { label: 'Position', key: 'position' },
-    {
-      label: 'Department',
-      key: 'department',
-    },
-    {
-      label: 'Description',
-      key: 'description',
-    },
+    { label: 'Department', key: 'department' },
+    { label: 'Description', key: 'description' },
     { label: 'Code', key: 'code' },
     { label: 'Sex', key: 'sex' },
     { label: 'Birth Date', key: 'birthDate' },
     { label: 'Status', key: 'status' },
-    {
-      label: 'Email Validation Status',
-      key: 'emailValidationStatus',
-    },
-    {
-      label: 'Phone Validation Status',
-      key: 'phoneValidationStatus',
-    },
+    { label: 'Email Validation Status', key: 'emailValidationStatus' },
+    { label: 'Phone Validation Status', key: 'phoneValidationStatus' },
     { label: 'Tags', key: 'tagIds', isDefault: true },
     { label: 'Created At', key: 'createdAt' },
     { label: 'Updated At', key: 'updatedAt' },
   ];
 
-  return [...systemFields];
+  const customFields = models
+    ? await getCustomPropertyHeaders(models, 'core:customer')
+    : [];
+
+  return [...systemFields, ...customFields];
 }

--- a/backend/plugins/frontline_api/src/meta/import-export/export/buildTicketExportRow.ts
+++ b/backend/plugins/frontline_api/src/meta/import-export/export/buildTicketExportRow.ts
@@ -66,10 +66,23 @@ export const buildTicketExportRow = (
     updatedAt: formatValue(ticket.updatedAt ? new Date(ticket.updatedAt) : ''),
   };
 
+  if (ticket.propertiesData && typeof ticket.propertiesData === 'object') {
+    for (const [fieldId, value] of Object.entries(ticket.propertiesData)) {
+      if (value !== undefined && value !== null) {
+        allFields[`propertiesData.${fieldId}`] = formatValue(value);
+      }
+    }
+  }
+
   if (selectedFields?.length) {
     const result: Record<string, any> = { _id: String(ticket._id || '') };
     for (const key of selectedFields) {
-      result[key] = allFields[key] ?? '';
+      if (key.startsWith('propertiesData.')) {
+        const fieldId = key.replace('propertiesData.', '');
+        result[key] = formatValue(ticket.propertiesData?.[fieldId]);
+      } else {
+        result[key] = allFields[key] ?? '';
+      }
     }
     return result;
   }

--- a/backend/plugins/frontline_api/src/meta/import-export/export/getTicketExportHeaders.ts
+++ b/backend/plugins/frontline_api/src/meta/import-export/export/getTicketExportHeaders.ts
@@ -2,12 +2,14 @@ import {
   ImportHeaderDefinition,
   IImportExportContext,
 } from 'erxes-api-shared/core-modules';
+import { IModels } from '~/connectionResolvers';
+import { getTicketCustomPropertyHeaders } from '../utils';
 
 export async function getTicketExportHeaders(
   _data: any,
-  _ctx: IImportExportContext,
+  { subdomain }: IImportExportContext<IModels>,
 ): Promise<ImportHeaderDefinition[]> {
-  return [
+  const systemFields: ImportHeaderDefinition[] = [
     { label: 'Name', key: 'name', isDefault: true },
     { label: 'Description', key: 'description' },
     { label: 'Type', key: 'type', isDefault: true },
@@ -23,4 +25,8 @@ export async function getTicketExportHeaders(
     { label: 'Created At', key: 'createdAt', isDefault: true },
     { label: 'Updated At', key: 'updatedAt' },
   ];
+
+  const customFields = await getTicketCustomPropertyHeaders(subdomain);
+
+  return [...systemFields, ...customFields];
 }

--- a/backend/plugins/frontline_api/src/meta/import-export/import/importHandlers.ts
+++ b/backend/plugins/frontline_api/src/meta/import-export/import/importHandlers.ts
@@ -5,47 +5,40 @@ import {
 } from 'erxes-api-shared/core-modules';
 import { processTicketRows } from './processTicketRows';
 import { IModels } from '~/connectionResolvers';
+import { getTicketCustomPropertyHeaders } from '../utils';
 
-const ticketImportMap = {
-  ticket: {
-    headers: [
-      { label: 'Name', key: 'name' },
-      { label: 'Description', key: 'description' },
-      { label: 'Type', key: 'type' },
-      { label: 'Priority', key: 'priority' },
-      { label: 'Status', key: 'statusType' },
-      { label: 'State', key: 'state' },
-      { label: 'Pipeline ID', key: 'pipelineId' },
-      { label: 'Channel ID', key: 'channelId' },
-      { label: 'Assignee ID', key: 'assigneeId' },
-      { label: 'Start Date', key: 'startDate' },
-      { label: 'Due Date', key: 'targetDate' },
-      { label: 'Tags', key: 'tags' },
-    ],
-    processRows: (models: IModels, rows: any[]) =>
-      processTicketRows(models, rows),
-  },
-};
+const TICKET_SYSTEM_HEADERS = [
+  { label: 'Name', key: 'name' },
+  { label: 'Description', key: 'description' },
+  { label: 'Type', key: 'type' },
+  { label: 'Priority', key: 'priority' },
+  { label: 'Status', key: 'statusType' },
+  { label: 'State', key: 'state' },
+  { label: 'Pipeline ID', key: 'pipelineId' },
+  { label: 'Channel ID', key: 'channelId' },
+  { label: 'Assignee ID', key: 'assigneeId' },
+  { label: 'Start Date', key: 'startDate' },
+  { label: 'Due Date', key: 'targetDate' },
+  { label: 'Tags', key: 'tags' },
+];
 
 export const ticketImportHandlers = {
   getImportHeaders: async (
     { collectionName }: { collectionName: string },
     { subdomain }: TCoreModuleProducerContext<IModels>,
   ): Promise<TGetImportHeadersOutput> => {
-    const handler =
-      ticketImportMap[collectionName as keyof typeof ticketImportMap];
-    if (!handler)
+    if (collectionName !== 'ticket')
       throw new Error(`Import headers handler not found for ${collectionName}`);
-    return handler.headers;
+
+    const customHeaders = await getTicketCustomPropertyHeaders(subdomain);
+    return [...TICKET_SYSTEM_HEADERS, ...customHeaders];
   },
   insertImportRows: async (
     { collectionName, rows }: TInsertImportRowsInput,
-    { models }: TCoreModuleProducerContext<IModels>,
+    { subdomain, models }: TCoreModuleProducerContext<IModels>,
   ) => {
-    const handler =
-      ticketImportMap[collectionName as keyof typeof ticketImportMap];
-    if (!handler)
+    if (collectionName !== 'ticket')
       throw new Error(`Import handler not found for ${collectionName}`);
-    return handler.processRows(models, rows);
+    return processTicketRows(subdomain, models, rows);
   },
 };

--- a/backend/plugins/frontline_api/src/meta/import-export/import/processTicketRows.ts
+++ b/backend/plugins/frontline_api/src/meta/import-export/import/processTicketRows.ts
@@ -3,6 +3,7 @@ import {
   TICKET_PRIORITY_TYPES,
   TICKET_DEFAULT_STATUSES,
 } from '@/ticket/constants/types';
+import { extractTicketPropertiesData } from '../utils';
 
 const priorityByName = new Map(
   TICKET_PRIORITY_TYPES.map((p) => [p.name.toLowerCase(), p.type]),
@@ -12,7 +13,7 @@ const statusByName = new Map(
   TICKET_DEFAULT_STATUSES.map((s) => [s.name.toLowerCase(), s.type]),
 );
 
-function prepareTicketDoc(row: any): any {
+async function prepareTicketDoc(subdomain: string, row: any): Promise<any> {
   const doc: any = {
     name: row.name || row.Name || '',
     description: row.description || row.Description || '',
@@ -69,10 +70,19 @@ function prepareTicketDoc(row: any): any {
       .filter(Boolean);
   }
 
+  for (const key of Object.keys(row)) {
+    if (key.startsWith('propertiesData.')) {
+      doc[key] = row[key];
+    }
+  }
+
+  await extractTicketPropertiesData(subdomain, doc);
+
   return doc;
 }
 
 export async function processTicketRows(
+  subdomain: string,
   models: IModels,
   rows: any[],
 ): Promise<{ successRows: any[]; errorRows: any[] }> {
@@ -85,7 +95,7 @@ export async function processTicketRows(
 
     for (const row of rows) {
       try {
-        const doc = prepareTicketDoc(row);
+        const doc = await prepareTicketDoc(subdomain, row);
 
         if (!doc.name) {
           errorRows.push({ ...row, error: 'Name is required' });

--- a/backend/plugins/frontline_api/src/meta/import-export/utils.ts
+++ b/backend/plugins/frontline_api/src/meta/import-export/utils.ts
@@ -1,0 +1,97 @@
+import { ImportHeaderDefinition } from 'erxes-api-shared/core-modules';
+import { getRealIdFromElk, sendTRPCMessage } from 'erxes-api-shared/utils';
+
+export const TICKET_CONTENT_TYPE = 'frontline:ticket.ticket';
+
+export const getTicketCustomPropertyHeaders = async (
+  subdomain: string,
+): Promise<ImportHeaderDefinition[]> => {
+  const fields: any[] = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'fields',
+    action: 'find',
+    input: {
+      query: { contentType: TICKET_CONTENT_TYPE },
+      projection: null,
+      sort: { order: 1 },
+    },
+    defaultValue: [],
+  });
+
+  if (!fields?.length) return [];
+
+  const groupIds = fields
+    .map((f) => f.groupId)
+    .filter(Boolean)
+    .map(String);
+
+  const groups: any[] = groupIds.length
+    ? await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        method: 'query',
+        module: 'fieldsGroups',
+        action: 'find',
+        input: { query: { _id: { $in: groupIds } } },
+        defaultValue: [],
+      })
+    : [];
+
+  const groupById = new Map(groups.map((g) => [String(g._id), g]));
+
+  return fields.map((field) => {
+    const group = field.groupId ? groupById.get(String(field.groupId)) : null;
+    const fieldId = getRealIdFromElk(String(field._id));
+    const label = group?.name ? `${group.name} / ${field.name}` : field.name;
+    const uniqueLabel = field.code ? `${label} [${field.code}]` : label;
+    const key = `propertiesData.${fieldId}`;
+
+    return {
+      label: uniqueLabel,
+      key,
+      aliases: [
+        label,
+        field.name,
+        field.code,
+        field.code ? `${field.name} [${field.code}]` : '',
+        key,
+      ].filter(Boolean),
+      type: 'customProperty' as const,
+    };
+  });
+};
+
+export const extractTicketPropertiesData = async (
+  subdomain: string,
+  doc: Record<string, any>,
+): Promise<void> => {
+  const propertiesData: Record<string, any> = {};
+
+  for (const key of Object.keys(doc)) {
+    if (!key.startsWith('propertiesData.')) continue;
+
+    const fieldId = key.replace('propertiesData.', '');
+    const value = doc[key];
+    delete doc[key];
+
+    if (value !== undefined && value !== null && value !== '') {
+      propertiesData[fieldId] = value;
+    }
+  }
+
+  if (!Object.keys(propertiesData).length) return;
+
+  const merged = { ...(doc.propertiesData || {}), ...propertiesData };
+
+  doc.propertiesData = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'mutation',
+    module: 'fields',
+    action: 'validateFieldValues',
+    input: { data: merged },
+    defaultValue: merged,
+  });
+};

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversation-messages/components/MessageItem.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversation-messages/components/MessageItem.tsx
@@ -138,7 +138,7 @@ const Attachment = ({
   length?: number;
 }) => {
   const { userId, customerId } = useConversationMessageContext();
-  const isImage = attachment.type.startsWith('image/');
+  const isImage = attachment.type.startsWith('image');
   if (!isImage) {
     return (
       <div

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ResponseTemplateSelector.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ResponseTemplateSelector.tsx
@@ -1,6 +1,6 @@
 import { useGetResponses } from '@/responseTemplate/hooks/useGetResponses';
-import { Popover, Skeleton, Button, Command, cn } from 'erxes-ui';
-import { useState, useMemo, ReactNode } from 'react';
+import { Popover, Skeleton, Button, Command, cn, EnumCursorDirection } from 'erxes-ui';
+import { useState, useMemo, ReactNode, useRef, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 import { IconLayoutGrid, IconList, IconFilter } from '@tabler/icons-react';
 import { useGetChannels } from '@/channels/hooks/useGetChannels';
@@ -53,17 +53,26 @@ export const ResponseTemplateSelector: React.FC<
   const [debouncedSearch] = useDebounce(search, 500);
   const [viewMode, setViewMode] = useAtom<ViewMode>(responseListViewAtom);
   const [selectedChannel, setSelectedChannel] = useState<string>('all');
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const isFetchingRef = useRef(false);
 
   const { channels, loading: channelsLoading } = useGetChannels();
-  const { responses, isInitialLoad: responsesInitialLoad } =
-    useGetResponses({
-      variables: {
-        filter: {
-          channelId: selectedChannel === 'all' ? undefined : selectedChannel,
-          searchValue: debouncedSearch || undefined,
-        },
+  const {
+    responses,
+    isInitialLoad: responsesInitialLoad,
+    handleFetchMore,
+    pageInfo,
+  } = useGetResponses({
+    variables: {
+      filter: {
+        channelId: selectedChannel === 'all' ? undefined : selectedChannel,
+        searchValue: debouncedSearch || undefined,
       },
-    });
+    },
+  });
 
   const availableChannels = useMemo<ChannelOption[]>(() => {
     if (!channels) return [];
@@ -91,6 +100,36 @@ export const ResponseTemplateSelector: React.FC<
       return matchesSearch && matchesChannel;
     });
   }, [responses, debouncedSearch, selectedChannel]);
+
+  // Clear the in-flight flag once Apollo delivers new results
+  useEffect(() => {
+    isFetchingRef.current = false;
+    setIsFetchingMore(false);
+  }, [responses]);
+
+  // Infinite scroll: fire when the sentinel enters the scroll container's viewport
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const scrollContainer = containerRef.current?.querySelector(
+      '[cmdk-list]',
+    ) as Element | null;
+
+    if (!sentinel || !scrollContainer || !pageInfo?.hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isFetchingRef.current) {
+          isFetchingRef.current = true;
+          setIsFetchingMore(true);
+          handleFetchMore({ direction: EnumCursorDirection.FORWARD });
+        }
+      },
+      { root: scrollContainer, rootMargin: '0px 0px 80px 0px', threshold: 0 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [pageInfo?.hasNextPage, handleFetchMore, filteredTemplates.length]);
 
   const handleSelectTemplate = (content: string): void => {
     onSelect(content);
@@ -166,50 +205,68 @@ export const ResponseTemplateSelector: React.FC<
                     : 'No templates available'}
                 </div>
               ) : (
-                filteredTemplates.map((template) => (
-                  <Command.Item
-                    key={template._id}
-                    value={template._id}
-                    onSelect={() => handleSelectTemplate(template.content)}
-                    className={cn(
-                      'flex rounded border border-transparent transition-all cursor-pointer gap-2',
-                      'hover:border-primary/20 hover:bg-accent/50',
-                      viewMode === 'grid'
-                        ? 'h-32 col-span-1 flex-col items-start p-3 overflow-hidden w-full'
-                        : 'col-span-2 h-auto flex-row items-center p-2.5',
-                    )}
-                  >
-                    {template.channelId && (
-                      <div
-                        className={cn(
-                          'text-[11px] text-primary shrink bg-primary/10 px-1.5 py-0.5 rounded font-medium',
-                          viewMode === 'grid'
-                            ? 'mb-1 order-first'
-                            : 'ml-auto order-last',
-                        )}
-                      >
-                        <ChannelsInline
-                          showIcon={true}
-                          channelIds={[template.channelId]}
-                        />
-                      </div>
-                    )}
-
-                    <div
-                      className={cn('min-w-0 flex-1', {
-                        'basis-1/3': viewMode === 'list',
-                        'w-full overflow-hidden': viewMode === 'grid',
-                      })}
+                <>
+                  {filteredTemplates.map((template) => (
+                    <Command.Item
+                      key={template._id}
+                      value={template._id}
+                      onSelect={() => handleSelectTemplate(template.content)}
+                      className={cn(
+                        'flex rounded border border-transparent transition-all cursor-pointer gap-2',
+                        'hover:border-primary/20 hover:bg-accent/50',
+                        viewMode === 'grid'
+                          ? 'h-32 col-span-1 flex-col items-start p-3 overflow-hidden w-full'
+                          : 'col-span-2 h-auto flex-row items-center p-2.5',
+                      )}
                     >
-                      <div className="font-semibold text-sm truncate leading-tight">
-                        {template.name}
+                      {template.channelId && (
+                        <div
+                          className={cn(
+                            'text-[11px] text-primary shrink bg-primary/10 px-1.5 py-0.5 rounded font-medium',
+                            viewMode === 'grid'
+                              ? 'mb-1 order-first'
+                              : 'ml-auto order-last',
+                          )}
+                        >
+                          <ChannelsInline
+                            showIcon={true}
+                            channelIds={[template.channelId]}
+                          />
+                        </div>
+                      )}
+
+                      <div
+                        className={cn('min-w-0 flex-1', {
+                          'basis-1/3': viewMode === 'list',
+                          'w-full overflow-hidden': viewMode === 'grid',
+                        })}
+                      >
+                        <div className="font-semibold text-sm truncate leading-tight">
+                          {template.name}
+                        </div>
+                        <div className="text-xs text-muted-foreground line-clamp-2 mt-1 leading-snug">
+                          {getPreviewText(template.content)}
+                        </div>
                       </div>
-                      <div className="text-xs text-muted-foreground line-clamp-2 mt-1 leading-snug">
-                        {getPreviewText(template.content)}
-                      </div>
+                    </Command.Item>
+                  ))}
+                  {pageInfo?.hasNextPage && (
+                    <div className="col-span-2 pt-2 text-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full text-xs text-muted-foreground"
+                        onClick={() =>
+                          handleFetchMore({
+                            direction: EnumCursorDirection.FORWARD,
+                          })
+                        }
+                      >
+                        Load more
+                      </Button>
                     </div>
-                  </Command.Item>
-                ))
+                  )}
+                </>
               )}
             </Command.List>
           </Command>

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FbMessengerMessageAttachments.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FbMessengerMessageAttachments.tsx
@@ -38,7 +38,7 @@ const Attachment = ({
 }) => {
   const { userId, customerId, botData } = useFbMessengerMessageContext();
   const isOutgoing = !!userId || !!botData?.length;
-  const isImage = attachment.type.startsWith('image/');
+  const isImage = attachment.type.startsWith('image');
 
   if (!isImage) {
     return (

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/attachments/Attachments.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/attachments/Attachments.tsx
@@ -29,7 +29,7 @@ const Attachments = () => {
   }
 
   const mediaAttachments = safeAttachments.filter((attachment) =>
-    attachment.type?.startsWith('image/'),
+    attachment.type?.startsWith('image'),
   );
   const fileAttachments = safeAttachments.filter((attachment) =>
     fileTypes.includes(attachment.type ?? ''),


### PR DESCRIPTION
…load more for frontline response templates; fix inbox image preview,

## Summary by Sourcery

Add support for custom property import/export for core contacts and frontline tickets, enhance frontline response template browsing with pagination, and fix image attachment detection in inbox and ticket UIs.

New Features:
- Include custom property fields in company and customer export headers and rows.
- Support custom property import/export for frontline tickets via propertiesData handling and validation.
- Add infinite scroll and manual "Load more" controls to the frontline response template selector.

Bug Fixes:
- Fix image attachment previews in inbox, Facebook Messenger, and ticket attachments by relaxing image MIME type checks.

Enhancements:
- Refactor frontline ticket import/export to centralize custom field header generation and ticket properties extraction/validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companies, customers, and tickets now include custom property fields in exports and imports (dynamic headers and flattened propertiesData).
  * Ticket import now extracts and validates custom property values.
  * Response template selector adds infinite scrolling with "Load more" pagination.

* **Bug Fixes**
  * Broader image attachment detection so more attachment types render as images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->