### PR TITLE
Fix oauth2

### DIFF
--- a/backend/core-api/src/meta/permissions.ts
+++ b/backend/core-api/src/meta/permissions.ts
@@ -752,7 +752,7 @@ export const permissions: IPermissionConfig = {
         {
           plugin: 'core',
           module: 'apps',
-          actions: ['appsManage'],
+          actions: ['appsRead', 'appsManage'],
           scope: 'all',
         },
         {

--- a/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
+++ b/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
@@ -27,13 +27,27 @@ const buildOAuthClientQuery = (searchValue?: string) => {
   return query;
 };
 
+const checkOAuthClientReadPermission = async (
+  checkPermission: IContext['checkPermission'],
+) => {
+  try {
+    await checkPermission('appsRead');
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== 'Permission required') {
+      throw error;
+    }
+
+    await checkPermission('appsManage');
+  }
+};
+
 export const oauthClientAppQueries = {
   async oauthClientApps(
     _parent: undefined,
     { searchValue, page = 1, perPage = 20 }: any,
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.find(buildOAuthClientQuery(searchValue))
       .skip((page - 1) * perPage)
@@ -46,7 +60,7 @@ export const oauthClientAppQueries = {
     { searchValue }: { searchValue?: string },
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.countDocuments(
       buildOAuthClientQuery(searchValue),
@@ -58,7 +72,7 @@ export const oauthClientAppQueries = {
     { _id }: { _id: string },
     { models, checkPermission }: IContext,
   ) {
-    await checkPermission('appsRead');
+    await checkOAuthClientReadPermission(checkPermission);
 
     return models.OAuthClientApps.findOne({ _id });
   },

--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -34,6 +34,10 @@ import {
 
 export const router: Router = Router();
 
+const getClientSecret = (req: Request): string | undefined =>
+  String(req.body?.client_secret || req.headers['oauth_secret'] || '').trim() ||
+  undefined;
+
 router.post('/oauth/device/code', async (req: Request, res: Response) => {
   try {
     const ip = getClientIp(req);
@@ -42,8 +46,7 @@ router.post('/oauth/device/code', async (req: Request, res: Response) => {
     const subdomain = getSubdomain(req);
     const models = await generateModels(subdomain);
     const clientId = String(req.body?.client_id || '').trim();
-    const clientSecret =
-      String(req.headers['oauth_secret'] || '').trim() || undefined;
+    const clientSecret = getClientSecret(req);
 
     const oauthClientApp = await getOAuthClientApp(models, clientId);
     validateClientSecret(oauthClientApp, clientSecret);
@@ -305,8 +308,7 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   if (grantType === DEVICE_CODE_GRANT) {
     try {
       const clientId = String(req.body?.client_id || '').trim();
-      const clientSecret =
-        String(req.headers['oauth_secret'] || '').trim() || undefined;
+      const clientSecret = getClientSecret(req);
       const deviceCode = String(req.body?.device_code || '').trim();
 
       const oauthClientApp = await getOAuthClientApp(models, clientId);
@@ -393,8 +395,7 @@ router.post('/oauth/token', async (req: Request, res: Response) => {
   if (grantType === 'refresh_token') {
     try {
       const clientId = String(req.body?.client_id || '').trim();
-      const clientSecret =
-        String(req.headers['oauth_secret'] || '').trim() || undefined;
+      const clientSecret = getClientSecret(req);
       const refreshToken = String(req.body?.refresh_token || '').trim();
 
       const oauthClientApp = await getOAuthClientApp(models, clientId);


### PR DESCRIPTION
## Summary by Sourcery

Allow OAuth client operations to fall back to manage permissions and broaden secret lookup for OAuth flows.

New Features:
- Support providing OAuth client secrets via either request headers or body fields.

Bug Fixes:
- Allow users with appsManage permission but without appsRead to access OAuth client app queries.
- Ensure OAuth client secret validation works when the secret is sent in the request body for device code and token flows.

Enhancements:
- Centralize OAuth client read permission checking into a shared helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read permission for OAuth client applications in admin group permissions.

* **Refactor**
  * Standardized OAuth client authentication to accept credentials from request body or headers.
  * Improved permission checking with fallback logic for OAuth client app access across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->