### PR TITLE
chore: add .deepsource.toml config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -15,8 +15,12 @@ test_patterns = [
   "**/__tests__/**",
   "**/*.test.ts",
   "**/*.test.tsx",
+  "**/*.test.js",
+  "**/*.test.jsx",
   "**/*.spec.ts",
   "**/*.spec.tsx",
+  "**/*.spec.js",
+  "**/*.spec.jsx",
 ]
 
 [[analyzers]]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,35 @@
+version = 1
+
+exclude_patterns = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/coverage/**",
+  "**/*.min.js",
+  "**/__generated__/**",
+  "**/*.generated.*",
+]
+
+test_patterns = [
+  "**/__tests__/**",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/*.spec.ts",
+  "**/*.spec.tsx",
+]
+
+[[analyzers]]
+name = "javascript"
+
+  [analyzers.meta]
+  plugins = ["react"]
+  environment = ["nodejs", "browser"]
+  dialect = "typescript"
+  module_system = "es-modules"
+
+[[analyzers]]
+name = "docker"
+
+[[transformers]]
+name = "prettier"


### PR DESCRIPTION
## What

Adds a `.deepsource.toml` configuration file to the repository root.

## Why

DeepSource reads its analysis config exclusively from the **default branch** root. Without a `.deepsource.toml` present, DeepSource reports a failing check on PRs:

> File .deepsource.toml not found in the default branch of the repository root.

## Config

- `javascript` analyzer — `dialect = typescript`, React plugin, node + browser environments (covers backend + frontend `.ts`/`.tsx`)
- `docker` analyzer — per-service Dockerfiles
- `prettier` transformer — matches the repo's `singleQuote` / `trailingComma` style
- Excludes `node_modules`, `dist`, `build`, `.next`, `coverage`, minified/generated files
- Test patterns for `__tests__` / `*.test.*` / `*.spec.*`

> Note: this only takes effect for DeepSource once merged into the default branch.

## Summary by Sourcery

Add DeepSource analysis configuration to the repository root.

Build:
- Add Prettier transformer configuration in DeepSource to match the repository's code style.

CI:
- Configure DeepSource analyzers for JavaScript/TypeScript (with React) and Docker, including test and exclude patterns to align with the existing project layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added project configuration for automated code analysis and formatting, including JavaScript/TypeScript and Docker analyzers, Prettier transformation, and exclusions for common build/output and generated files to streamline quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->