### PR TITLE
security: pin kimi-code-reviewer action to specific commit SHA

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: howardpen9/kimi-code-reviewer@main
+      - uses: howardpen9/kimi-code-reviewer@183bb281ce03338ef8ddfb6ed6d5ff4aaa866bcb
         with:
           kimi_api_key: ${{ secrets.KIMI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
SonarCloud flagged a security hotspot: using mutable tags for external GitHub actions is security-sensitive.

## Risk
If the maintainer account is compromised, malicious code pushed to main would be executed immediately in our CI.

## Fix
Replace @main with the full commit SHA to ensure immutable, verifiable code execution.

## References
- SonarCloud rule: githubactions:S7637
- GitHub Security Best Practices

## Summary by Sourcery

CI:
- Update the kimi-review workflow to reference howardpen9/kimi-code-reviewer by commit SHA instead of the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.** This update includes internal infrastructure and automation improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->