### PR TITLE
feat: Sentry error monitoring (frontend + backend) with expected-error classification

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,12 @@
 # NODE_OPTIONS=--max-old-space-size=1536
 # ENABLED_PLUGINS=operation
 # DISABLE_CHANGE_STREAM=true
-# SENTRY_DSN=https://14fdff36aaa2eeaddef3444cb3a65b86@sentry.erxes.io/2
-# SENTRY_ENVIRONMENT=local
+# --- Sentry: backend API services (environment e.g. production-api / amaraa-test-local) ---
+# SENTRY_DSN=api_sentry_dsn
+# SENTRY_ENVIRONMENT=api_sentry_environment_name
+# SENTRY_TRACES_SAMPLE_RATE=0.1
+# --- Sentry: frontend (core-ui host + MF remotes). In prod, docker-entrypoint.sh
+#     injects any REACT_APP_* var into window.env at container start. ---
+# REACT_APP_SENTRY_DSN=ui_sentry_dsn
+# REACT_APP_SENTRY_ENVIRONMENT=ui_sentry_environment_name
 # RELEASE_VERSION=erxes-<git-sha-or-version>

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -4,11 +4,12 @@ import {
   sendTRPCMessage,
   redis,
   getActivePlugins,
+  ExpectedError,
 } from '../../utils';
 
 export const checkLogin = (user?: IUserDocument) => {
   if (!user?._id) {
-    throw new Error('Login required');
+    throw new ExpectedError('Login required', 'UNAUTHORIZED');
   }
 };
 
@@ -197,7 +198,7 @@ const checkOAuthScope = async (action: string, user?: IUserDocument) => {
     actionScopes.length === 0 ||
     !actionScopes.some((scope) => oauthScopes.includes(scope))
   ) {
-    throw new Error('OAuth scope required');
+    throw new ExpectedError('OAuth scope required', 'FORBIDDEN');
   }
 };
 
@@ -211,7 +212,7 @@ export const checkPermissionGroup = (
     const allowed = await canGroup(subdomain, action, user);
 
     if (!allowed) {
-      throw new Error('Permission required');
+      throw new ExpectedError('Permission required', 'FORBIDDEN');
     }
 
     await checkOAuthScope(action, user);
@@ -224,11 +225,11 @@ export const wrapPublicResolver = (resolver: Resolver, wrapperConfig: any) => {
 
     if (forClientPortal) {
       if (!context.clientPortal) {
-        throw new Error('Client portal required');
+        throw new ExpectedError('Client portal required', 'UNAUTHORIZED');
       }
 
       if (cpUserRequired && !context.cpUser) {
-        throw new Error('Client portal user required');
+        throw new ExpectedError('Client portal user required', 'UNAUTHORIZED');
       }
     }
 

--- a/backend/erxes-api-shared/src/utils/errorClassifier.test.ts
+++ b/backend/erxes-api-shared/src/utils/errorClassifier.test.ts
@@ -1,4 +1,12 @@
-import { classifyError, isExpectedError, extractMessage, sentryExpectedErrorFilter } from './errorClassifier';
+import {
+  classifyError,
+  isExpectedError,
+  extractMessage,
+  sentryExpectedErrorFilter,
+  ExpectedError,
+  createExpectedError,
+  EXPECTED_ERROR_NAME,
+} from './errorClassifier';
 
 describe('errorClassifier', () => {
   describe('classifyError', () => {
@@ -15,6 +23,25 @@ describe('errorClassifier', () => {
       expect(result.category).toBe(category);
       expect(result.isExpected).toBe(isExpected);
       expect(result.statusCode).toBe(statusCode);
+    });
+
+    // Regression: real prod Sentry noise that previously leaked through because
+    // the messages don't contain "is required"/"are required"/etc.
+    test.each([
+      ['Login required'],
+      ['Permission required'],
+      ['OAuth scope required'],
+      ['Client portal required'],
+      ['Client portal user required'],
+      ['You do not have permission to manage this identifier'],
+      ['Access denied: You do not have access to this private pipeline'],
+      ['This operation is only allowed in saas version.'],
+      ['Start date must be before end date'],
+    ])('should classify auth/business noise "%s" as EXPECTED', (msg) => {
+      const result = classifyError(new Error(msg));
+      expect(result.category).toBe('EXPECTED');
+      expect(result.isExpected).toBe(true);
+      expect(result.statusCode).toBe(200);
     });
 
     it('should classify "MongoNetworkError" as SYSTEM', () => {
@@ -51,6 +78,37 @@ describe('errorClassifier', () => {
       const error = new Error('Validation failed') as any;
       error.code = 'VALIDATION_ERROR';
       const result = classifyError(error);
+      expect(result.category).toBe('EXPECTED');
+    });
+  });
+
+  describe('ExpectedError (explicit marker)', () => {
+    it('is always EXPECTED regardless of message wording', () => {
+      // A message that matches NONE of the regex patterns must still be expected.
+      const result = classifyError(new ExpectedError('totally novel wording xyz'));
+      expect(result.category).toBe('EXPECTED');
+      expect(result.isExpected).toBe(true);
+      expect(result.statusCode).toBe(200);
+    });
+
+    it('beats SYSTEM patterns when explicitly marked', () => {
+      // Even a message containing a SYSTEM keyword stays EXPECTED when the
+      // thrower has declared intent via ExpectedError.
+      const result = classifyError(new ExpectedError('TypeError-looking message'));
+      expect(result.category).toBe('EXPECTED');
+    });
+
+    it('createExpectedError produces an ExpectedError', () => {
+      const err = createExpectedError('Login required', 'UNAUTHORIZED');
+      expect(err).toBeInstanceOf(ExpectedError);
+      expect(err.name).toBe(EXPECTED_ERROR_NAME);
+      expect(err.code).toBe('UNAUTHORIZED');
+      expect(err.isExpected).toBe(true);
+      expect(classifyError(err).category).toBe('EXPECTED');
+    });
+
+    it('honours a plain object with isExpected === true', () => {
+      const result = classifyError({ message: 'whatever', isExpected: true });
       expect(result.category).toBe('EXPECTED');
     });
   });
@@ -152,6 +210,22 @@ describe('errorClassifier', () => {
     it('should return event when no exception', () => {
       const event = {};
       expect(sentryExpectedErrorFilter(event as any)).toBe(event as any);
+    });
+
+    it('should drop events by ExpectedError type even if message is unmatched', () => {
+      const event = {
+        exception: {
+          values: [{ type: EXPECTED_ERROR_NAME, value: 'novel wording xyz' }],
+        },
+      };
+      expect(sentryExpectedErrorFilter(event as any)).toBeNull();
+    });
+
+    it('should drop "Login required" (regression)', () => {
+      const event = {
+        exception: { values: [{ type: 'Error', value: 'Login required' }] },
+      };
+      expect(sentryExpectedErrorFilter(event as any)).toBeNull();
     });
   });
 });

--- a/backend/erxes-api-shared/src/utils/errorClassifier.ts
+++ b/backend/erxes-api-shared/src/utils/errorClassifier.ts
@@ -18,6 +18,60 @@ export interface IClassificationResult {
   isExpected: boolean;
 }
 
+/**
+ * Marker name used to recognise an expected error even after it has been
+ * serialised by Sentry (where only `exception.values[].type` survives).
+ */
+export const EXPECTED_ERROR_NAME = 'ExpectedError';
+
+/**
+ * Throw this for known business conditions (auth, validation, "not found", …)
+ * instead of a plain `Error`. It is classified as EXPECTED deterministically —
+ * independent of the message text — so renaming the message never silently
+ * turns it back into Sentry noise.
+ *
+ *   throw new ExpectedError('Login required', 'UNAUTHORIZED');
+ */
+export class ExpectedError extends Error {
+  /** Always true; read by {@link classifyError}. */
+  readonly isExpected = true;
+  /** Optional machine-readable code (e.g. UNAUTHORIZED, FORBIDDEN). */
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = EXPECTED_ERROR_NAME;
+    this.code = code;
+    // Restore prototype chain for `instanceof` after transpile to ES5/ES2017.
+    Object.setPrototypeOf(this, ExpectedError.prototype);
+  }
+}
+
+/** Convenience factory mirroring {@link ExpectedError}. */
+export function createExpectedError(message: string, code?: string): ExpectedError {
+  return new ExpectedError(message, code);
+}
+
+/**
+ * True when an error explicitly declares itself expected — via the
+ * {@link ExpectedError} class, an `isExpected === true` flag, or the marker name.
+ */
+function isExplicitlyExpected(
+  error: unknown,
+  errorName?: string,
+): boolean {
+  if (errorName === EXPECTED_ERROR_NAME) return true;
+  if (
+    error &&
+    typeof error === 'object' &&
+    'isExpected' in error &&
+    (error as { isExpected?: unknown }).isExpected === true
+  ) {
+    return true;
+  }
+  return false;
+}
+
 // Expected error patterns — business logic conditions
 const EXPECTED_PATTERNS: RegExp[] = [
   /not found/i,
@@ -70,6 +124,29 @@ const EXPECTED_PATTERNS: RegExp[] = [
   /duplicate/i,
   /unique constraint/i,
   /schema validation/i,
+  // Auth / permission / session — the dominant Sentry noise.
+  // These originate from the core permission chokepoint
+  // (backend/erxes-api-shared/src/core-modules/permissions/utils.ts) and from
+  // ad-hoc throws across plugins. SYSTEM patterns are matched first, so these
+  // cannot shadow real infrastructure errors.
+  /login required/i, // "Login required"
+  /permission required/i, // "Permission required"
+  /scope required/i, // "OAuth scope required"
+  /portal (user )?required/i, // "Client portal required", "Client portal user required"
+  /have permission/i, // "You do not have permission to ..."
+  /no permission/i,
+  /access denied/i, // "Access denied: You do not have access ..."
+  /requires (login|permission|authentication|authorization)/i,
+  /login failed/i,
+  /session expired/i,
+  // Business validation phrasing seen in prod that the generic rules miss
+  /only allowed (in|for|on)/i, // "only allowed in saas version"
+  /only available (in|for|on)/i,
+  /must be before/i, // "Start date must be before end date"
+  /must be after/i,
+  /must be greater/i,
+  /must be less/i,
+  /must be a valid/i,
 ];
 
 // System error patterns — infrastructure/bugs
@@ -141,6 +218,14 @@ export function classifyError(error: unknown): IClassificationResult {
   const message = extractMessage(error);
   const code = extractCode(error);
   const errorName = extractErrorName(error);
+
+  // Explicit opt-in marker wins over every heuristic. Code that knows an error
+  // is an expected business condition can throw `new ExpectedError(...)` (or set
+  // `isExpected === true` / name === 'ExpectedError') and be classified
+  // deterministically regardless of how the message is later reworded.
+  if (isExplicitlyExpected(error, errorName)) {
+    return { category: 'EXPECTED', statusCode: 200, isExpected: true };
+  }
 
   // Check explicit error codes first
   if (code) {
@@ -329,6 +414,14 @@ export function sentryExpectedErrorFilter(
   _hint?: Sentry.EventHint,
 ): Sentry.ErrorEvent | null {
   const error = event.exception?.values?.[0];
+
+  // Only the message (`value`) and constructor (`type`) survive serialisation,
+  // so classify from those. The marker type is checked first because it is
+  // wording-independent.
+  if (error?.type === EXPECTED_ERROR_NAME) {
+    return null;
+  }
+
   if (error?.value) {
     const classification = classifyError(error.value);
     if (classification.category === 'EXPECTED') {

--- a/frontend/core-ui/rspack.config.ts
+++ b/frontend/core-ui/rspack.config.ts
@@ -37,6 +37,13 @@ export default composePlugins(
         'process.env.REACT_APP_HIDE_CORE_MODULES': JSON.stringify(
           process.env.REACT_APP_HIDE_CORE_MODULES,
         ),
+
+        'process.env.REACT_APP_SENTRY_DSN': JSON.stringify(
+          process.env.REACT_APP_SENTRY_DSN,
+        ),
+        'process.env.REACT_APP_SENTRY_ENVIRONMENT': JSON.stringify(
+          process.env.REACT_APP_SENTRY_ENVIRONMENT,
+        ),
       }),
     );
 

--- a/frontend/core-ui/src/bootstrap.tsx
+++ b/frontend/core-ui/src/bootstrap.tsx
@@ -10,6 +10,10 @@ import './styles.css';
 
 import { App } from '@/app/components/App';
 import { ClientConfigError } from '@/error-handler/components/ClientConfigError';
+import { initSentry } from './sentry';
+
+// Install browser error handlers as early as possible, before any rendering.
+initSentry();
 
 async function initFederation() {
   const root = ReactDOM.createRoot(

--- a/frontend/core-ui/src/modules/app/hooks/useCreateAppRouter.tsx
+++ b/frontend/core-ui/src/modules/app/hooks/useCreateAppRouter.tsx
@@ -20,6 +20,7 @@ import { SegmentRoutes } from '@/app/components/SegmentsRoutes';
 import { SettingsRoutes } from '@/app/components/SettingsRoutes';
 import { getPluginsRoutes } from '@/app/hooks/usePluginsRouter';
 import { PermissionRouteGuard } from '@/auth/components/PermissionRouteGuard';
+import { RouteErrorBoundary } from '@/error-handler/components/RouteErrorBoundary';
 import { UserProvider } from '@/auth/providers/UserProvider';
 import { OrganizationProvider } from '@/organization/providers/OrganizationProvider';
 import { useAtomValue } from 'jotai';
@@ -57,7 +58,11 @@ export const useCreateAppRouter = () => {
   const isOS = useVersion();
   return createBrowserRouter(
     createRoutesFromElements(
-      <Route element={<Providers />} loader={async () => null}>
+      <Route
+        element={<Providers />}
+        loader={async () => null}
+        errorElement={<RouteErrorBoundary />}
+      >
         <Route path={AppPath.MainOnboarding} element={<MainOnboardingPage />} />
         <Route path={AppPath.CreateOwner} element={<CreateOwnerPage />} />
         <Route element={<OrganizationProvider />}>

--- a/frontend/core-ui/src/modules/error-handler/components/AppErrorBoundary.tsx
+++ b/frontend/core-ui/src/modules/error-handler/components/AppErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import * as Sentry from '@sentry/react';
 
 import { GenericErrorFallback } from '@/error-handler/components/GenericErrorFallback';
 
@@ -8,10 +9,23 @@ export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
     window.location.reload();
   };
 
+  // React render crashes are caught here in-process, so Sentry receives the real
+  // Error (with stack + component stack) — not the cross-origin "Script error."
+  // that window.onerror would otherwise report for Module Federation remotes.
+  const handleError = (
+    error: Error,
+    info: { componentStack?: string | null },
+  ) => {
+    Sentry.captureException(error, {
+      extra: { componentStack: info.componentStack },
+    });
+  };
+
   return (
     <ErrorBoundary
       FallbackComponent={GenericErrorFallback}
       onReset={handleReset}
+      onError={handleError}
     >
       {children}
     </ErrorBoundary>

--- a/frontend/core-ui/src/modules/error-handler/components/RouteErrorBoundary.tsx
+++ b/frontend/core-ui/src/modules/error-handler/components/RouteErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { useRouteError } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+
+import { GenericErrorFallback } from '@/error-handler/components/GenericErrorFallback';
+
+/**
+ * React Router's data router catches render errors thrown inside routed
+ * components in its OWN internal boundary (RenderErrorBoundary) before they can
+ * bubble up to the top-level <AppErrorBoundary>. Without a route-level
+ * errorElement, those errors are swallowed by React Router's default boundary
+ * and never reach Sentry (and React, having handled them, never fires
+ * window.onerror either). Sentry's wrapCreateBrowserRouterV7 only adds tracing
+ * spans — it does NOT capture these errors — so this errorElement is the single
+ * capture point for routed render/loader errors.
+ *
+ * Wired as the root route's errorElement, this catches every routed error —
+ * host pages AND Module Federation remotes (errors bubble to the nearest
+ * ancestor errorElement) — reports it to Sentry, and renders the shared
+ * fallback UI.
+ *
+ * Capture happens SYNCHRONOUSLY during render, not in a useEffect. Effects run
+ * only after a successful commit, and React's concurrent error-recovery path
+ * (recoverFromConcurrentError) can discard this element before effects flush —
+ * which silently dropped the report and is why crashes showed in the dev
+ * overlay but never reached Sentry. The WeakSet de-dupes the captures that
+ * StrictMode's double render and React's sync error-recovery retries produce.
+ */
+const reportedErrors = new WeakSet<object>();
+
+export const RouteErrorBoundary = () => {
+  const error = useRouteError();
+
+  if (error != null) {
+    if (typeof error === 'object') {
+      if (!reportedErrors.has(error)) {
+        reportedErrors.add(error);
+        Sentry.captureException(error);
+      }
+    } else {
+      Sentry.captureException(error);
+    }
+  }
+
+  return (
+    <GenericErrorFallback
+      error={error instanceof Error ? error : new Error(String(error))}
+      resetErrorBoundary={() => window.location.reload()}
+    />
+  );
+};

--- a/frontend/core-ui/src/sentry.ts
+++ b/frontend/core-ui/src/sentry.ts
@@ -1,0 +1,70 @@
+/**
+ * Frontend Sentry initialization (browser).
+ *
+ * The host (core-ui) is the single Module Federation container that loads every
+ * plugin remote into the same window, so initializing Sentry here installs the
+ * global error/unhandledrejection handlers for the whole app — host AND remotes.
+ *
+ * Errors are separated from the backend by environment tag:
+ *   - production-ui        (deployed UI)
+ *   - amaraa-test-local-ui (local dev)
+ * while the API services report under production-api / amaraa-test-local.
+ *
+ * Mirrors the backend `beforeSend` noise filter
+ * (backend/erxes-api-shared/src/utils/errorClassifier.ts) so expected business
+ * conditions surfaced client-side don't become Sentry noise.
+ *
+ * NOTE: local-dev errors only appear in Sentry if the project's "localhost"
+ * inbound filter is OFF (Project Settings → Inbound Filters). With it ON, Sentry
+ * accepts the POST (HTTP 200) but silently discards events whose stack frames
+ * are localhost — which looks exactly like the SDK "not sending".
+ */
+import * as Sentry from '@sentry/react';
+import {
+  NODE_ENV,
+  REACT_APP_SENTRY_DSN,
+  REACT_APP_SENTRY_ENVIRONMENT,
+} from 'erxes-ui';
+
+// Browser/runtime noise + expected business errors that must never reach Sentry.
+const NOISE_PATTERNS: RegExp[] = [
+  /ResizeObserver loop/i,
+  /Non-Error promise rejection captured/i,
+  /Network request failed/i,
+  /Load failed/i,
+  // expected business/auth conditions (kept in sync with the backend classifier)
+  /login required/i,
+  /permission required/i,
+  /scope required/i,
+  /portal (user )?required/i,
+  /not authenticated/i,
+  /unauthorized/i,
+  /forbidden/i,
+];
+
+let initialized = false;
+
+export function initSentry() {
+  if (initialized) return;
+
+  const dsn = REACT_APP_SENTRY_DSN;
+  if (!dsn) return; // no-op when unconfigured (e.g. contributors without a DSN)
+
+  Sentry.init({
+    dsn,
+    environment: REACT_APP_SENTRY_ENVIRONMENT || NODE_ENV,
+    integrations: [Sentry.browserTracingIntegration()],
+    // Full traces locally, light sampling in prod.
+    tracesSampleRate: NODE_ENV === 'development' ? 1.0 : 0.1,
+    beforeSend(event) {
+      const message =
+        event.exception?.values?.[0]?.value || event.message || '';
+      if (NOISE_PATTERNS.some((pattern) => pattern.test(message))) {
+        return null;
+      }
+      return event;
+    },
+  });
+
+  initialized = true;
+}

--- a/frontend/libs/erxes-ui/src/utils/config/index.ts
+++ b/frontend/libs/erxes-ui/src/utils/config/index.ts
@@ -53,11 +53,24 @@ const hideCoreModules = () => {
   );
 };
 
+const sentryDsn = () => {
+  return window.env?.REACT_APP_SENTRY_DSN ?? process.env.REACT_APP_SENTRY_DSN;
+};
+
+const sentryEnvironment = () => {
+  return (
+    window.env?.REACT_APP_SENTRY_ENVIRONMENT ??
+    process.env.REACT_APP_SENTRY_ENVIRONMENT
+  );
+};
+
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const REACT_APP_API_URL = getApi();
 const REACT_APP_IMAGE_CDN_URL = cdnUrl();
 const REACT_APP_GOOGLE_MAP_API_KEY = googleMapApiKey();
 const REACT_APP_HIDE_CORE_MODULES = hideCoreModules();
+const REACT_APP_SENTRY_DSN = sentryDsn();
+const REACT_APP_SENTRY_ENVIRONMENT = sentryEnvironment();
 
 export {
   NODE_ENV,
@@ -65,4 +78,6 @@ export {
   REACT_APP_IMAGE_CDN_URL,
   REACT_APP_GOOGLE_MAP_API_KEY,
   REACT_APP_HIDE_CORE_MODULES,
+  REACT_APP_SENTRY_DSN,
+  REACT_APP_SENTRY_ENVIRONMENT,
 };

--- a/frontend/plugins/operation_ui/src/modules/operation/utils/parseDescriptionBlocks.ts
+++ b/frontend/plugins/operation_ui/src/modules/operation/utils/parseDescriptionBlocks.ts
@@ -1,0 +1,21 @@
+import { Block } from '@blocknote/core';
+
+/**
+ * Operation descriptions (task / triage / project) are normally BlockNote JSON
+ * (a Block[]), but legacy or API/script-created records can hold plain text.
+ * Parsing defensively keeps a non-JSON description from throwing during render
+ * and crashing the page — the text is rendered as a single paragraph instead.
+ */
+export const parseDescriptionBlocks = (
+  description?: string | null,
+): Block[] | undefined => {
+  if (!description) return undefined;
+  try {
+    const parsed = JSON.parse(description);
+    return Array.isArray(parsed) && parsed.length > 0
+      ? (parsed as Block[])
+      : undefined;
+  } catch {
+    return [{ type: 'paragraph', content: description } as unknown as Block];
+  }
+};

--- a/frontend/plugins/operation_ui/src/modules/project/components/details/ProjectFields.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/components/details/ProjectFields.tsx
@@ -19,6 +19,7 @@ import { SelectProjectPriority } from '@/project/components/select/SelectProject
 import { ActivityList } from '@/activity/components/ActivityList';
 import { SelectProjectStatus } from '@/project/components/select/SelectProjectStatus';
 import { SelectTags, SelectMember } from 'ui-modules';
+import { parseDescriptionBlocks } from '@/operation/utils/parseDescriptionBlocks';
 
 export const ProjectFields = ({ projectId }: { projectId: string }) => {
   const { project } = useGetProject({
@@ -41,7 +42,7 @@ export const ProjectFields = ({ projectId }: { projectId: string }) => {
 
   const [descriptionContent, setDescriptionContent] = useState<
     Block[] | undefined
-  >(description ? JSON.parse(description) : undefined);
+  >(parseDescriptionBlocks(description));
   const editor = useBlockEditor({
     initialContent: descriptionContent?.length ? descriptionContent : undefined,
     placeholder: 'Description...',
@@ -108,7 +109,7 @@ export const ProjectFields = ({ projectId }: { projectId: string }) => {
     if (!debouncedDescriptionContent) return;
     if (
       JSON.stringify(debouncedDescriptionContent) ===
-      JSON.stringify(description ? JSON.parse(description) : undefined)
+      JSON.stringify(parseDescriptionBlocks(description))
     ) {
       return;
     }

--- a/frontend/plugins/operation_ui/src/modules/task/components/detail/TaskFields.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/detail/TaskFields.tsx
@@ -24,6 +24,24 @@ import { useDebounce } from 'use-debounce';
 import { TagsSelect } from 'ui-modules';
 import { IconTags } from '@tabler/icons-react';
 
+// Task descriptions are normally BlockNote JSON (a Block[]), but legacy or
+// API/script-created tasks can hold plain text. Parsing defensively keeps a
+// non-JSON description from throwing during render and crashing the page —
+// the text is rendered as a single paragraph instead.
+const parseDescriptionBlocks = (
+  description?: string,
+): Block[] | undefined => {
+  if (!description) return undefined;
+  try {
+    const parsed = JSON.parse(description);
+    return Array.isArray(parsed) && parsed.length > 0
+      ? (parsed as Block[])
+      : undefined;
+  } catch {
+    return [{ type: 'paragraph', content: description } as unknown as Block];
+  }
+};
+
 export const TaskFields = ({ task }: { task: ITask }) => {
   const {
     _id: taskId,
@@ -42,11 +60,7 @@ export const TaskFields = ({ task }: { task: ITask }) => {
 
   const startDate = (task as any)?.startDate;
   const description = (task as any)?.description;
-  const parsedDescription = description ? JSON.parse(description) : undefined;
-  const initialDescriptionContent =
-    Array.isArray(parsedDescription) && parsedDescription.length > 0
-      ? parsedDescription
-      : undefined;
+  const initialDescriptionContent = parseDescriptionBlocks(description);
 
   const [descriptionContent, setDescriptionContent] = useState<
     Block[] | undefined
@@ -84,7 +98,7 @@ export const TaskFields = ({ task }: { task: ITask }) => {
     if (!debouncedDescriptionContent) return;
     if (
       JSON.stringify(debouncedDescriptionContent) ===
-      JSON.stringify(description ? JSON.parse(description) : undefined)
+      JSON.stringify(parseDescriptionBlocks(description))
     ) {
       return;
     }

--- a/frontend/plugins/operation_ui/src/modules/task/components/detail/TaskFields.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/detail/TaskFields.tsx
@@ -23,24 +23,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { TagsSelect } from 'ui-modules';
 import { IconTags } from '@tabler/icons-react';
-
-// Task descriptions are normally BlockNote JSON (a Block[]), but legacy or
-// API/script-created tasks can hold plain text. Parsing defensively keeps a
-// non-JSON description from throwing during render and crashing the page —
-// the text is rendered as a single paragraph instead.
-const parseDescriptionBlocks = (
-  description?: string,
-): Block[] | undefined => {
-  if (!description) return undefined;
-  try {
-    const parsed = JSON.parse(description);
-    return Array.isArray(parsed) && parsed.length > 0
-      ? (parsed as Block[])
-      : undefined;
-  } catch {
-    return [{ type: 'paragraph', content: description } as unknown as Block];
-  }
-};
+import { parseDescriptionBlocks } from '@/operation/utils/parseDescriptionBlocks';
 
 export const TaskFields = ({ task }: { task: ITask }) => {
   const {

--- a/frontend/plugins/operation_ui/src/modules/triage/components/TriageFields.tsx
+++ b/frontend/plugins/operation_ui/src/modules/triage/components/TriageFields.tsx
@@ -11,16 +11,13 @@ import { DeclineTriage } from './triage-selects/DeclineTriage';
 import { SelectStatus } from '@/operation/components/SelectStatus';
 import { useConvertTriage } from '../hooks/useConvertTriage';
 import { STATUS_TYPES } from '@/operation/components/StatusInline';
+import { parseDescriptionBlocks } from '@/operation/utils/parseDescriptionBlocks';
 
 export const TriageFields = ({ triage }: { triage: ITriage }) => {
   const { _id: triageId, priority, status, name: _name } = triage || {};
 
   const description = (triage as ITriage)?.description;
-  const parsedDescription = description ? JSON.parse(description) : undefined;
-  const initialDescriptionContent =
-    Array.isArray(parsedDescription) && parsedDescription.length > 0
-      ? parsedDescription
-      : undefined;
+  const initialDescriptionContent = parseDescriptionBlocks(description);
 
   const [descriptionContent, setDescriptionContent] = useState<
     Block[] | undefined
@@ -66,7 +63,7 @@ export const TriageFields = ({ triage }: { triage: ITriage }) => {
     if (!debouncedDescriptionContent) return;
     if (
       JSON.stringify(debouncedDescriptionContent) ===
-      JSON.stringify(description ? JSON.parse(description) : undefined)
+      JSON.stringify(parseDescriptionBlocks(description))
     ) {
       return;
     }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@module-federation/sdk": "^0.8.9",
     "@react-pdf/renderer": "3.1.14",
     "@sendgrid/mail": "^8.1.5",
+    "@sentry/react": "^10.55.0",
     "@sniptt/guards": "^0.2.0",
     "@tabler/icons-react": "^3.34.0",
     "@tanstack/react-table": "^8.20.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@sendgrid/mail':
         specifier: ^8.1.5
         version: 8.1.5
+      '@sentry/react':
+        specifier: ^10.55.0
+        version: 10.56.0(react@18.3.1)
       '@sniptt/guards':
         specifier: ^0.2.0
         version: 0.2.0
@@ -787,6 +790,204 @@ importers:
         specifier: ^1.0.15
         version: 1.0.15
 
+  backend/core-api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@blocknote/core':
+        specifier: ^0.35.0
+        version: 0.35.0(@types/hast@3.0.4)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sendgrid/mail':
+        specifier: ^8.1.5
+        version: 8.1.5
+      '@sentry/node':
+        specifier: ^10.55.0
+        version: 10.55.0
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      '@workos-inc/node':
+        specifier: ^7.65.0
+        version: 7.65.0(express@4.21.2)(koa@2.15.3)
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bcryptjs:
+        specifier: ^3.0.2
+        version: 3.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      firebase-admin:
+        specifier: ^13.6.0
+        version: 13.6.0(encoding@0.1.13)
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      formidable:
+        specifier: ^3.5.4
+        version: 3.5.4
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      jimp:
+        specifier: ^1.6.0
+        version: 1.6.0
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongodb:
+        specifier: ^6.18.0
+        version: 6.18.0(socks@2.8.7)
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      multer:
+        specifier: ^1.4.2
+        version: 1.4.4
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      nodemailer:
+        specifier: ^6.9.10
+        version: 6.9.10
+      sha256:
+        specifier: ^0.2.0
+        version: 0.2.0
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      telnyx:
+        specifier: ^1.7.2
+        version: 1.27.0
+      tmp:
+        specifier: ^0.2.3
+        version: 0.2.3
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      underscore:
+        specifier: ^1.13.7
+        version: 1.13.7
+      validator:
+        specifier: ^13.15.0
+        version: 13.15.0
+      xss:
+        specifier: ^1.0.15
+        version: 1.0.15
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/erxes-api-shared:
     dependencies:
       '@apollo/server':
@@ -980,6 +1181,192 @@ importers:
         specifier: ^2.7.0
         version: 2.7.1
 
+  backend/gateway/dist:
+    dependencies:
+      '@apollo/client':
+        specifier: ^3.11.8
+        version: 3.13.6(@types/react@19.1.12)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@bull-board/api':
+        specifier: ^6.7.7
+        version: 6.9.0(@bull-board/ui@6.9.0)
+      '@bull-board/express':
+        specifier: ^6.7.7
+        version: 6.9.0
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@envelop/core':
+        specifier: ^5.2.3
+        version: 5.2.3
+      '@escape.tech/graphql-armor-character-limit':
+        specifier: ^2.3.0
+        version: 2.3.0
+      '@escape.tech/graphql-armor-max-aliases':
+        specifier: ^2.6.0
+        version: 2.6.0
+      '@escape.tech/graphql-armor-max-depth':
+        specifier: ^2.4.0
+        version: 2.4.0
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@graphql-tools/schema':
+        specifier: ^10.0.23
+        version: 10.0.23(graphql@16.10.0)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: ^10.55.0
+        version: 10.55.0
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-parse-resolve-info:
+        specifier: ^4.14.1
+        version: 4.14.1(graphql@16.10.0)
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-ws:
+        specifier: ^5.16.0
+        version: 5.16.2(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      http-proxy-middleware:
+        specifier: ^3.0.3
+        version: 3.0.5
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      ws:
+        specifier: ^8.18.2
+        version: 8.19.0
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.1
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+
   backend/plugins/accounting_api:
     dependencies:
       erxes-api-shared:
@@ -1012,6 +1399,156 @@ importers:
       tmp:
         specifier: ^0.2.3
         version: 0.2.3
+
+  backend/plugins/content_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      html-to-text:
+        specifier: ^8.2.1
+        version: 8.2.1
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      simple-git:
+        specifier: ^3.26.0
+        version: 3.28.0
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tmp:
+        specifier: ^0.2.3
+        version: 0.2.3
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
 
   backend/plugins/frontline_api:
     dependencies:
@@ -1145,6 +1682,153 @@ importers:
         specifier: ^6.18.0
         version: 6.18.0(socks@2.8.7)
 
+  backend/plugins/operation_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.48
+        version: 0.5.48
+      mongodb:
+        specifier: ^6.18.0
+        version: 6.18.0(socks@2.8.7)
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/plugins/payment_api:
     dependencies:
       erxes-api-shared:
@@ -1159,6 +1843,156 @@ importers:
       stripe:
         specifier: ^17.2.1
         version: 17.7.0
+
+  backend/plugins/payment_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      qrcode:
+        specifier: ^1.5.0
+        version: 1.5.4
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      stripe:
+        specifier: ^17.2.1
+        version: 17.7.0
+      tailwindcss-animate:
+        specifier: 1.0.7
+        version: 1.0.7(tailwindcss@4.1.17)
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
 
   backend/plugins/payment_api/src/widget:
     dependencies:
@@ -1308,6 +2142,150 @@ importers:
         specifier: ^1.13.7
         version: 1.13.7
 
+  backend/plugins/sales_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      sift:
+        specifier: ^17.1.3
+        version: 17.1.3
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      underscore:
+        specifier: ^1.13.7
+        version: 1.13.7
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/plugins/tourism_api:
     dependencies:
       erxes-api-shared:
@@ -1319,6 +2297,150 @@ importers:
       moment-timezone:
         specifier: ^0.5.48
         version: 0.5.48
+
+  backend/plugins/tourism_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.26.10)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: 5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.48
+        version: 0.5.48
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
 
   backend/services/automations:
     dependencies:
@@ -1441,7 +2563,7 @@ packages:
   '@apollo/server@4.11.3':
     resolution: {integrity: sha512-mW8idE2q0/BN14mimfJU5DAnoPHZRrAWgwsVLBEdACds+mxapIYxIbI6AH4AsOpxfrpvHts3PCYDbopy1XPW1g==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -6741,8 +7863,32 @@ packages:
     resolution: {integrity: sha512-W+YuMnkVs4+HA/bgfto4VHKcPKLc7NiZ50/NH2pzO6UHCCFuq8/GNB98YJlLEr/ESDyzAaDr7lVE7hoBwFTT3Q==}
     engines: {node: '>=12.*'}
 
+  '@sentry-internal/browser-utils@10.56.0':
+    resolution: {integrity: sha512-I8tZWAFg8SZpD8BFUpglEtSTzhZjacmcThB5/Mlq/iFiiT8mBPG4ZWDWssSfmIBKvZywJZJ83uDA0+uiJU73Tw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.56.0':
+    resolution: {integrity: sha512-fkRR9JroESTIlErkht3OrH4DXKd/DbPozr2KLdX7boMo31hPu4cL9fuqzwOrwyDPRq9B4j+qEgIWB8JrTbgvmg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.56.0':
+    resolution: {integrity: sha512-SDg2K0CAZT/TnhrixQGwXoi6ZsWUB+DQy3UUk0bSQm6c/5k5zFBpGOiughQN+DYsDilKREfPKmUEEnqvUjm1HQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.56.0':
+    resolution: {integrity: sha512-DjF09hpy3TF7Km/kOZc73YJmBqcbPCxuZ5rtRs+KtVHu3Vq48xeW83qKUcFEZv20ur9UD99OAJ/gaEt//1Qbwg==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.56.0':
+    resolution: {integrity: sha512-80X3NmsGB6tLmfzXYdjzWWdVAdL5CRukGKLcRWIcNhgGjtskOmnzaGb93egEZGI5bUTbtONJ0oyscQ3Z9yoAtQ==}
+    engines: {node: '>=18'}
+
   '@sentry/core@10.55.0':
     resolution: {integrity: sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.56.0':
+    resolution: {integrity: sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==}
     engines: {node: '>=18'}
 
   '@sentry/node-core@10.55.0':
@@ -6781,6 +7927,12 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/react@10.56.0':
+    resolution: {integrity: sha512-HfPLyvnrydfyjRXw9Q0GMzj7w2YtEwuC9z5RrPUfarA2qpA0/J8cfGLzyFX2v0jBmA/kkj6J1uBUoSVhCTxFHg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@shikijs/types@3.2.1':
     resolution: {integrity: sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==}
@@ -18026,6 +19178,29 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@apollo/client@3.13.6(@types/react@19.1.12)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.10.0
+      graphql-tag: 2.12.6(graphql@16.10.0)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.1
+      prop-types: 15.8.1
+      rehackt: 0.1.0(@types/react@19.1.12)(react@18.3.1)
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.8.1
+      zen-observable-ts: 1.2.5
+    optionalDependencies:
+      graphql-ws: 5.16.2(graphql@16.10.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@apollo/client@3.13.6(@types/react@19.1.12)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
@@ -25592,7 +26767,35 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@sentry-internal/browser-utils@10.56.0':
+    dependencies:
+      '@sentry/core': 10.56.0
+
+  '@sentry-internal/feedback@10.56.0':
+    dependencies:
+      '@sentry/core': 10.56.0
+
+  '@sentry-internal/replay-canvas@10.56.0':
+    dependencies:
+      '@sentry-internal/replay': 10.56.0
+      '@sentry/core': 10.56.0
+
+  '@sentry-internal/replay@10.56.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.56.0
+      '@sentry/core': 10.56.0
+
+  '@sentry/browser@10.56.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.56.0
+      '@sentry-internal/feedback': 10.56.0
+      '@sentry-internal/replay': 10.56.0
+      '@sentry-internal/replay-canvas': 10.56.0
+      '@sentry/core': 10.56.0
+
   '@sentry/core@10.55.0': {}
+
+  '@sentry/core@10.56.0': {}
 
   '@sentry/node-core@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -25628,6 +26831,12 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.55.0
+
+  '@sentry/react@10.56.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 10.56.0
+      '@sentry/core': 10.56.0
+      react: 18.3.1
 
   '@shikijs/types@3.2.1':
     dependencies:
@@ -36813,6 +38022,11 @@ snapshots:
   rehackt@0.1.0(@types/react@18.3.1)(react@18.3.1):
     optionalDependencies:
       '@types/react': 18.3.1
+      react: 18.3.1
+
+  rehackt@0.1.0(@types/react@19.1.12)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 19.1.12
       react: 18.3.1
 
   rehackt@0.1.0(@types/react@19.1.12)(react@19.1.1):


### PR DESCRIPTION
## Summary

Adds Sentry error monitoring across the stack, with a deterministic "expected error" classifier so known business conditions don't become noise. Also fixes a render crash in the task detail view that this work surfaced.

## Backend (`erxes-api-shared`)
- New `ExpectedError` class + classifier: known business conditions (auth / permission / OAuth scope / client-portal) are tagged **EXPECTED** by type, independent of message text, so renaming a message can't silently turn it back into Sentry noise.
- `permissions/utils.ts` login/permission/scope/client-portal checks now throw `ExpectedError`.

## Frontend (`core-ui` host + Module Federation remotes)
- `initSentry()` runs first in `bootstrap` — the host is the single MF container, so global error/unhandledrejection handlers cover host **and** remotes.
- DSN/environment wired via `DefinePlugin` (rspack) + `erxes-ui` config getters (`REACT_APP_SENTRY_*`, injected into `window.env` in prod by the docker entrypoint).
- `beforeSend` noise filter mirrors the backend classifier.
- **Capture architecture:** React Router v7's data router swallows routed render errors in its own boundary; `Sentry.wrapCreateBrowserRouterV7` only adds tracing and does **not** capture. So `RouteErrorBoundary` (the root `errorElement`) captures routed render/loader errors **synchronously** (effects can be skipped during React's error-recovery path). `AppErrorBoundary` covers non-router React errors.

## Bug fix (`operation_ui`)
- `TaskFields` ran `JSON.parse(description)` unguarded during render. Legacy / API-created tasks store plain-text descriptions, which threw and crashed the whole page. Now parsed defensively: valid JSON → blocks, plain text → a paragraph block, never throws. (`CopyTask` already guarded this; left as-is.)

## Notes
- Local-dev errors only reach a self-hosted Sentry if the project's **"localhost" inbound filter is OFF** (Project Settings → Inbound Filters). With it on, Sentry accepts the POST (HTTP 200) then silently discards events whose stack frames are `localhost` — which looks exactly like the SDK "not sending". Documented in `sentry.ts`.
- `.env.sample` documents the `SENTRY_*` / `REACT_APP_SENTRY_*` vars (and removes a real DSN that was previously committed there).

## Testing
- Verified end-to-end that capture fires (`RouteErrorBoundary` → `beforeSend` → transport 200) and that non-localhost error events land as issues.
- `TaskFields` parse verified against the real failing description plus malformed/empty/object inputs — no throw in any case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive client/server error monitoring setup and early client initialization.
  * Introduced explicit "expected" error marking to prevent noisy issues from being reported.
  * Added route- and app-level error boundaries that report errors and avoid duplicate reports.

* **Bug Fixes**
  * Improved description parsing to handle legacy/plain-text formats reliably.

* **Tests**
  * Added regression tests ensuring expected errors are classified and filtered before reporting.

* **Chore**
  * Added sample environment entries for Sentry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->