### PR TITLE
Revert direct commit: restore issue-webhook-dispatcher.yml

### DIFF
--- a/.github/workflows/issue-webhook-dispatcher.yml
+++ b/.github/workflows/issue-webhook-dispatcher.yml
@@ -1,0 +1,28 @@
+name: Issue Webhook Dispatcher
+
+on:
+  issues:
+    types: [opened, labeled, edited]
+
+jobs:
+  dispatch:
+    name: Send issue to auto-fix webhook
+    if: |
+      github.event.issue.pull_request == null &&
+      (
+        contains(github.event.issue.labels.*.name, 'bug') ||
+        contains(github.event.issue.labels.*.name, 'sentry')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: Send webhook to auto-fix listener
+        run: |
+          curl -X POST "${{ secrets.AUTO_FIX_WEBHOOK_URL }}/webhook/github/issue" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: issues" \
+            -d '${{ toJson(github.event) }}' \
+            --fail-with-body
+        env:
+          AUTO_FIX_WEBHOOK_URL: ${{ secrets.AUTO_FIX_WEBHOOK_URL }}


### PR DESCRIPTION
This reverts commit 85afcb5711 which was directly pushed to main, bypassing PR review.

Restores the file so it can be properly removed via a separate PR.

## Summary by Sourcery

CI:
- Reintroduce the issue-webhook-dispatcher workflow to post selected issue events to an external auto-fix listener via webhook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated issue processing for specific issue events and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->