### PR TITLE
fix deal move board, pipeline

### DIFF
--- a/frontend/libs/ui-modules/src/modules/sales/components/DealSelect.tsx
+++ b/frontend/libs/ui-modules/src/modules/sales/components/DealSelect.tsx
@@ -1,14 +1,42 @@
+import { useState } from 'react';
 import { BoardSelect } from './BoardSelect';
+import { Button, Separator } from 'erxes-ui';
 import { DealSelectProps } from '../types';
+import { IconLoader2 } from '@tabler/icons-react';
 import { PipelineSelect } from './PipelineSelect';
-import { Separator } from 'erxes-ui';
+import { StageSelect } from './StageSelect';
 
 export const DealSelect = ({
-  boardId,
-  pipelineId,
-  onChangePipeline,
-  onChangeBoard,
+  boardId: initialBoardId,
+  pipelineId: initialPipelineId,
+  stageId: initialStageId,
+  onMove,
+  moveLoading,
 }: DealSelectProps) => {
+  const [localBoardId, setLocalBoardId] = useState(initialBoardId || '');
+  const [localPipelineId, setLocalPipelineId] = useState(
+    initialPipelineId || '',
+  );
+  const [localStageId, setLocalStageId] = useState(initialStageId || '');
+
+  const handleBoardChange = (boardId: string | string[]) => {
+    const id = Array.isArray(boardId) ? boardId[0] : boardId;
+    setLocalBoardId(id);
+    setLocalPipelineId('');
+    setLocalStageId('');
+  };
+
+  const handlePipelineChange = (pipelineId: string | string[]) => {
+    const id = Array.isArray(pipelineId) ? pipelineId[0] : pipelineId;
+    setLocalPipelineId(id);
+    setLocalStageId('');
+  };
+
+  const handleStageChange = (stageId: string | string[]) => {
+    const id = Array.isArray(stageId) ? stageId[0] : stageId;
+    setLocalStageId(id);
+  };
+
   return (
     <div className="flex flex-col">
       <div className="px-4 py-1">
@@ -16,8 +44,8 @@ export const DealSelect = ({
       </div>
       <div className="px-2">
         <BoardSelect
-          boardId={boardId}
-          onChange={onChangeBoard}
+          boardId={localBoardId}
+          onChange={handleBoardChange}
           className="border-none shadow-none h-8 font-normal hover:bg-accent/50 selection:bg-transparent"
         />
       </div>
@@ -27,10 +55,34 @@ export const DealSelect = ({
       </div>
       <div className="px-2">
         <PipelineSelect
-          pipelineId={pipelineId}
-          onChange={onChangePipeline}
+          pipelineId={localPipelineId}
+          onChange={handlePipelineChange}
           className="border-none shadow-none h-8 font-normal px-2 hover:bg-accent/50 w-full justify-between"
         />
+      </div>
+      <Separator className="mt-2 mb-1" />
+      <div className="px-4 py-1 mt-1">
+        <span className="text-xs  text-gray-400">STAGE</span>
+      </div>
+      <div className="px-2">
+        <StageSelect
+          stageId={localStageId}
+          pipelineId={localPipelineId}
+          onChange={handleStageChange}
+          className="border-none shadow-none h-8 font-normal px-2 hover:bg-accent/50 w-full justify-between"
+        />
+      </div>
+      <Separator className="mt-2 mb-1" />
+      <div className="px-2 py-1">
+        <Button
+          className="w-full"
+          size="sm"
+          disabled={!localStageId || moveLoading}
+          onClick={() => onMove?.(localBoardId, localPipelineId, localStageId)}
+        >
+          {moveLoading && <IconLoader2 className="animate-spin" size={14} />}
+          Move
+        </Button>
       </div>
     </div>
   );

--- a/frontend/libs/ui-modules/src/modules/sales/types/deals.ts
+++ b/frontend/libs/ui-modules/src/modules/sales/types/deals.ts
@@ -1,7 +1,14 @@
 export interface DealSelectProps {
   boardId?: string;
   pipelineId?: string;
+  stageId?: string;
   type?: string;
-  onChangePipeline?: (pipelineId: string | string[], callback?: () => void) => void;
+  onChangeStage?: (stageId: string | string[], callback?: () => void) => void;
+  onChangePipeline?: (
+    pipelineId: string | string[],
+    callback?: () => void,
+  ) => void;
   onChangeBoard?: (boardId: string | string[], callback?: () => void) => void;
+  onMove?: (boardId: string, pipelineId: string, stageId: string) => void;
+  moveLoading?: boolean;
 }

--- a/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/MoveDealDropdown.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/MoveDealDropdown.tsx
@@ -1,11 +1,10 @@
-import { Button, DropdownMenu } from 'erxes-ui';
-import { dealPipelineState } from '@/deals/states/dealContainerState';
+import { Button, DropdownMenu, toast } from 'erxes-ui';
 import { memo, useState, type MouseEvent } from 'react';
 
 import { DealSelect } from 'ui-modules';
 import { IDeal } from '../../types/deals';
 import { IconLayoutBoard } from '@tabler/icons-react';
-import { useAtomValue } from 'jotai';
+import { useDealsContext } from '@/deals/context/DealContext';
 
 interface MoveDealDropdownProps {
   deal: IDeal;
@@ -14,10 +13,29 @@ interface MoveDealDropdownProps {
 export const MoveDealDropdown = memo(function MoveDealDropdown({
   deal,
 }: MoveDealDropdownProps) {
-  const pipeline = useAtomValue(dealPipelineState);
-
-  const pipelineId = pipeline.pipelineId || deal.pipeline?._id;
+  const { editDeals } = useDealsContext();
   const [open, setOpen] = useState(false);
+  const [isMoving, setIsMoving] = useState(false);
+
+  const handleMove = async (
+    _boardId: string,
+    _pipelineId: string,
+    stageId: string,
+  ) => {
+    setIsMoving(true);
+    try {
+      await editDeals({
+        variables: {
+          _id: deal._id,
+          stageId,
+        },
+      });
+      toast({ title: 'Deal moved successfully', variant: 'success' });
+      setOpen(false);
+    } finally {
+      setIsMoving(false);
+    }
+  };
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -34,7 +52,10 @@ export const MoveDealDropdown = memo(function MoveDealDropdown({
       <DropdownMenu.Content className="w-62 py-2">
         <DealSelect
           boardId={deal.boardId}
-          pipelineId={pipelineId}
+          pipelineId={deal.pipeline?._id}
+          stageId={deal.stageId}
+          onMove={handleMove}
+          moveLoading={isMoving}
         />
       </DropdownMenu.Content>
     </DropdownMenu>

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/ProductColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/ProductColumns.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 'use client';
 
 import {
@@ -16,6 +17,8 @@ import {
   cn,
   formatAmount,
   Badge,
+  Popover,
+  Input,
 } from 'erxes-ui';
 import {
   IconCurrencyDollar,
@@ -31,6 +34,8 @@ import {
 import { ColumnDef } from '@tanstack/table-core';
 import { IProductData } from 'ui-modules';
 import { productMoreColumn } from './ProductMoreColumn';
+import { useUpdateProductRecord } from '../hooks/useProductRecord';
+import { useState } from 'react';
 
 const DUPLICATE_PRODUCT_CELL_CLASS = 'bg-pink-50/80 dark:bg-pink-950/30';
 
@@ -118,20 +123,67 @@ export const productColumns: ColumnDef<IProductData>[] = [
         table.options.data,
         productId,
       );
+      const [open, setOpen] = useState<boolean>(false);
+      const [_name, setName] = useState<string>(cell.getValue() as string);
+      const { updateRecord } = useUpdateProductRecord();
+      const onChange = (el: React.ChangeEvent<HTMLInputElement>) => {
+        setName(el.currentTarget.value);
+      };
+      const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          onSave();
+        }
+        if (e.key === 'Escape') {
+          setName(cell.getValue() as string);
+          setOpen(false);
+        }
+      };
 
+      const onSave = () => {
+        if (_name !== cell.getValue()) {
+          updateRecord(cell.row.original, {
+            product: { ...cell.row.original.product, name: _name },
+          });
+        }
+        setOpen(false);
+      };
       return (
-        <RecordTableInlineCell
-          className={cn(hasDuplicateProduct && DUPLICATE_PRODUCT_CELL_CLASS)}
+        <Popover
+          open={open}
+          onOpenChange={(open) => {
+            setOpen(open);
+            if (!open) {
+              onSave();
+            }
+          }}
         >
-          <div className="flex gap-1.5 items-center min-w-0">
-            {product?.code && (
-              <span className="font-mono text-xs bg-muted border rounded px-1 text-muted-foreground shrink-0">
-                {product.code}
-              </span>
-            )}
-            <span>{product?.name}</span>
-          </div>
-        </RecordTableInlineCell>
+          <RecordTableInlineCell.Trigger
+            className={cn(hasDuplicateProduct && DUPLICATE_PRODUCT_CELL_CLASS)}
+          >
+            <div className="flex gap-1.5 items-center min-w-0">
+              {product?.code && (
+                <Badge
+                  variant="secondary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(true);
+                  }}
+                >
+                  {product.code}
+                </Badge>
+              )}
+              <span>{product?.name}</span>
+            </div>
+          </RecordTableInlineCell.Trigger>
+          <RecordTableInlineCell.Content>
+            <Input
+              value={_name}
+              onChange={onChange}
+              onKeyDown={handleKeyDown}
+            />
+          </RecordTableInlineCell.Content>
+        </Popover>
       );
     },
     size: 260,

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/ProductMoreColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/ProductMoreColumn.tsx
@@ -1,5 +1,12 @@
 import { Cell, ColumnDef } from '@tanstack/react-table';
-import { Combobox, Command, Popover, RecordTable, useConfirm } from 'erxes-ui';
+import {
+  Combobox,
+  Command,
+  Popover,
+  RecordTable,
+  useConfirm,
+  useToast,
+} from 'erxes-ui';
 
 import { IProductData } from 'ui-modules';
 import { IconTrash } from '@tabler/icons-react';
@@ -7,7 +14,6 @@ import { atom } from 'jotai';
 import { useRemoveProducts } from '../hooks/useRemoveProduct';
 
 export const renderingProductDetailAtom = atom(false);
-const confirmOptions = { confirmationValue: 'delete' };
 
 export const ProductMoreColumnCell = ({
   cell,
@@ -17,11 +23,11 @@ export const ProductMoreColumnCell = ({
   const { _id } = cell.row.original;
   const { confirm } = useConfirm();
   const { removeProducts, loading: removeLoading } = useRemoveProducts();
+  const { toast } = useToast();
 
   const onRemove = () => {
     confirm({
       message: 'Are you sure you want to remove the selected?',
-      options: confirmOptions,
     }).then(async () => {
       try {
         removeProducts({
@@ -30,7 +36,11 @@ export const ProductMoreColumnCell = ({
           },
         });
       } catch (e) {
-        console.error(e.message);
+        toast({
+          title: 'Error',
+          description: e.message,
+          variant: 'destructive',
+        });
       }
     });
   };
@@ -46,6 +56,7 @@ export const ProductMoreColumnCell = ({
             <Command.Item
               disabled={removeLoading}
               value="remove"
+              className="text-destructive"
               onSelect={onRemove}
             >
               <IconTrash /> Delete


### PR DESCRIPTION
## Summary by Sourcery

Enable inline editing of product names and improve deal move workflow in the sales UI.

New Features:
- Allow inline editing of product names within the product table using a popover input.
- Add stage selection and an explicit Move action to the deal move dropdown, with local selection state and loading feedback.

Bug Fixes:
- Fix deal move behavior by updating the move dropdown to use the deals context mutation and correctly apply the selected stage.

Enhancements:
- Improve product deletion UX by removing the confirmation value requirement and surfacing errors via toasts.
- Refine DealSelect props to support stage selection and move callbacks for more flexible reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stage selection to deal movement workflow—users can now select board, pipeline, and stage before moving deals.
  * Enabled inline editing of product names directly within the product table.

* **Improvements**
  * Enhanced error feedback with toast notifications for product management actions.
  * Streamlined deal movement with a dedicated "Move" action button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->