### PR TITLE
feat(frontline): restrict inbox channel list to user's own channels

### DIFF
--- a/backend/plugins/frontline_api/src/modules/channel/graphql/resolvers/queries/channel.ts
+++ b/backend/plugins/frontline_api/src/modules/channel/graphql/resolvers/queries/channel.ts
@@ -9,7 +9,7 @@ export const channelQueries = {
 
   getMyChannels: async (
     _parent: undefined,
-    _params: undefined,
+    { name }: { name?: string },
     { models, user }: IContext,
   ) => {
     if (!user?._id) throw new Error('Unauthorized');
@@ -18,7 +18,8 @@ export const channelQueries = {
       memberId: userId,
     }).distinct('channelId');
 
-    return models.Channels.find({ _id: { $in: channelIds } });
+    const nameFilter = name ? { name: { $regex: name, $options: 'i' } } : {};
+    return models.Channels.find({ _id: { $in: channelIds }, ...nameFilter });
   },
 
   getChannels: async (

--- a/backend/plugins/frontline_api/src/modules/channel/graphql/resolvers/queries/channel.ts
+++ b/backend/plugins/frontline_api/src/modules/channel/graphql/resolvers/queries/channel.ts
@@ -32,7 +32,10 @@ export const channelQueries = {
       : {};
 
     if (params.channelIds && params.channelIds.length > 0) {
-      return models.Channels.find({ _id: { $in: params.channelIds }, ...nameFilter });
+      return models.Channels.find({
+        _id: { $in: params.channelIds },
+        ...nameFilter,
+      });
     }
 
     if (params.integrationId) {
@@ -43,7 +46,7 @@ export const channelQueries = {
     }
 
     // System owners and users with showAllChannels permission see every channel.
-    if (user?.isOwner || await canGroup(subdomain, 'showAllChannels', user)) {
+    if (user?.isOwner || (await canGroup(subdomain, 'showAllChannels', user))) {
       return models.Channels.find(nameFilter);
     }
 

--- a/backend/plugins/frontline_api/src/modules/channel/graphql/schemas/channel.ts
+++ b/backend/plugins/frontline_api/src/modules/channel/graphql/schemas/channel.ts
@@ -27,6 +27,7 @@ export const types = `
 export const queries = `
     getChannel(_id: String!): Channel
     getChannels(name: String, userId: String, channelIds: [String], integrationId: String): [Channel]
+    getMyChannels(name: String): [Channel]
     getChannelMembers(channelId: String, channelIds: [String]): [ChannelMember]
 `;
 

--- a/frontend/plugins/frontline_ui/src/modules/channels/graphql/queries.ts
+++ b/frontend/plugins/frontline_ui/src/modules/channels/graphql/queries.ts
@@ -62,4 +62,19 @@ const GET_CHANNEL_MEMBERS = gql`
   }
 `;
 
-export { GET_CHANNELS, GET_CHANNEL, GET_CHANNEL_MEMBERS };
+const GET_MY_CHANNELS = gql`
+  query GetMyChannels($name: String) {
+    getMyChannels(name: $name) {
+      _id
+      icon
+      name
+      description
+      createdAt
+      updatedAt
+      memberCount
+      pipelineCount
+    }
+  }
+`;
+
+export { GET_CHANNELS, GET_CHANNEL, GET_CHANNEL_MEMBERS, GET_MY_CHANNELS };

--- a/frontend/plugins/frontline_ui/src/modules/channels/hooks/useGetMyChannels.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/hooks/useGetMyChannels.tsx
@@ -1,0 +1,23 @@
+import { useQuery, QueryHookOptions } from '@apollo/client';
+import { IChannel } from '@/channels/types';
+import { GET_MY_CHANNELS } from '@/channels/graphql';
+
+interface IGetMyChannelsQueryResponse {
+  getMyChannels: IChannel[];
+}
+
+export const useGetMyChannels = (
+  options?: QueryHookOptions<IGetMyChannelsQueryResponse>,
+) => {
+  const { data, loading } = useQuery<IGetMyChannelsQueryResponse>(
+    GET_MY_CHANNELS,
+    {
+      fetchPolicy: 'cache-and-network',
+      ...options,
+    },
+  );
+
+  const channels = data?.getMyChannels;
+
+  return { channels, loading };
+};

--- a/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/ChooseChannel.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/ChooseChannel.tsx
@@ -7,10 +7,10 @@ import {
 } from 'erxes-ui';
 import { IChannel } from '@/inbox/types/Channel';
 import { IconCheck } from '@tabler/icons-react';
-import { useGetChannels } from '@/channels/hooks/useGetChannels';
+import { useGetMyChannels } from '@/channels/hooks/useGetMyChannels';
 
 export const ChooseChannel = () => {
-  const { channels, loading } = useGetChannels();
+  const { channels, loading } = useGetMyChannels();
 
   if (loading)
     return (

--- a/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/SelectChannel.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/SelectChannel.tsx
@@ -109,8 +109,6 @@ export const SelectChannelsContent = ({
 
   const channelsData = myChannelsOnly ? myChannels : allChannels;
 
-
-
   const channelsTotalCount = channelsData?.length || 0;
 
   return (

--- a/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/SelectChannel.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/channel/components/SelectChannel.tsx
@@ -21,6 +21,7 @@ import { IChannel } from '@/inbox/types/Channel';
 import { IconTopologyStar3 } from '@tabler/icons-react';
 import { useDebounce } from 'use-debounce';
 import { useGetChannels } from '@/channels/hooks/useGetChannels';
+import { useGetMyChannels } from '@/channels/hooks/useGetMyChannels';
 import React, { useState } from 'react';
 
 const SelectChannelProvider = ({
@@ -88,17 +89,27 @@ const SelectChannelsValue = ({ placeholder }: { placeholder?: string }) => {
   );
 };
 
-export const SelectChannelsContent = () => {
+export const SelectChannelsContent = ({
+  myChannelsOnly = false,
+}: {
+  myChannelsOnly?: boolean;
+}) => {
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebounce(search, 500);
   const { onSelect, channels } = useSelectChannelContext();
-  const { channels: channelsData, loading } = useGetChannels({
-    variables: {
-      searchValue: debouncedSearch,
-    },
+
+  const { channels: allChannels, loading: allLoading } = useGetChannels({
+    variables: { searchValue: debouncedSearch },
+    skip: myChannelsOnly,
+  });
+  const { channels: myChannels, loading: myLoading } = useGetMyChannels({
+    variables: { name: debouncedSearch },
+    skip: !myChannelsOnly,
   });
 
-  // Mock the missing properties for now
+  const channelsData = myChannelsOnly ? myChannels : allChannels;
+
+
 
   const channelsTotalCount = channelsData?.length || 0;
 
@@ -209,7 +220,7 @@ export const SelectChannelFilterView = () => {
           resetFilterState();
         }}
       >
-        <SelectChannelsContent />
+        <SelectChannelsContent myChannelsOnly />
       </SelectChannelProvider>
     </Filter.View>
   );
@@ -261,7 +272,7 @@ export const SelectChannelFilterBar = ({
             </Filter.BarButton>
           </Popover.Trigger>
           <Combobox.Content>
-            <SelectChannelsContent />
+            <SelectChannelsContent myChannelsOnly />
           </Combobox.Content>
         </Popover>
       </SelectChannelProvider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to filter your channels by name when searching
  * Channel selection interface now supports "my channels only" mode to display only your personal channels
  * Users can more effectively browse and organize their channels with the new name-based filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->