### PR TITLE
fix(uom): fix empty state layout overflow in record table

### DIFF
--- a/frontend/core-ui/src/modules/products/settings/components/uoms/UomsRecordTable.tsx
+++ b/frontend/core-ui/src/modules/products/settings/components/uoms/UomsRecordTable.tsx
@@ -8,6 +8,24 @@ import { AddUomSheet } from './AddUomSheet';
 export const UomsRecordTable = () => {
   const { uoms, loading } = useUoms();
 
+  if (!loading && (uoms?.length ?? 0) === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
+        <div className="mb-6">
+          <IconRulerMeasure
+            size={64}
+            className="mx-auto mb-4 text-muted-foreground"
+          />
+          <h3 className="mb-2 text-xl font-semibold">No UOMs yet</h3>
+          <p className="max-w-md text-muted-foreground">
+            Get started by creating your first UOM.
+          </p>
+        </div>
+        <AddUomSheet />
+      </div>
+    );
+  }
+
   return (
     <RecordTable.Provider
       columns={uomsColumns}
@@ -20,24 +38,7 @@ export const UomsRecordTable = () => {
           <RecordTable.Header />
           <RecordTable.Body>
             {loading && <RecordTable.RowSkeleton rows={10} />}
-            {!loading && (uoms?.length ?? 0) === 0 && (
-              <div className="flex justify-center px-8 w-full h-full">
-                <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-                  <div className="mb-6">
-                    <IconRulerMeasure
-                      size={64}
-                      className="mx-auto mb-4 text-muted-foreground"
-                    />
-                    <h3 className="mb-2 text-xl font-semibold">No UOMs yet</h3>
-                    <p className="max-w-md text-muted-foreground">
-                      Get started by creating your first UOM.
-                    </p>
-                  </div>
-                  <AddUomSheet />
-                </div>
-              </div>
-            )}
-            {!loading && (uoms?.length ?? 0) > 0 && <RecordTable.RowList />}
+            {!loading && <RecordTable.RowList />}
           </RecordTable.Body>
         </RecordTable>
       </RecordTable.Scroll>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix layout overflow by rendering the empty UOM state as a full-page view instead of inside the table body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the empty state display and loading behavior for item lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->