### PR TITLE
feat(loyalty): sales deal target + date-filter & company-edit fixes

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/filter/components/Filter.tsx
+++ b/frontend/libs/erxes-ui/src/modules/filter/components/Filter.tsx
@@ -406,10 +406,21 @@ const FilterDialogStringView = ({
   );
 };
 
-const FilterPopoverDateView = ({ filterKey, label }: { filterKey: string; label?: string }) => {
-  const { resetFilterState } = useFilterContext();
+const FilterPopoverDateView = ({
+  filterKey,
+  label,
+}: {
+  filterKey: string;
+  label?: string;
+}) => {
+  const { resetFilterState, sessionKey } = useFilterContext();
 
-  const [query, setQuery] = useFilterQueryState<string>(filterKey, filterKey);
+  // Reset the table cursor keyed by sessionKey (not filterKey) so picking a date
+  // preset clears pagination — consistent with FilterBarDate / DialogDateView.
+  const [query, setQuery] = useFilterQueryState<string>(
+    filterKey,
+    sessionKey ?? '',
+  );
 
   return (
     <DateFilterCommand

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/graphql/queries.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/graphql/queries.ts
@@ -45,7 +45,6 @@ export const SCORE_LOGS_QUERY = gql`
         ownerType
         owner
         totalScore
-        preScore
         change
         action
         description


### PR DESCRIPTION
## Summary by Sourcery

Adjust date filter popover state handling and align loyalty score log query fields with current schema.

Bug Fixes:
- Ensure date filter popover resets table pagination by scoping its query state to the session key rather than the filter key.
- Stop requesting the deprecated preScore field in the loyalty score logs GraphQL query to prevent schema mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date filter behavior to properly reset pagination and cursor state when users select a new date, ensuring consistent filtering experience across the application.

* **Chores**
  * Removed unused data field from loyalty score logs queries to improve data efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->