### PR TITLE
feat(permissions): show members tab in permission group details dialog

### DIFF
--- a/backend/core-api/src/apollo/resolvers/resolvers.ts
+++ b/backend/core-api/src/apollo/resolvers/resolvers.ts
@@ -1,4 +1,5 @@
 import automationsResolvers from '@/automations/graphql/resolvers/customResolver';
+import permissionResolvers from '@/permissions/graphql/resolvers/customResolvers';
 import broadcastResolvers from '@/broadcast/graphql/resolvers/customResolvers';
 import clientPortalResolvers from '@/clientportal/graphql/resolvers/customResolvers';
 import contactResolvers from '@/contacts/graphql/resolvers/customResolvers';
@@ -32,4 +33,5 @@ export const customResolvers = {
   ...propertiesResolvers,
   ...broadcastResolvers,
   ...templateResolvers,
+  ...permissionResolvers,
 };

--- a/backend/core-api/src/modules/permissions/graphql/resolvers/customResolvers.ts
+++ b/backend/core-api/src/modules/permissions/graphql/resolvers/customResolvers.ts
@@ -1,0 +1,14 @@
+import { IContext } from '~/connectionResolvers';
+
+const memberResolver = (idField: 'id' | '_id') =>
+  async (group: Record<string, string>, _args: unknown, { models }: IContext) =>
+    models.Users.find({ permissionGroupIds: group[idField] }).sort({ 'details.firstName': 1 });
+
+export default {
+  PermissionGroup: {
+    members: memberResolver('_id'),
+  },
+  DefaultPermissionGroup: {
+    members: memberResolver('id'),
+  },
+};

--- a/backend/core-api/src/modules/permissions/graphql/resolvers/customResolvers.ts
+++ b/backend/core-api/src/modules/permissions/graphql/resolvers/customResolvers.ts
@@ -1,8 +1,11 @@
 import { IContext } from '~/connectionResolvers';
 
-const memberResolver = (idField: 'id' | '_id') =>
+const memberResolver =
+  (idField: 'id' | '_id') =>
   async (group: Record<string, string>, _args: unknown, { models }: IContext) =>
-    models.Users.find({ permissionGroupIds: group[idField] }).sort({ 'details.firstName': 1 });
+    models.Users.find({ permissionGroupIds: group[idField] }).sort({
+      'details.firstName': 1,
+    });
 
 export default {
   PermissionGroup: {

--- a/backend/core-api/src/modules/permissions/graphql/schemas/permission.ts
+++ b/backend/core-api/src/modules/permissions/graphql/schemas/permission.ts
@@ -49,6 +49,7 @@ export const types = `
     description: String
     plugin: String!
     permissions: [PermissionGroupPermission]!
+    members: [User]
   }
 
   type PermissionGroup {
@@ -56,6 +57,7 @@ export const types = `
     name: String!
     description: String
     permissions: [PermissionGroupPermission]!
+    members: [User]
     createdAt: Date
     updatedAt: Date
   }

--- a/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
+++ b/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
@@ -1,10 +1,11 @@
-import { IconLock, IconShield } from '@tabler/icons-react';
+import { IconLock, IconShield, IconUsers } from '@tabler/icons-react';
 import { Button, Collapsible, Dialog, Separator, Spinner } from 'erxes-ui';
 import { useState } from 'react';
 import { useGetPermissionModules } from '@/settings/permissions/hooks/useGetPermissionModules';
 import {
   IDefaultPermissionGroup,
   IPermissionGroup,
+  IPermissionGroupMember,
   IPermissionModule,
   IPermissionGroupPermission,
 } from '@/settings/permissions/types';
@@ -44,8 +45,11 @@ export const PermissionGroupDetails = ({
   trigger,
 }: Props) => {
   const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'permissions' | 'members'>('permissions');
   const { permissionModulesByPlugin, loading: modulesLoading } =
     useGetPermissionModules();
+
+  const members: IPermissionGroupMember[] = group.members ?? [];
 
   const getModuleInfo = (
     moduleName: string,
@@ -114,8 +118,77 @@ export const PermissionGroupDetails = ({
 
         <Separator />
 
+        <div className="flex gap-1 px-6 pt-3">
+            <Button
+              variant={tab === 'permissions' ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => setTab('permissions')}
+            >
+              Permissions
+            </Button>
+            <Button
+              variant={tab === 'members' ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => setTab('members')}
+            >
+              <IconUsers size={14} className="mr-1" />
+              Members
+              {members.length > 0 && (
+                <span className="ml-1.5 text-xs bg-muted text-muted-foreground rounded px-1.5 py-0.5">
+                  {members.length}
+                </span>
+              )}
+            </Button>
+        </div>
+
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4 styled-scroll">
-          {modulesLoading ? (
+          {tab === 'members' ? (
+            members.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 text-center">
+                <p className="text-muted-foreground font-medium">No members</p>
+                <p className="text-sm text-muted-foreground/70 mt-1">
+                  No team members are assigned to this group
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {members.map((member: IPermissionGroupMember) => {
+                  const name =
+                    [member.details?.firstName, member.details?.lastName]
+                      .filter(Boolean)
+                      .join(' ') || member.email;
+                  return (
+                    <div
+                      key={member._id}
+                      className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border bg-background"
+                    >
+                      {member.details?.avatar ? (
+                        <img
+                          src={member.details.avatar}
+                          alt={name}
+                          className="w-8 h-8 rounded-full object-cover shrink-0"
+                        />
+                      ) : (
+                        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            {name.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{name}</p>
+                        {name !== member.email && (
+                          <p className="text-xs text-muted-foreground truncate">
+                            {member.email}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )
+          ) : modulesLoading ? (
             <div className="flex justify-center py-16">
               <Spinner />
             </div>

--- a/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
+++ b/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
@@ -119,26 +119,26 @@ export const PermissionGroupDetails = ({
         <Separator />
 
         <div className="flex gap-1 px-6 pt-3">
-            <Button
-              variant={tab === 'permissions' ? 'default' : 'ghost'}
-              size="sm"
-              onClick={() => setTab('permissions')}
-            >
-              Permissions
-            </Button>
-            <Button
-              variant={tab === 'members' ? 'default' : 'ghost'}
-              size="sm"
-              onClick={() => setTab('members')}
-            >
-              <IconUsers size={14} className="mr-1" />
-              Members
-              {members.length > 0 && (
-                <span className="ml-1.5 text-xs bg-muted text-muted-foreground rounded px-1.5 py-0.5">
-                  {members.length}
-                </span>
-              )}
-            </Button>
+          <Button
+            variant={tab === 'permissions' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setTab('permissions')}
+          >
+            Permissions
+          </Button>
+          <Button
+            variant={tab === 'members' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setTab('members')}
+          >
+            <IconUsers size={14} className="mr-1" />
+            Members
+            {members.length > 0 && (
+              <span className="ml-1.5 text-xs bg-muted text-muted-foreground rounded px-1.5 py-0.5">
+                {members.length}
+              </span>
+            )}
+          </Button>
         </div>
 
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4 styled-scroll">

--- a/frontend/core-ui/src/modules/settings/permissions/graphql/permissionGroupQueries.ts
+++ b/frontend/core-ui/src/modules/settings/permissions/graphql/permissionGroupQueries.ts
@@ -12,6 +12,15 @@ export const GET_PERMISSION_DEFAULT_GROUPS = gql`
         actions
         scope
       }
+      members {
+        _id
+        email
+        details {
+          firstName
+          lastName
+          avatar
+        }
+      }
     }
   }
 `;
@@ -26,6 +35,15 @@ export const GET_PERMISSION_GROUPS = gql`
         module
         actions
         scope
+      }
+      members {
+        _id
+        email
+        details {
+          firstName
+          lastName
+          avatar
+        }
       }
     }
   }

--- a/frontend/core-ui/src/modules/settings/permissions/types.ts
+++ b/frontend/core-ui/src/modules/settings/permissions/types.ts
@@ -35,6 +35,17 @@ export interface IDefaultPermissionGroup {
   description?: string;
   plugin: string;
   permissions: IPermissionGroupPermission[];
+  members?: IPermissionGroupMember[];
+}
+
+export interface IPermissionGroupMember {
+  _id: string;
+  email: string;
+  details?: {
+    firstName?: string;
+    lastName?: string;
+    avatar?: string;
+  };
 }
 
 export interface IPermissionGroup {
@@ -42,6 +53,7 @@ export interface IPermissionGroup {
   name: string;
   description?: string;
   permissions: IPermissionGroupPermission[];
+  members?: IPermissionGroupMember[];
   createdAt?: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary by Sourcery

Add support for viewing permission group members in the permission group details dialog and expose group members via GraphQL.

New Features:
- Introduce a Members tab in the permission group details dialog to display users assigned to the group.
- Extend permission group GraphQL queries and types to include associated user members for both default and custom groups.

Enhancements:
- Add backend resolvers to populate permission group members based on users' permissionGroupIds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Members view in permission group settings, allowing users to see group members with their names, emails, and avatars displayed in a dedicated tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->