### PR TITLE
fix(payment-widget): resolve paymentsPublic empty result due to GraphQL variable mismatch

### DIFF
--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -161,12 +161,21 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       ? `${getEnv({ name: 'DOMAIN' })}/gateway`
       : 'http://localhost:5173';
 
-    const invoice = await models.Invoices.createInvoice({
-      ...input,
-    });
     if (!input.paymentIds || input.paymentIds.length === 0) {
       throw new Error('paymentIds is required');
     }
+
+    const validPayments = await models.PaymentMethods.find({
+      _id: { $in: input.paymentIds },
+    });
+
+    if (validPayments.length !== input.paymentIds.length) {
+      throw new Error('Some paymentIds are invalid');
+    }
+
+    const invoice = await models.Invoices.createInvoice({
+      ...input,
+    });
 
     return `${domain}/pl:payment/widget/invoice/${invoice._id}`;
   },

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -165,14 +165,6 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       throw new Error('paymentIds is required');
     }
 
-    const validPayments = await models.PaymentMethods.find({
-      _id: { $in: input.paymentIds },
-    });
-
-    if (validPayments.length !== input.paymentIds.length) {
-      throw new Error('Some paymentIds are invalid');
-    }
-
     const invoice = await models.Invoices.createInvoice({
       ...input,
     });
@@ -203,6 +195,10 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       ? `${getEnv({ name: 'DOMAIN' })}/gateway`
       : 'http://localhost:5173';
     const domain = DOMAIN.replace('<subdomain>', subdomain);
+
+    if (!input.paymentIds || input.paymentIds.length === 0) {
+      throw new Error('paymentIds is required');
+    }
 
     const invoice = await models.Invoices.createInvoice({ ...input });
 
@@ -446,11 +442,7 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
   async cpInvoiceUpdate(
     _root,
-    {
-      _id,
-      contentType,
-      contentTypeId,
-    }: { _id: string; contentType: string; contentTypeId: string },
+    { _id, contentType, contentTypeId }: { _id: string; contentType: string; contentTypeId: string },
     { models }: IContext,
   ) {
     const invoice = await models.Invoices.getInvoice({ _id });
@@ -459,13 +451,10 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       throw new Error('Content type and ID already set for this invoice');
     }
 
-    return models.Invoices.updateOne(
-      { _id },
-      {
-        contentType: contentType || invoice.contentType,
-        contentTypeId: contentTypeId || invoice.contentTypeId,
-      },
-    );
+    return models.Invoices.updateOne({ _id }, {
+      contentType: contentType || invoice.contentType,
+      contentTypeId: contentTypeId || invoice.contentTypeId,
+    });
   },
 };
 

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -442,7 +442,11 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
   async cpInvoiceUpdate(
     _root,
-    { _id, contentType, contentTypeId }: { _id: string; contentType: string; contentTypeId: string },
+    {
+      _id,
+      contentType,
+      contentTypeId,
+    }: { _id: string; contentType: string; contentTypeId: string },
     { models }: IContext,
   ) {
     const invoice = await models.Invoices.getInvoice({ _id });
@@ -451,10 +455,13 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       throw new Error('Content type and ID already set for this invoice');
     }
 
-    return models.Invoices.updateOne({ _id }, {
-      contentType: contentType || invoice.contentType,
-      contentTypeId: contentTypeId || invoice.contentTypeId,
-    });
+    return models.Invoices.updateOne(
+      { _id },
+      {
+        contentType: contentType || invoice.contentType,
+        contentTypeId: contentTypeId || invoice.contentTypeId,
+      },
+    );
   },
 };
 

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -164,6 +164,9 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
     const invoice = await models.Invoices.createInvoice({
       ...input,
     });
+    if (!input.paymentIds || input.paymentIds.length === 0) {
+      throw new Error('paymentIds is required');
+    }
 
     return `${domain}/pl:payment/widget/invoice/${invoice._id}`;
   },

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -437,7 +437,11 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
   async cpInvoiceUpdate(
     _root,
-    { _id, contentType, contentTypeId }: { _id: string; contentType: string; contentTypeId: string },
+    {
+      _id,
+      contentType,
+      contentTypeId,
+    }: { _id: string; contentType: string; contentTypeId: string },
     { models }: IContext,
   ) {
     const invoice = await models.Invoices.getInvoice({ _id });
@@ -446,10 +450,13 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
       throw new Error('Content type and ID already set for this invoice');
     }
 
-    return models.Invoices.updateOne({ _id }, {
-      contentType: contentType || invoice.contentType,
-      contentTypeId: contentTypeId || invoice.contentTypeId,
-    });
+    return models.Invoices.updateOne(
+      { _id },
+      {
+        contentType: contentType || invoice.contentType,
+        contentTypeId: contentTypeId || invoice.contentTypeId,
+      },
+    );
   },
 };
 

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
@@ -3,40 +3,38 @@ import { IContext } from '~/connectionResolvers';
 
 const queries: Record<string, Resolver> = {
   async paymentsPublic(_root, args, { models }: IContext) {
-    const { kind, _ids, ids } = args;
+    const { kind, _ids, currency } = args;
+    const query: any = {};
 
-    const finalIds = _ids || ids;
-
-    if (!finalIds || finalIds.length === 0) {
-      return [];
+    if (_ids) {
+      query._id = { $in: _ids };
     }
-
-    const query: any = {
-      _id: { $in: finalIds },
-    };
 
     if (kind) {
       query.kind = kind;
     }
 
-    const result = await models.PaymentMethods.find(query);
+    if (currency) {
+      query.acceptedCurrencies = { $in: [currency] }; 
+    }
 
-    return result;
+    return models.PaymentMethods.find(query);
   },
 
   async cpPaymentsPublic(_root, args, { models }: IContext) {
-    const { kind, _ids } = args;
+    const { kind, _ids, currency } = args;
+    const query: any = {};
 
-    if (!_ids || _ids.length === 0) {
-      return [];
+    if (_ids) {
+      query._id = { $in: _ids };
     }
-
-    const query: any = {
-      _id: { $in: _ids },
-    };
 
     if (kind) {
       query.kind = kind;
+    }
+    
+    if (currency) {
+      query.acceptedCurrencies = { $in: [currency] }; 
     }
 
     return models.PaymentMethods.find(query);
@@ -47,7 +45,9 @@ const queries: Record<string, Resolver> = {
     return models.PaymentMethods.getStripeKey(_id);
   },
 };
+
 export default queries;
+
 queries.cpPaymentsPublic.wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
@@ -15,7 +15,7 @@ const queries: Record<string, Resolver> = {
     }
 
     if (currency) {
-      query.acceptedCurrencies = { $in: [currency] }; 
+      query.acceptedCurrencies = { $in: [currency] };
     }
 
     return models.PaymentMethods.find(query);
@@ -32,9 +32,9 @@ const queries: Record<string, Resolver> = {
     if (kind) {
       query.kind = kind;
     }
-    
+
     if (currency) {
-      query.acceptedCurrencies = { $in: [currency] }; 
+      query.acceptedCurrencies = { $in: [currency] };
     }
 
     return models.PaymentMethods.find(query);

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
@@ -3,7 +3,6 @@ import { IContext } from '~/connectionResolvers';
 
 const queries: Record<string, Resolver> = {
   async paymentsPublic(_root, args, { models }: IContext) {
-
     const { kind, _ids, ids } = args;
 
     const finalIds = _ids || ids;
@@ -21,7 +20,6 @@ const queries: Record<string, Resolver> = {
     }
 
     const result = await models.PaymentMethods.find(query);
-
 
     return result;
   },

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/queries/paymentPublic.ts
@@ -3,36 +3,42 @@ import { IContext } from '~/connectionResolvers';
 
 const queries: Record<string, Resolver> = {
   async paymentsPublic(_root, args, { models }: IContext) {
-    const { kind, _ids, currency } = args;
-    const query: any = {};
-    if (_ids) {
-      query._id = { $in: _ids };
+
+    const { kind, _ids, ids } = args;
+
+    const finalIds = _ids || ids;
+
+    if (!finalIds || finalIds.length === 0) {
+      return [];
     }
+
+    const query: any = {
+      _id: { $in: finalIds },
+    };
 
     if (kind) {
       query.kind = kind;
     }
 
-    if (currency) {
-      query.acceptedCurrencies = currency;
-    }
+    const result = await models.PaymentMethods.find(query);
 
-    return models.PaymentMethods.find(query);
+
+    return result;
   },
 
   async cpPaymentsPublic(_root, args, { models }: IContext) {
-    const { kind, _ids, currency } = args;
-    const query: any = {};
-    if (_ids) {
-      query._id = { $in: _ids };
+    const { kind, _ids } = args;
+
+    if (!_ids || _ids.length === 0) {
+      return [];
     }
+
+    const query: any = {
+      _id: { $in: _ids },
+    };
 
     if (kind) {
       query.kind = kind;
-    }
-
-    if (currency) {
-      query.acceptedCurrencies = currency;
     }
 
     return models.PaymentMethods.find(query);
@@ -40,13 +46,10 @@ const queries: Record<string, Resolver> = {
 
   async paymentsGetStripeKey(_root, args, { models }: IContext) {
     const { _id } = args;
-
     return models.PaymentMethods.getStripeKey(_id);
   },
 };
-
 export default queries;
-
 queries.cpPaymentsPublic.wrapperConfig = {
   forClientPortal: true,
 };

--- a/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
+++ b/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
@@ -13,7 +13,7 @@ export const TRANSACTION_SUBSCRIPTION = gql`
 `;
 
 export const PAYMENTS_QRY = gql`
-  query PaymentsPublic($kind: String, $ids: [String], $currency: String) {
+  query PaymentsPublic($kind: String, $_ids: [String], $currency: String) {
     paymentsPublic(kind: $kind, _ids: $_ids, currency: $currency) {
       _id
       kind

--- a/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
+++ b/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
@@ -13,13 +13,13 @@ export const TRANSACTION_SUBSCRIPTION = gql`
 `;
 
 export const PAYMENTS_QRY = gql`
-query PaymentsPublic($kind: String, $ids: [String], $currency: String) {
-  paymentsPublic(kind: $kind, _ids: $ids, currency: $currency) {
-    _id
-    kind
-    name
+  query PaymentsPublic($kind: String, $ids: [String], $currency: String) {
+    paymentsPublic(kind: $kind, _ids: $_ids, currency: $currency) {
+      _id
+      kind
+      name
+    }
   }
-}
 `;
 
 export const INVOICE = gql`

--- a/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
+++ b/backend/plugins/payment_api/src/widget/src/lib/graphql.ts
@@ -54,9 +54,9 @@ export const INVOICE = gql`
 `;
 
 export const ADD_TRANSACTION = gql`
-mutation PaymentTransactionsAdd($input: PaymentTransactionInput!) {
-  paymentTransactionsAdd(input: $input) {
-          _id
+  mutation PaymentTransactionsAdd($input: PaymentTransactionInput!) {
+    paymentTransactionsAdd(input: $input) {
+      _id
       amount
       invoiceId
       paymentId
@@ -64,8 +64,8 @@ mutation PaymentTransactionsAdd($input: PaymentTransactionInput!) {
       status
       response
       details
+    }
   }
-}
 `;
 
 export const CHECK_INVOICE = gql`

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -142,6 +142,13 @@ const InvoiceDetail = () => {
   if (invoiceDetail && invoiceDetail.amount < 100000) {
     payments = payments.filter((p: any) => p.kind !== 'storepay');
   }
+  if (invoiceDetail.status === 'paid') {
+    return (
+      <div className="py-12 flex items-center justify-center">
+        Payment has been successfully processed. Thank you!
+      </div>
+    );
+  }
 
   const updatedProps = {
     invoiceDetail,

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -8,7 +8,7 @@ import {
   INVOICE,
   INVOICE_SUBSCRIPTION,
   PAYMENTS_QRY,
-  TRANSACTION_SUBSCRIPTION
+  TRANSACTION_SUBSCRIPTION,
 } from '../lib/graphql';
 import React from 'react';
 
@@ -47,7 +47,7 @@ const InvoiceDetail = () => {
     if (invoiceSubscription.data?.invoiceUpdated) {
       const res = invoiceSubscription.data.invoiceUpdated;
 
-      if (res.status === 'paid' && !hasPostedRef.current) { 
+      if (res.status === 'paid' && !hasPostedRef.current) {
         hasPostedRef.current = true;
 
         const message = {
@@ -89,8 +89,8 @@ const InvoiceDetail = () => {
           paymentId,
           details,
           amount: invoiceDetail.amount,
-        }
-      }
+        },
+      },
     }).then(() => {
       invoiceDetailQuery.refetch();
     });
@@ -106,7 +106,7 @@ const InvoiceDetail = () => {
         invoiceDetailQuery.refetch();
         if (status !== 'paid') {
           window.alert('Not paid yet!, Please try again later.');
-        } else if (!hasPostedRef.current) { 
+        } else if (!hasPostedRef.current) {
           hasPostedRef.current = true;
 
           window.alert('Payment has been successfully processed. Thank you!');
@@ -130,7 +130,7 @@ const InvoiceDetail = () => {
       window.opener.postMessage(message, '*');
     }
 
-    if (window.parent && window.parent !== window) { 
+    if (window.parent && window.parent !== window) {
       window.parent.postMessage(message, '*');
     }
   };
@@ -142,7 +142,6 @@ const InvoiceDetail = () => {
   if (invoiceDetail && invoiceDetail.amount < 100000) {
     payments = payments.filter((p: any) => p.kind !== 'storepay');
   }
-
 
   const updatedProps = {
     invoiceDetail,

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -126,12 +126,14 @@ const InvoiceDetail = () => {
   };
 
   const postMessage = (message: any) => {
-    if (window.opener) {
-      window.opener.postMessage(message, '*');
+    const win = globalThis as unknown as Window;
+
+    if (win.opener) {
+      win.opener.postMessage(message, '*');
     }
 
-    if (window.parent && window.parent !== window) {
-      window.parent.postMessage(message, '*');
+    if (win.parent && win.parent !== win) {
+      win.parent.postMessage(message, '*');
     }
   };
 

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -8,12 +8,13 @@ import {
   INVOICE,
   INVOICE_SUBSCRIPTION,
   PAYMENTS_QRY,
-  TRANSACTION_SUBSCRIPTION,
+  TRANSACTION_SUBSCRIPTION
 } from '../lib/graphql';
 import React from 'react';
 
 const InvoiceDetail = () => {
   const { id } = useParams();
+  const hasPostedRef = React.useRef(false); //
   const [checkInvoice, { loading: checkInvoiceLoading }] =
     useMutation(CHECK_INVOICE);
 
@@ -34,8 +35,7 @@ const InvoiceDetail = () => {
   const invoiceDetail = invoiceDetailQuery.data?.invoiceDetail || null;
 
   const { data, loading: paymentsLoading } = useQuery(PAYMENTS_QRY, {
-    skip: !invoiceDetail || !invoiceDetail?.paymentIds?.length,
-
+    skip: !invoiceDetail,
     variables: {
       ...(invoiceDetail?.paymentIds?.length > 0 && {
         _ids: invoiceDetail?.paymentIds,
@@ -45,17 +45,20 @@ const InvoiceDetail = () => {
   });
   React.useEffect(() => {
     if (invoiceSubscription.data?.invoiceUpdated) {
-      const message = {
-        fromPayment: true,
-        message: 'paymentSuccessful',
-        invoiceId: id,
-        invoice: invoiceSubscription.data.invoiceUpdated,
-        contentType: invoiceDetail?.contentType,
-        contentTypeId: invoiceDetail?.contentTypeId,
-      };
-
       const res = invoiceSubscription.data.invoiceUpdated;
-      if (res.status === 'paid') {
+
+      if (res.status === 'paid' && !hasPostedRef.current) { 
+        hasPostedRef.current = true;
+
+        const message = {
+          fromPayment: true,
+          message: 'paymentSuccessful',
+          invoiceId: id,
+          invoice: res,
+          contentType: invoiceDetail?.contentType,
+          contentTypeId: invoiceDetail?.contentTypeId,
+        };
+
         window.alert('Payment has been successfully processed. Thank you!');
         postMessage(message);
       }
@@ -86,8 +89,8 @@ const InvoiceDetail = () => {
           paymentId,
           details,
           amount: invoiceDetail.amount,
-        },
-      },
+        }
+      }
     }).then(() => {
       invoiceDetailQuery.refetch();
     });
@@ -95,29 +98,41 @@ const InvoiceDetail = () => {
 
   const checkInvoiceHandler = (id: string) => {
     checkInvoice({ variables: { id } })
-      .catch((e) => console.error(e))
+      .catch((e) => {
+        console.error(e);
+      })
       .then(({ data }: any) => {
         const status = data?.invoicesCheck;
         invoiceDetailQuery.refetch();
         if (status !== 'paid') {
           window.alert('Not paid yet!, Please try again later.');
-        } else {
+        } else if (!hasPostedRef.current) { 
+          hasPostedRef.current = true;
+
           window.alert('Payment has been successfully processed. Thank you!');
-          postMessage({
+
+          const message = {
             fromPayment: true,
             message: 'paymentSuccessful',
             invoiceId: id,
             invoice: invoiceDetail,
             contentType: invoiceDetail.contentType,
             contentTypeId: invoiceDetail.contentTypeId,
-          });
+          };
+
+          postMessage(message);
         }
       });
   };
 
   const postMessage = (message: any) => {
-    if (window.opener) window.opener.postMessage(message, '*');
-    if (window.parent) window.parent.postMessage(message, '*');
+    if (window.opener) {
+      window.opener.postMessage(message, '*');
+    }
+
+    if (window.parent && window.parent !== window) { 
+      window.parent.postMessage(message, '*');
+    }
   };
 
   const { paymentTransactionsAdd: newTransaction } =
@@ -128,35 +143,18 @@ const InvoiceDetail = () => {
     payments = payments.filter((p: any) => p.kind !== 'storepay');
   }
 
-  if (invoiceDetail.status === 'paid') {
-    window.alert('Payment has been successfully processed. Thank you!');
-    postMessage({
-      fromPayment: true,
-      message: 'paymentSuccessful',
-      invoiceId: id,
-      invoice: invoiceDetail,
-      contentType: invoiceDetail.contentType,
-      contentTypeId: invoiceDetail.contentTypeId,
-    });
 
-    return (
-      <div className="py-12 flex items-center justify-center">
-        Payment has been successfully processed. Thank you!
-      </div>
-    );
-  }
+  const updatedProps = {
+    invoiceDetail,
+    payments,
+    newTransaction,
+    requestNewTransaction,
+    checkInvoiceHandler,
+    transactionLoading: addTransactionResponse.loading,
+    checkInvoiceLoading,
+  };
 
-  return (
-    <Payment
-      invoiceDetail={invoiceDetail}
-      payments={payments}
-      newTransaction={newTransaction}
-      requestNewTransaction={requestNewTransaction}
-      checkInvoiceHandler={checkInvoiceHandler}
-      transactionLoading={addTransactionResponse.loading}
-      checkInvoiceLoading={checkInvoiceLoading}
-    />
-  );
+  return <Payment {...updatedProps} />;
 };
 
 export default InvoiceDetail;

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -8,7 +8,7 @@ import {
   INVOICE,
   INVOICE_SUBSCRIPTION,
   PAYMENTS_QRY,
-  TRANSACTION_SUBSCRIPTION
+  TRANSACTION_SUBSCRIPTION,
 } from '../lib/graphql';
 import React from 'react';
 
@@ -34,12 +34,11 @@ const InvoiceDetail = () => {
   const invoiceDetail = invoiceDetailQuery.data?.invoiceDetail || null;
 
   const { data, loading: paymentsLoading } = useQuery(PAYMENTS_QRY, {
-
     skip: !invoiceDetail || !invoiceDetail?.paymentIds?.length,
 
     variables: {
       ...(invoiceDetail?.paymentIds?.length > 0 && {
-        _ids: invoiceDetail?.paymentIds, 
+        _ids: invoiceDetail?.paymentIds,
       }),
       currency: invoiceDetail?.currency || '',
     },
@@ -87,8 +86,8 @@ const InvoiceDetail = () => {
           paymentId,
           details,
           amount: invoiceDetail.amount,
-        }
-      }
+        },
+      },
     }).then(() => {
       invoiceDetailQuery.refetch();
     });
@@ -124,8 +123,6 @@ const InvoiceDetail = () => {
   const { paymentTransactionsAdd: newTransaction } =
     addTransactionResponse.data || {};
   let payments = data?.paymentsPublic || [];
-
-
 
   if (invoiceDetail && invoiceDetail.amount < 100000) {
     payments = payments.filter((p: any) => p.kind !== 'storepay');

--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -34,15 +34,16 @@ const InvoiceDetail = () => {
   const invoiceDetail = invoiceDetailQuery.data?.invoiceDetail || null;
 
   const { data, loading: paymentsLoading } = useQuery(PAYMENTS_QRY, {
-    skip: !invoiceDetail,
+
+    skip: !invoiceDetail || !invoiceDetail?.paymentIds?.length,
+
     variables: {
       ...(invoiceDetail?.paymentIds?.length > 0 && {
-        ids: invoiceDetail?.paymentIds,
+        _ids: invoiceDetail?.paymentIds, 
       }),
       currency: invoiceDetail?.currency || '',
     },
   });
-
   React.useEffect(() => {
     if (invoiceSubscription.data?.invoiceUpdated) {
       const message = {
@@ -50,8 +51,8 @@ const InvoiceDetail = () => {
         message: 'paymentSuccessful',
         invoiceId: id,
         invoice: invoiceSubscription.data.invoiceUpdated,
-        contentType: invoiceDetail.contentType,
-        contentTypeId: invoiceDetail.contentTypeId,
+        contentType: invoiceDetail?.contentType,
+        contentTypeId: invoiceDetail?.contentTypeId,
       };
 
       const res = invoiceSubscription.data.invoiceUpdated;
@@ -95,9 +96,7 @@ const InvoiceDetail = () => {
 
   const checkInvoiceHandler = (id: string) => {
     checkInvoice({ variables: { id } })
-      .catch((e) => {
-        console.error(e);
-      })
+      .catch((e) => console.error(e))
       .then(({ data }: any) => {
         const status = data?.invoicesCheck;
         invoiceDetailQuery.refetch();
@@ -105,34 +104,29 @@ const InvoiceDetail = () => {
           window.alert('Not paid yet!, Please try again later.');
         } else {
           window.alert('Payment has been successfully processed. Thank you!');
-          const message = {
+          postMessage({
             fromPayment: true,
             message: 'paymentSuccessful',
             invoiceId: id,
             invoice: invoiceDetail,
             contentType: invoiceDetail.contentType,
             contentTypeId: invoiceDetail.contentTypeId,
-          };
-          postMessage(message);
+          });
         }
       });
   };
 
   const postMessage = (message: any) => {
-    if (window.opener) {
-      window.opener.postMessage(message, '*');
-    }
-
-    if (window.parent) {
-      window.parent.postMessage(message, '*');
-    }
+    if (window.opener) window.opener.postMessage(message, '*');
+    if (window.parent) window.parent.postMessage(message, '*');
   };
 
   const { paymentTransactionsAdd: newTransaction } =
     addTransactionResponse.data || {};
   let payments = data?.paymentsPublic || [];
 
-  // if invoice amount is less than 100000, hide storepay
+
+
   if (invoiceDetail && invoiceDetail.amount < 100000) {
     payments = payments.filter((p: any) => p.kind !== 'storepay');
   }
@@ -155,17 +149,17 @@ const InvoiceDetail = () => {
     );
   }
 
-  const updatedProps = {
-    invoiceDetail,
-    payments,
-    newTransaction,
-    requestNewTransaction,
-    checkInvoiceHandler,
-    transactionLoading: addTransactionResponse.loading,
-    checkInvoiceLoading,
-  };
-
-  return <Payment {...updatedProps} />;
+  return (
+    <Payment
+      invoiceDetail={invoiceDetail}
+      payments={payments}
+      newTransaction={newTransaction}
+      requestNewTransaction={requestNewTransaction}
+      checkInvoiceHandler={checkInvoiceHandler}
+      transactionLoading={addTransactionResponse.loading}
+      checkInvoiceLoading={checkInvoiceLoading}
+    />
+  );
 };
 
 export default InvoiceDetail;


### PR DESCRIPTION
## Summary by Sourcery

Align payment widget and backend GraphQL paymentsPublic query to correctly use paymentIds, preventing empty payment method results and enforcing required payment IDs on invoice creation.

Bug Fixes:
- Fix paymentsPublic query variable mismatch between widget and backend by aligning usage of ids/_ids, preventing empty payment results for valid invoices.
- Guard payment fetching and invoice update messaging against missing invoice details to avoid runtime errors.

Enhancements:
- Simplify widget message posting and Payment component rendering while returning empty payment method lists early when no IDs are provided.
- Enforce presence of paymentIds when creating invoices to ensure invoices are always associated with at least one payment method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice URL generation now validates that selected payments are provided to avoid invalid requests.
  * Invoice update behavior now correctly retains content-type details when saving changes.

* **Improvements**
  * Public payment lookup now better handles ID and currency filtering, including when no IDs are provided.
  * Invoice detail view now avoids unnecessary queries, refetches after creating transactions, and sends safer, more complete “payment successful” messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->