### PR TITLE
fix(frontline): use Facebook Private Reply API for new comment-triggered conversations

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
@@ -131,22 +131,19 @@ export const receiveInboxMessage = async (
     }
 
     if (conversationId) {
-      if (!assignedUserId) {
-        const existingConversation = await Conversations.findOne({
-          $and: [{ _id: conversationId }, { integrationId: integrationId }],
-        }).lean();
-
-        assignedUserId = existingConversation?.assignedUserId || null;
-      }
-
       const conversation = await Conversations.findOne({
-        $and: [{ _id: conversationId }, { integrationId: integrationId }],
+        _id: conversationId,
       }).lean();
+
+      if (!assignedUserId) {
+        assignedUserId = conversation?.assignedUserId || null;
+      }
 
       if (conversation) {
         const updatedDoc = {
           content,
           assignedUserId,
+          integrationId,
           updatedAt,
 
           readUserIds: [],

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/index.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/index.ts
@@ -144,6 +144,7 @@ export const actionCreateMessage = async ({
     senderId,
     recipientId,
     botId,
+    didCreateConversation,
   } = await getOrCreateFacebookMessageActionContext(
     models,
     subdomain,
@@ -171,12 +172,17 @@ export const actionCreateMessage = async ({
       throw new Error('There are no generated messages to send.');
     }
 
-    for (const { botData, inputData, ...message } of messages) {
+    for (const [
+      index,
+      { botData, inputData, ...message },
+    ] of messages.entries()) {
       const sendReplyResult = await sendMessage(models, bot, {
         senderId,
         recipientId,
         integration,
         message,
+        commentId:
+          index === 0 && didCreateConversation ? target?.comment_id : undefined,
       });
 
       if (!sendReplyResult) {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/utils.ts
@@ -280,7 +280,7 @@ export const generateMessages = async ({
     if (['image', 'audio', 'video'].includes(type)) {
       const url = image || video || audio;
 
-      url &&
+      if (url) {
         generatedMessages.push({
           attachment: {
             type: type as 'image' | 'audio' | 'video',
@@ -290,6 +290,7 @@ export const generateMessages = async ({
           },
           botData,
         });
+      }
     }
   }
 
@@ -299,7 +300,14 @@ export const generateMessages = async ({
 export const sendMessage = async (
   models: IModels,
   bot: IFacebookBotDocument,
-  { senderId, recipientId, integration, message, tag }: ISendMessageData,
+  {
+    senderId,
+    recipientId,
+    integration,
+    message,
+    tag,
+    commentId,
+  }: ISendMessageData,
   isLoop?: boolean,
 ) => {
   await trySendTypingOn(
@@ -309,6 +317,7 @@ export const sendMessage = async (
     integration.erxesApiId,
     tag,
   );
+  const recipient = commentId ? { comment_id: commentId } : { id: senderId };
 
   try {
     // Send the actual message
@@ -316,7 +325,7 @@ export const sendMessage = async (
       models,
       'me/messages',
       {
-        recipient: { id: senderId },
+        recipient,
         message,
         tag,
       },
@@ -341,6 +350,7 @@ export const sendMessage = async (
           integration,
           message,
           tag: bot?.tag,
+          commentId,
         },
         true,
       );
@@ -389,6 +399,7 @@ export const getOrCreateFacebookMessageActionContext = async (
   recipientId: string;
   senderId: string;
   botId: string;
+  didCreateConversation: boolean;
 }> => {
   if (collectionType === 'comments') {
     return await getOrCreateCommentMessageActionContext({
@@ -451,6 +462,7 @@ async function getOrCreateDirectMessageActionContext({
     recipientId,
     senderId,
     botId,
+    didCreateConversation: false,
   };
 }
 
@@ -589,6 +601,7 @@ async function getOrCreateCommentMessageActionContext({
     recipientId,
     senderId,
     botId,
+    didCreateConversation,
   };
 }
 

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/types/automationTypes.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/types/automationTypes.ts
@@ -20,6 +20,7 @@ export type ISendMessageData = {
   integration: IFacebookIntegrationDocument;
   message: any;
   tag?: string;
+  commentId?: string;
 };
 
 export type ICheckTriggerData = {


### PR DESCRIPTION
…red conversations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation lookup and message assignment logic for better accuracy.
  * Enhanced Facebook/Meta integration message sending, including improved handling of comment-based conversations and message threading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->