### PR TITLE
fix(content): preserve CMS page slug on edit

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/db/models/Page.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Page.ts
@@ -51,26 +51,7 @@ export const loadPageClass = (models: IModels) => {
         throw new Error('Page not found');
       }
 
-      if (doc.name && doc.name !== existing.name) {
-        if (!doc.slug) {
-          const baseSlug = slugify(doc.name, { lower: true });
-          doc.slug = await generateUniqueSlug(
-            models.Pages,
-            doc.clientPortalId,
-            'slug',
-            baseSlug,
-          );
-        } else {
-          doc.slug = await generateUniqueSlug(
-            models.Pages,
-            doc.clientPortalId,
-            'slug',
-            doc.slug,
-          );
-        }
-      } else {
-        doc.slug = existing.slug;
-      }
+      doc.slug = existing.slug;
 
       return models.Pages.findOneAndUpdate(
         { _id },


### PR DESCRIPTION
## Summary
- Preserve the existing stored CMS page slug when editing a page.
- Leave CMS page create behavior unchanged, including unique slug generation on create.

## Root cause
The updatePage model method regenerated a unique slug whenever the page name changed, which caused repeated edit saves to append suffixes such as _2 or -2.

## Validation
- pnpm nx lint content_api passed with existing warnings in unrelated content_api files.
- pnpm nx build content_api failed because local dependency linkage cannot resolve @babel/preset-typescript for the erxes-api-shared:build dependency task.
- Retry with NODE_PATH=node_modules/.pnpm/node_modules allowed content_api TypeScript compilation to complete, but erxes-api-shared:build still failed in Preconstruct package resolution.

## Summary by Sourcery

Bug Fixes:
- Stop regenerating unique slugs on CMS page updates so that repeated edits no longer produce incremented slug variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page URL slugs now remain unchanged when updating existing pages, rather than being regenerated based on page name modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->