### PR TITLE
fix(content): generate Mongolian-aware CMS slugs from title

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/db/models/Categories.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Categories.ts
@@ -3,7 +3,11 @@ import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import { IPostCategory, IPostCategoryDocument } from '@/cms/@types/posts';
 import { postCategorySchema } from '@/cms/db/definitions/posts';
-import { createSlug, generateUniqueSlug } from '@/cms/utils/common';
+import {
+  createSlug,
+  generateUniqueSlug,
+  generateUniqueSlugWithExclusion,
+} from '@/cms/utils/common';
 
 export interface ICategoryModel extends Model<IPostCategoryDocument> {
   getCategories: (query: any) => Promise<IPostCategoryDocument[]>;
@@ -33,11 +37,13 @@ export const loadCategoryClass = (models: IModels) => {
     public static updateCategory = async (id: string, data: IPostCategory) => {
       if (data.name) {
         const baseSlug = createSlug(data.name);
-        data.slug = await generateUniqueSlug(
+        data.slug = await generateUniqueSlugWithExclusion(
           models.Categories,
           data.clientPortalId,
           'slug',
           baseSlug,
+          id,
+          1,
         );
       }
 

--- a/backend/plugins/content_api/src/modules/cms/db/models/Categories.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Categories.ts
@@ -1,10 +1,9 @@
 import { Model } from 'mongoose';
 
-import slugify from 'slugify';
 import { IModels } from '~/connectionResolvers';
 import { IPostCategory, IPostCategoryDocument } from '@/cms/@types/posts';
 import { postCategorySchema } from '@/cms/db/definitions/posts';
-import { generateUniqueSlug } from '@/cms/utils/common';
+import { createSlug, generateUniqueSlug } from '@/cms/utils/common';
 
 export interface ICategoryModel extends Model<IPostCategoryDocument> {
   getCategories: (query: any) => Promise<IPostCategoryDocument[]>;
@@ -20,7 +19,7 @@ export interface ICategoryModel extends Model<IPostCategoryDocument> {
 export const loadCategoryClass = (models: IModels) => {
   class Categories {
     public static createCategory = async (data: IPostCategory) => {
-      const baseSlug = slugify(data.name, { lower: true });
+      const baseSlug = createSlug(data.name);
       data.slug = await generateUniqueSlug(
         models.Categories,
         data.clientPortalId,
@@ -33,7 +32,7 @@ export const loadCategoryClass = (models: IModels) => {
 
     public static updateCategory = async (id: string, data: IPostCategory) => {
       if (data.name) {
-        const baseSlug = slugify(data.name, { lower: true });
+        const baseSlug = createSlug(data.name);
         data.slug = await generateUniqueSlug(
           models.Categories,
           data.clientPortalId,

--- a/backend/plugins/content_api/src/modules/cms/db/models/Posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Posts.ts
@@ -43,7 +43,11 @@ const prepareExcerpt = (content: string) => {
     : plainTextContent;
 };
 
-const prepareSlug = (slug?: string | null) => createSlug(slug ?? '');
+const prepareSlug = (slug?: string | null) => {
+  const slugValue = slug?.trim();
+
+  return slugValue ? createSlug(slugValue) : '';
+};
 
 const isValidReactionType = (reaction: string): reaction is PostReactionType =>
   POST_REACTION_TYPES.includes(reaction as PostReactionType);

--- a/backend/plugins/content_api/src/modules/cms/db/models/Posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Posts.ts
@@ -8,10 +8,10 @@ import {
   PostReactionType,
 } from '@/cms/@types/posts';
 import { IModels } from '~/connectionResolvers';
-import slugify from 'slugify';
 import { htmlToText } from 'html-to-text';
 import { postSchema } from '@/cms/db/definitions/posts';
 import {
+  createSlug,
   generateUniqueSlug,
   generateUniqueSlugWithExclusion,
 } from '@/cms/utils/common';
@@ -43,8 +43,7 @@ const prepareExcerpt = (content: string) => {
     : plainTextContent;
 };
 
-const prepareSlug = (slug?: string | null) =>
-  slugify(String(slug || '').trim(), { lower: true });
+const prepareSlug = (slug?: string | null) => createSlug(slug ?? '');
 
 const isValidReactionType = (reaction: string): reaction is PostReactionType =>
   POST_REACTION_TYPES.includes(reaction as PostReactionType);
@@ -102,29 +101,6 @@ export const loadPostClass = (models: IModels) => {
 
       return models.Posts.countDocuments({ clientPortalId });
     };
-
-    public static async generateUniqueSlug(
-      title: string,
-      attempt = 0,
-    ): Promise<string> {
-      let baseSlug = slugify(title, { lower: true });
-
-      // If it's a retry attempt, append the attempt number to the slug
-      if (attempt > 0) {
-        baseSlug = `${baseSlug}-${attempt}`;
-      }
-
-      // Check if the slug already exists
-      const existingPost = await models.Posts.findOne({ slug: baseSlug });
-
-      // If a post with this slug exists, recursively try again with an incremented attempt number
-      if (existingPost) {
-        return this.generateUniqueSlug(title, attempt + 1);
-      }
-
-      // Return the unique slug
-      return baseSlug;
-    }
 
     public static getPosts = async (query: any, sort: any) => {
       return models.Posts.find(query).sort(sort).lean();

--- a/backend/plugins/content_api/src/modules/cms/db/models/Tag.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Tag.ts
@@ -2,9 +2,8 @@ import { Model } from 'mongoose';
 
 import { IPostTag, IPostTagDocument } from '@/cms/@types/posts';
 import { postTagSchema } from '@/cms/db/definitions/posts';
-import slugify from 'slugify';
 import { IModels } from '~/connectionResolvers';
-import { generateUniqueSlug } from '@/cms/utils/common';
+import { createSlug, generateUniqueSlug } from '@/cms/utils/common';
 
 export interface IPostTagModel extends Model<IPostTagDocument> {
   getPostTags: (query: any) => Promise<IPostTagDocument[]>;
@@ -17,7 +16,7 @@ export interface IPostTagModel extends Model<IPostTagDocument> {
 export const loadPostTagClass = (models: IModels) => {
   class PostTags {
     public static createTag = async (data: IPostTag) => {
-      const baseSlug = data.slug || slugify(data.name, { lower: true });
+      const baseSlug = createSlug(data.slug || data.name);
 
       // Generate unique slug
       const uniqueSlug = await generateUniqueSlug(
@@ -50,7 +49,7 @@ export const loadPostTagClass = (models: IModels) => {
 
     public static updateTag = async (id: string, data: IPostTag) => {
       if (data.name) {
-        const baseSlug = slugify(data.name, { lower: true });
+        const baseSlug = createSlug(data.name);
         // Generate unique slug excluding current document
         data.slug = await generateUniqueSlug(
           models.PostTags,

--- a/backend/plugins/content_api/src/modules/cms/db/models/Tag.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Tag.ts
@@ -3,7 +3,11 @@ import { Model } from 'mongoose';
 import { IPostTag, IPostTagDocument } from '@/cms/@types/posts';
 import { postTagSchema } from '@/cms/db/definitions/posts';
 import { IModels } from '~/connectionResolvers';
-import { createSlug, generateUniqueSlug } from '@/cms/utils/common';
+import {
+  createSlug,
+  generateUniqueSlug,
+  generateUniqueSlugWithExclusion,
+} from '@/cms/utils/common';
 
 export interface IPostTagModel extends Model<IPostTagDocument> {
   getPostTags: (query: any) => Promise<IPostTagDocument[]>;
@@ -51,11 +55,13 @@ export const loadPostTagClass = (models: IModels) => {
       if (data.name) {
         const baseSlug = createSlug(data.name);
         // Generate unique slug excluding current document
-        data.slug = await generateUniqueSlug(
+        data.slug = await generateUniqueSlugWithExclusion(
           models.PostTags,
           data.clientPortalId,
           'slug',
           baseSlug,
+          id,
+          1,
         );
       }
 

--- a/backend/plugins/content_api/src/modules/cms/utils/common.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/common.ts
@@ -108,6 +108,76 @@ export const customFieldsDataByFieldCode = async (
   return results;
 };
 
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+  а: 'a',
+  б: 'b',
+  в: 'v',
+  г: 'g',
+  д: 'd',
+  е: 'e',
+  ё: 'yo',
+  ж: 'j',
+  з: 'z',
+  и: 'i',
+  й: 'i',
+  к: 'k',
+  л: 'l',
+  м: 'm',
+  н: 'n',
+  о: 'o',
+  ө: 'u',
+  п: 'p',
+  р: 'r',
+  с: 's',
+  т: 't',
+  у: 'u',
+  ү: 'u',
+  ф: 'f',
+  х: 'kh',
+  ц: 'ts',
+  ч: 'ch',
+  ш: 'sh',
+  щ: 'shch',
+  ъ: '',
+  ы: 'y',
+  ь: '',
+  э: 'e',
+  ю: 'yu',
+  я: 'ya',
+};
+
+/**
+ * Build a URL-safe slug from a post title. Mongolian Cyrillic characters are
+ * transliterated to Latin, the rest is normalized to `[a-z0-9-]`, and the
+ * result is capped at `maxLength` characters without breaking the final word.
+ */
+export const createSlug = (title: string, maxLength = 60): string => {
+  let slug = String(title ?? '')
+    .toLowerCase()
+    .split('')
+    .map((char) => CYRILLIC_TO_LATIN[char] ?? char)
+    .join('')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  // Cut to maxLength without breaking the last word when possible.
+  if (slug.length > maxLength) {
+    slug = slug.slice(0, maxLength);
+    const lastDash = slug.lastIndexOf('-');
+    if (lastDash > 0) {
+      slug = slug.slice(0, lastDash);
+    }
+    slug = slug.replace(/-+$/, '');
+  }
+
+  return slug;
+};
+
 export const generateUniqueSlug = async (
   model: any,
   cpId: string,

--- a/backend/plugins/content_api/src/modules/cms/utils/common.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/common.ts
@@ -146,36 +146,69 @@ const CYRILLIC_TO_LATIN: Record<string, string> = {
   я: 'ya',
 };
 
-/**
- * Build a URL-safe slug from a post title. Mongolian Cyrillic characters are
- * transliterated to Latin, the rest is normalized to `[a-z0-9-]`, and the
- * result is capped at `maxLength` characters without breaking the final word.
- */
-export const createSlug = (title: string, maxLength = 60): string => {
-  let slug = String(title ?? '')
-    .toLowerCase()
-    .split('')
-    .map((char) => CYRILLIC_TO_LATIN[char] ?? char)
-    .join('')
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9\s-]/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
+const DEFAULT_SLUG_MAX_LENGTH = 60;
+const FALLBACK_SLUG = 'untitled';
 
-  // Cut to maxLength without breaking the last word when possible.
-  if (slug.length > maxLength) {
-    slug = slug.slice(0, maxLength);
-    const lastDash = slug.lastIndexOf('-');
-    if (lastDash > 0) {
-      slug = slug.slice(0, lastDash);
-    }
-    slug = slug.replace(/-+$/, '');
+const resolveSlugMaxLength = (maxLength: number) =>
+  Number.isInteger(maxLength) && maxLength > 0
+    ? maxLength
+    : DEFAULT_SLUG_MAX_LENGTH;
+
+const collapseHyphens = (value: string) =>
+  value
+    .split('-')
+    .filter(Boolean)
+    .join('-');
+
+const trimTrailingHyphens = (value: string) => {
+  let end = value.length;
+
+  while (end > 0 && value[end - 1] === '-') {
+    end -= 1;
   }
 
-  return slug;
+  return value.slice(0, end);
+};
+
+const limitSlugLength = (slug: string, maxLength: number) => {
+  if (slug.length <= maxLength) {
+    return slug;
+  }
+
+  let limitedSlug = slug.slice(0, maxLength);
+  const lastDash = limitedSlug.lastIndexOf('-');
+
+  if (lastDash > 0) {
+    limitedSlug = limitedSlug.slice(0, lastDash);
+  }
+
+  limitedSlug = trimTrailingHyphens(limitedSlug);
+
+  return limitedSlug || FALLBACK_SLUG.slice(0, maxLength);
+};
+
+/**
+ * Build a URL-safe slug from a CMS name or title. Keep this behavior aligned
+ * with the frontend CMS slug utility.
+ */
+export const createSlug = (
+  title: string | null | undefined,
+  maxLength = DEFAULT_SLUG_MAX_LENGTH,
+): string => {
+  const slugMaxLength = resolveSlugMaxLength(maxLength);
+  const slug =
+    collapseHyphens(
+      Array.from(String(title ?? '').toLowerCase())
+        .map((char) => CYRILLIC_TO_LATIN[char] ?? char)
+        .join('')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/gu, '')
+        .replace(/[^a-z0-9\s-]/gu, '')
+        .trim()
+        .replace(/\s+/gu, '-'),
+    ) || FALLBACK_SLUG;
+
+  return limitSlugLength(slug, slugMaxLength);
 };
 
 export const generateUniqueSlug = async (

--- a/backend/plugins/content_api/src/modules/cms/utils/common.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/common.ts
@@ -155,10 +155,7 @@ const resolveSlugMaxLength = (maxLength: number) =>
     : DEFAULT_SLUG_MAX_LENGTH;
 
 const collapseHyphens = (value: string) =>
-  value
-    .split('-')
-    .filter(Boolean)
-    .join('-');
+  value.split('-').filter(Boolean).join('-');
 
 const trimTrailingHyphens = (value: string) => {
   let end = value.length;

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -12,6 +12,7 @@ import {
   CMS_CUSTOM_FIELD_GROUPS,
 } from './graphql';
 import { CONTENT_CMS_LIST } from '../graphql/queries';
+import { createSlug } from '../utils/createSlug';
 import {
   CategoryCustomFieldsSection,
   FieldGroup,
@@ -133,15 +134,6 @@ const EMPTY_FORM_VALUES: CategoryFormType = {
   status: 'active',
   customFieldsData: [],
 };
-
-const generateSlug = (name: string): string =>
-  name
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^a-z0-9\s-]/g, '')
-    .replaceAll(/\s+/g, '-')
-    .replaceAll(/-+/g, '-')
-    .replaceAll(/^-+|-+$/g, '');
 
 const collectDescendantIds = (
   allCategories: Category[],
@@ -338,7 +330,7 @@ export function CmsCategoryDrawer({
     ) {
       return;
     }
-    const generatedSlug = generateSlug(nameValue);
+    const generatedSlug = createSlug(nameValue);
     if (generatedSlug !== slugValue) {
       form.setValue('slug', generatedSlug);
     }

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -874,8 +874,8 @@ export function CmsCategoryDrawer({
                       ? 'Saving...'
                       : 'Creating...'
                     : isEditing
-                    ? 'Save Changes'
-                    : 'Create Category'}
+                      ? 'Save Changes'
+                      : 'Create Category'}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
@@ -41,9 +41,9 @@ export const PostsRecordTable = ({
   );
   const columns = usePostsColumns(onEditPost, refetch, cmsConfig);
 
-  if (loading) return <Spinner />;
+  if (loading && (!posts || posts.length === 0)) return <Spinner />;
 
-  if (!posts || posts.length === 0) {
+  if (!loading && (!posts || posts.length === 0)) {
     return <PostsEmptyState clientPortalId={clientPortalId} />;
   }
 

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
@@ -40,7 +40,13 @@ export const PostsRecordTable = ({
     [clientPortalId, cmsData?.contentCMSList],
   );
   const columns = usePostsColumns(onEditPost, refetch, cmsConfig);
+
   if (loading) return <Spinner />;
+
+  if (!posts || posts.length === 0) {
+    return <PostsEmptyState clientPortalId={clientPortalId} />;
+  }
+
   return (
     <RecordTable.Provider
       columns={columns}
@@ -67,9 +73,6 @@ export const PostsRecordTable = ({
             />
           </RecordTable.Body>
         </RecordTable>
-        {!loading && posts?.length === 0 && (
-          <PostsEmptyState clientPortalId={clientPortalId} />
-        )}
       </RecordTable.CursorProvider>
       <PostsCommandbar refetch={refetch} />
     </RecordTable.Provider>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/useInlineCategory.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/useInlineCategory.ts
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { CMS_CATEGORIES_ADD } from '../../../../categories/graphql/mutations/categoriesAddMutation';
-
-const toSlug = (name: string) =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+import { createSlug } from '../../../../utils/createSlug';
 
 export const useInlineCategory = (websiteId: string) => {
   const [addCategoryMutation] = useMutation(CMS_CATEGORIES_ADD);
@@ -27,7 +22,7 @@ export const useInlineCategory = (websiteId: string) => {
         variables: {
           input: {
             name: newCategoryName.trim(),
-            slug: toSlug(newCategoryName.trim()),
+            slug: createSlug(newCategoryName.trim()),
             clientPortalId: websiteId,
           },
         },

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/useInlineTag.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/useInlineTag.ts
@@ -1,11 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { CMS_TAGS_ADD } from '../../../../tags/graphql/mutations';
-
-const toSlug = (name: string) =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+import { createSlug } from '../../../../utils/createSlug';
 
 export const useInlineTag = (websiteId: string) => {
   const [addTagMutation] = useMutation(CMS_TAGS_ADD);
@@ -26,7 +21,7 @@ export const useInlineTag = (websiteId: string) => {
             variables: {
               input: {
                 name: opt.label,
-                slug: toSlug(opt.label),
+                slug: createSlug(opt.label),
                 clientPortalId: websiteId,
                 colorCode: '',
               },

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
@@ -8,6 +8,7 @@ import {
   CMS_TRANSLATIONS,
   CMS_EDIT_TRANSLATION,
 } from '../../../../graphql/queries';
+import { createSlug } from '../../../../utils/createSlug';
 
 interface PostFormData {
   title: string;
@@ -85,12 +86,6 @@ export const usePostForm = (editingPost?: { _id: string }) => {
   const handleEditorChange = (value: string) => {
     form.setValue('content', value, { shouldDirty: true, shouldTouch: true });
   };
-
-  const generateSlug = (text: string) =>
-    text
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
 
   const { data: fullPostData } = useQuery(CMS_POST, {
     variables: { id: editingPost?._id },
@@ -184,7 +179,7 @@ export const usePostForm = (editingPost?: { _id: string }) => {
     } else {
       const title = form.getValues('title');
       if (title && !form.getValues('slug')) {
-        form.setValue('slug', generateSlug(title));
+        form.setValue('slug', createSlug(title));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -227,7 +222,6 @@ export const usePostForm = (editingPost?: { _id: string }) => {
     setDefaultLangData,
     previousTypeRef,
     handleEditorChange,
-    generateSlug,
     fullPost,
     saveTranslation,
     updateCustomFieldValue,

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -4,6 +4,7 @@ import {
   makeAttachmentArrayFromUrls,
   normalizeAttachment,
 } from '../../../formHelpers';
+import { createSlug } from '../../../../utils/createSlug';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useRef, useEffect, useCallback } from 'react';
 
@@ -195,17 +196,6 @@ const computeTitle = (data: PostFormData, contentHtml: string): string => {
   );
 };
 
-const generateSlug = (title: string): string => {
-  const baseSlug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  const timestamp = Date.now().toString(36).slice(-6);
-
-  return `${baseSlug || 'post'}-${timestamp}`;
-};
-
 const redirectToPosts = (
   websiteId: string,
   searchParams: URLSearchParams,
@@ -270,7 +260,8 @@ const buildPostInput = (
   const audioPayload = normalizeAttachment(data.audio ?? undefined);
   const pdfPayload = normalizeAttachment(data.pdf ?? undefined);
   const slug =
-    data.slug?.trim() || (!editingPostId ? generateSlug(main.title) : '');
+    data.slug?.trim() ||
+    (!editingPostId ? createSlug(main.title) || 'post' : '');
 
   return {
     clientPortalId: websiteId,

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -259,9 +259,8 @@ const buildPostInput = (
   const videoPayload = normalizeAttachment(data.video ?? undefined);
   const audioPayload = normalizeAttachment(data.audio ?? undefined);
   const pdfPayload = normalizeAttachment(data.pdf ?? undefined);
-  const slug =
-    data.slug?.trim() ||
-    (!editingPostId ? createSlug(main.title) || 'post' : '');
+  const generatedSlug = editingPostId ? '' : createSlug(main.title);
+  const slug = data.slug?.trim() || generatedSlug;
 
   return {
     clientPortalId: websiteId,

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -259,7 +259,9 @@ const buildPostInput = (
   const videoPayload = normalizeAttachment(data.video ?? undefined);
   const audioPayload = normalizeAttachment(data.audio ?? undefined);
   const pdfPayload = normalizeAttachment(data.pdf ?? undefined);
-  const generatedSlug = editingPostId ? '' : createSlug(main.title);
+  const isEditing = Boolean(editingPostId);
+  const generatedSlug = isEditing ? '' : createSlug(main.title);
+  const shouldSetImages = isEditing || imagesPayload.length > 0;
   const slug = data.slug?.trim() || generatedSlug;
 
   return {
@@ -277,7 +279,7 @@ const buildPostInput = (
     autoArchiveDate: data.enableAutoArchive ? data.autoArchiveDate : undefined,
     excerpt: main.excerpt,
     thumbnail: normalizeAttachment(data.thumbnail ?? undefined),
-    images: imagesPayload.length ? imagesPayload : undefined,
+    images: shouldSetImages ? imagesPayload : undefined,
     video: videoPayload,
     videoUrl: data.videoUrl,
     audio: audioPayload,

--- a/frontend/plugins/content_ui/src/modules/cms/tags/TagDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/TagDrawer.tsx
@@ -524,10 +524,10 @@ export function TagDrawer({
                     ? 'Saving...'
                     : 'Creating...'
                   : hasPermissionError
-                  ? 'Permission Required'
-                  : isEditing
-                  ? 'Save Changes'
-                  : 'Create Tag'}
+                    ? 'Permission Required'
+                    : isEditing
+                      ? 'Save Changes'
+                      : 'Create Tag'}
               </Button>
             </div>
           </form>

--- a/frontend/plugins/content_ui/src/modules/cms/tags/TagDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/TagDrawer.tsx
@@ -13,6 +13,7 @@ import {
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 import { CMS_TAGS_ADD, CMS_TAGS_EDIT } from '@/cms/tags/graphql/mutations';
 import { CMS_TAG_DETAIL } from '@/cms/tags/graphql/queries';
+import { createSlug } from '@/cms/utils/createSlug';
 import { CmsTag, TagFormData } from '@/cms/tags/types/tagTypes';
 
 interface TagDrawerProps {
@@ -56,12 +57,6 @@ const tagToFormValues = (
     clientPortalId: tag.clientPortalId || clientPortalId,
   };
 };
-
-const generateSlug = (name: string) =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
 
 const hasTranslationValue = (data?: TranslationData): boolean =>
   Boolean(data?.title?.trim());
@@ -417,7 +412,7 @@ export function TagDrawer({
   };
 
   const handleNameChange = (name: string) => {
-    const slug = generateSlug(name);
+    const slug = createSlug(name);
     form.setValue('slug', slug);
   };
 

--- a/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
@@ -1,0 +1,69 @@
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+  а: 'a',
+  б: 'b',
+  в: 'v',
+  г: 'g',
+  д: 'd',
+  е: 'e',
+  ё: 'yo',
+  ж: 'j',
+  з: 'z',
+  и: 'i',
+  й: 'i',
+  к: 'k',
+  л: 'l',
+  м: 'm',
+  н: 'n',
+  о: 'o',
+  ө: 'u',
+  п: 'p',
+  р: 'r',
+  с: 's',
+  т: 't',
+  у: 'u',
+  ү: 'u',
+  ф: 'f',
+  х: 'kh',
+  ц: 'ts',
+  ч: 'ch',
+  ш: 'sh',
+  щ: 'shch',
+  ъ: '',
+  ы: 'y',
+  ь: '',
+  э: 'e',
+  ю: 'yu',
+  я: 'ya',
+};
+
+/**
+ * Build a URL-safe slug from a post title. Mongolian Cyrillic characters are
+ * transliterated to Latin, the rest is normalized to `[a-z0-9-]`, and the
+ * result is capped at `maxLength` characters without breaking the final word.
+ */
+export const createSlug = (title: string, maxLength = 60): string => {
+  let slug = String(title ?? '')
+    .toLowerCase()
+    .split('')
+    .map((char) => CYRILLIC_TO_LATIN[char] ?? char)
+    .join('')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  // Cut to maxLength without breaking the last word when possible.
+  if (slug.length > maxLength) {
+    slug = slug.slice(0, maxLength);
+    const lastDash = slug.lastIndexOf('-');
+    if (lastDash > 0) {
+      slug = slug.slice(0, lastDash);
+    }
+    slug = slug.replace(/-+$/, '');
+  }
+
+  return slug;
+};

--- a/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
@@ -64,11 +64,11 @@ const truncateSlug = (slug: string, maxLength: number) => {
   const slicedSlug = slug.slice(0, maxLength);
   const lastWordSeparator = slicedSlug.lastIndexOf('-');
   const truncatedSlug =
-    lastWordSeparator > 0
-      ? slicedSlug.slice(0, lastWordSeparator)
-      : slicedSlug;
+    lastWordSeparator > 0 ? slicedSlug.slice(0, lastWordSeparator) : slicedSlug;
 
-  return removeEndingHyphens(truncatedSlug) || FALLBACK_SLUG.slice(0, maxLength);
+  return (
+    removeEndingHyphens(truncatedSlug) || FALLBACK_SLUG.slice(0, maxLength)
+  );
 };
 
 /**

--- a/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/utils/createSlug.ts
@@ -1,69 +1,104 @@
-const CYRILLIC_TO_LATIN: Record<string, string> = {
-  а: 'a',
-  б: 'b',
-  в: 'v',
-  г: 'g',
-  д: 'd',
-  е: 'e',
-  ё: 'yo',
-  ж: 'j',
-  з: 'z',
-  и: 'i',
-  й: 'i',
-  к: 'k',
-  л: 'l',
-  м: 'm',
-  н: 'n',
-  о: 'o',
-  ө: 'u',
-  п: 'p',
-  р: 'r',
-  с: 's',
-  т: 't',
-  у: 'u',
-  ү: 'u',
-  ф: 'f',
-  х: 'kh',
-  ц: 'ts',
-  ч: 'ch',
-  ш: 'sh',
-  щ: 'shch',
-  ъ: '',
-  ы: 'y',
-  ь: '',
-  э: 'e',
-  ю: 'yu',
-  я: 'ya',
+const MONGOLIAN_CYRILLIC_PAIRS = [
+  ['а', 'a'],
+  ['б', 'b'],
+  ['в', 'v'],
+  ['г', 'g'],
+  ['д', 'd'],
+  ['е', 'e'],
+  ['ё', 'yo'],
+  ['ж', 'j'],
+  ['з', 'z'],
+  ['и', 'i'],
+  ['й', 'i'],
+  ['к', 'k'],
+  ['л', 'l'],
+  ['м', 'm'],
+  ['н', 'n'],
+  ['о', 'o'],
+  ['ө', 'u'],
+  ['п', 'p'],
+  ['р', 'r'],
+  ['с', 's'],
+  ['т', 't'],
+  ['у', 'u'],
+  ['ү', 'u'],
+  ['ф', 'f'],
+  ['х', 'kh'],
+  ['ц', 'ts'],
+  ['ч', 'ch'],
+  ['ш', 'sh'],
+  ['щ', 'shch'],
+  ['ъ', ''],
+  ['ы', 'y'],
+  ['ь', ''],
+  ['э', 'e'],
+  ['ю', 'yu'],
+  ['я', 'ya'],
+] as const;
+
+const cyrillicToLatin = new Map<string, string>(MONGOLIAN_CYRILLIC_PAIRS);
+const MONGOLIAN_CYRILLIC_PATTERN = /[абвгдеёжзийклмнопрстуүфхцчшщъыьэюяө]/gu;
+const DEFAULT_SLUG_MAX_LENGTH = 60;
+const FALLBACK_SLUG = 'untitled';
+
+const getSlugMaxLength = (maxLength: number) =>
+  Number.isInteger(maxLength) && maxLength > 0
+    ? maxLength
+    : DEFAULT_SLUG_MAX_LENGTH;
+
+const removeEndingHyphens = (slug: string) => {
+  let endIndex = slug.length;
+
+  while (slug.charAt(endIndex - 1) === '-') {
+    endIndex -= 1;
+  }
+
+  return slug.slice(0, endIndex);
+};
+
+const truncateSlug = (slug: string, maxLength: number) => {
+  if (slug.length <= maxLength) {
+    return slug;
+  }
+
+  const slicedSlug = slug.slice(0, maxLength);
+  const lastWordSeparator = slicedSlug.lastIndexOf('-');
+  const truncatedSlug =
+    lastWordSeparator > 0
+      ? slicedSlug.slice(0, lastWordSeparator)
+      : slicedSlug;
+
+  return removeEndingHyphens(truncatedSlug) || FALLBACK_SLUG.slice(0, maxLength);
 };
 
 /**
- * Build a URL-safe slug from a post title. Mongolian Cyrillic characters are
- * transliterated to Latin, the rest is normalized to `[a-z0-9-]`, and the
- * result is capped at `maxLength` characters without breaking the final word.
+ * Build a URL-safe slug from a CMS name or title. Keep this behavior aligned
+ * with the backend CMS slug utility.
  */
-export const createSlug = (title: string, maxLength = 60): string => {
-  let slug = String(title ?? '')
+export const createSlug = (
+  title: string | null | undefined,
+  maxLength = DEFAULT_SLUG_MAX_LENGTH,
+): string => {
+  const normalizedSlug = String(title ?? '')
     .toLowerCase()
-    .split('')
-    .map((char) => CYRILLIC_TO_LATIN[char] ?? char)
-    .join('')
+    .replace(
+      MONGOLIAN_CYRILLIC_PATTERN,
+      (char) => cyrillicToLatin.get(char) ?? char,
+    )
     .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\u0300-\u036f]/gu, '')
+    .replace(/[^a-z0-9\s-]/gu, '')
     .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/\s+/gu, '-');
 
-  // Cut to maxLength without breaking the last word when possible.
-  if (slug.length > maxLength) {
-    slug = slug.slice(0, maxLength);
-    const lastDash = slug.lastIndexOf('-');
-    if (lastDash > 0) {
-      slug = slug.slice(0, lastDash);
-    }
-    slug = slug.replace(/-+$/, '');
-  }
+  const compactSlug =
+    normalizedSlug
+      .split('-')
+      .reduce<string[]>((parts, part) => {
+        if (part) parts.push(part);
+        return parts;
+      }, [])
+      .join('-') || FALLBACK_SLUG;
 
-  return slug;
+  return truncateSlug(compactSlug, getSlugMaxLength(maxLength));
 };


### PR DESCRIPTION
## Problem

The CMS slug generators used `/[^a-z0-9]+/g`, which strips every Cyrillic character. Mongolian post **titles** and tag/category **names** collapsed to empty or `post-<timestamp>` slugs.

## Fix

Introduce a shared `createSlug` util (mirrored frontend + backend, since they can't share code) that:
- transliterates Mongolian Cyrillic → Latin (`х→kh`, `ө/ү→u`, …)
- normalizes to `[a-z0-9-]`
- caps length at 60 chars **without breaking the last word**

Wired into every CMS slug-from-name/title path:

| Area | Frontend | Backend |
|---|---|---|
| Posts | `usePostForm`, `usePostSubmission` | `Posts.prepareSlug` |
| Tags | `TagDrawer`, `useInlineTag` | `Tag.ts` |
| Categories | `CmsCategoryDrawer`, `useInlineCategory` | `Categories.ts` |

## Notable behavior changes
- **Dropped the random `-<timestamp>` suffix** on auto-generated post slugs; the backend's existing `generateUniqueSlug` already dedupes (`_2`, `_3`) → cleaner URLs.
- Removed the **dead `Posts.generateUniqueSlug` static method** (only self-recursive, never called) and its now-orphaned `slugify` import.

## Testing
- `createSlug` checked against Mongolian sentences, `ө/ү/х` letters, >60-char titles (cuts at word boundary), a single long word (hard cut, not empty), and emoji/empty input (→ fallback).
- `tsc --strict` clean on the new util.

## Out of scope
- CMS **pages** (`Page.ts`) and **menus** (`Menu.ts`) still use `slugify` and carry the same latent Cyrillic issue — left untouched per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared Mongolian-aware slug generation utility and apply it across CMS posts, tags, and categories on frontend and backend.

New Features:
- Add a reusable slug generation helper that transliterates Mongolian Cyrillic to Latin and enforces URL-safe, length-limited slugs.

Bug Fixes:
- Ensure auto-generated slugs for Mongolian titles, tags, and categories no longer collapse to empty or fallback values due to Cyrillic stripping.
- Align frontend and backend slug generation so CMS entities consistently produce valid slugs from Mongolian content.

Enhancements:
- Simplify post slug handling by relying on the existing backend unique-slug generator instead of adding timestamp-based suffixes on the frontend.
- Remove an unused Posts.generateUniqueSlug method and redundant slugification logic now superseded by the shared slug utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated slug generation into a shared createSlug utility used across backend and frontend.
  * Standardized unique-slug handling with exclusion-aware uniqueness checks and improved Cyrillic/Mongolian transliteration and truncation rules.

* **UI Improvements**
  * Category, tag, and post forms now auto-generate slugs using the unified rules; some internal slug helpers were removed (hook API no longer exposes generateSlug).
  * Posts list now shows a spinner when loading and a separate empty-state when no posts exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->