### PR TITLE
feat(erxes-agent): configurable temperature per agent

### DIFF
--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -23,7 +23,7 @@ const agentCache = new Map<string, Agent>();
 const toolsCache = new Map<string, ToolsInput>();
 
 // Increment this whenever routing.ts, the meta-tools, or provider logic changes.
-const ROUTING_VERSION = 23;
+const ROUTING_VERSION = 24;
 
 export interface AgentWithTools {
   agent: Agent;
@@ -129,6 +129,12 @@ export async function getOrCreateAgent(
     ? Math.max(configuredSteps, stepFloor)
     : configuredSteps;
 
+  // Configured sampling temperature. Unset → provider/SDK default (the legacy
+  // loop hardcodes 0, which models like Kimi thinking — "only 1 is allowed" —
+  // reject; setting it here lets the dashboard fix that per agent).
+  const temperature = agentConfig.temperature;
+  const hasTemperature = typeof temperature === 'number';
+
   const agent = new Agent({
     id: agentConfig.agentId,
     name: agentConfig.name,
@@ -139,9 +145,18 @@ export async function getOrCreateAgent(
     // OpenAI-compatible loop (generateLegacy/streamLegacy) reads its own two
     // keys and otherwise falls back to Mastra's internal default — all three
     // must be set or legacy turns get silently truncated mid-task.
-    defaultOptions: { maxSteps },
-    defaultGenerateOptionsLegacy: { maxSteps },
-    defaultStreamOptionsLegacy: { maxSteps },
+    defaultOptions: {
+      maxSteps,
+      ...(hasTemperature ? { modelSettings: { temperature } } : {}),
+    },
+    defaultGenerateOptionsLegacy: {
+      maxSteps,
+      ...(hasTemperature ? { temperature } : {}),
+    },
+    defaultStreamOptionsLegacy: {
+      maxSteps,
+      ...(hasTemperature ? { temperature } : {}),
+    },
     // The two legacy keys are read at runtime but missing from Mastra's
     // published AgentConfig type, hence the cast.
   } as unknown as ConstructorParameters<typeof Agent>[0]) as unknown as Agent;

--- a/backend/plugins/erxes-agent_api/src/modules/agent/@types/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/@types/agent.ts
@@ -11,6 +11,7 @@ export interface IMastraAgent {
   allowedTools?: string[];
   memoryEnabled?: boolean;
   maxSteps?: number;
+  temperature?: number;
   isEnabled?: boolean;
 }
 

--- a/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agent.ts
@@ -22,6 +22,10 @@ export const agentSchema = new Schema(
     allowedTools: [{ type: String }],
     memoryEnabled: { type: Boolean, default: true },
     maxSteps: { type: Number, default: 10 },
+    // Sampling temperature sent to the model. Unset → the provider/SDK default
+    // (the legacy OpenAI-compatible loop defaults to 0). Some models pin it:
+    // e.g. Kimi thinking models reject anything but 1.
+    temperature: { type: Number, min: 0, max: 2, label: 'Temperature' },
     isEnabled: { type: Boolean, default: true },
   },
   { timestamps: true },

--- a/backend/plugins/erxes-agent_api/src/modules/agent/graphql/schemas/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/graphql/schemas/agent.ts
@@ -11,6 +11,7 @@ export const types = `
     allowedTools: [String]
     memoryEnabled: Boolean
     maxSteps: Int
+    temperature: Float
     isEnabled: Boolean
     createdAt: Date
     updatedAt: Date
@@ -27,6 +28,7 @@ export const types = `
     allowedTools: [String]
     memoryEnabled: Boolean
     maxSteps: Int
+    temperature: Float
     isEnabled: Boolean
   }
 

--- a/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
@@ -30,6 +30,7 @@ export const MASTRA_AGENT_CREATE = gql`
       allowedTools
       memoryEnabled
       maxSteps
+      temperature
       isEnabled
       createdAt
       updatedAt
@@ -51,6 +52,7 @@ export const MASTRA_AGENT_UPDATE = gql`
       allowedTools
       memoryEnabled
       maxSteps
+      temperature
       isEnabled
       createdAt
       updatedAt

--- a/frontend/plugins/erxes-agent_ui/src/graphql/queries.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/queries.ts
@@ -14,6 +14,7 @@ export const MASTRA_AGENTS = gql`
       allowedTools
       memoryEnabled
       maxSteps
+      temperature
       isEnabled
       createdAt
       updatedAt
@@ -59,6 +60,7 @@ export const MASTRA_AGENT = gql`
       allowedTools
       memoryEnabled
       maxSteps
+      temperature
       isEnabled
       createdAt
       updatedAt

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
@@ -17,6 +17,7 @@ import {
   Label,
   Input,
   Separator,
+  Slider,
   Switch,
   Textarea,
   Tooltip,
@@ -91,6 +92,7 @@ export const AgentFormPage = () => {
     allowedTools: [] as string[],
     memoryEnabled: true,
     maxSteps: 10,
+    temperature: null as number | null,
     isEnabled: true,
   });
   const [autoSlug, setAutoSlug] = useState(true);
@@ -163,6 +165,7 @@ export const AgentFormPage = () => {
         allowedTools: a.allowedTools || [],
         memoryEnabled: a.memoryEnabled ?? true,
         maxSteps: a.maxSteps ?? 10,
+        temperature: a.temperature ?? null,
         isEnabled: a.isEnabled ?? true,
       });
       setAutoSlug(false);
@@ -760,6 +763,53 @@ export const AgentFormPage = () => {
                     <Tooltip.Content className="max-w-xs">
                       Prevents infinite loops. Raise this if the agent
                       frequently stops mid-task.
+                    </Tooltip.Content>
+                  </Tooltip>
+                </Tooltip.Provider>
+              </div>
+            </Field>
+
+            <Separator />
+
+            <Field
+              label="Temperature"
+              hint="Sampling randomness (0–2). Some models only accept a fixed value — e.g. Kimi thinking models require 1."
+            >
+              <div className="flex items-center gap-3">
+                <Slider
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={[form.temperature ?? 1]}
+                  onValueChange={([v]: number[]) => set('temperature', v)}
+                  className="flex-1 max-w-xs"
+                />
+                <span className="w-16 text-sm tabular-nums text-muted-foreground">
+                  {form.temperature != null
+                    ? form.temperature.toFixed(1)
+                    : 'Default'}
+                </span>
+                {form.temperature != null && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() => set('temperature', null)}
+                  >
+                    Use default
+                  </Button>
+                )}
+                <Tooltip.Provider>
+                  <Tooltip>
+                    <Tooltip.Trigger asChild>
+                      <IconInfoCircle className="size-4 text-muted-foreground" />
+                    </Tooltip.Trigger>
+                    <Tooltip.Content className="max-w-xs">
+                      Lower values give more deterministic answers, higher
+                      values more creative ones. If the provider rejects the
+                      configured value (e.g. &quot;only 1 is allowed&quot;), set
+                      it to the value the model requires.
                     </Tooltip.Content>
                   </Tooltip>
                 </Tooltip.Provider>


### PR DESCRIPTION
## Summary

- Fixes chat failures like `Agent execution failed: invalid temperature: only 1 is allowed for this model` — Mastra's bundled legacy OpenAI-compatible loop hardcodes `temperature: 0` when none is set (`prepareCallSettings`, marked `// TODO v5 remove default 0` upstream), and models with pinned sampling (e.g. Kimi thinking models) reject anything but their required value.
- Adds an optional `temperature` field to the agent config (Mongoose schema `0–2`, GraphQL `Float` on type + input) and threads it through `getOrCreateAgent`: modern loop via `defaultOptions.modelSettings.temperature`, legacy loop via `defaultGenerateOptionsLegacy` / `defaultStreamOptionsLegacy`. Unset keeps current behavior.
- Agents dashboard form gains a Temperature slider (0–2, step 0.1) in the Behavior section, with a "Use default" reset; `ROUTING_VERSION` bumped so cached runtime agents rebuild.

## Test plan

- [x] `pnpm nx test erxes-agent_api` — 189 passed
- [x] `tsc --noEmit` clean for both `erxes-agent_api` and `erxes-agent_ui`
- [ ] Edit an agent using a Kimi thinking model, set temperature to 1, confirm chat replies instead of the invalid-temperature error
- [ ] Confirm an agent with temperature unset behaves exactly as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable temperature parameter for AI agents, enabling precise control over model sampling behavior and response characteristics
  * Temperature adjustment available via 0-2 slider in agent configuration form with 0.1 increments
  * Optional setting with "Use default" option to revert to model defaults
  * Temperature setting applies across all AI model providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->