### PR TITLE
feat: add reaction icon in knowledgebase article

### DIFF
--- a/backend/plugins/frontline_api/src/modules/knowledgebase/db/models/Article.ts
+++ b/backend/plugins/frontline_api/src/modules/knowledgebase/db/models/Article.ts
@@ -11,6 +11,13 @@ export interface IArticleCreate extends IArticle {
   code?: string; // Add code field
 }
 
+const FIXED_REACTION_SVGS = [
+  `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-mood-sad"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 10l.01 0" /><path d="M15 10l.01 0" /><path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" /></svg>`,
+  `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-mood-neutral"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 10l.01 0" /><path d="M15 10l.01 0" /></svg>`,
+  `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 9l.01 0" /><path d="M15 9l.01 0" /><path d="M8 13a4 4 0 1 0 8 0h-8" /></svg>`,
+  `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-thumb-up"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M7 11v8a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1v-7a1 1 0 0 1 1 -1h3a4 4 0 0 0 4 -4v-1a2 2 0 0 1 4 0v5h3a2 2 0 0 1 2 2l-1 5a2 3 0 0 1 -2 2h-7a3 3 0 0 1 -3 -3" /></svg>`,
+  `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-thumb-down"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M7 13v-8a1 1 0 0 0 -1 -1h-2a1 1 0 0 0 -1 1v7a1 1 0 0 0 1 1h3a4 4 0 0 1 4 4v1a2 2 0 0 0 4 0v-5h3a2 2 0 0 0 2 -2l-1 -5a2 3 0 0 0 -2 -2h-7a3 3 0 0 0 -3 3" /></svg>`,
+];
 export interface IArticleModel extends Model<IArticleDocument> {
   getArticle(_id: string): Promise<IArticleDocument>;
   createDoc(fields: IArticleCreate, userId?: string): Promise<IArticleDocument>;
@@ -47,7 +54,9 @@ export const loadArticleClass = (models: IModels) => {
 
       // Auto-generate code if not provided
       if (!docFields.code) {
-        docFields.code = `ART-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        docFields.code = `ART-${Date.now()}-${Math.random()
+          .toString(36)
+          .substr(2, 9)}`;
       }
 
       // Ensure content is not empty (only if content is being updated)
@@ -60,6 +69,7 @@ export const loadArticleClass = (models: IModels) => {
 
       const doc = {
         ...docFields,
+        reactionChoices: FIXED_REACTION_SVGS,
         createdDate: new Date(),
         createdBy: userId,
         modifiedDate: new Date(),
@@ -103,6 +113,7 @@ export const loadArticleClass = (models: IModels) => {
 
       const doc = {
         ...docFields,
+        reactionChoices: FIXED_REACTION_SVGS,
         modifiedBy: userId,
         modifiedDate: new Date(),
       };

--- a/frontend/libs/erxes-ui/src/components/multiselect.tsx
+++ b/frontend/libs/erxes-ui/src/components/multiselect.tsx
@@ -9,12 +9,14 @@ import { cn } from 'erxes-ui/lib';
 
 export interface MultiSelectOption {
   value: string;
-  label: string;
+  label: string | React.ReactNode;
   disable?: boolean;
   /** fixed option that can&lsquo;t be removed. */
   fixed?: boolean;
   /** Group the options by providing key. */
-  [key: string]: string | boolean | undefined;
+  [key: string]: any;
+  svg?: string;
+  icon?: string;
 }
 interface GroupOption {
   [key: string]: MultiSelectOption[];
@@ -474,33 +476,39 @@ export const MultipleSelector = React.forwardRef<
           <div className="flex flex-wrap gap-1 w-full">
             {selected.map((option) => {
               return (
-                <div
+                <Command.Item
                   key={option.value}
+                  value={option.value}
+                  disabled={option.disable}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onSelect={() => {
+                    if (selected.length >= maxSelected) {
+                      onMaxSelected?.(selected.length);
+                      return;
+                    }
+                    setInputValue('');
+                    const newOptions = [...selected, option];
+                    setSelected(newOptions);
+                    onChange?.(newOptions);
+                  }}
                   className={cn(
-                    'animate-fadeIn relative inline-flex h-7 cursor-default items-center rounded-md border border-solid bg-background pe-7 pl-2 ps-2 text-xs font-medium text-secondary-foreground transition-all hover:bg-background disabled:cursor-not-allowed disabled:opacity-50 data-fixed:pe-2',
-                    badgeClassName,
+                    'cursor-pointer',
+                    option.disable && 'cursor-not-allowed opacity-50',
                   )}
-                  data-fixed={option.fixed}
-                  data-disabled={disabled || undefined}
                 >
-                  {option.label}
-                  <button
-                    className="absolute -inset-y-px -end-px flex size-7 items-center justify-center rounded-e-lg border border-transparent p-0 text-muted-foreground/80 outline-0 transition-colors hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-ring/70"
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        handleUnselect(option);
-                      }
-                    }}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    onClick={() => handleUnselect(option)}
-                    aria-label="Remove"
-                  >
-                    <IconX size={14} strokeWidth={2} aria-hidden="true" />
-                  </button>
-                </div>
+                  <div className="flex items-center gap-2 w-full">
+                    {option.svg && (
+                      <span
+                        className="w-5 h-5 flex items-center justify-center [&>svg]:w-full [&>svg]:h-full"
+                        dangerouslySetInnerHTML={{ __html: option.svg }}
+                      />
+                    )}
+                    <span>{option.label}</span>
+                  </div>
+                </Command.Item>
               );
             })}
             {/* Avoid having the "Search" Icon */}

--- a/frontend/plugins/content_ui/src/modules/shared/constants/index.ts
+++ b/frontend/plugins/content_ui/src/modules/shared/constants/index.ts
@@ -49,6 +49,8 @@ import {
   IconFolder,
 } from '@tabler/icons-react';
 
+import { IconComponent } from 'erxes-ui';
+
 export const ICONS = [
   { value: 'alarm', label: 'alarm', icon: IconAlarm },
   { value: 'briefcase', label: 'briefcase', icon: IconBriefcase },
@@ -102,19 +104,35 @@ export const ICONS = [
 ];
 
 export const REACTIONS = [
-  { value: 'https://erxes.s3.amazonaws.com/icons/sad.svg', label: 'Sad' },
+  {
+    value: 'https://erxes.s3.amazonaws.com/icons/sad.svg',
+    label: 'Sad',
+    icon: 'mood-sad',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-mood-sad"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 10l.01 0" /><path d="M15 10l.01 0" /><path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" /></svg>`,
+  },
   {
     value: 'https://erxes.s3.amazonaws.com/icons/neutral.svg',
     label: 'Neutral',
+    icon: 'mood-neutral',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-mood-neutral"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 10l.01 0" /><path d="M15 10l.01 0" /></svg>`,
   },
   {
     value: 'https://erxes.s3.amazonaws.com/icons/grinning.svg',
     label: 'Happy',
+    icon: 'mood-happy',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 9l.01 0" /><path d="M15 9l.01 0" /><path d="M8 13a4 4 0 1 0 8 0h-8" /></svg>`,
   },
-  { value: 'https://erxes.s3.amazonaws.com/icons/like.svg', label: 'Like' },
+  {
+    value: 'https://erxes.s3.amazonaws.com/icons/like.svg',
+    label: 'Like',
+    icon: 'thumbs-up',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-thumb-up"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M7 11v8a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1v-7a1 1 0 0 1 1 -1h3a4 4 0 0 0 4 -4v-1a2 2 0 0 1 4 0v5h3a2 2 0 0 1 2 2l-1 5a2 3 0 0 1 -2 2h-7a3 3 0 0 1 -3 -3" /></svg>`,
+  },
   {
     value: 'https://erxes.s3.amazonaws.com/icons/dislike.svg',
     label: 'Dislike',
+    icon: 'thumbs-down',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-thumb-down"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M7 13v-8a1 1 0 0 0 -1 -1h-2a1 1 0 0 0 -1 1v7a1 1 0 0 0 1 1h3a4 4 0 0 1 4 4v1a2 2 0 0 0 4 0v-5h3a2 2 0 0 0 2 -2l-1 -5a2 3 0 0 0 -2 -2h-7a3 3 0 0 0 -3 3" /></svg>`,
   },
 ];
 

--- a/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/ArticleDrawer.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/ArticleDrawer.tsx
@@ -290,15 +290,22 @@ export function ArticleDrawer({
                         <Form.Label>Reaction Choices</Form.Label>
                         <Form.Control>
                           <MultipleSelector
-                            options={REACTIONS}
+                            options={REACTIONS.map((r) => ({
+                              value: r.value,
+                              label: r.label,
+                              svg: r.svg,
+                            }))}
                             value={
-                              field.value?.map((choice) => ({
-                                value: choice,
-                                label:
-                                  REACTIONS.find(
-                                    (reaction) => reaction.value === choice,
-                                  )?.label || '',
-                              })) || []
+                              field.value?.map((choice) => {
+                                const reaction = REACTIONS.find(
+                                  (r) => r.value === choice,
+                                );
+                                return {
+                                  value: choice,
+                                  label: reaction?.label || '',
+                                  svg: reaction?.svg || '',
+                                };
+                              }) || []
                             }
                             onChange={(value) => {
                               field.onChange(value.map((item) => item.value));


### PR DESCRIPTION
## Summary by Sourcery

Add support for rich reaction options with icons and SVGs in the multiselect component and knowledge base article reactions.

New Features:
- Allow multiselect options to include React node labels, SVG markup, and icon metadata.
- Display reaction SVG icons alongside labels when selecting reactions for knowledge base articles.

Enhancements:
- Relax multiselect option typing to support additional metadata used by UI elements.
- Refine selected options rendering to use command items for better interaction handling and visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select now supports rich labels, icons and SVG rendering for options and selected tokens.
  * Reactions now include icon identifiers and embedded SVGs for clearer visual choices.
  * Article editor shows reaction choices with their visual icons/SVGs, and new default reaction graphics are applied to articles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->