### PR TITLE
feat: federate plugin locale through gateway

### DIFF
--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -39,8 +39,7 @@ import {
   startSubscriptionServer,
   stopSubscriptionServer,
 } from './subscription';
-import * as fs from 'fs';
-import * as path from 'path';
+import { isValidLocaleParams, resolveLocale } from '~/util/locales';
 
 dotenv.config();
 
@@ -163,51 +162,19 @@ app.get('/debug-sentry', () => {
 });
 
 app.get('/locales/:lng/:file', async (req, res) => {
-  const localesRoot = path.join(__dirname, './locales');
-  try {
-    const requestedPath = path.resolve(
-      localesRoot,
-      req.params.lng,
-      req.params.file,
-    );
-    const realPath = fs.realpathSync(requestedPath);
-    if (!realPath.startsWith(localesRoot + path.sep)) {
-      return res.status(403).send('Forbidden');
-    }
-    const lngJson = fs.readFileSync(realPath);
+  const { lng, file } = req.params;
 
-    return res.json(JSON.parse(lngJson.toString()));
-  } catch {
-    console.log('Locale not found locally, trying plugins');
+  if (!isValidLocaleParams(lng, file)) {
+    return res.status(400).send('Invalid locale');
   }
 
-  try {
-    const { lng, file } = req.params;
+  const locale = await resolveLocale(lng, file);
 
-    const plugins = await getPlugins();
-
-    for (const pluginName of plugins) {
-      try {
-        const plugin = await getPlugin(pluginName);
-
-        if (!plugin?.address) continue;
-
-        const response = await fetch(`${plugin.address}/locales/${lng}/${file}`);
-
-        if (response.ok) {
-          const json = await response.json();
-
-          return res.json(json);
-        }
-      } catch {
-        console.log(`Error occurred while fetching locale from plugin: ${pluginName}`);
-      }
-    }
-  } catch {
-    console.log('Error occurred while fetching locales');
+  if (locale === null) {
+    return res.status(404).send('Locale not found');
   }
 
-  res.status(404).send('Locale not found');
+  return res.json(locale);
 });
 
 app.use('/pl:serviceName', async (req, res) => {

--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -175,11 +175,41 @@ app.get('/locales/:lng/:file', async (req, res) => {
       return res.status(403).send('Forbidden');
     }
     const lngJson = fs.readFileSync(realPath);
-    res.json(JSON.parse(lngJson.toString()));
+
+    return res.json(JSON.parse(lngJson.toString()));
   } catch {
-    res.status(500).send('Error fetching locale');
+    console.log('Locale not found locally, trying plugins');
   }
+
+  try {
+    const { lng, file } = req.params;
+
+    const plugins = await getPlugins();
+
+    for (const pluginName of plugins) {
+      try {
+        const plugin = await getPlugin(pluginName);
+
+        if (!plugin?.address) continue;
+
+        const response = await fetch(`${plugin.address}/locales/${lng}/${file}`);
+
+        if (response.ok) {
+          const json = await response.json();
+
+          return res.json(json);
+        }
+      } catch {
+        console.log(`Error occurred while fetching locale from plugin: ${pluginName}`);
+      }
+    }
+  } catch {
+    console.log('Error occurred while fetching locales');
+  }
+
+  res.status(404).send('Locale not found');
 });
+
 app.use('/pl:serviceName', async (req, res) => {
   try {
     const serviceName: string = req.params.serviceName.replace(':', '');

--- a/backend/gateway/src/util/locales.ts
+++ b/backend/gateway/src/util/locales.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getPlugin, getPlugins } from 'erxes-api-shared/utils';
+
+const LNG_PATTERN = /^[a-zA-Z]{2,5}(?:[-_][a-zA-Z0-9]{2,8})?$/;
+const FILE_PATTERN = /^[a-zA-Z0-9._-]+\.json$/;
+
+export const isValidLocaleParams = (lng: string, file: string): boolean =>
+  LNG_PATTERN.test(lng) && FILE_PATTERN.test(file);
+
+const readLocalLocale = (lng: string, file: string): unknown | null => {
+  const localesRoot = path.join(__dirname, '../locales');
+
+  const requestedPath = path.resolve(localesRoot, lng, file);
+  const realPath = fs.realpathSync(requestedPath);
+
+  if (!realPath.startsWith(localesRoot + path.sep)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(realPath).toString());
+};
+
+const fetchPluginLocale = async (
+  lng: string,
+  file: string,
+): Promise<unknown | null> => {
+  for (const pluginName of await getPlugins()) {
+    try {
+      const plugin = await getPlugin(pluginName);
+
+      if (!plugin?.address) continue;
+
+      const response = await fetch(`${plugin.address}/locales/${lng}/${file}`, {
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (response.ok) {
+        return await response.json();
+      }
+    } catch {
+      console.log(`Error fetching locale from plugin: ${pluginName}`);
+    }
+  }
+
+  return null;
+};
+
+export const resolveLocale = async (
+  lng: string,
+  file: string,
+): Promise<unknown | null> => {
+  try {
+    const local = readLocalLocale(lng, file);
+
+    if (local !== null) {
+      return local;
+    }
+  } catch {
+    console.log('Locale not found locally, trying plugins');
+  }
+
+  return fetchPluginLocale(lng, file);
+};

--- a/frontend/core-ui/src/modules/plugins/providers/PluginConfigsProvidersEffect.tsx
+++ b/frontend/core-ui/src/modules/plugins/providers/PluginConfigsProvidersEffect.tsx
@@ -3,6 +3,7 @@ import { IUIConfig } from 'erxes-ui';
 import { useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { loadingPluginsConfigState, pluginsConfigState } from 'ui-modules';
+import { i18nInstance } from '~/i18n';
 
 type RemoteConfig = {
   CONFIG: IUIConfig;
@@ -23,6 +24,10 @@ export const PluginConfigsProvidersEffect = () => {
               `${remote.name}/config`,
             )) as RemoteConfig;
             const pluginConfig = remoteConfig.CONFIG;
+
+            if (pluginConfig.i18n) {
+              i18nInstance.loadNamespaces(pluginConfig.name);
+            }
 
             setPluginsConfig((prev) => ({
               ...prev,

--- a/frontend/libs/erxes-ui/src/types/UIConfig.ts
+++ b/frontend/libs/erxes-ui/src/types/UIConfig.ts
@@ -2,6 +2,7 @@ export type IUIConfig = {
   name: string;
   path: string;
   icon?: React.ElementType;
+  i18n?: boolean;
   hasFloatingWidget?: boolean;
   settingsNavigation?: () => React.ReactNode;
   navigationGroup?: {


### PR DESCRIPTION
## Summary by Sourcery

Federate locale loading through the gateway to fall back to plugin-provided translations when local files are missing.

New Features:
- Allow the gateway to proxy locale files from registered plugins when they are not available locally.
- Enable plugins to declare i18n support in their UI config.
- Automatically load plugin i18n namespaces on the frontend when a plugin indicates i18n support.

Enhancements:
- Improve locale endpoint error handling by distinguishing between local, plugin, and overall failures and returning 404 when no locale is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can register and load their own internationalization namespaces and translations into the app.
  * New configuration flag to declare a plugin’s internationalization support.

* **Bug Fixes**
  * Locale endpoint now validates requests and returns clearer 400/404 responses for invalid or missing locales.
  * Improved locale fetching with safer resolution and fallback to plugins when local lookups fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->