### PR TITLE
fix(products): send UOM code instead of name to prevent duplicate

### DIFF
--- a/frontend/core-ui/src/modules/products/product-detail/components/ProductDetailSheet.tsx
+++ b/frontend/core-ui/src/modules/products/product-detail/components/ProductDetailSheet.tsx
@@ -89,11 +89,11 @@ export const ProductDetailSheet = () => {
         }))
       : data.subUoms;
 
-    const uomName = data.uom
-      ? uoms.find((u) => u._id === data.uom)?.name || data.uom
+    const uomCode = data.uom
+      ? uoms.find((u) => u._id === data.uom)?.code || data.uom
       : data.uom;
 
-    return { ...data, attachment, attachmentMore, subUoms, uom: uomName };
+    return { ...data, attachment, attachmentMore, subUoms, uom: uomCode };
   };
 
   const handleSave = (data: ProductFormValues) => {

--- a/frontend/libs/ui-modules/src/modules/products/components/AddProductForm.tsx
+++ b/frontend/libs/ui-modules/src/modules/products/components/AddProductForm.tsx
@@ -114,10 +114,13 @@ export function AddProductForm({
       ) {
         const customFieldsObj = Object.entries(value)
           .filter(([_, val]) => val !== undefined && val !== null && val !== '')
-          .reduce((acc, [fieldId, val]) => {
-            acc[fieldId] = val;
-            return acc;
-          }, {} as Record<string, unknown>);
+          .reduce(
+            (acc, [fieldId, val]) => {
+              acc[fieldId] = val;
+              return acc;
+            },
+            {} as Record<string, unknown>,
+          );
         if (Object.keys(customFieldsObj).length > 0) {
           cleanData['propertiesData'] = customFieldsObj;
         }
@@ -708,7 +711,7 @@ function AddProductFormFieldsDetail({
                       <SelectCategory
                         value={field.value}
                         onSelect={field.onChange}
-                        mode='single'
+                        mode="single"
                       />
                     </Form.Control>
                     <Form.Message />

--- a/frontend/libs/ui-modules/src/modules/products/components/AddProductForm.tsx
+++ b/frontend/libs/ui-modules/src/modules/products/components/AddProductForm.tsx
@@ -71,9 +71,9 @@ export function AddProductForm({
   const { productsAdd, loading } = useAddProduct();
   const { uoms } = useUom();
 
-  const uomIdToName = useMemo(() => {
+  const uomIdToCode = useMemo(() => {
     const map = new Map<string, string>();
-    uoms.forEach((uom) => map.set(uom._id, uom.name));
+    uoms.forEach((uom) => map.set(uom._id, uom.code));
     return map;
   }, [uoms]);
 
@@ -125,15 +125,15 @@ export function AddProductForm({
       }
 
       if (key === 'uom') {
-        const uomName = uomIdToName.get(value as string);
-        cleanData[key] = uomName || value;
+        const uomCode = uomIdToCode.get(value as string);
+        cleanData[key] = uomCode || value;
         return;
       }
 
       if (key === 'subUoms' && Array.isArray(value)) {
         cleanData[key] = value.map((subUom: SubUomItem) => {
           const { _id, ...rest } = subUom;
-          const mappedUom = uomIdToName.get(rest.uom);
+          const mappedUom = uomIdToCode.get(rest.uom);
           return {
             ...rest,
             uom: mappedUom || rest.uom,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent creation of duplicate products by sending UOM codes rather than names for main and sub UOM fields in product forms and detail views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unit-of-measure (UOM) data handling to use UOM codes instead of names in product forms and submissions for improved consistency across product detail and add product workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->