### PR TITLE
fix: skip Claude Code Action on PRs from read-only contributors

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,6 +12,14 @@ jobs:
   claude-code:
     runs-on: ubuntu-latest
 
+    # Auto-run on PRs only when the author has write access. Read-only
+    # contributors (author_association NONE/CONTRIBUTOR/FIRST_TIME_*) are
+    # skipped here instead of failing the action with exit code 1.
+    # Comment-triggered runs (@claude) are unaffected.
+    if: >
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

The `claude-code.yml` workflow auto-runs on every `pull_request` (opened/synchronize), but `anthropics/claude-code-action@v1` requires the PR author to have **write** access to the repo. When a contributor with only **read** access opens or pushes to a PR, the action hard-fails:

```
Permission level retrieved: read
##[warning]Actor has insufficient permissions: read
##[error]Action failed with error: Actor does not have write permissions to the repository
##[error]Process completed with exit code 1
```

This produces a recurring failed check on PRs from external/read-only contributors (e.g. PR #7905).

## Fix

Add a job-level `if:` guard so the auto-PR run only fires when the PR author is an `OWNER`, `MEMBER`, or `COLLABORATOR` (i.e. has write access). Read-only contributors are cleanly **skipped** instead of failing the check. Comment-triggered (`@claude`) runs on issues and PR reviews are unaffected.

## Notes

- `author_association` is a good proxy for write access but not a literal permission check; an outside collaborator granted write via a team could still show `CONTRIBUTOR`. This guard errs toward skipping rather than failing.
- The benign `Internal error: directory mismatch ... tsconfig.json` line in the logs is an unrelated upstream bug in the action itself ("You don't need to do anything") and is not addressed here.

## Summary by Sourcery

CI:
- Skip the claude-code job on pull_request events unless the PR author is an OWNER, MEMBER, or COLLABORATOR, preventing failures for read-only contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow security and stability by restricting automated processes to trusted contributors, improving reliability of the development pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->