### PR TITLE
ci: add missing checkout step to Claude Code Action

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -18,6 +18,12 @@ jobs:
       issues: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Problem

The `claude-code-action` workflow fails on fork PRs because it attempts to read changed files and fetch PR branches without first checking out the repository.

**Errors observed:**
- `fatal: not a git repository (or any of the parent directories): .git`
- `fatal: could not open 'backend/plugins/AGENT.md' for reading: No such file or directory`
- `Command failed: git fetch origin --depth=20 pull/7870/head:translate-backend-agent-doc`

## Solution

Add `actions/checkout@v4` with `fetch-depth: 0` before the Claude Code Action step so the action has access to the git history and changed files.

## Changes

- Added checkout step to `.github/workflows/claude-code.yml`

## Summary by Sourcery

CI:
- Update the Claude Code workflow to run actions/checkout@v4 with full fetch depth before executing the Claude Code Action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration workflow by adding an explicit repository checkout step to ensure full history is available and credentials are not persisted, enhancing reliability and security of automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->