### PR TITLE
ci: switch to howardpen9/kimi-code-reviewer for better fork PR support

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -2,63 +2,24 @@
 name: Kimi Code Review
 
 on:
-  # Trigger on PR events
   pull_request:
-    types: [opened, synchronize, reopened]
-  # Trigger on comment events (for /review, /ask commands)
-  issue_comment:
-    types: [created]
-  # Trigger on inline review comments
-  pull_request_review_comment:
-    types: [created]
+    types: [opened, synchronize]
 
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
-  kimi-review:
+  review:
     runs-on: ubuntu-latest
-    # Only run on PRs or comment events that start with "/"
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       startsWith(github.event.comment.body, '/')) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       startsWith(github.event.comment.body, '/'))
-    
     steps:
-      # Step 1: Get PR information (for comment events)
-      - name: Get PR ref (for comments)
-        id: get-pr
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.issue?.number || context.payload.pull_request?.number;
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            core.setOutput('ref', pr.data.head.ref);
-            core.setOutput('sha', pr.data.head.sha);
-
-      # Step 2: Checkout the code
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && steps.get-pr.outputs.ref || github.head_ref }}
 
-      # Step 3: Run Kimi Code Review Action
-      - uses: xiaoju111a/kimi-actions@main
+      - uses: howardpen9/kimi-code-reviewer@main
         with:
           kimi_api_key: ${{ secrets.KIMI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          auto_review: 'true'  # Set to 'true' for automatic reviews on PR open
-          # Optional configurations (uncomment to use):
-          # language: 'en-US'              # Options: 'en-US', 'zh-CN'
-          # model: 'kimi-k2.5'             # Default model
-          # review_level: 'normal'         # Options: 'strict', 'normal', 'gentle'
-          # max_files: '50'                # Maximum files to review
-          # exclude_patterns: '*.lock,*.min.js,node_modules/**'
+          language: en
+          model: kimi-k2.6
+          fail_on: critical


### PR DESCRIPTION
## Problem
Kimi Code Review action fails on fork PRs because it tries to checkout branch refs that only exist in forks.

## Changes
- Replace xiaoju111a/kimi-actions with howardpen9/kimi-code-reviewer
- Fix checkout failures on fork PRs (no manual ref fetching needed)
- Use TypeScript instead of Docker (faster startup)
- Add inline annotations via GitHub Checks API
- Update model to kimi-k2.6
- Add checks:write permission
- Support for .kimi-review.yml config file

## Summary by Sourcery

Switch the Kimi code review GitHub workflow to a new action with improved fork PR support and simplified triggers.

CI:
- Replace the previous Kimi review Docker-based action with the howardpen9/kimi-code-reviewer TypeScript action.
- Simplify workflow triggers to only run on pull_request opened and synchronize events, removing comment-based invocations.
- Grant checks:write permission and configure the action to use the kimi-k2.6 model with stricter failure conditions and language settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified code review workflow to automatically trigger on pull request creation and updates, removing the ability to request reviews via comments or reopened events.
  * Standardized review configuration with consistent language, model, and critical failure threshold settings applied uniformly across all pull requests.
  * Updated workflow permissions to support enhanced code review capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->