### PR TITLE
feat(erxes-agent): scheduled agent runs

### DIFF
--- a/backend/plugins/erxes-agent_api/src/apollo/resolvers/index.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/resolvers/index.ts
@@ -2,10 +2,12 @@ import { apolloCustomScalars } from 'erxes-api-shared/utils';
 import { queries } from './queries';
 import { mutations } from './mutations';
 import { learningCustomResolvers } from '@/learning/graphql/resolvers/queries/learning';
+import { scheduleCustomResolvers } from '@/schedule/graphql/resolvers/queries/schedule';
 
 export const resolvers = {
   Query: { ...queries },
   Mutation: { ...mutations },
   ...apolloCustomScalars,
   ...learningCustomResolvers,
+  ...scheduleCustomResolvers,
 };

--- a/backend/plugins/erxes-agent_api/src/apollo/resolvers/mutations.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/resolvers/mutations.ts
@@ -4,6 +4,7 @@ import { settingsMutations } from '@/settings/graphql/resolvers/mutations/settin
 import { sessionMutations } from '@/session/graphql/resolvers/mutations/session';
 import { workflowMutations } from '@/workflow/graphql/resolvers/mutations/workflow';
 import { learningMutations } from '@/learning/graphql/resolvers/mutations/learning';
+import { scheduleMutations } from '@/schedule/graphql/resolvers/mutations/schedule';
 
 export const mutations = {
   ...agentMutations,
@@ -12,4 +13,5 @@ export const mutations = {
   ...sessionMutations,
   ...workflowMutations,
   ...learningMutations,
+  ...scheduleMutations,
 };

--- a/backend/plugins/erxes-agent_api/src/apollo/resolvers/queries.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/resolvers/queries.ts
@@ -5,6 +5,7 @@ import { settingsQueries } from '@/settings/graphql/resolvers/queries/settings';
 import { sessionQueries } from '@/session/graphql/resolvers/queries/session';
 import { workflowQueries } from '@/workflow/graphql/resolvers/queries/workflow';
 import { learningQueries } from '@/learning/graphql/resolvers/queries/learning';
+import { scheduleQueries } from '@/schedule/graphql/resolvers/queries/schedule';
 
 export const queries = {
   ...agentQueries,
@@ -14,4 +15,5 @@ export const queries = {
   ...sessionQueries,
   ...workflowQueries,
   ...learningQueries,
+  ...scheduleQueries,
 };

--- a/backend/plugins/erxes-agent_api/src/apollo/schema/schema.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/schema/schema.ts
@@ -33,6 +33,11 @@ import {
   queries as learningQueries,
   mutations as learningMutations,
 } from '@/learning/graphql/schemas/learning';
+import {
+  types as scheduleTypes,
+  queries as scheduleQueries,
+  mutations as scheduleMutations,
+} from '@/schedule/graphql/schemas/schedule';
 
 export const types = `
   ${agentTypes}
@@ -42,6 +47,7 @@ export const types = `
   ${sessionTypes}
   ${workflowTypes}
   ${learningTypes}
+  ${scheduleTypes}
 `;
 
 export const queries = `
@@ -52,6 +58,7 @@ export const queries = `
   ${sessionQueries}
   ${workflowQueries}
   ${learningQueries}
+  ${scheduleQueries}
 `;
 
 export const mutations = `
@@ -62,4 +69,5 @@ export const mutations = `
   ${sessionMutations}
   ${workflowMutations}
   ${learningMutations}
+  ${scheduleMutations}
 `;

--- a/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
+++ b/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
@@ -55,6 +55,11 @@ import {
   IMastraLearningDocument,
   IMastraFeedbackDocument,
 } from '@/learning/@types/learning';
+import {
+  loadScheduleClass,
+  IMastraScheduleModel,
+} from '@/schedule/db/models/Schedule';
+import { IMastraScheduleDocument } from '@/schedule/@types/schedule';
 
 export interface IModels {
   MastraAgent: IMastraAgentModel;
@@ -67,6 +72,7 @@ export interface IModels {
   MastraWorkflowRun: IMastraWorkflowRunModel;
   MastraLearning: IMastraLearningModel;
   MastraFeedback: IMastraFeedbackModel;
+  MastraSchedule: IMastraScheduleModel;
 }
 
 export interface IContext extends IMainContext {
@@ -128,6 +134,11 @@ export const loadClasses = (db: mongoose.Connection): IModels => {
     IMastraFeedbackDocument,
     IMastraFeedbackModel
   >('mastra_feedbacks', loadFeedbackClass(models));
+
+  models.MastraSchedule = db.model<
+    IMastraScheduleDocument,
+    IMastraScheduleModel
+  >('mastra_schedules', loadScheduleClass(models));
 
   return models;
 };

--- a/backend/plugins/erxes-agent_api/src/main.ts
+++ b/backend/plugins/erxes-agent_api/src/main.ts
@@ -71,5 +71,15 @@ startPlugin({
       ]);
       await initWorkflowSchedules(redis);
     }
+
+    // Agent schedules: reconcile BullMQ job schedulers with enabled
+    // MastraSchedule documents (boot kick + every 5 minutes).
+    {
+      const [{ initAgentSchedules }, { redis }] = await Promise.all([
+        import('~/mastra/schedules/scheduler'),
+        import('erxes-api-shared/utils'),
+      ]);
+      await initAgentSchedules(redis);
+    }
   },
 });

--- a/backend/plugins/erxes-agent_api/src/mastra/jobSchedulers.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/jobSchedulers.ts
@@ -1,0 +1,27 @@
+import type { Queue } from 'bullmq';
+
+/**
+ * Removes a tenant prefix's BullMQ job schedulers that are no longer desired.
+ * Pages through ALL schedulers — the queue is shared across tenants, and a
+ * bounded read would stop pruning stale entries past the window. Used by both
+ * the workflow and the agent-schedule reconcilers.
+ */
+export async function pruneStaleJobSchedulers(
+  queue: Queue,
+  prefix: string,
+  desired: { has(key: string): boolean },
+): Promise<void> {
+  const PAGE = 500;
+  const existing: Array<{ key?: string; id?: string | null }> = [];
+  for (let start = 0; ; start += PAGE) {
+    const batch = await queue.getJobSchedulers(start, start + PAGE - 1);
+    existing.push(...batch);
+    if (!batch.length || batch.length < PAGE) break;
+  }
+  for (const scheduler of existing) {
+    const key = scheduler.key ?? scheduler.id;
+    if (key?.startsWith(prefix) && !desired.has(key)) {
+      await queue.removeJobScheduler(key);
+    }
+  }
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
@@ -104,8 +104,8 @@ export async function runSchedule(args: {
     const reply = await runWithAuth(authCtx, () =>
       runAgentTurn({
         // Same narrowing as chat turns (turn.ts): Mastra's generate() output
-        // is wider than the slice TurnAgent consumes. NOSONAR
-        agent: agent as unknown as TurnAgent,
+        // is wider than the slice TurnAgent consumes.
+        agent: agent as unknown as TurnAgent, // NOSONAR typescript:S4325 — removing it fails tsc
         tools,
         convo,
         message: schedule.prompt,

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
@@ -43,15 +43,23 @@ export async function runSchedule(args: {
   const { models, subdomain, schedule } = args;
   const startedAt = Date.now();
 
+  /** Persists last-run bookkeeping; never rejects, so the outcome (and the
+   * "never throws" contract above) survives a failing recordRun write. */
   const finish = async (
     outcome: ScheduleRunOutcome,
   ): Promise<ScheduleRunOutcome> => {
-    await models.MastraSchedule.recordRun(schedule._id, {
-      status: outcome.status,
-      error: outcome.error,
-      reply: outcome.reply,
-      durationMs: Date.now() - startedAt,
-    });
+    try {
+      await models.MastraSchedule.recordRun(schedule._id, {
+        status: outcome.status,
+        error: outcome.error,
+        reply: outcome.reply,
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (e) {
+      console.error(
+        `[erxes-agent:schedules] recordRun failed for ${schedule._id}: ${e?.message}`,
+      );
+    }
     return outcome;
   };
 
@@ -82,9 +90,9 @@ export async function runSchedule(args: {
     // Replay the thread's own history so successive runs can build on earlier
     // output (e.g. "compare with yesterday") — same gate as chat turns.
     const history =
-      agentConfig.memoryEnabled !== false
-        ? await models.MastraMessage.getRecent(threadId, HISTORY_LIMIT)
-        : [];
+      agentConfig.memoryEnabled === false
+        ? []
+        : await models.MastraMessage.getRecent(threadId, HISTORY_LIMIT);
     const convo: TurnMessage[] = [
       ...history.map((msg) => ({ role: msg.role, content: msg.content })),
       { role: 'user', content: schedule.prompt },
@@ -95,6 +103,8 @@ export async function runSchedule(args: {
 
     const reply = await runWithAuth(authCtx, () =>
       runAgentTurn({
+        // Same narrowing as chat turns (turn.ts): Mastra's generate() output
+        // is wider than the slice TurnAgent consumes. NOSONAR
         agent: agent as unknown as TurnAgent,
         tools,
         convo,

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
@@ -1,0 +1,117 @@
+// ---------------------------------------------------------------------------
+// Scheduled agent run — executes one schedule's prompt against its agent and
+// appends the exchange to the schedule's dedicated output thread.
+//
+// Both the cron worker (scheduler.ts) and the Run-now mutation come through
+// runSchedule(). Runs always execute under the app token (the background
+// principal), never a user session — Run now is a test of exactly what the
+// cron will do, so it must use the same auth.
+// ---------------------------------------------------------------------------
+
+import type { IModels } from '~/connectionResolvers';
+import type { IMastraScheduleDocument } from '@/schedule/@types/schedule';
+import {
+  HISTORY_LIMIT,
+  runAgentTurn,
+  TurnAgent,
+  TurnMessage,
+} from '@/agent/turn';
+import { getOrCreateAgent } from '~/mastra/agentRuntime';
+import { isLegacyProvider } from '~/mastra/providers';
+import { runWithAuth } from '~/mastra/requestContext';
+
+/** The dedicated output thread of one schedule — derived, never stored. */
+export const scheduleThreadId = (scheduleId: string) =>
+  `schedule-${scheduleId}`;
+
+export interface ScheduleRunOutcome {
+  status: 'success' | 'failed';
+  reply?: string;
+  error?: string;
+}
+
+/**
+ * Runs one schedule end to end: agent turn → thread persistence → last-run
+ * bookkeeping on the schedule document. Never throws — failures land in
+ * lastStatus/lastError so the list page surfaces them.
+ */
+export async function runSchedule(args: {
+  models: IModels;
+  subdomain: string;
+  schedule: IMastraScheduleDocument;
+}): Promise<ScheduleRunOutcome> {
+  const { models, subdomain, schedule } = args;
+  const startedAt = Date.now();
+
+  const finish = async (
+    outcome: ScheduleRunOutcome,
+  ): Promise<ScheduleRunOutcome> => {
+    await models.MastraSchedule.recordRun(schedule._id, {
+      status: outcome.status,
+      error: outcome.error,
+      reply: outcome.reply,
+      durationMs: Date.now() - startedAt,
+    });
+    return outcome;
+  };
+
+  try {
+    const agentConfig = await models.MastraAgent.findOne({
+      agentId: schedule.agentId,
+      isEnabled: true,
+    });
+    if (!agentConfig) {
+      return finish({
+        status: 'failed',
+        error: `Agent "${schedule.agentId}" not found or disabled`,
+      });
+    }
+
+    const settings = await models.MastraSettings.findOne({});
+    const providers = await models.MastraProvider.find({ isEnabled: true });
+    const { agent, tools } = await getOrCreateAgent(agentConfig, models);
+
+    const threadId = scheduleThreadId(schedule._id);
+    await models.MastraThread.ensureThread(
+      threadId,
+      schedule.agentId,
+      schedule.createdByUserId || '',
+      `Schedule: ${schedule.name}`,
+    );
+
+    // Replay the thread's own history so successive runs can build on earlier
+    // output (e.g. "compare with yesterday") — same gate as chat turns.
+    const history =
+      agentConfig.memoryEnabled !== false
+        ? await models.MastraMessage.getRecent(threadId, HISTORY_LIMIT)
+        : [];
+    const convo: TurnMessage[] = [
+      ...history.map((msg) => ({ role: msg.role, content: msg.content })),
+      { role: 'user', content: schedule.prompt },
+    ];
+
+    const authCtx = { token: settings?.erxesApiToken, subdomain };
+    const isLegacy = isLegacyProvider(agentConfig.provider, providers);
+
+    const reply = await runWithAuth(authCtx, () =>
+      runAgentTurn({
+        agent: agent as unknown as TurnAgent,
+        tools,
+        convo,
+        message: schedule.prompt,
+        isLegacy,
+        authCtx,
+      }),
+    );
+
+    await models.MastraMessage.addMessage(threadId, 'user', schedule.prompt);
+    if (reply) {
+      await models.MastraMessage.addMessage(threadId, 'assistant', reply);
+    }
+    await models.MastraThread.touchThread(threadId);
+
+    return finish({ status: 'success', reply: reply ?? '' });
+  } catch (e) {
+    return finish({ status: 'failed', error: e?.message || String(e) });
+  }
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/scheduler.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/scheduler.ts
@@ -16,6 +16,7 @@ import {
   getSaasOrganizations,
 } from 'erxes-api-shared/utils';
 import { generateModels } from '../../connectionResolvers';
+import { pruneStaleJobSchedulers } from '../jobSchedulers';
 import { runSchedule } from './runner';
 
 const SERVICE = 'erxes-agent';
@@ -58,21 +59,7 @@ async function reconcileTenant(runQueue: Queue, tenant: string): Promise<void> {
     });
   }
 
-  // Page through ALL schedulers — the queue is shared across tenants, and a
-  // bounded read would stop pruning stale entries past the window.
-  const PAGE = 500;
-  const existing: Array<{ key?: string; id?: string | null }> = [];
-  for (let start = 0; ; start += PAGE) {
-    const batch = await runQueue.getJobSchedulers(start, start + PAGE - 1);
-    existing.push(...batch);
-    if (!batch.length || batch.length < PAGE) break;
-  }
-  for (const scheduler of existing) {
-    const key = scheduler.key ?? scheduler.id;
-    if (key?.startsWith(`agsched-${tenant}-`) && !desired.has(key)) {
-      await runQueue.removeJobScheduler(key);
-    }
-  }
+  await pruneStaleJobSchedulers(runQueue, `agsched-${tenant}-`, desired);
 
   for (const [id, { pattern, tz, scheduleId }] of desired) {
     try {

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/scheduler.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/scheduler.ts
@@ -1,0 +1,180 @@
+// ---------------------------------------------------------------------------
+// Agent schedules — BullMQ job schedulers, one per enabled MastraSchedule.
+//
+// Same reconcile-and-run pattern as the workflow schedule trigger: a reconcile
+// job fires on a cron, diffs BullMQ's job schedulers against the current set
+// of enabled schedules, and upserts/removes accordingly. Each fired job runs
+// one schedule's prompt against its agent (runner.ts). Reconciling keeps
+// Mongo as the single source of truth and self-heals after Redis flushes.
+// ---------------------------------------------------------------------------
+
+import { Queue } from 'bullmq';
+import type { Job } from 'bullmq';
+import {
+  createMQWorkerWithListeners,
+  getEnv,
+  getSaasOrganizations,
+} from 'erxes-api-shared/utils';
+import { generateModels } from '../../connectionResolvers';
+import { runSchedule } from './runner';
+
+const SERVICE = 'erxes-agent';
+const RECONCILE_QUEUE = 'agent-schedule-reconcile';
+const RUN_QUEUE = 'agent-schedule-run';
+const RECONCILE_CRON = '*/5 * * * *';
+
+// The shared Redis connection type, extracted from the MQ helper so this
+// module needs no direct ioredis type dependency.
+type RedisConnection = Parameters<typeof createMQWorkerWithListeners>[3];
+
+/** The BullMQ job-scheduler id for one tenant's schedule. */
+const schedulerId = (tenant: string, scheduleId: string) =>
+  `agsched-${tenant}-${scheduleId}`;
+
+/** Tenants to reconcile: every saas org's subdomain, or the pinned 'os'. */
+async function tenants(): Promise<string[]> {
+  if (getEnv({ name: 'VERSION' }) === 'saas') {
+    const orgs = await getSaasOrganizations();
+    return orgs.map((org: { subdomain: string }) => org.subdomain);
+  }
+  return ['os'];
+}
+
+/** Diffs BullMQ job schedulers against one tenant's enabled schedules. */
+async function reconcileTenant(runQueue: Queue, tenant: string): Promise<void> {
+  const models = await generateModels(tenant);
+  const schedules = await models.MastraSchedule.getSchedules();
+
+  const desired = new Map<
+    string,
+    { pattern: string; tz: string; scheduleId: string }
+  >();
+  for (const schedule of schedules) {
+    if (!schedule.isEnabled || !schedule.cron?.trim()) continue;
+    desired.set(schedulerId(tenant, schedule._id), {
+      pattern: schedule.cron.trim(),
+      tz: schedule.timezone || 'UTC',
+      scheduleId: schedule._id,
+    });
+  }
+
+  // Page through ALL schedulers — the queue is shared across tenants, and a
+  // bounded read would stop pruning stale entries past the window.
+  const PAGE = 500;
+  const existing: Array<{ key?: string; id?: string | null }> = [];
+  for (let start = 0; ; start += PAGE) {
+    const batch = await runQueue.getJobSchedulers(start, start + PAGE - 1);
+    existing.push(...batch);
+    if (!batch.length || batch.length < PAGE) break;
+  }
+  for (const scheduler of existing) {
+    const key = scheduler.key ?? scheduler.id;
+    if (key?.startsWith(`agsched-${tenant}-`) && !desired.has(key)) {
+      await runQueue.removeJobScheduler(key);
+    }
+  }
+
+  for (const [id, { pattern, tz, scheduleId }] of desired) {
+    try {
+      await runQueue.upsertJobScheduler(
+        id,
+        { pattern, tz },
+        { name: RUN_QUEUE, data: { subdomain: tenant, scheduleId } },
+      );
+    } catch (e) {
+      // Invalid cron/tz in a saved schedule must not break other schedules.
+      console.error(
+        `[erxes-agent:schedules] invalid cron "${pattern}" on schedule ${scheduleId}: ${e?.message}`,
+      );
+    }
+  }
+}
+
+/** Reconciles every tenant, isolating per-tenant failures. */
+async function reconcileAll(runQueue: Queue): Promise<void> {
+  for (const tenant of await tenants()) {
+    try {
+      await reconcileTenant(runQueue, tenant);
+    } catch (e) {
+      console.error(
+        `[erxes-agent:schedules] reconcile failed for ${tenant}: ${e?.message}`,
+      );
+    }
+  }
+}
+
+/** Runs one fired schedule, skipping stale or disabled ones. */
+async function runScheduledAgent(
+  subdomain: string,
+  scheduleId: string,
+): Promise<string> {
+  const models = await generateModels(subdomain);
+
+  let schedule;
+  try {
+    schedule = await models.MastraSchedule.getSchedule(scheduleId);
+  } catch {
+    return 'skipped: schedule deleted (next reconcile removes the cron)';
+  }
+  if (!schedule.isEnabled) return 'skipped: disabled';
+
+  const outcome = await runSchedule({ models, subdomain, schedule });
+  return `run ${scheduleId}: ${outcome.status}${
+    outcome.error ? ` (${outcome.error})` : ''
+  }`;
+}
+
+/** Boot hook: registers the reconcile cron + run worker, then kicks one pass. */
+export async function initAgentSchedules(
+  redis: RedisConnection,
+): Promise<void> {
+  const reconcileQueue = new Queue(`${SERVICE}-${RECONCILE_QUEUE}`, {
+    connection: redis,
+  });
+  await reconcileQueue.upsertJobScheduler(
+    `${SERVICE}-agent-schedule-reconcile-cron`,
+    { pattern: RECONCILE_CRON, tz: 'UTC' },
+    { name: RECONCILE_QUEUE },
+  );
+
+  const runQueue = new Queue(`${SERVICE}-${RUN_QUEUE}`, { connection: redis });
+
+  createMQWorkerWithListeners(
+    SERVICE,
+    RECONCILE_QUEUE,
+    async () => {
+      await reconcileAll(runQueue);
+      return 'reconciled';
+    },
+    redis,
+    () => {
+      // eslint-disable-next-line no-console
+      console.log('[erxes-agent:schedules] reconciler ready');
+    },
+  );
+
+  createMQWorkerWithListeners(
+    SERVICE,
+    RUN_QUEUE,
+    (job: Job) => {
+      const { subdomain, scheduleId } = job.data || {};
+      if (
+        typeof subdomain !== 'string' ||
+        !subdomain ||
+        typeof scheduleId !== 'string' ||
+        !scheduleId
+      ) {
+        return Promise.resolve('skipped: malformed job');
+      }
+      return runScheduledAgent(subdomain, scheduleId);
+    },
+    redis,
+    () => {
+      // eslint-disable-next-line no-console
+      console.log('[erxes-agent:schedules] runner ready');
+    },
+  );
+
+  // Boot kick — a fresh deploy honors schedules without waiting for the cron.
+  await reconcileAll(runQueue);
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/scheduler.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/scheduler.ts
@@ -17,6 +17,7 @@ import {
   getSaasOrganizations,
 } from 'erxes-api-shared/utils';
 import { generateModels } from '../../connectionResolvers';
+import { pruneStaleJobSchedulers } from '../jobSchedulers';
 import { TriggerEnvelope } from './envelope';
 import { runWorkflow } from './runtime';
 
@@ -59,21 +60,7 @@ async function reconcileTenant(runQueue: Queue, tenant: string): Promise<void> {
     });
   }
 
-  // Page through ALL schedulers — the queue is shared across tenants, and a
-  // bounded read would stop pruning stale entries past the window.
-  const PAGE = 500;
-  const existing: Array<{ key?: string; id?: string | null }> = [];
-  for (let start = 0; ; start += PAGE) {
-    const batch = await runQueue.getJobSchedulers(start, start + PAGE - 1);
-    existing.push(...batch);
-    if (!batch.length || batch.length < PAGE) break;
-  }
-  for (const scheduler of existing) {
-    const key = scheduler.key ?? scheduler.id;
-    if (key?.startsWith(`wfsched-${tenant}-`) && !desired.has(key)) {
-      await runQueue.removeJobScheduler(key);
-    }
-  }
+  await pruneStaleJobSchedulers(runQueue, `wfsched-${tenant}-`, desired);
 
   for (const [id, { pattern, workflowId }] of desired) {
     try {

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/@types/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/@types/schedule.ts
@@ -1,0 +1,33 @@
+import { Document } from 'mongoose';
+
+export type MastraScheduleRunStatus = 'success' | 'failed' | 'skipped';
+
+export interface IMastraSchedule {
+  name: string;
+  description?: string;
+  // The MastraAgent.agentId this schedule runs.
+  agentId: string;
+  // 5-field cron expression (UTC unless timezone is set).
+  cron: string;
+  // IANA timezone the cron fires in; defaults to UTC.
+  timezone?: string;
+  // The user message sent to the agent on every run.
+  prompt: string;
+  isEnabled?: boolean;
+  createdByUserId?: string;
+  // Last-run bookkeeping, written by the runner after every fire.
+  lastRunAt?: Date;
+  lastStatus?: MastraScheduleRunStatus;
+  lastError?: string;
+  lastReply?: string;
+  lastDurationMs?: number;
+  runCount?: number;
+}
+
+export interface IMastraScheduleDocument extends IMastraSchedule, Document {
+  _id: string;
+  isEnabled: boolean;
+  runCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/__tests__/cron.test.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/__tests__/cron.test.ts
@@ -1,0 +1,48 @@
+import { validateCron, validateTimezone } from '../cron';
+
+describe('validateCron', () => {
+  it('accepts standard 5-field expressions and normalizes whitespace', () => {
+    expect(validateCron('0 9 * * *')).toBe('0 9 * * *');
+    expect(validateCron('  */15  *   * * 1-5 ')).toBe('*/15 * * * 1-5');
+    expect(validateCron('0 9 1 * *')).toBe('0 9 1 * *');
+  });
+
+  it('accepts 6-field (seconds) expressions', () => {
+    expect(validateCron('30 0 9 * * *')).toBe('30 0 9 * * *');
+  });
+
+  it('rejects empty and non-string input', () => {
+    expect(() => validateCron('')).toThrow('required');
+    expect(() => validateCron('   ')).toThrow('required');
+    expect(() => validateCron(undefined)).toThrow('required');
+    expect(() => validateCron({ $gt: '' })).toThrow('required');
+  });
+
+  it('rejects wrong field counts', () => {
+    expect(() => validateCron('0 9 * *')).toThrow('5 fields');
+    expect(() => validateCron('0 9 * * * * *')).toThrow('5 fields');
+  });
+
+  it('rejects fields with cron-unsafe characters', () => {
+    expect(() => validateCron('0 9 * * $(rm)')).toThrow('Invalid cron field');
+    expect(() => validateCron('0 9 * * {}')).toThrow('Invalid cron field');
+  });
+});
+
+describe('validateTimezone', () => {
+  it('defaults blank input to UTC', () => {
+    expect(validateTimezone(undefined)).toBe('UTC');
+    expect(validateTimezone(null)).toBe('UTC');
+    expect(validateTimezone('')).toBe('UTC');
+  });
+
+  it('accepts valid IANA timezones', () => {
+    expect(validateTimezone('UTC')).toBe('UTC');
+    expect(validateTimezone('Asia/Ulaanbaatar')).toBe('Asia/Ulaanbaatar');
+  });
+
+  it('rejects unknown or non-string timezones', () => {
+    expect(() => validateTimezone('Not/AZone')).toThrow('Unknown timezone');
+    expect(() => validateTimezone(42)).toThrow('Invalid timezone');
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/__tests__/cron.test.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/__tests__/cron.test.ts
@@ -14,13 +14,13 @@ describe('validateCron', () => {
   it('rejects empty and non-string input', () => {
     expect(() => validateCron('')).toThrow('required');
     expect(() => validateCron('   ')).toThrow('required');
-    expect(() => validateCron(undefined)).toThrow('required');
+    expect(() => validateCron()).toThrow('required');
     expect(() => validateCron({ $gt: '' })).toThrow('required');
   });
 
   it('rejects wrong field counts', () => {
-    expect(() => validateCron('0 9 * *')).toThrow('5 fields');
-    expect(() => validateCron('0 9 * * * * *')).toThrow('5 fields');
+    expect(() => validateCron('0 9 * *')).toThrow('5 or 6 fields');
+    expect(() => validateCron('0 9 * * * * *')).toThrow('5 or 6 fields');
   });
 
   it('rejects fields with cron-unsafe characters', () => {
@@ -31,7 +31,7 @@ describe('validateCron', () => {
 
 describe('validateTimezone', () => {
   it('defaults blank input to UTC', () => {
-    expect(validateTimezone(undefined)).toBe('UTC');
+    expect(validateTimezone()).toBe('UTC');
     expect(validateTimezone(null)).toBe('UTC');
     expect(validateTimezone('')).toBe('UTC');
   });

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/cron.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/cron.ts
@@ -1,0 +1,34 @@
+// Structural cron check — 5 standard fields (or 6 with seconds, which BullMQ
+// also accepts) of cron-safe characters. BullMQ's parser is the authority at
+// upsert time; this only keeps obvious garbage out of Mongo so one bad save
+// can't silently never fire.
+const CRON_FIELD = /^[\d*/,\-A-Za-z?#LW]+$/;
+
+export function validateCron(cron: unknown): string {
+  if (typeof cron !== 'string' || !cron.trim()) {
+    throw new Error('Cron expression is required');
+  }
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length < 5 || fields.length > 6) {
+    throw new Error(
+      `Cron expression must have 5 fields (minute hour day month weekday), got ${fields.length}`,
+    );
+  }
+  for (const field of fields) {
+    if (!CRON_FIELD.test(field)) {
+      throw new Error(`Invalid cron field "${field}"`);
+    }
+  }
+  return fields.join(' ');
+}
+
+export function validateTimezone(timezone: unknown): string {
+  if (timezone == null || timezone === '') return 'UTC';
+  if (typeof timezone !== 'string') throw new Error('Invalid timezone');
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
+    return timezone;
+  } catch {
+    throw new Error(`Unknown timezone "${timezone}"`);
+  }
+}

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/cron.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/cron.ts
@@ -2,16 +2,17 @@
 // also accepts) of cron-safe characters. BullMQ's parser is the authority at
 // upsert time; this only keeps obvious garbage out of Mongo so one bad save
 // can't silently never fire.
-const CRON_FIELD = /^[\d*/,\-A-Za-z?#LW]+$/;
+const CRON_FIELD = /^[\d*/,\-A-Za-z?#]+$/;
 
-export function validateCron(cron: unknown): string {
+/** Validates a cron expression structurally; returns it whitespace-normalized. */
+export function validateCron(cron?: unknown): string {
   if (typeof cron !== 'string' || !cron.trim()) {
     throw new Error('Cron expression is required');
   }
   const fields = cron.trim().split(/\s+/);
   if (fields.length < 5 || fields.length > 6) {
     throw new Error(
-      `Cron expression must have 5 fields (minute hour day month weekday), got ${fields.length}`,
+      `Cron expression must have 5 or 6 fields (minute hour day month weekday, optionally with leading seconds), got ${fields.length}`,
     );
   }
   for (const field of fields) {
@@ -22,12 +23,16 @@ export function validateCron(cron: unknown): string {
   return fields.join(' ');
 }
 
-export function validateTimezone(timezone: unknown): string {
+/** Validates an IANA timezone name; blank input defaults to UTC. */
+export function validateTimezone(timezone?: unknown): string {
   if (timezone == null || timezone === '') return 'UTC';
   if (typeof timezone !== 'string') throw new Error('Invalid timezone');
   try {
-    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
-    return timezone;
+    // Constructing the formatter throws RangeError on unknown zones; the
+    // resolved option is the canonical spelling of the zone we validated.
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+    }).resolvedOptions().timeZone;
   } catch {
     throw new Error(`Unknown timezone "${timezone}"`);
   }

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/db/definitions/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/db/definitions/schedule.ts
@@ -1,5 +1,16 @@
 import { Schema } from 'mongoose';
 import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+import { validateCron, validateTimezone } from '@/schedule/cron';
+
+/** Schema-level backstop: returns false instead of letting the check throw. */
+const passes = (check: (value: string) => string) => (value: string) => {
+  try {
+    check(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 export const scheduleSchema = new Schema(
   {
@@ -7,8 +18,27 @@ export const scheduleSchema = new Schema(
     name: { type: String, required: true, label: 'Name' },
     description: { type: String, label: 'Description' },
     agentId: { type: String, required: true, index: true, label: 'Agent' },
-    cron: { type: String, required: true, label: 'Cron expression' },
-    timezone: { type: String, default: 'UTC', label: 'Timezone' },
+    // The model statics validate with specific error messages; these schema
+    // validators are a backstop so no write path can store a cron/timezone
+    // the reconciler would then log errors about every 5 minutes.
+    cron: {
+      type: String,
+      required: true,
+      label: 'Cron expression',
+      validate: {
+        validator: passes(validateCron),
+        message: 'Invalid cron expression',
+      },
+    },
+    timezone: {
+      type: String,
+      default: 'UTC',
+      label: 'Timezone',
+      validate: {
+        validator: passes(validateTimezone),
+        message: 'Unknown timezone',
+      },
+    },
     prompt: { type: String, required: true, label: 'Prompt' },
     // Disabled by default: a schedule only fires after an explicit enable
     // (Run now is allowed regardless, for testing).

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/db/definitions/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/db/definitions/schedule.ts
@@ -1,0 +1,29 @@
+import { Schema } from 'mongoose';
+import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+
+export const scheduleSchema = new Schema(
+  {
+    _id: mongooseStringRandomId,
+    name: { type: String, required: true, label: 'Name' },
+    description: { type: String, label: 'Description' },
+    agentId: { type: String, required: true, index: true, label: 'Agent' },
+    cron: { type: String, required: true, label: 'Cron expression' },
+    timezone: { type: String, default: 'UTC', label: 'Timezone' },
+    prompt: { type: String, required: true, label: 'Prompt' },
+    // Disabled by default: a schedule only fires after an explicit enable
+    // (Run now is allowed regardless, for testing).
+    isEnabled: { type: Boolean, default: false, index: true, label: 'Enabled' },
+    createdByUserId: { type: String, label: 'Created by' },
+    lastRunAt: { type: Date, label: 'Last run' },
+    lastStatus: {
+      type: String,
+      enum: ['success', 'failed', 'skipped'],
+      label: 'Last status',
+    },
+    lastError: { type: String, label: 'Last error' },
+    lastReply: { type: String, label: 'Last reply' },
+    lastDurationMs: { type: Number, label: 'Last duration (ms)' },
+    runCount: { type: Number, default: 0, label: 'Run count' },
+  },
+  { timestamps: true },
+);

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/db/models/Schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/db/models/Schedule.ts
@@ -1,0 +1,115 @@
+import { Model } from 'mongoose';
+import { IModels } from '~/connectionResolvers';
+import { scheduleSchema } from '@/schedule/db/definitions/schedule';
+import {
+  IMastraSchedule,
+  IMastraScheduleDocument,
+  MastraScheduleRunStatus,
+} from '@/schedule/@types/schedule';
+import { validateCron, validateTimezone } from '@/schedule/cron';
+
+export interface IMastraScheduleModel extends Model<IMastraScheduleDocument> {
+  getSchedule(_id: string): Promise<IMastraScheduleDocument>;
+  getSchedules(): Promise<IMastraScheduleDocument[]>;
+  createSchedule(doc: IMastraSchedule): Promise<IMastraScheduleDocument>;
+  updateSchedule(
+    _id: string,
+    doc: Partial<IMastraSchedule>,
+  ): Promise<IMastraScheduleDocument>;
+  setEnabled(_id: string, isEnabled: boolean): Promise<IMastraScheduleDocument>;
+  removeSchedule(_id: string): Promise<{ ok?: number }>;
+  recordRun(
+    _id: string,
+    outcome: {
+      status: MastraScheduleRunStatus;
+      error?: string;
+      reply?: string;
+      durationMs?: number;
+    },
+  ): Promise<void>;
+}
+
+export const loadScheduleClass = (_models: IModels) => {
+  class MastraSchedule {
+    public static async getSchedule(_id: string) {
+      const schedule = await _models.MastraSchedule.findOne({ _id });
+      if (!schedule) throw new Error('Schedule not found');
+      return schedule;
+    }
+
+    public static async getSchedules() {
+      return _models.MastraSchedule.find().sort({ createdAt: -1 });
+    }
+
+    public static async createSchedule(doc: IMastraSchedule) {
+      return _models.MastraSchedule.create({
+        ...doc,
+        cron: validateCron(doc.cron),
+        timezone: validateTimezone(doc.timezone),
+      });
+    }
+
+    public static async updateSchedule(
+      _id: string,
+      doc: Partial<IMastraSchedule>,
+    ) {
+      const patch: Partial<IMastraSchedule> = { ...doc };
+      if (doc.cron !== undefined) patch.cron = validateCron(doc.cron);
+      if (doc.timezone !== undefined) {
+        patch.timezone = validateTimezone(doc.timezone);
+      }
+      const updated = await _models.MastraSchedule.findOneAndUpdate(
+        { _id },
+        { $set: patch },
+        { new: true },
+      );
+      if (!updated) throw new Error('Schedule not found');
+      return updated;
+    }
+
+    public static async setEnabled(_id: string, isEnabled: boolean) {
+      const updated = await _models.MastraSchedule.findOneAndUpdate(
+        { _id },
+        { $set: { isEnabled } },
+        { new: true },
+      );
+      if (!updated) throw new Error('Schedule not found');
+      return updated;
+    }
+
+    public static async removeSchedule(_id: string) {
+      // The schedule's output thread (and its messages) goes with it.
+      const threadId = `schedule-${_id}`;
+      await _models.MastraMessage.deleteMany({ threadId });
+      await _models.MastraThread.deleteOne({ threadId });
+      return _models.MastraSchedule.deleteOne({ _id });
+    }
+
+    public static async recordRun(
+      _id: string,
+      outcome: {
+        status: MastraScheduleRunStatus;
+        error?: string;
+        reply?: string;
+        durationMs?: number;
+      },
+    ) {
+      await _models.MastraSchedule.updateOne(
+        { _id },
+        {
+          $set: {
+            lastRunAt: new Date(),
+            lastStatus: outcome.status,
+            lastError: outcome.error ?? '',
+            lastReply: (outcome.reply ?? '').slice(0, 2000),
+            lastDurationMs: outcome.durationMs,
+          },
+          $inc: { runCount: 1 },
+        },
+      );
+    }
+  }
+
+  scheduleSchema.loadClass(MastraSchedule);
+  return scheduleSchema;
+};

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/db/models/Schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/db/models/Schedule.ts
@@ -29,19 +29,25 @@ export interface IMastraScheduleModel extends Model<IMastraScheduleDocument> {
   ): Promise<void>;
 }
 
+/** Bind the MastraSchedule statics onto the schedule schema (mongoose loadClass). */
 export const loadScheduleClass = (_models: IModels) => {
+  /** Static lifecycle helpers for scheduled agent runs. */
+  // skipcq: JS-0327 — the mongoose loadClass pattern requires a class of statics
   class MastraSchedule {
+    /** Fetch one schedule; throws when it does not exist. */
     public static async getSchedule(_id: string) {
       const schedule = await _models.MastraSchedule.findOne({ _id });
       if (!schedule) throw new Error('Schedule not found');
       return schedule;
     }
 
-    public static async getSchedules() {
+    /** All schedules, newest first. */
+    public static getSchedules() {
       return _models.MastraSchedule.find().sort({ createdAt: -1 });
     }
 
-    public static async createSchedule(doc: IMastraSchedule) {
+    /** Create a schedule after validating its cron and timezone. */
+    public static createSchedule(doc: IMastraSchedule) {
       return _models.MastraSchedule.create({
         ...doc,
         cron: validateCron(doc.cron),
@@ -49,6 +55,7 @@ export const loadScheduleClass = (_models: IModels) => {
       });
     }
 
+    /** Patch a schedule, re-validating cron/timezone when they change. */
     public static async updateSchedule(
       _id: string,
       doc: Partial<IMastraSchedule>,
@@ -61,12 +68,13 @@ export const loadScheduleClass = (_models: IModels) => {
       const updated = await _models.MastraSchedule.findOneAndUpdate(
         { _id },
         { $set: patch },
-        { new: true },
+        { new: true, runValidators: true },
       );
       if (!updated) throw new Error('Schedule not found');
       return updated;
     }
 
+    /** Flip the cron gate; Run-now stays available regardless. */
     public static async setEnabled(_id: string, isEnabled: boolean) {
       const updated = await _models.MastraSchedule.findOneAndUpdate(
         { _id },
@@ -77,14 +85,20 @@ export const loadScheduleClass = (_models: IModels) => {
       return updated;
     }
 
+    /** Delete a schedule along with its output thread and messages. */
     public static async removeSchedule(_id: string) {
-      // The schedule's output thread (and its messages) goes with it.
+      // The schedule goes first: if the thread cleanup below fails, the
+      // leftovers are orphaned chat data, not a live schedule whose history
+      // already vanished. (No multi-document transaction — erxes must run on
+      // standalone Mongo, where transactions are unavailable.)
+      const result = await _models.MastraSchedule.deleteOne({ _id });
       const threadId = `schedule-${_id}`;
       await _models.MastraMessage.deleteMany({ threadId });
       await _models.MastraThread.deleteOne({ threadId });
-      return _models.MastraSchedule.deleteOne({ _id });
+      return result;
     }
 
+    /** Stamp last-run bookkeeping (status, error, reply, duration) on the doc. */
     public static async recordRun(
       _id: string,
       outcome: {

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/resolvers/mutations/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/resolvers/mutations/schedule.ts
@@ -1,0 +1,79 @@
+import { IUserDocument } from 'erxes-api-shared/core-types';
+import { IContext, IModels } from '~/connectionResolvers';
+import { IMastraSchedule } from '@/schedule/@types/schedule';
+import { runSchedule } from '~/mastra/schedules/runner';
+
+/** Resolve the logged-in user's _id, rejecting unauthenticated calls. */
+const requireUserId = (user: IUserDocument | null | undefined): string => {
+  const userId = user?._id;
+  if (!userId) throw new Error('Login required');
+  return userId;
+};
+
+/** The referenced agent must exist and be enabled before a schedule saves. */
+const assertAgentRunnable = async (models: IModels, agentId: unknown) => {
+  if (typeof agentId !== 'string' || !agentId) {
+    throw new Error('agentId must be a non-empty string');
+  }
+  const agent = await models.MastraAgent.findOne({ agentId, isEnabled: true });
+  if (!agent) throw new Error(`Agent "${agentId}" not found or disabled`);
+};
+
+/** Mutations for scheduled agent runs. */
+export const scheduleMutations = {
+  mastraScheduleCreate: async (
+    _parent: undefined,
+    { doc }: { doc: IMastraSchedule },
+    { models, user }: IContext,
+  ) => {
+    const userId = requireUserId(user);
+    await assertAgentRunnable(models, doc.agentId);
+    return models.MastraSchedule.createSchedule({
+      ...doc,
+      createdByUserId: userId,
+    });
+  },
+
+  mastraScheduleUpdate: async (
+    _parent: undefined,
+    { _id, doc }: { _id: string; doc: Partial<IMastraSchedule> },
+    { models, user }: IContext,
+  ) => {
+    requireUserId(user);
+    if (doc.agentId !== undefined) {
+      await assertAgentRunnable(models, doc.agentId);
+    }
+    return models.MastraSchedule.updateSchedule(_id, doc);
+  },
+
+  mastraScheduleRemove: (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models, user }: IContext,
+  ) => {
+    requireUserId(user);
+    return models.MastraSchedule.removeSchedule(_id);
+  },
+
+  mastraScheduleSetEnabled: (
+    _parent: undefined,
+    { _id, isEnabled }: { _id: string; isEnabled: boolean },
+    { models, user }: IContext,
+  ) => {
+    requireUserId(user);
+    return models.MastraSchedule.setEnabled(_id, isEnabled);
+  },
+
+  // Manual fire. Allowed even when the schedule is disabled — disabling gates
+  // the cron, not deliberate test runs (same contract as workflow run-start).
+  mastraScheduleRunNow: async (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models, subdomain, user }: IContext,
+  ) => {
+    requireUserId(user);
+    const schedule = await models.MastraSchedule.getSchedule(_id);
+    await runSchedule({ models, subdomain, schedule });
+    return models.MastraSchedule.getSchedule(_id);
+  },
+};

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/resolvers/queries/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/resolvers/queries/schedule.ts
@@ -1,0 +1,40 @@
+import { IUserDocument } from 'erxes-api-shared/core-types';
+import { IContext } from '~/connectionResolvers';
+import { IMastraScheduleDocument } from '@/schedule/@types/schedule';
+import { scheduleThreadId } from '~/mastra/schedules/runner';
+
+/** Resolve the logged-in user's _id, rejecting unauthenticated calls. */
+const requireUserId = (user: IUserDocument | null | undefined): string => {
+  const userId = user?._id;
+  if (!userId) throw new Error('Login required');
+  return userId;
+};
+
+/** Queries over scheduled agent runs. */
+export const scheduleQueries = {
+  mastraSchedules: (
+    _parent: undefined,
+    _args: undefined,
+    { models, user }: IContext,
+  ) => {
+    requireUserId(user);
+    return models.MastraSchedule.getSchedules();
+  },
+
+  mastraSchedule: (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models, user }: IContext,
+  ) => {
+    requireUserId(user);
+    return models.MastraSchedule.getSchedule(_id);
+  },
+};
+
+/** Field resolvers — threadId is derived, never stored. */
+export const scheduleCustomResolvers = {
+  MastraSchedule: {
+    threadId: (schedule: IMastraScheduleDocument) =>
+      scheduleThreadId(schedule._id),
+  },
+};

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/schemas/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/schemas/schedule.ts
@@ -21,6 +21,16 @@ export const types = `
   }
 
   input MastraScheduleInput {
+    name: String!
+    description: String
+    agentId: String!
+    cron: String!
+    timezone: String
+    prompt: String!
+    isEnabled: Boolean
+  }
+
+  input MastraScheduleUpdateInput {
     name: String
     description: String
     agentId: String
@@ -38,7 +48,7 @@ export const queries = `
 
 export const mutations = `
   mastraScheduleCreate(doc: MastraScheduleInput!): MastraSchedule
-  mastraScheduleUpdate(_id: String!, doc: MastraScheduleInput!): MastraSchedule
+  mastraScheduleUpdate(_id: String!, doc: MastraScheduleUpdateInput!): MastraSchedule
   mastraScheduleRemove(_id: String!): JSON
   mastraScheduleSetEnabled(_id: String!, isEnabled: Boolean!): MastraSchedule
   mastraScheduleRunNow(_id: String!): MastraSchedule

--- a/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/schemas/schedule.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/schedule/graphql/schemas/schedule.ts
@@ -1,0 +1,45 @@
+export const types = `
+  type MastraSchedule {
+    _id: String
+    name: String
+    description: String
+    agentId: String
+    cron: String
+    timezone: String
+    prompt: String
+    isEnabled: Boolean
+    createdByUserId: String
+    threadId: String
+    lastRunAt: Date
+    lastStatus: String
+    lastError: String
+    lastReply: String
+    lastDurationMs: Int
+    runCount: Int
+    createdAt: Date
+    updatedAt: Date
+  }
+
+  input MastraScheduleInput {
+    name: String
+    description: String
+    agentId: String
+    cron: String
+    timezone: String
+    prompt: String
+    isEnabled: Boolean
+  }
+`;
+
+export const queries = `
+  mastraSchedules: [MastraSchedule]
+  mastraSchedule(_id: String!): MastraSchedule
+`;
+
+export const mutations = `
+  mastraScheduleCreate(doc: MastraScheduleInput!): MastraSchedule
+  mastraScheduleUpdate(_id: String!, doc: MastraScheduleInput!): MastraSchedule
+  mastraScheduleRemove(_id: String!): JSON
+  mastraScheduleSetEnabled(_id: String!, isEnabled: Boolean!): MastraSchedule
+  mastraScheduleRunNow(_id: String!): MastraSchedule
+`;

--- a/frontend/plugins/erxes-agent_ui/src/components/FormLayout.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/components/FormLayout.tsx
@@ -1,0 +1,40 @@
+import { Card, Label } from 'erxes-ui';
+
+// Shared scaffolding for the plugin's create/edit pages (agents, workflows,
+// schedules) so each page lays out fields the same way.
+
+/** Card wrapper for one group of related form fields. */
+export const FormSection = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) => (
+  <Card className="shadow-none">
+    <Card.Header className="pb-3">
+      <Card.Title className="text-base">{title}</Card.Title>
+      {description && <Card.Description>{description}</Card.Description>}
+    </Card.Header>
+    <Card.Content className="space-y-4">{children}</Card.Content>
+  </Card>
+);
+
+/** Labeled form control with an optional hint line. */
+export const Field = ({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) => (
+  <div className="space-y-1.5">
+    <Label className="font-medium">{label}</Label>
+    {children}
+    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+  </div>
+);

--- a/frontend/plugins/erxes-agent_ui/src/components/FormLayout.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/components/FormLayout.tsx
@@ -1,3 +1,4 @@
+import { cloneElement, isValidElement, useId } from 'react';
 import { Card, Label } from 'erxes-ui';
 
 // Shared scaffolding for the plugin's create/edit pages (agents, workflows,
@@ -22,7 +23,12 @@ export const FormSection = ({
   </Card>
 );
 
-/** Labeled form control with an optional hint line. */
+/**
+ * Labeled form control with an optional hint line. A single element child is
+ * bound to the label: it gets an auto-generated id (its own id wins when set)
+ * and the label's htmlFor points at it, so screen readers and label clicks
+ * reach the control.
+ */
 export const Field = ({
   label,
   hint,
@@ -31,10 +37,21 @@ export const Field = ({
   label: string;
   hint?: string;
   children: React.ReactNode;
-}) => (
-  <div className="space-y-1.5">
-    <Label className="font-medium">{label}</Label>
-    {children}
-    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
-  </div>
-);
+}) => {
+  const autoId = useId();
+  let control = children;
+  let htmlFor: string | undefined;
+  if (isValidElement<{ id?: string }>(children)) {
+    htmlFor = children.props.id ?? autoId;
+    control = cloneElement(children, { id: htmlFor });
+  }
+  return (
+    <div className="space-y-1.5">
+      <Label className="font-medium" htmlFor={htmlFor}>
+        {label}
+      </Label>
+      {control}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/components/RecordTableShared.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/components/RecordTableShared.tsx
@@ -1,0 +1,80 @@
+import { ColumnDef } from '@tanstack/react-table';
+import {
+  IconToggleLeft,
+  IconToggleRight,
+  IconTrash,
+} from '@tabler/icons-react';
+import {
+  Badge,
+  Button,
+  Command,
+  RecordTable,
+  RecordTableInlineCell,
+} from 'erxes-ui';
+
+// Bits shared by the plugin's record tables (agents, workflows, schedules)
+// so the row menus and status columns stay identical across the lists.
+
+/** Enable/disable + delete tail of a row actions menu. */
+export const ToggleDeleteMenuItems = ({
+  isEnabled,
+  onToggle,
+  onDelete,
+}: {
+  isEnabled: boolean;
+  onToggle: () => void;
+  onDelete: () => void;
+}) => (
+  <>
+    <Command.Item asChild>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="justify-start w-full h-8"
+        onClick={onToggle}
+      >
+        {isEnabled ? (
+          <>
+            <IconToggleLeft className="size-4" /> Disable
+          </>
+        ) : (
+          <>
+            <IconToggleRight className="size-4" /> Enable
+          </>
+        )}
+      </Button>
+    </Command.Item>
+    <Command.Item asChild>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="justify-start w-full h-8 text-destructive"
+        onClick={onDelete}
+      >
+        <IconTrash className="size-4" /> Delete
+      </Button>
+    </Command.Item>
+  </>
+);
+
+/** The Active/Disabled status column over a row's isEnabled flag. */
+export const enabledStatusColumn = <
+  T extends { isEnabled: boolean },
+>(): ColumnDef<T> => ({
+  id: 'status',
+  accessorKey: 'isEnabled',
+  header: () => (
+    <RecordTable.InlineHead icon={IconToggleRight} label="Status" />
+  ),
+  cell: ({ cell }) => {
+    const isEnabled = cell.getValue() as boolean;
+    return (
+      <RecordTableInlineCell>
+        <Badge variant={isEnabled ? 'success' : 'secondary'}>
+          {isEnabled ? 'Active' : 'Disabled'}
+        </Badge>
+      </RecordTableInlineCell>
+    );
+  },
+  size: 100,
+});

--- a/frontend/plugins/erxes-agent_ui/src/config.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/config.tsx
@@ -1,4 +1,4 @@
-import { IconRobot, IconSitemap } from '@tabler/icons-react';
+import { IconCalendarTime, IconRobot, IconSitemap } from '@tabler/icons-react';
 import { lazy, Suspense } from 'react';
 import { IUIConfig } from 'erxes-ui';
 
@@ -45,6 +45,11 @@ export const CONFIG: IUIConfig = {
       name: 'workflows',
       icon: IconSitemap,
       path: 'erxes-agent/workflows',
+    },
+    {
+      name: 'schedules',
+      icon: IconCalendarTime,
+      path: 'erxes-agent/schedules',
     },
   ],
 };

--- a/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
@@ -229,7 +229,10 @@ export const MASTRA_SCHEDULE_CREATE = gql`
 `;
 
 export const MASTRA_SCHEDULE_UPDATE = gql`
-  mutation MastraScheduleUpdate($_id: String!, $doc: MastraScheduleInput!) {
+  mutation MastraScheduleUpdate(
+    $_id: String!
+    $doc: MastraScheduleUpdateInput!
+  ) {
     mastraScheduleUpdate(_id: $_id, doc: $doc) {
       _id
       name

--- a/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
@@ -211,6 +211,69 @@ export const MASTRA_WORKFLOW_VALIDATE = gql`
   }
 `;
 
+export const MASTRA_SCHEDULE_CREATE = gql`
+  mutation MastraScheduleCreate($doc: MastraScheduleInput!) {
+    mastraScheduleCreate(doc: $doc) {
+      _id
+      name
+      description
+      agentId
+      cron
+      timezone
+      prompt
+      isEnabled
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const MASTRA_SCHEDULE_UPDATE = gql`
+  mutation MastraScheduleUpdate($_id: String!, $doc: MastraScheduleInput!) {
+    mastraScheduleUpdate(_id: $_id, doc: $doc) {
+      _id
+      name
+      description
+      agentId
+      cron
+      timezone
+      prompt
+      isEnabled
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const MASTRA_SCHEDULE_REMOVE = gql`
+  mutation MastraScheduleRemove($_id: String!) {
+    mastraScheduleRemove(_id: $_id)
+  }
+`;
+
+export const MASTRA_SCHEDULE_SET_ENABLED = gql`
+  mutation MastraScheduleSetEnabled($_id: String!, $isEnabled: Boolean!) {
+    mastraScheduleSetEnabled(_id: $_id, isEnabled: $isEnabled) {
+      _id
+      isEnabled
+    }
+  }
+`;
+
+export const MASTRA_SCHEDULE_RUN_NOW = gql`
+  mutation MastraScheduleRunNow($_id: String!) {
+    mastraScheduleRunNow(_id: $_id) {
+      _id
+      lastRunAt
+      lastStatus
+      lastError
+      lastReply
+      lastDurationMs
+      runCount
+    }
+  }
+`;
+
 export const MASTRA_WORKFLOW_RUN_START = gql`
   mutation MastraWorkflowRunStart($_id: String!, $input: JSON) {
     mastraWorkflowRunStart(_id: $_id, input: $input) {

--- a/frontend/plugins/erxes-agent_ui/src/graphql/queries.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/queries.ts
@@ -313,6 +313,54 @@ export const MASTRA_WORKFLOW = gql`
   }
 `;
 
+export const MASTRA_SCHEDULES = gql`
+  query MastraSchedules {
+    mastraSchedules {
+      _id
+      name
+      description
+      agentId
+      cron
+      timezone
+      prompt
+      isEnabled
+      threadId
+      lastRunAt
+      lastStatus
+      lastError
+      lastReply
+      lastDurationMs
+      runCount
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const MASTRA_SCHEDULE = gql`
+  query MastraSchedule($_id: String!) {
+    mastraSchedule(_id: $_id) {
+      _id
+      name
+      description
+      agentId
+      cron
+      timezone
+      prompt
+      isEnabled
+      threadId
+      lastRunAt
+      lastStatus
+      lastError
+      lastReply
+      lastDurationMs
+      runCount
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
 export const MASTRA_WORKFLOW_RUNS = gql`
   query MastraWorkflowRuns($workflowId: String!, $page: Int, $perPage: Int) {
     mastraWorkflowRuns(

--- a/frontend/plugins/erxes-agent_ui/src/modules/MastraMain.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/MastraMain.tsx
@@ -41,6 +41,18 @@ const LearningsIndexPage = lazy(() =>
   })),
 );
 
+const SchedulesIndexPage = lazy(() =>
+  import('~/pages/schedules/SchedulesIndexPage').then((m) => ({
+    default: m.SchedulesIndexPage,
+  })),
+);
+
+const ScheduleFormPage = lazy(() =>
+  import('~/pages/schedules/ScheduleFormPage').then((m) => ({
+    default: m.ScheduleFormPage,
+  })),
+);
+
 const MastraMain = () => {
   return (
     <Suspense fallback={<div />}>
@@ -55,6 +67,9 @@ const MastraMain = () => {
         <Route path="/workflows/edit/:id" element={<WorkflowFormPage />} />
         <Route path="/workflows/:id" element={<WorkflowDetailPage />} />
         <Route path="/learnings" element={<LearningsIndexPage />} />
+        <Route path="/schedules" element={<SchedulesIndexPage />} />
+        <Route path="/schedules/new" element={<ScheduleFormPage />} />
+        <Route path="/schedules/edit/:id" element={<ScheduleFormPage />} />
       </Routes>
     </Suspense>
   );

--- a/frontend/plugins/erxes-agent_ui/src/modules/MastraNavigation.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/MastraNavigation.tsx
@@ -4,6 +4,7 @@ import {
   IconMessageCircle,
   IconSitemap,
   IconBulb,
+  IconCalendarTime,
 } from '@tabler/icons-react';
 import { NavigationMenuLinkItem } from 'erxes-ui';
 import { chatStore } from '~/pages/chat/chatStore';
@@ -42,6 +43,11 @@ export const MastraNavigation = () => {
         name="Workflows"
         icon={IconSitemap}
         path="erxes-agent/workflows"
+      />
+      <NavigationMenuLinkItem
+        name="Schedules"
+        icon={IconCalendarTime}
+        path="erxes-agent/schedules"
       />
       <NavigationMenuLinkItem
         name="Agent knowledge"

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
@@ -12,7 +12,6 @@ import {
   Alert,
   Breadcrumb,
   Button,
-  Card,
   Checkbox,
   Label,
   Input,
@@ -29,6 +28,7 @@ import {
   MASTRA_AVAILABLE_ERXES_TOOLS,
 } from '~/graphql/queries';
 import { MASTRA_AGENT_CREATE, MASTRA_AGENT_UPDATE } from '~/graphql/mutations';
+import { Field, FormSection } from '~/components/FormLayout';
 import {
   SelectModel,
   SelectProvider,
@@ -41,40 +41,6 @@ function toSlug(name: string) {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');
 }
-
-const FormSection = ({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) => (
-  <Card className="shadow-none">
-    <Card.Header className="pb-3">
-      <Card.Title className="text-base">{title}</Card.Title>
-      {description && <Card.Description>{description}</Card.Description>}
-    </Card.Header>
-    <Card.Content className="space-y-4">{children}</Card.Content>
-  </Card>
-);
-
-const Field = ({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}) => (
-  <div className="space-y-1.5">
-    <Label className="font-medium">{label}</Label>
-    {children}
-    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
-  </div>
-);
 
 export const AgentFormPage = () => {
   const { id } = useParams();
@@ -514,7 +480,9 @@ export const AgentFormPage = () => {
                 <div className="flex items-center justify-between gap-2">
                   <p className="text-xs text-muted-foreground">
                     {allowed.length > 0
-                      ? `${allowed.length} rule${allowed.length !== 1 ? 's' : ''} selected`
+                      ? `${allowed.length} rule${
+                          allowed.length !== 1 ? 's' : ''
+                        } selected`
                       : 'Nothing selected yet — this agent will have no tools.'}
                   </p>
                   {allowed.length > 0 && (
@@ -585,7 +553,9 @@ export const AgentFormPage = () => {
                                   className="flex items-center gap-1.5 min-w-0 hover:opacity-80"
                                 >
                                   <IconChevronRight
-                                    className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${pluginOpen ? 'rotate-90' : ''}`}
+                                    className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+                                      pluginOpen ? 'rotate-90' : ''
+                                    }`}
                                   />
                                   <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                                     {plugin}
@@ -639,7 +609,9 @@ export const AgentFormPage = () => {
                                             className="flex items-center gap-1.5 min-w-0"
                                           >
                                             <IconChevronRight
-                                              className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${open ? 'rotate-90' : ''}`}
+                                              className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+                                                open ? 'rotate-90' : ''
+                                              }`}
                                             />
                                             <span className="text-sm font-medium capitalize truncate">
                                               {module}

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentsIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentsIndexPage.tsx
@@ -10,10 +10,7 @@ import {
   IconTool,
   IconCalendar,
   IconPencil,
-  IconTrash,
   IconMessageCircle,
-  IconToggleLeft,
-  IconToggleRight,
 } from '@tabler/icons-react';
 import {
   Badge,
@@ -32,6 +29,10 @@ import {
 import { PageHeader } from 'ui-modules';
 import { MASTRA_AGENTS } from '~/graphql/queries';
 import { MASTRA_AGENT_REMOVE, MASTRA_AGENT_UPDATE } from '~/graphql/mutations';
+import {
+  ToggleDeleteMenuItems,
+  enabledStatusColumn,
+} from '~/components/RecordTableShared';
 import { useMastraAgentList, IMastraAgentRow } from './useMastraAgentList';
 
 type IAgent = IMastraAgentRow;
@@ -107,34 +108,11 @@ const AgentMoreCell = ({
                 <IconPencil className="size-4" /> Edit
               </Button>
             </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8"
-                onClick={handleToggle}
-              >
-                {agent.isEnabled ? (
-                  <>
-                    <IconToggleLeft className="size-4" /> Disable
-                  </>
-                ) : (
-                  <>
-                    <IconToggleRight className="size-4" /> Enable
-                  </>
-                )}
-              </Button>
-            </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8 text-destructive"
-                onClick={handleDelete}
-              >
-                <IconTrash className="size-4" /> Delete
-              </Button>
-            </Command.Item>
+            <ToggleDeleteMenuItems
+              isEnabled={agent.isEnabled}
+              onToggle={handleToggle}
+              onDelete={handleDelete}
+            />
           </Command.List>
         </Command>
       </Combobox.Content>
@@ -213,24 +191,7 @@ const baseColumns: ColumnDef<IAgent>[] = [
     },
     size: 110,
   },
-  {
-    id: 'status',
-    accessorKey: 'isEnabled',
-    header: () => (
-      <RecordTable.InlineHead icon={IconToggleRight} label="Status" />
-    ),
-    cell: ({ cell }) => {
-      const isEnabled = cell.getValue() as boolean;
-      return (
-        <RecordTableInlineCell>
-          <Badge variant={isEnabled ? 'success' : 'secondary'}>
-            {isEnabled ? 'Active' : 'Disabled'}
-          </Badge>
-        </RecordTableInlineCell>
-      );
-    },
-    size: 100,
-  },
+  enabledStatusColumn<IAgent>(),
   {
     id: 'createdAt',
     accessorKey: 'createdAt',

--- a/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
@@ -963,8 +963,10 @@ export const ChatPage = () => {
   // The route is keyed by the agent record _id, but inbound links (e.g.
   // Schedules → View output) may carry the agent slug — accept both.
   const selectedAgent = agentId
-    ? agents.find((a: any) => a._id === agentId || a.agentId === agentId) ??
-      null
+    ? agents.find(
+        (a: { _id: string; agentId: string }) =>
+          a._id === agentId || a.agentId === agentId,
+      ) ?? null
     : null;
 
   const [input, setInput] = useState('');

--- a/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
@@ -995,10 +995,10 @@ export const ChatPage = () => {
   useEffect(() => {
     if (selectedAgent && agentId && selectedAgent._id !== agentId) {
       const search = searchParams.toString();
-      navigate(
-        `/erxes-agent/chat/${selectedAgent._id}${search ? `?${search}` : ''}`,
-        { replace: true },
-      );
+      const suffix = search ? `?${search}` : '';
+      navigate(`/erxes-agent/chat/${selectedAgent._id}${suffix}`, {
+        replace: true,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedAgent?._id, agentId]);

--- a/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useReducer } from 'react';
 import { useQuery, useApolloClient } from '@apollo/client';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   IconRobot,
   IconSend,
@@ -449,7 +449,9 @@ const isImageAttachment = (att: { name: string; type?: string }) =>
 const attachmentSrc = (att: ChatAttachment) =>
   /^https?:\/\//i.test(att.url)
     ? att.url
-    : `${REACT_APP_API_URL}/read-file?key=${encodeURIComponent(att.url)}&inline=true&name=${encodeURIComponent(att.name)}`;
+    : `${REACT_APP_API_URL}/read-file?key=${encodeURIComponent(
+        att.url,
+      )}&inline=true&name=${encodeURIComponent(att.name)}`;
 
 const formatFileSize = (size?: number) => {
   if (!size || size <= 0) return '';
@@ -665,7 +667,9 @@ const ThinkingSection = ({ text, live }: { text: string; live?: boolean }) => {
           } ${live ? 'text-primary' : ''}`}
         />
         <IconSparkles
-          className={`size-3.5 shrink-0 ${live ? 'text-primary animate-pulse' : ''}`}
+          className={`size-3.5 shrink-0 ${
+            live ? 'text-primary animate-pulse' : ''
+          }`}
         />
         {live ? (
           <span className="ea-shimmer-text font-medium">Thinking…</span>
@@ -956,8 +960,11 @@ export const ChatPage = () => {
     !!storageData?.mastraAttachmentStorageStatus?.enabled;
 
   const agents = (data?.mastraAgents || []).filter((a: any) => a.isEnabled);
+  // The route is keyed by the agent record _id, but inbound links (e.g.
+  // Schedules → View output) may carry the agent slug — accept both.
   const selectedAgent = agentId
-    ? (agents.find((a: any) => a._id === agentId) ?? null)
+    ? agents.find((a: any) => a._id === agentId || a.agentId === agentId) ??
+      null
     : null;
 
   const [input, setInput] = useState('');
@@ -979,6 +986,31 @@ export const ChatPage = () => {
   const messages: Message[] = state?.messages ?? [];
   const chatLoading = state?.loading ?? false;
   const messagesLoading = state?.messagesLoading ?? false;
+
+  // Slug routes normalize to the _id route so the chat store stays keyed
+  // by _id no matter which link form brought the user here.
+  const [searchParams] = useSearchParams();
+  useEffect(() => {
+    if (selectedAgent && agentId && selectedAgent._id !== agentId) {
+      const search = searchParams.toString();
+      navigate(
+        `/erxes-agent/chat/${selectedAgent._id}${search ? `?${search}` : ''}`,
+        { replace: true },
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAgent?._id, agentId]);
+
+  // Deep link: ?thread=<id> (e.g. a schedule's output thread) opens that
+  // session once the agent's sessions have loaded.
+  const threadParam = searchParams.get('thread');
+  useEffect(() => {
+    if (!agentId || !threadParam || !sessionsLoaded) return;
+    if (threadParam !== activeThreadId) {
+      chatStore.selectSession(apolloClient, agentId, threadParam);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId, threadParam, sessionsLoaded]);
 
   // Track the viewed agent (clears its unread badge); clear on navigate away.
   useEffect(() => {

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
@@ -204,8 +204,8 @@ export const ScheduleFormPage = () => {
   const isSaving = creating || updating;
   const saveLabel = isEdit ? 'Save Changes' : 'Create Schedule';
 
-  // skipcq: JS-0415 — page scaffolding (header/breadcrumb) nests past the cap
   return (
+    // skipcq: JS-0415 — page scaffolding (header/breadcrumb) nests past the cap
     <div className="flex flex-col h-full">
       <PageHeader>
         <PageHeader.Start>

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import {
   IconArrowLeft,
   IconCalendarTime,
@@ -12,8 +15,8 @@ import {
   Breadcrumb,
   Combobox,
   Command,
+  Form,
   Input,
-  Label,
   Popover,
   Separator,
   Switch,
@@ -30,8 +33,36 @@ import {
   MASTRA_SCHEDULE_CREATE,
   MASTRA_SCHEDULE_UPDATE,
 } from '~/graphql/mutations';
-import { Field, FormSection } from '~/components/FormLayout';
+import { FormSection } from '~/components/FormLayout';
 import { ScheduleTimingFields } from './ScheduleTimingFields';
+
+const scheduleFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string(),
+  agentId: z.string().min(1, 'Pick the agent this schedule should run'),
+  cron: z
+    .string()
+    .min(1, 'Cron expression is required')
+    .refine((value) => {
+      const fields = value.trim().split(/\s+/).length;
+      return fields >= 5 && fields <= 6;
+    }, 'Cron expression must have 5 or 6 fields'),
+  timezone: z.string(),
+  prompt: z.string().min(1, 'Prompt is required'),
+  isEnabled: z.boolean(),
+});
+
+type ScheduleFormValues = z.infer<typeof scheduleFormSchema>;
+
+const DEFAULT_VALUES: ScheduleFormValues = {
+  name: '',
+  description: '',
+  agentId: '',
+  cron: '0 9 * * *',
+  timezone: 'UTC',
+  prompt: '',
+  isEnabled: false,
+};
 
 interface IAgentOption {
   agentId: string;
@@ -97,14 +128,9 @@ export const ScheduleFormPage = () => {
   const navigate = useNavigate();
   const isEdit = Boolean(id);
 
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    agentId: '',
-    cron: '0 9 * * *',
-    timezone: 'UTC',
-    prompt: '',
-    isEnabled: false,
+  const form = useForm<ScheduleFormValues>({
+    resolver: zodResolver(scheduleFormSchema),
+    defaultValues: DEFAULT_VALUES,
   });
 
   const { data: scheduleData } = useQuery(MASTRA_SCHEDULE, {
@@ -115,53 +141,43 @@ export const ScheduleFormPage = () => {
   useEffect(() => {
     if (isEdit && scheduleData?.mastraSchedule) {
       const schedule = scheduleData.mastraSchedule;
-      setForm({
+      form.reset({
         name: schedule.name || '',
         description: schedule.description || '',
         agentId: schedule.agentId || '',
-        cron: schedule.cron || '0 9 * * *',
+        cron: schedule.cron || DEFAULT_VALUES.cron,
         timezone: schedule.timezone || 'UTC',
         prompt: schedule.prompt || '',
         isEnabled: schedule.isEnabled ?? false,
       });
     }
-  }, [scheduleData, isEdit]);
+  }, [scheduleData, isEdit, form]);
 
-  const mutationOptions = {
+  const mutationOptions = (successTitle: string) => ({
     refetchQueries: [{ query: MASTRA_SCHEDULES }],
     awaitRefetchQueries: true,
-    onCompleted: () => navigate('/erxes-agent/schedules'),
+    onCompleted: () => {
+      toast({ title: successTitle });
+      navigate('/erxes-agent/schedules');
+    },
     onError: (e: { message: string }) =>
       toast({ title: 'Error', description: e.message, variant: 'destructive' }),
-  };
+  });
   const [createSchedule, { loading: creating }] = useMutation(
     MASTRA_SCHEDULE_CREATE,
-    mutationOptions,
+    mutationOptions('Schedule created'),
   );
   const [updateSchedule, { loading: updating }] = useMutation(
     MASTRA_SCHEDULE_UPDATE,
-    mutationOptions,
+    mutationOptions('Schedule updated'),
   );
 
-  /** Patch one form field by key. */
-  const set = (k: string, v: string | boolean) =>
-    setForm((f) => ({ ...f, [k]: v }));
-
-  /** Save the schedule; the missing-agent case also disables both buttons. */
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!form.agentId) {
-      toast({
-        title: 'Agent required',
-        description: 'Pick the agent this schedule should run.',
-        variant: 'destructive',
-      });
-      return;
-    }
+  /** Save the schedule; zod has already validated by the time this runs. */
+  const onSubmit = (doc: ScheduleFormValues) => {
     if (isEdit) {
-      updateSchedule({ variables: { _id: id, doc: form } });
+      updateSchedule({ variables: { _id: id, doc } });
     } else {
-      createSchedule({ variables: { doc: form } });
+      createSchedule({ variables: { doc } });
     }
   };
 
@@ -199,108 +215,153 @@ export const ScheduleFormPage = () => {
               <IconArrowLeft /> Back
             </Link>
           </Button>
-          <Button
-            type="submit"
-            form="schedule-form"
-            disabled={isSaving || !form.agentId}
-          >
+          <Button type="submit" form="schedule-form" disabled={isSaving}>
             {isSaving ? 'Saving…' : saveLabel}
           </Button>
         </PageHeader.End>
       </PageHeader>
 
       <div className="flex-1 overflow-auto p-4">
-        <form
-          id="schedule-form"
-          onSubmit={handleSubmit}
-          className="max-w-2xl mx-auto space-y-4"
-        >
-          <FormSection title="Basic Info">
-            <Field label="Name *">
-              <Input
-                value={form.name}
-                onChange={(e) => set('name', e.target.value)}
-                placeholder="Daily sales summary"
-                required
+        <Form {...form}>
+          <form
+            id="schedule-form"
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="max-w-2xl mx-auto space-y-4"
+          >
+            <FormSection title="Basic Info">
+              <Form.Field
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Name</Form.Label>
+                    <Form.Control>
+                      <Input {...field} placeholder="Daily sales summary" />
+                    </Form.Control>
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
-            </Field>
 
-            <Field label="Description">
-              <Input
-                value={form.description}
-                onChange={(e) => set('description', e.target.value)}
-                placeholder="What this schedule does"
+              <Form.Field
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Description</Form.Label>
+                    <Form.Control>
+                      <Input {...field} placeholder="What this schedule does" />
+                    </Form.Control>
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
-            </Field>
 
-            <Field label="Agent *" hint="The agent this schedule runs.">
-              <SelectAgent
-                value={form.agentId}
-                onValueChange={(v) => set('agentId', v)}
+              <Form.Field
+                control={form.control}
+                name="agentId"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Agent</Form.Label>
+                    <SelectAgent
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                    <Form.Description>
+                      The agent this schedule runs.
+                    </Form.Description>
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
-            </Field>
 
-            <Field
-              label="Prompt *"
-              hint="Sent to the agent as the user message on every run."
-            >
-              <Textarea
-                value={form.prompt}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  set('prompt', e.target.value)
-                }
-                placeholder="Summarize yesterday's new deals and flag anything unusual…"
-                rows={5}
-                required
+              <Form.Field
+                control={form.control}
+                name="prompt"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Prompt</Form.Label>
+                    <Form.Control>
+                      <Textarea
+                        {...field}
+                        placeholder="Summarize yesterday's new deals and flag anything unusual…"
+                        rows={5}
+                      />
+                    </Form.Control>
+                    <Form.Description>
+                      Sent to the agent as the user message on every run.
+                    </Form.Description>
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
-            </Field>
-          </FormSection>
+            </FormSection>
 
-          <FormSection title="Timing" description="How often the agent runs.">
-            <ScheduleTimingFields
-              key={id ?? 'new'}
-              cron={form.cron}
-              timezone={form.timezone}
-              onCronChange={(v) => set('cron', v)}
-              onTimezoneChange={(v) => set('timezone', v)}
-            />
-          </FormSection>
-
-          <FormSection title="Activation">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <Label className="font-medium">Enabled</Label>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  Disabled schedules never fire on the cron — you can still test
-                  them with “Run now”.
-                </p>
-              </div>
-              <Switch
-                checked={form.isEnabled}
-                onCheckedChange={(v: boolean) => set('isEnabled', v)}
+            <FormSection title="Timing" description="How often the agent runs.">
+              <Form.Field
+                control={form.control}
+                name="cron"
+                render={({ field }) => (
+                  <Form.Item>
+                    <ScheduleTimingFields
+                      key={id ?? 'new'}
+                      cron={field.value}
+                      timezone={form.watch('timezone')}
+                      onCronChange={field.onChange}
+                      onTimezoneChange={(tz) =>
+                        form.setValue('timezone', tz, { shouldDirty: true })
+                      }
+                    />
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
+            </FormSection>
+
+            <FormSection title="Activation">
+              <Form.Field
+                control={form.control}
+                name="isEnabled"
+                render={({ field }) => (
+                  <Form.Item className="flex items-center justify-between gap-4 space-y-0">
+                    <div>
+                      <Form.Label>Enabled</Form.Label>
+                      <Form.Description className="mt-0.5">
+                        Disabled schedules never fire on the cron — you can
+                        still test them with “Run now”.
+                      </Form.Description>
+                    </div>
+                    <Form.Control>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+
+              <Alert>
+                <IconInfoCircle className="size-4" />
+                <Alert.Title>Background runs</Alert.Title>
+                <Alert.Description>
+                  Scheduled runs execute with the app token configured in
+                  General Settings, not your user session. Output lands in a
+                  dedicated chat thread named after the schedule.
+                </Alert.Description>
+              </Alert>
+            </FormSection>
+
+            <div className="flex gap-3 pb-4 sm:hidden">
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? 'Saving…' : saveLabel}
+              </Button>
+              <Button type="button" variant="outline" asChild>
+                <Link to="/erxes-agent/schedules">Cancel</Link>
+              </Button>
             </div>
-
-            <Alert>
-              <IconInfoCircle className="size-4" />
-              <Alert.Title>Background runs</Alert.Title>
-              <Alert.Description>
-                Scheduled runs execute with the app token configured in General
-                Settings, not your user session. Output lands in a dedicated
-                chat thread named after the schedule.
-              </Alert.Description>
-            </Alert>
-          </FormSection>
-
-          <div className="flex gap-3 pb-4 sm:hidden">
-            <Button type="submit" disabled={isSaving || !form.agentId}>
-              {isSaving ? 'Saving…' : saveLabel}
-            </Button>
-            <Button type="button" variant="outline" asChild>
-              <Link to="/erxes-agent/schedules">Cancel</Link>
-            </Button>
-          </div>
-        </form>
+          </form>
+        </Form>
       </div>
     </div>
   );

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
@@ -10,7 +10,6 @@ import {
   Alert,
   Button,
   Breadcrumb,
-  Card,
   Combobox,
   Command,
   Input,
@@ -31,43 +30,8 @@ import {
   MASTRA_SCHEDULE_CREATE,
   MASTRA_SCHEDULE_UPDATE,
 } from '~/graphql/mutations';
+import { Field, FormSection } from '~/components/FormLayout';
 import { ScheduleTimingFields } from './ScheduleTimingFields';
-
-/** Card wrapper for one group of related form fields. */
-const FormSection = ({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) => (
-  <Card className="shadow-none">
-    <Card.Header className="pb-3">
-      <Card.Title className="text-base">{title}</Card.Title>
-      {description && <Card.Description>{description}</Card.Description>}
-    </Card.Header>
-    <Card.Content className="space-y-4">{children}</Card.Content>
-  </Card>
-);
-
-/** Labeled form control with an optional hint line. */
-const Field = ({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}) => (
-  <div className="space-y-1.5">
-    <Label className="font-medium">{label}</Label>
-    {children}
-    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
-  </div>
-);
 
 interface IAgentOption {
   agentId: string;

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useQuery, useMutation } from '@apollo/client';
+import {
+  IconArrowLeft,
+  IconCalendarTime,
+  IconInfoCircle,
+} from '@tabler/icons-react';
+import {
+  Alert,
+  Button,
+  Breadcrumb,
+  Card,
+  Combobox,
+  Command,
+  Input,
+  Label,
+  Popover,
+  Separator,
+  Switch,
+  Textarea,
+  toast,
+} from 'erxes-ui';
+import { PageHeader } from 'ui-modules';
+import { MASTRA_AGENTS, MASTRA_SCHEDULE, MASTRA_SCHEDULES } from '~/graphql/queries';
+import {
+  MASTRA_SCHEDULE_CREATE,
+  MASTRA_SCHEDULE_UPDATE,
+} from '~/graphql/mutations';
+import { ScheduleTimingFields } from './ScheduleTimingFields';
+
+const FormSection = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) => (
+  <Card className="shadow-none">
+    <Card.Header className="pb-3">
+      <Card.Title className="text-base">{title}</Card.Title>
+      {description && <Card.Description>{description}</Card.Description>}
+    </Card.Header>
+    <Card.Content className="space-y-4">{children}</Card.Content>
+  </Card>
+);
+
+const Field = ({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) => (
+  <div className="space-y-1.5">
+    <Label className="font-medium">{label}</Label>
+    {children}
+    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+  </div>
+);
+
+interface IAgentOption {
+  agentId: string;
+  name: string;
+  isEnabled: boolean;
+}
+
+const SelectAgent = ({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (agentId: string) => void;
+}) => {
+  const { data, loading } = useQuery(MASTRA_AGENTS);
+  const [open, setOpen] = useState(false);
+  const agents: IAgentOption[] = (data?.mastraAgents || []).filter(
+    (a: IAgentOption) => a.isEnabled,
+  );
+  const selected = agents.find((a) => a.agentId === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Combobox.Trigger className="h-9">
+        <Combobox.Value
+          value={selected ? selected.name : value || ''}
+          placeholder="Select agent…"
+          loading={loading && !agents.length && !!value}
+        />
+      </Combobox.Trigger>
+      <Combobox.Content>
+        <Command>
+          <Command.Input placeholder="Search agents…" />
+          <Command.List>
+            <Combobox.Empty loading={loading} />
+            {agents.map((a) => (
+              <Command.Item
+                key={a.agentId}
+                value={`${a.name} ${a.agentId}`}
+                onSelect={() => {
+                  onValueChange(a.agentId);
+                  setOpen(false);
+                }}
+              >
+                {a.name}
+                <span className="ml-2 text-xs text-muted-foreground font-mono">
+                  {a.agentId}
+                </span>
+                <Combobox.Check checked={a.agentId === value} />
+              </Command.Item>
+            ))}
+          </Command.List>
+        </Command>
+      </Combobox.Content>
+    </Popover>
+  );
+};
+
+export const ScheduleFormPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const isEdit = !!id;
+
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    agentId: '',
+    cron: '0 9 * * *',
+    timezone: 'UTC',
+    prompt: '',
+    isEnabled: false,
+  });
+
+  const { data: scheduleData } = useQuery(MASTRA_SCHEDULE, {
+    variables: { _id: id },
+    skip: !isEdit,
+  });
+
+  useEffect(() => {
+    if (isEdit && scheduleData?.mastraSchedule) {
+      const s = scheduleData.mastraSchedule;
+      setForm({
+        name: s.name || '',
+        description: s.description || '',
+        agentId: s.agentId || '',
+        cron: s.cron || '0 9 * * *',
+        timezone: s.timezone || 'UTC',
+        prompt: s.prompt || '',
+        isEnabled: s.isEnabled ?? false,
+      });
+    }
+  }, [scheduleData, isEdit]);
+
+  const mutationOptions = {
+    refetchQueries: [{ query: MASTRA_SCHEDULES }],
+    awaitRefetchQueries: true,
+    onCompleted: () => navigate('/erxes-agent/schedules'),
+    onError: (e: { message: string }) =>
+      toast({ title: 'Error', description: e.message, variant: 'destructive' }),
+  };
+  const [createSchedule, { loading: creating }] = useMutation(
+    MASTRA_SCHEDULE_CREATE,
+    mutationOptions,
+  );
+  const [updateSchedule, { loading: updating }] = useMutation(
+    MASTRA_SCHEDULE_UPDATE,
+    mutationOptions,
+  );
+
+  const set = (k: string, v: string | boolean) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.agentId) return;
+    if (isEdit) {
+      updateSchedule({ variables: { _id: id, doc: form } });
+    } else {
+      createSchedule({ variables: { doc: form } });
+    }
+  };
+
+  const isSaving = creating || updating;
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader>
+        <PageHeader.Start>
+          <Breadcrumb>
+            <Breadcrumb.List className="gap-1">
+              <Breadcrumb.Item>
+                <Button variant="ghost" asChild>
+                  <Link to="/erxes-agent/schedules">
+                    <IconCalendarTime />
+                    Schedules
+                  </Link>
+                </Button>
+              </Breadcrumb.Item>
+              <Breadcrumb.Separator />
+              <Breadcrumb.Item>
+                <span className="text-muted-foreground">
+                  {isEdit ? 'Edit Schedule' : 'New Schedule'}
+                </span>
+              </Breadcrumb.Item>
+            </Breadcrumb.List>
+          </Breadcrumb>
+          <Separator.Inline />
+        </PageHeader.Start>
+        <PageHeader.End>
+          <Button variant="outline" asChild>
+            <Link to="/erxes-agent/schedules">
+              <IconArrowLeft /> Back
+            </Link>
+          </Button>
+          <Button
+            type="submit"
+            form="schedule-form"
+            disabled={isSaving || !form.agentId}
+          >
+            {isSaving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Schedule'}
+          </Button>
+        </PageHeader.End>
+      </PageHeader>
+
+      <div className="flex-1 overflow-auto p-4">
+        <form
+          id="schedule-form"
+          onSubmit={handleSubmit}
+          className="max-w-2xl mx-auto space-y-4"
+        >
+          <FormSection title="Basic Info">
+            <Field label="Name *">
+              <Input
+                value={form.name}
+                onChange={(e) => set('name', e.target.value)}
+                placeholder="Daily sales summary"
+                required
+              />
+            </Field>
+
+            <Field label="Description">
+              <Input
+                value={form.description}
+                onChange={(e) => set('description', e.target.value)}
+                placeholder="What this schedule does"
+              />
+            </Field>
+
+            <Field label="Agent *" hint="The agent this schedule runs.">
+              <SelectAgent
+                value={form.agentId}
+                onValueChange={(v) => set('agentId', v)}
+              />
+            </Field>
+
+            <Field
+              label="Prompt *"
+              hint="Sent to the agent as the user message on every run."
+            >
+              <Textarea
+                value={form.prompt}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  set('prompt', e.target.value)
+                }
+                placeholder="Summarize yesterday's new deals and flag anything unusual…"
+                rows={5}
+                required
+              />
+            </Field>
+          </FormSection>
+
+          <FormSection title="Timing" description="How often the agent runs.">
+            <ScheduleTimingFields
+              cron={form.cron}
+              timezone={form.timezone}
+              onCronChange={(v) => set('cron', v)}
+              onTimezoneChange={(v) => set('timezone', v)}
+            />
+          </FormSection>
+
+          <FormSection title="Activation">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label className="font-medium">Enabled</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Disabled schedules never fire on the cron — you can still test
+                  them with “Run now”.
+                </p>
+              </div>
+              <Switch
+                checked={form.isEnabled}
+                onCheckedChange={(v: boolean) => set('isEnabled', v)}
+              />
+            </div>
+
+            <Alert>
+              <IconInfoCircle className="size-4" />
+              <Alert.Title>Background runs</Alert.Title>
+              <Alert.Description>
+                Scheduled runs execute with the app token configured in General
+                Settings, not your user session. Output lands in a dedicated
+                chat thread named after the schedule.
+              </Alert.Description>
+            </Alert>
+          </FormSection>
+
+          <div className="flex gap-3 pb-4 sm:hidden">
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Schedule'}
+            </Button>
+            <Button type="button" variant="outline" asChild>
+              <Link to="/erxes-agent/schedules">Cancel</Link>
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleFormPage.tsx
@@ -22,13 +22,18 @@ import {
   toast,
 } from 'erxes-ui';
 import { PageHeader } from 'ui-modules';
-import { MASTRA_AGENTS, MASTRA_SCHEDULE, MASTRA_SCHEDULES } from '~/graphql/queries';
+import {
+  MASTRA_AGENTS,
+  MASTRA_SCHEDULE,
+  MASTRA_SCHEDULES,
+} from '~/graphql/queries';
 import {
   MASTRA_SCHEDULE_CREATE,
   MASTRA_SCHEDULE_UPDATE,
 } from '~/graphql/mutations';
 import { ScheduleTimingFields } from './ScheduleTimingFields';
 
+/** Card wrapper for one group of related form fields. */
 const FormSection = ({
   title,
   description,
@@ -47,6 +52,7 @@ const FormSection = ({
   </Card>
 );
 
+/** Labeled form control with an optional hint line. */
 const Field = ({
   label,
   hint,
@@ -69,6 +75,7 @@ interface IAgentOption {
   isEnabled: boolean;
 }
 
+/** Combobox over the enabled agents; the schedule runs against the pick. */
 const SelectAgent = ({
   value,
   onValueChange,
@@ -89,7 +96,7 @@ const SelectAgent = ({
         <Combobox.Value
           value={selected ? selected.name : value || ''}
           placeholder="Select agent…"
-          loading={loading && !agents.length && !!value}
+          loading={loading && !agents.length && Boolean(value)}
         />
       </Combobox.Trigger>
       <Combobox.Content>
@@ -120,10 +127,11 @@ const SelectAgent = ({
   );
 };
 
+/** Create/edit form for one scheduled agent run. */
 export const ScheduleFormPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const isEdit = !!id;
+  const isEdit = Boolean(id);
 
   const [form, setForm] = useState({
     name: '',
@@ -142,15 +150,15 @@ export const ScheduleFormPage = () => {
 
   useEffect(() => {
     if (isEdit && scheduleData?.mastraSchedule) {
-      const s = scheduleData.mastraSchedule;
+      const schedule = scheduleData.mastraSchedule;
       setForm({
-        name: s.name || '',
-        description: s.description || '',
-        agentId: s.agentId || '',
-        cron: s.cron || '0 9 * * *',
-        timezone: s.timezone || 'UTC',
-        prompt: s.prompt || '',
-        isEnabled: s.isEnabled ?? false,
+        name: schedule.name || '',
+        description: schedule.description || '',
+        agentId: schedule.agentId || '',
+        cron: schedule.cron || '0 9 * * *',
+        timezone: schedule.timezone || 'UTC',
+        prompt: schedule.prompt || '',
+        isEnabled: schedule.isEnabled ?? false,
       });
     }
   }, [scheduleData, isEdit]);
@@ -171,12 +179,21 @@ export const ScheduleFormPage = () => {
     mutationOptions,
   );
 
+  /** Patch one form field by key. */
   const set = (k: string, v: string | boolean) =>
     setForm((f) => ({ ...f, [k]: v }));
 
+  /** Save the schedule; the missing-agent case also disables both buttons. */
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!form.agentId) return;
+    if (!form.agentId) {
+      toast({
+        title: 'Agent required',
+        description: 'Pick the agent this schedule should run.',
+        variant: 'destructive',
+      });
+      return;
+    }
     if (isEdit) {
       updateSchedule({ variables: { _id: id, doc: form } });
     } else {
@@ -185,7 +202,9 @@ export const ScheduleFormPage = () => {
   };
 
   const isSaving = creating || updating;
+  const saveLabel = isEdit ? 'Save Changes' : 'Create Schedule';
 
+  // skipcq: JS-0415 — page scaffolding (header/breadcrumb) nests past the cap
   return (
     <div className="flex flex-col h-full">
       <PageHeader>
@@ -221,7 +240,7 @@ export const ScheduleFormPage = () => {
             form="schedule-form"
             disabled={isSaving || !form.agentId}
           >
-            {isSaving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Schedule'}
+            {isSaving ? 'Saving…' : saveLabel}
           </Button>
         </PageHeader.End>
       </PageHeader>
@@ -275,6 +294,7 @@ export const ScheduleFormPage = () => {
 
           <FormSection title="Timing" description="How often the agent runs.">
             <ScheduleTimingFields
+              key={id ?? 'new'}
               cron={form.cron}
               timezone={form.timezone}
               onCronChange={(v) => set('cron', v)}
@@ -309,8 +329,8 @@ export const ScheduleFormPage = () => {
           </FormSection>
 
           <div className="flex gap-3 pb-4 sm:hidden">
-            <Button type="submit" disabled={isSaving}>
-              {isSaving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Schedule'}
+            <Button type="submit" disabled={isSaving || !form.agentId}>
+              {isSaving ? 'Saving…' : saveLabel}
             </Button>
             <Button type="button" variant="outline" asChild>
               <Link to="/erxes-agent/schedules">Cancel</Link>

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleTimingFields.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleTimingFields.tsx
@@ -1,0 +1,364 @@
+import { useMemo, useState } from 'react';
+import { IconClock, IconWorld } from '@tabler/icons-react';
+import { Button, Combobox, Command, Input, Label, Popover } from 'erxes-ui';
+
+// ─── Friendly timing builder ──────────────────────────────────────────────────
+//
+// Most users should never see a cron string: they pick a frequency (hourly /
+// daily / weekly / monthly) plus a time, and the builder emits the cron under
+// the hood. "Custom" exposes the raw expression for everything else. A saved
+// cron that matches a simple pattern reopens in the structured view.
+
+export type ScheduleFrequency =
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'custom';
+
+interface TimingParts {
+  freq: Exclude<ScheduleFrequency, 'custom'>;
+  minute: number;
+  hour: number;
+  weekdays: number[];
+  dayOfMonth: number;
+}
+
+const DEFAULT_PARTS: TimingParts = {
+  freq: 'daily',
+  minute: 0,
+  hour: 9,
+  weekdays: [1],
+  dayOfMonth: 1,
+};
+
+const WEEKDAYS = [
+  { value: 1, label: 'Mon' },
+  { value: 2, label: 'Tue' },
+  { value: 3, label: 'Wed' },
+  { value: 4, label: 'Thu' },
+  { value: 5, label: 'Fri' },
+  { value: 6, label: 'Sat' },
+  { value: 0, label: 'Sun' },
+];
+
+const FREQUENCIES: { value: ScheduleFrequency; label: string }[] = [
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'custom', label: 'Custom (cron)' },
+];
+
+export function buildCron(parts: TimingParts): string {
+  const { freq, minute, hour, weekdays, dayOfMonth } = parts;
+  if (freq === 'hourly') return `${minute} * * * *`;
+  if (freq === 'daily') return `${minute} ${hour} * * *`;
+  if (freq === 'weekly') {
+    const days = [...weekdays].sort((a, b) => a - b).join(',');
+    return `${minute} ${hour} * * ${days || '1'}`;
+  }
+  return `${minute} ${hour} ${dayOfMonth} * *`;
+}
+
+const num = (s: string): number | null =>
+  /^\d+$/.test(s) ? parseInt(s, 10) : null;
+
+/** Expand a cron weekday field ("1,3" / "1-5") to a day list; null if fancy. */
+function expandWeekdays(field: string): number[] | null {
+  const days = new Set<number>();
+  for (const part of field.split(',')) {
+    const range = part.match(/^(\d)-(\d)$/);
+    if (range) {
+      const [from, to] = [parseInt(range[1], 10), parseInt(range[2], 10)];
+      if (from > to || to > 7) return null;
+      for (let d = from; d <= to; d++) days.add(d % 7);
+      continue;
+    }
+    const d = num(part);
+    if (d == null || d > 7) return null;
+    days.add(d % 7);
+  }
+  return days.size ? [...days] : null;
+}
+
+/** Read a cron back into builder parts; null when it needs the custom view. */
+export function parseCron(cron: string): TimingParts | null {
+  const f = cron.trim().split(/\s+/);
+  if (f.length !== 5) return null;
+  const minute = num(f[0]);
+  if (minute == null || minute > 59) return null;
+
+  if (f[1] === '*' && f[2] === '*' && f[3] === '*' && f[4] === '*') {
+    return { ...DEFAULT_PARTS, freq: 'hourly', minute };
+  }
+  const hour = num(f[1]);
+  if (hour == null || hour > 23) return null;
+
+  if (f[2] === '*' && f[3] === '*') {
+    if (f[4] === '*') return { ...DEFAULT_PARTS, freq: 'daily', minute, hour };
+    const weekdays = expandWeekdays(f[4]);
+    if (!weekdays) return null;
+    return { ...DEFAULT_PARTS, freq: 'weekly', minute, hour, weekdays };
+  }
+
+  if (f[3] === '*' && f[4] === '*') {
+    const dayOfMonth = num(f[2]);
+    if (dayOfMonth == null || dayOfMonth < 1 || dayOfMonth > 31) return null;
+    return { ...DEFAULT_PARTS, freq: 'monthly', minute, hour, dayOfMonth };
+  }
+  return null;
+}
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+function ordinal(n: number): string {
+  if (n % 100 >= 11 && n % 100 <= 13) return `${n}th`;
+  return `${n}${['th', 'st', 'nd', 'rd'][n % 10] ?? 'th'}`;
+}
+
+export function describeTiming(
+  freq: ScheduleFrequency,
+  parts: TimingParts,
+  cron: string,
+  timezone: string,
+): string {
+  const time = `${pad(parts.hour)}:${pad(parts.minute)}`;
+  const tz = timezone || 'UTC';
+  if (freq === 'hourly') {
+    return `Runs every hour at minute ${parts.minute} · ${tz}`;
+  }
+  if (freq === 'daily') return `Runs every day at ${time} · ${tz}`;
+  if (freq === 'weekly') {
+    const names = WEEKDAYS.filter((d) => parts.weekdays.includes(d.value))
+      .map((d) => d.label)
+      .join(', ');
+    return `Runs every ${names || 'Mon'} at ${time} · ${tz}`;
+  }
+  if (freq === 'monthly') {
+    return `Runs on the ${ordinal(parts.dayOfMonth)} of every month at ${time} · ${tz}`;
+  }
+  return `Runs on cron "${cron.trim() || '—'}" · ${tz}`;
+}
+
+const SelectTimezone = ({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (tz: string) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+  const zones = useMemo<string[]>(() => {
+    try {
+      // Not in the project's TS lib target yet, but present in every browser
+      // this app supports.
+      const intl = Intl as unknown as {
+        supportedValuesOf?: (key: string) => string[];
+      };
+      const all = intl.supportedValuesOf?.('timeZone') ?? [];
+      return ['UTC', ...all.filter((z) => z !== 'UTC')];
+    } catch {
+      return ['UTC'];
+    }
+  }, []);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Combobox.Trigger className="h-9">
+        <Combobox.Value value={value || 'UTC'} placeholder="Select timezone…" />
+      </Combobox.Trigger>
+      <Combobox.Content>
+        <Command>
+          <Command.Input placeholder="Search timezones…" />
+          <Command.List>
+            <Combobox.Empty />
+            {zones.map((zone) => (
+              <Command.Item
+                key={zone}
+                value={zone}
+                onSelect={() => {
+                  onValueChange(zone);
+                  setOpen(false);
+                }}
+              >
+                {zone}
+                <Combobox.Check checked={zone === (value || 'UTC')} />
+              </Command.Item>
+            ))}
+          </Command.List>
+        </Command>
+      </Combobox.Content>
+    </Popover>
+  );
+};
+
+export const ScheduleTimingFields = ({
+  cron,
+  timezone,
+  onCronChange,
+  onTimezoneChange,
+}: {
+  cron: string;
+  timezone: string;
+  onCronChange: (cron: string) => void;
+  onTimezoneChange: (timezone: string) => void;
+}) => {
+  // The cron string is the single source of truth (it's what saves). The
+  // builder view is derived from it; only the "Custom" choice is sticky local
+  // state, since a parseable cron would otherwise snap back to the builder.
+  const parsed = parseCron(cron);
+  const [customMode, setCustomMode] = useState(false);
+  const parts = parsed ?? DEFAULT_PARTS;
+  const freq: ScheduleFrequency =
+    customMode || !parsed ? 'custom' : parsed.freq;
+
+  const apply = (patch: Partial<TimingParts>) =>
+    onCronChange(buildCron({ ...parts, ...patch }));
+
+  const pickFrequency = (next: ScheduleFrequency) => {
+    if (next === 'custom') {
+      setCustomMode(true);
+      return;
+    }
+    setCustomMode(false);
+    apply({ freq: next });
+  };
+
+  const toggleWeekday = (day: number) => {
+    const has = parts.weekdays.includes(day);
+    const next = has
+      ? parts.weekdays.filter((d) => d !== day)
+      : [...parts.weekdays, day];
+    // Never allow zero selected days — a weekly schedule must fire somewhere.
+    if (next.length) apply({ weekdays: next });
+  };
+
+  const timeValue = `${pad(parts.hour)}:${pad(parts.minute)}`;
+  const onTimeChange = (v: string) => {
+    const match = v.match(/^(\d{1,2}):(\d{1,2})$/);
+    if (match) {
+      apply({ hour: parseInt(match[1], 10), minute: parseInt(match[2], 10) });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label className="font-medium">Repeats</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {FREQUENCIES.map((f) => (
+            <Button
+              key={f.value}
+              type="button"
+              variant={freq === f.value ? 'secondary' : 'outline'}
+              size="sm"
+              className="h-8"
+              onClick={() => pickFrequency(f.value)}
+            >
+              {f.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {freq === 'weekly' && (
+        <div className="space-y-1.5">
+          <Label className="font-medium">On days</Label>
+          <div className="flex flex-wrap gap-1.5">
+            {WEEKDAYS.map((d) => (
+              <Button
+                key={d.value}
+                type="button"
+                variant={
+                  parts.weekdays.includes(d.value) ? 'secondary' : 'outline'
+                }
+                size="sm"
+                className="h-8 w-12"
+                onClick={() => toggleWeekday(d.value)}
+              >
+                {d.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {freq === 'monthly' && (
+        <div className="space-y-1.5">
+          <Label className="font-medium">Day of month</Label>
+          <Input
+            type="number"
+            min={1}
+            max={31}
+            value={parts.dayOfMonth}
+            onChange={(e) => {
+              const day = parseInt(e.target.value, 10);
+              if (day >= 1 && day <= 31) apply({ dayOfMonth: day });
+            }}
+            className="w-24"
+          />
+        </div>
+      )}
+
+      {freq === 'hourly' && (
+        <div className="space-y-1.5">
+          <Label className="font-medium">At minute</Label>
+          <Input
+            type="number"
+            min={0}
+            max={59}
+            value={parts.minute}
+            onChange={(e) => {
+              const minute = parseInt(e.target.value, 10);
+              if (minute >= 0 && minute <= 59) apply({ minute });
+            }}
+            className="w-24"
+          />
+        </div>
+      )}
+
+      {(freq === 'daily' || freq === 'weekly' || freq === 'monthly') && (
+        <div className="space-y-1.5">
+          <Label className="font-medium">At time</Label>
+          <Input
+            type="time"
+            value={timeValue}
+            onChange={(e) => onTimeChange(e.target.value)}
+            className="w-32"
+          />
+        </div>
+      )}
+
+      {freq === 'custom' && (
+        <div className="space-y-1.5">
+          <Label className="font-medium">Cron expression *</Label>
+          <Input
+            value={cron}
+            onChange={(e) => onCronChange(e.target.value)}
+            placeholder="0 9 * * *"
+            className="font-mono text-sm"
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            Standard 5-field cron: minute hour day month weekday.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label className="font-medium">Timezone</Label>
+        <SelectTimezone value={timezone} onValueChange={onTimezoneChange} />
+      </div>
+
+      <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm">
+        {freq === 'custom' ? (
+          <IconClock className="size-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <IconWorld className="size-4 shrink-0 text-muted-foreground" />
+        )}
+        <span>{describeTiming(freq, parts, cron, timezone)}</span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleTimingFields.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/ScheduleTimingFields.tsx
@@ -50,6 +50,7 @@ const FREQUENCIES: { value: ScheduleFrequency; label: string }[] = [
   { value: 'custom', label: 'Custom (cron)' },
 ];
 
+/** Emit the cron expression for one structured timing choice. */
 export function buildCron(parts: TimingParts): string {
   const { freq, minute, hour, weekdays, dayOfMonth } = parts;
   if (freq === 'hourly') return `${minute} * * * *`;
@@ -61,62 +62,74 @@ export function buildCron(parts: TimingParts): string {
   return `${minute} ${hour} ${dayOfMonth} * *`;
 }
 
+/** Parse a plain decimal string; null for anything fancier. */
 const num = (s: string): number | null =>
-  /^\d+$/.test(s) ? parseInt(s, 10) : null;
+  /^\d+$/.test(s) ? Number.parseInt(s, 10) : null;
 
 /** Expand a cron weekday field ("1,3" / "1-5") to a day list; null if fancy. */
 function expandWeekdays(field: string): number[] | null {
   const days = new Set<number>();
   for (const part of field.split(',')) {
-    const range = part.match(/^(\d)-(\d)$/);
+    const range = /^(\d)-(\d)$/.exec(part);
     if (range) {
-      const [from, to] = [parseInt(range[1], 10), parseInt(range[2], 10)];
+      const from = Number.parseInt(range[1], 10);
+      const to = Number.parseInt(range[2], 10);
       if (from > to || to > 7) return null;
-      for (let d = from; d <= to; d++) days.add(d % 7);
+      for (let day = from; day <= to; day++) days.add(day % 7);
       continue;
     }
-    const d = num(part);
-    if (d == null || d > 7) return null;
-    days.add(d % 7);
+    const day = num(part);
+    if (day == null || day > 7) return null;
+    days.add(day % 7);
   }
   return days.size ? [...days] : null;
 }
 
 /** Read a cron back into builder parts; null when it needs the custom view. */
 export function parseCron(cron: string): TimingParts | null {
-  const f = cron.trim().split(/\s+/);
-  if (f.length !== 5) return null;
-  const minute = num(f[0]);
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const minute = num(fields[0]);
   if (minute == null || minute > 59) return null;
 
-  if (f[1] === '*' && f[2] === '*' && f[3] === '*' && f[4] === '*') {
+  if (
+    fields[1] === '*' &&
+    fields[2] === '*' &&
+    fields[3] === '*' &&
+    fields[4] === '*'
+  ) {
     return { ...DEFAULT_PARTS, freq: 'hourly', minute };
   }
-  const hour = num(f[1]);
+  const hour = num(fields[1]);
   if (hour == null || hour > 23) return null;
 
-  if (f[2] === '*' && f[3] === '*') {
-    if (f[4] === '*') return { ...DEFAULT_PARTS, freq: 'daily', minute, hour };
-    const weekdays = expandWeekdays(f[4]);
+  if (fields[2] === '*' && fields[3] === '*') {
+    if (fields[4] === '*') {
+      return { ...DEFAULT_PARTS, freq: 'daily', minute, hour };
+    }
+    const weekdays = expandWeekdays(fields[4]);
     if (!weekdays) return null;
     return { ...DEFAULT_PARTS, freq: 'weekly', minute, hour, weekdays };
   }
 
-  if (f[3] === '*' && f[4] === '*') {
-    const dayOfMonth = num(f[2]);
+  if (fields[3] === '*' && fields[4] === '*') {
+    const dayOfMonth = num(fields[2]);
     if (dayOfMonth == null || dayOfMonth < 1 || dayOfMonth > 31) return null;
     return { ...DEFAULT_PARTS, freq: 'monthly', minute, hour, dayOfMonth };
   }
   return null;
 }
 
+/** Zero-pad to two digits for HH:MM rendering. */
 const pad = (n: number) => String(n).padStart(2, '0');
 
+/** English ordinal suffix: 1st, 2nd, 3rd, 4th… 11th–13th included. */
 function ordinal(n: number): string {
   if (n % 100 >= 11 && n % 100 <= 13) return `${n}th`;
   return `${n}${['th', 'st', 'nd', 'rd'][n % 10] ?? 'th'}`;
 }
 
+/** Human-readable one-liner of when the schedule fires. */
 export function describeTiming(
   freq: ScheduleFrequency,
   parts: TimingParts,
@@ -136,11 +149,14 @@ export function describeTiming(
     return `Runs every ${names || 'Mon'} at ${time} · ${tz}`;
   }
   if (freq === 'monthly') {
-    return `Runs on the ${ordinal(parts.dayOfMonth)} of every month at ${time} · ${tz}`;
+    return `Runs on the ${ordinal(
+      parts.dayOfMonth,
+    )} of every month at ${time} · ${tz}`;
   }
   return `Runs on cron "${cron.trim() || '—'}" · ${tz}`;
 }
 
+/** Combobox over the browser-supported IANA timezones, UTC pinned first. */
 const SelectTimezone = ({
   value,
   onValueChange,
@@ -213,9 +229,11 @@ export const ScheduleTimingFields = ({
   const freq: ScheduleFrequency =
     customMode || !parsed ? 'custom' : parsed.freq;
 
+  /** Re-emit the cron with some builder parts changed. */
   const apply = (patch: Partial<TimingParts>) =>
     onCronChange(buildCron({ ...parts, ...patch }));
 
+  /** Switch frequency; "Custom" only flips the view, keeping the cron. */
   const pickFrequency = (next: ScheduleFrequency) => {
     if (next === 'custom') {
       setCustomMode(true);
@@ -225,6 +243,7 @@ export const ScheduleTimingFields = ({
     apply({ freq: next });
   };
 
+  /** Toggle one weekday in the weekly view. */
   const toggleWeekday = (day: number) => {
     const has = parts.weekdays.includes(day);
     const next = has
@@ -235,10 +254,14 @@ export const ScheduleTimingFields = ({
   };
 
   const timeValue = `${pad(parts.hour)}:${pad(parts.minute)}`;
+  /** Push an HH:MM time-input value into the cron. */
   const onTimeChange = (v: string) => {
-    const match = v.match(/^(\d{1,2}):(\d{1,2})$/);
+    const match = /^(\d{1,2}):(\d{1,2})$/.exec(v);
     if (match) {
-      apply({ hour: parseInt(match[1], 10), minute: parseInt(match[2], 10) });
+      apply({
+        hour: Number.parseInt(match[1], 10),
+        minute: Number.parseInt(match[2], 10),
+      });
     }
   };
 
@@ -293,7 +316,7 @@ export const ScheduleTimingFields = ({
             max={31}
             value={parts.dayOfMonth}
             onChange={(e) => {
-              const day = parseInt(e.target.value, 10);
+              const day = Number.parseInt(e.target.value, 10);
               if (day >= 1 && day <= 31) apply({ dayOfMonth: day });
             }}
             className="w-24"
@@ -310,7 +333,7 @@ export const ScheduleTimingFields = ({
             max={59}
             value={parts.minute}
             onChange={(e) => {
-              const minute = parseInt(e.target.value, 10);
+              const minute = Number.parseInt(e.target.value, 10);
               if (minute >= 0 && minute <= 59) apply({ minute });
             }}
             className="w-24"

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
@@ -12,9 +12,6 @@ import {
   IconPencil,
   IconPlayerPlay,
   IconRobot,
-  IconTrash,
-  IconToggleLeft,
-  IconToggleRight,
 } from '@tabler/icons-react';
 import {
   Badge,
@@ -39,6 +36,10 @@ import {
   MASTRA_SCHEDULE_RUN_NOW,
   MASTRA_SCHEDULE_SET_ENABLED,
 } from '~/graphql/mutations';
+import {
+  ToggleDeleteMenuItems,
+  enabledStatusColumn,
+} from '~/components/RecordTableShared';
 
 export interface IScheduleRow {
   _id: string;
@@ -170,41 +171,18 @@ const ScheduleMoreCell = ({
                 <IconPencil className="size-4" /> Edit
               </Button>
             </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8"
-                onClick={() =>
-                  setEnabled({
-                    variables: {
-                      _id: schedule._id,
-                      isEnabled: !schedule.isEnabled,
-                    },
-                  })
-                }
-              >
-                {schedule.isEnabled ? (
-                  <>
-                    <IconToggleLeft className="size-4" /> Disable
-                  </>
-                ) : (
-                  <>
-                    <IconToggleRight className="size-4" /> Enable
-                  </>
-                )}
-              </Button>
-            </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8 text-destructive"
-                onClick={handleDelete}
-              >
-                <IconTrash className="size-4" /> Delete
-              </Button>
-            </Command.Item>
+            <ToggleDeleteMenuItems
+              isEnabled={schedule.isEnabled}
+              onToggle={() =>
+                setEnabled({
+                  variables: {
+                    _id: schedule._id,
+                    isEnabled: !schedule.isEnabled,
+                  },
+                })
+              }
+              onDelete={handleDelete}
+            />
           </Command.List>
         </Command>
       </Combobox.Content>
@@ -317,24 +295,7 @@ const baseColumns: ColumnDef<IScheduleRow>[] = [
     ),
     size: 150,
   },
-  {
-    id: 'status',
-    accessorKey: 'isEnabled',
-    header: () => (
-      <RecordTable.InlineHead icon={IconToggleRight} label="Status" />
-    ),
-    cell: ({ cell }) => {
-      const isEnabled = cell.getValue() as boolean;
-      return (
-        <RecordTableInlineCell>
-          <Badge variant={isEnabled ? 'success' : 'secondary'}>
-            {isEnabled ? 'Active' : 'Disabled'}
-          </Badge>
-        </RecordTableInlineCell>
-      );
-    },
-    size: 100,
-  },
+  enabledStatusColumn<IScheduleRow>(),
   {
     id: 'lastRun',
     header: () => (

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
@@ -109,8 +109,8 @@ const ScheduleMoreCell = ({
       options: { okLabel: 'Delete', cancelLabel: 'Cancel' },
     }).then(() => removeSchedule({ variables: { _id: schedule._id } }));
 
-  // skipcq: JS-0415 — action menu scaffolding nests past the lint cap
   return (
+    // skipcq: JS-0415 — action menu scaffolding nests past the lint cap
     <Popover>
       <Popover.Trigger asChild>
         <RecordTable.MoreButton className="w-full h-full" />
@@ -384,8 +384,8 @@ export const SchedulesIndexPage = () => {
 
   const columns = useMemo(() => buildColumns(refetch), [refetch]);
 
-  // skipcq: JS-0415 — page scaffolding (header/empty state/table) nests past the cap
   return (
+    // skipcq: JS-0415 — page scaffolding (header/empty state/table) nests past the cap
     <div className="flex flex-col h-full">
       <PageHeader>
         <PageHeader.Start>

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
@@ -61,6 +61,7 @@ export interface IScheduleRow {
 
 // ─── More menu cell ───────────────────────────────────────────────────────────
 
+/** Row actions: run now, view output thread, edit, enable/disable, delete. */
 const ScheduleMoreCell = ({
   schedule,
   refetch,
@@ -101,12 +102,14 @@ const ScheduleMoreCell = ({
       toast({ title: 'Error', description: e.message, variant: 'destructive' }),
   });
 
+  /** Confirm, then remove the schedule together with its output thread. */
   const handleDelete = () =>
     confirm({
       message: `Remove "${schedule.name}" and its output thread? This cannot be undone.`,
       options: { okLabel: 'Delete', cancelLabel: 'Cancel' },
     }).then(() => removeSchedule({ variables: { _id: schedule._id } }));
 
+  // skipcq: JS-0415 — action menu scaffolding nests past the lint cap
   return (
     <Popover>
       <Popover.Trigger asChild>
@@ -140,7 +143,17 @@ const ScheduleMoreCell = ({
                 variant="ghost"
                 size="sm"
                 className="justify-start w-full h-8"
-                onClick={() => navigate(`/erxes-agent/chat/${schedule.agentId}`)}
+                disabled={!schedule.lastRunAt}
+                title={
+                  schedule.lastRunAt
+                    ? undefined
+                    : 'No output yet — the thread is created on the first run'
+                }
+                onClick={() =>
+                  navigate(
+                    `/erxes-agent/chat/${schedule.agentId}?thread=${schedule.threadId}`,
+                  )
+                }
               >
                 <IconMessageCircle className="size-4" /> View output
               </Button>
@@ -201,6 +214,14 @@ const ScheduleMoreCell = ({
 
 // ─── Columns ──────────────────────────────────────────────────────────────────
 
+/** Badge variant per run status — skipped is neutral, not a green success. */
+const STATUS_VARIANTS = {
+  failed: 'destructive',
+  skipped: 'secondary',
+  success: 'success',
+} as const;
+
+/** Status badge (with error tooltip on failure) plus relative run time. */
 const LastRunCell = ({ schedule }: { schedule: IScheduleRow }) => {
   if (!schedule.lastRunAt) {
     return (
@@ -211,7 +232,7 @@ const LastRunCell = ({ schedule }: { schedule: IScheduleRow }) => {
   }
   const failed = schedule.lastStatus === 'failed';
   const badge = (
-    <Badge variant={failed ? 'destructive' : 'success'}>
+    <Badge variant={STATUS_VARIANTS[schedule.lastStatus ?? 'success']}>
       {schedule.lastStatus}
     </Badge>
   );
@@ -325,9 +346,7 @@ const baseColumns: ColumnDef<IScheduleRow>[] = [
   {
     id: 'runCount',
     accessorKey: 'runCount',
-    header: () => (
-      <RecordTable.InlineHead icon={IconPlayerPlay} label="Runs" />
-    ),
+    header: () => <RecordTable.InlineHead icon={IconPlayerPlay} label="Runs" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <span className="text-sm tabular-nums">
@@ -341,6 +360,20 @@ const baseColumns: ColumnDef<IScheduleRow>[] = [
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
+/** The full column set, with the actions column bound to this list's refetch. */
+const buildColumns = (refetch: () => void): ColumnDef<IScheduleRow>[] => [
+  {
+    id: 'more',
+    cell: ({ row }) => (
+      <ScheduleMoreCell schedule={row.original} refetch={refetch} />
+    ),
+    size: 33,
+  },
+  RecordTable.checkboxColumn as ColumnDef<IScheduleRow>,
+  ...baseColumns,
+];
+
+/** Record table of all agent schedules with row actions. */
 export const SchedulesIndexPage = () => {
   const { data, loading, refetch } = useQuery(MASTRA_SCHEDULES, {
     fetchPolicy: 'network-only',
@@ -349,21 +382,9 @@ export const SchedulesIndexPage = () => {
 
   const schedules: IScheduleRow[] = data?.mastraSchedules || [];
 
-  const columns = useMemo<ColumnDef<IScheduleRow>[]>(
-    () => [
-      {
-        id: 'more',
-        cell: ({ row }) => (
-          <ScheduleMoreCell schedule={row.original} refetch={refetch} />
-        ),
-        size: 33,
-      },
-      RecordTable.checkboxColumn as ColumnDef<IScheduleRow>,
-      ...baseColumns,
-    ],
-    [refetch],
-  );
+  const columns = useMemo(() => buildColumns(refetch), [refetch]);
 
+  // skipcq: JS-0415 — page scaffolding (header/empty state/table) nests past the cap
   return (
     <div className="flex flex-col h-full">
       <PageHeader>
@@ -393,6 +414,7 @@ export const SchedulesIndexPage = () => {
       </PageHeader>
 
       {!loading && schedules.length === 0 ? (
+        // skipcq: JS-0415 — empty-state scaffolding nests past the lint cap
         <div className="flex-1 flex items-center justify-center p-4">
           <Empty className="border border-dashed max-w-sm w-full">
             <Empty.Header>
@@ -415,6 +437,7 @@ export const SchedulesIndexPage = () => {
           </Empty>
         </div>
       ) : (
+        // skipcq: JS-0415 — record-table scaffolding nests past the lint cap
         <div className="flex-1 min-h-0">
           <RecordTable.Provider
             columns={columns}

--- a/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/schedules/SchedulesIndexPage.tsx
@@ -1,0 +1,448 @@
+import { useMemo } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useQuery, useMutation } from '@apollo/client';
+import { ColumnDef } from '@tanstack/react-table';
+import {
+  IconPlus,
+  IconAlignLeft,
+  IconCalendarTime,
+  IconClock,
+  IconHistory,
+  IconMessageCircle,
+  IconPencil,
+  IconPlayerPlay,
+  IconRobot,
+  IconTrash,
+  IconToggleLeft,
+  IconToggleRight,
+} from '@tabler/icons-react';
+import {
+  Badge,
+  Breadcrumb,
+  Button,
+  Combobox,
+  Command,
+  Empty,
+  Popover,
+  RecordTable,
+  RecordTableInlineCell,
+  RelativeDateDisplay,
+  Separator,
+  Tooltip,
+  toast,
+  useConfirm,
+} from 'erxes-ui';
+import { PageHeader } from 'ui-modules';
+import { MASTRA_SCHEDULES } from '~/graphql/queries';
+import {
+  MASTRA_SCHEDULE_REMOVE,
+  MASTRA_SCHEDULE_RUN_NOW,
+  MASTRA_SCHEDULE_SET_ENABLED,
+} from '~/graphql/mutations';
+
+export interface IScheduleRow {
+  _id: string;
+  name: string;
+  description?: string;
+  agentId: string;
+  cron: string;
+  timezone?: string;
+  prompt: string;
+  isEnabled: boolean;
+  threadId: string;
+  lastRunAt?: string;
+  lastStatus?: 'success' | 'failed' | 'skipped';
+  lastError?: string;
+  lastDurationMs?: number;
+  runCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ─── More menu cell ───────────────────────────────────────────────────────────
+
+const ScheduleMoreCell = ({
+  schedule,
+  refetch,
+}: {
+  schedule: IScheduleRow;
+  refetch: () => void;
+}) => {
+  const navigate = useNavigate();
+  const { confirm } = useConfirm();
+
+  const [removeSchedule] = useMutation(MASTRA_SCHEDULE_REMOVE, {
+    onCompleted: () => refetch(),
+    onError: (e) =>
+      toast({ title: 'Error', description: e.message, variant: 'destructive' }),
+  });
+
+  const [setEnabled] = useMutation(MASTRA_SCHEDULE_SET_ENABLED, {
+    onCompleted: () => refetch(),
+    onError: (e) =>
+      toast({ title: 'Error', description: e.message, variant: 'destructive' }),
+  });
+
+  const [runNow, { loading: running }] = useMutation(MASTRA_SCHEDULE_RUN_NOW, {
+    onCompleted: (data) => {
+      const outcome = data?.mastraScheduleRunNow;
+      if (outcome?.lastStatus === 'failed') {
+        toast({
+          title: 'Run failed',
+          description: outcome.lastError || schedule.name,
+          variant: 'destructive',
+        });
+      } else {
+        toast({ title: 'Run finished', description: schedule.name });
+      }
+      refetch();
+    },
+    onError: (e) =>
+      toast({ title: 'Error', description: e.message, variant: 'destructive' }),
+  });
+
+  const handleDelete = () =>
+    confirm({
+      message: `Remove "${schedule.name}" and its output thread? This cannot be undone.`,
+      options: { okLabel: 'Delete', cancelLabel: 'Cancel' },
+    }).then(() => removeSchedule({ variables: { _id: schedule._id } }));
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <RecordTable.MoreButton className="w-full h-full" />
+      </Popover.Trigger>
+      <Combobox.Content
+        side="right"
+        align="start"
+        avoidCollisions={false}
+        className="w-44 min-w-0 [&>button]:cursor-pointer"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Command>
+          <Command.List>
+            <Command.Item asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full h-8"
+                disabled={running}
+                onClick={() => {
+                  toast({ title: 'Running…', description: schedule.name });
+                  runNow({ variables: { _id: schedule._id } });
+                }}
+              >
+                <IconPlayerPlay className="size-4" /> Run now
+              </Button>
+            </Command.Item>
+            <Command.Item asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full h-8"
+                onClick={() => navigate(`/erxes-agent/chat/${schedule.agentId}`)}
+              >
+                <IconMessageCircle className="size-4" /> View output
+              </Button>
+            </Command.Item>
+            <Command.Item asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full h-8"
+                onClick={() =>
+                  navigate(`/erxes-agent/schedules/edit/${schedule._id}`)
+                }
+              >
+                <IconPencil className="size-4" /> Edit
+              </Button>
+            </Command.Item>
+            <Command.Item asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full h-8"
+                onClick={() =>
+                  setEnabled({
+                    variables: {
+                      _id: schedule._id,
+                      isEnabled: !schedule.isEnabled,
+                    },
+                  })
+                }
+              >
+                {schedule.isEnabled ? (
+                  <>
+                    <IconToggleLeft className="size-4" /> Disable
+                  </>
+                ) : (
+                  <>
+                    <IconToggleRight className="size-4" /> Enable
+                  </>
+                )}
+              </Button>
+            </Command.Item>
+            <Command.Item asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full h-8 text-destructive"
+                onClick={handleDelete}
+              >
+                <IconTrash className="size-4" /> Delete
+              </Button>
+            </Command.Item>
+          </Command.List>
+        </Command>
+      </Combobox.Content>
+    </Popover>
+  );
+};
+
+// ─── Columns ──────────────────────────────────────────────────────────────────
+
+const LastRunCell = ({ schedule }: { schedule: IScheduleRow }) => {
+  if (!schedule.lastRunAt) {
+    return (
+      <RecordTableInlineCell>
+        <span className="text-xs text-muted-foreground">Never</span>
+      </RecordTableInlineCell>
+    );
+  }
+  const failed = schedule.lastStatus === 'failed';
+  const badge = (
+    <Badge variant={failed ? 'destructive' : 'success'}>
+      {schedule.lastStatus}
+    </Badge>
+  );
+  return (
+    <RecordTableInlineCell>
+      <div className="flex items-center gap-2">
+        {failed && schedule.lastError ? (
+          <Tooltip.Provider>
+            <Tooltip>
+              <Tooltip.Trigger asChild>{badge}</Tooltip.Trigger>
+              <Tooltip.Content className="max-w-sm break-words">
+                {schedule.lastError}
+              </Tooltip.Content>
+            </Tooltip>
+          </Tooltip.Provider>
+        ) : (
+          badge
+        )}
+        <RelativeDateDisplay value={schedule.lastRunAt} asChild>
+          <span className="text-xs text-muted-foreground">
+            <RelativeDateDisplay.Value value={schedule.lastRunAt} />
+          </span>
+        </RelativeDateDisplay>
+      </div>
+    </RecordTableInlineCell>
+  );
+};
+
+const baseColumns: ColumnDef<IScheduleRow>[] = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: () => (
+      <RecordTable.InlineHead icon={IconAlignLeft} label="Schedule" />
+    ),
+    cell: ({ row }) => {
+      const { _id, name, description } = row.original;
+      return (
+        <RecordTableInlineCell>
+          <Link
+            to={`/erxes-agent/schedules/edit/${_id}`}
+            className="font-medium hover:underline cursor-pointer"
+          >
+            {name}
+          </Link>
+          {description && (
+            <div className="text-xs text-muted-foreground line-clamp-1">
+              {description}
+            </div>
+          )}
+        </RecordTableInlineCell>
+      );
+    },
+    size: 260,
+  },
+  {
+    id: 'agent',
+    accessorKey: 'agentId',
+    header: () => <RecordTable.InlineHead icon={IconRobot} label="Agent" />,
+    cell: ({ cell }) => (
+      <RecordTableInlineCell>
+        <Badge variant="secondary" className="font-mono">
+          {cell.getValue() as string}
+        </Badge>
+      </RecordTableInlineCell>
+    ),
+    size: 160,
+  },
+  {
+    id: 'cron',
+    accessorKey: 'cron',
+    header: () => <RecordTable.InlineHead icon={IconClock} label="Cron" />,
+    cell: ({ row }) => (
+      <RecordTableInlineCell>
+        <span className="font-mono text-xs">{row.original.cron}</span>
+        {row.original.timezone && row.original.timezone !== 'UTC' && (
+          <span className="text-[10px] text-muted-foreground ml-1.5">
+            {row.original.timezone}
+          </span>
+        )}
+      </RecordTableInlineCell>
+    ),
+    size: 150,
+  },
+  {
+    id: 'status',
+    accessorKey: 'isEnabled',
+    header: () => (
+      <RecordTable.InlineHead icon={IconToggleRight} label="Status" />
+    ),
+    cell: ({ cell }) => {
+      const isEnabled = cell.getValue() as boolean;
+      return (
+        <RecordTableInlineCell>
+          <Badge variant={isEnabled ? 'success' : 'secondary'}>
+            {isEnabled ? 'Active' : 'Disabled'}
+          </Badge>
+        </RecordTableInlineCell>
+      );
+    },
+    size: 100,
+  },
+  {
+    id: 'lastRun',
+    header: () => (
+      <RecordTable.InlineHead icon={IconHistory} label="Last run" />
+    ),
+    cell: ({ row }) => <LastRunCell schedule={row.original} />,
+    size: 180,
+  },
+  {
+    id: 'runCount',
+    accessorKey: 'runCount',
+    header: () => (
+      <RecordTable.InlineHead icon={IconPlayerPlay} label="Runs" />
+    ),
+    cell: ({ cell }) => (
+      <RecordTableInlineCell>
+        <span className="text-sm tabular-nums">
+          {(cell.getValue() as number) || 0}
+        </span>
+      </RecordTableInlineCell>
+    ),
+    size: 70,
+  },
+];
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export const SchedulesIndexPage = () => {
+  const { data, loading, refetch } = useQuery(MASTRA_SCHEDULES, {
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const schedules: IScheduleRow[] = data?.mastraSchedules || [];
+
+  const columns = useMemo<ColumnDef<IScheduleRow>[]>(
+    () => [
+      {
+        id: 'more',
+        cell: ({ row }) => (
+          <ScheduleMoreCell schedule={row.original} refetch={refetch} />
+        ),
+        size: 33,
+      },
+      RecordTable.checkboxColumn as ColumnDef<IScheduleRow>,
+      ...baseColumns,
+    ],
+    [refetch],
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader>
+        <PageHeader.Start>
+          <Breadcrumb>
+            <Breadcrumb.List className="gap-1">
+              <Breadcrumb.Item>
+                <Button variant="ghost" asChild>
+                  <Link to="/erxes-agent/schedules">
+                    <IconCalendarTime />
+                    Schedules
+                  </Link>
+                </Button>
+              </Breadcrumb.Item>
+            </Breadcrumb.List>
+          </Breadcrumb>
+          <Separator.Inline />
+          <PageHeader.FavoriteToggleButton />
+        </PageHeader.Start>
+        <PageHeader.End>
+          <Button asChild>
+            <Link to="/erxes-agent/schedules/new">
+              <IconPlus /> New Schedule
+            </Link>
+          </Button>
+        </PageHeader.End>
+      </PageHeader>
+
+      {!loading && schedules.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center p-4">
+          <Empty className="border border-dashed max-w-sm w-full">
+            <Empty.Header>
+              <Empty.Media variant="icon">
+                <IconCalendarTime />
+              </Empty.Media>
+              <Empty.Title>No schedules yet</Empty.Title>
+              <Empty.Description>
+                Run an agent on a recurring cron — daily reports, periodic
+                checks, reminders.
+              </Empty.Description>
+            </Empty.Header>
+            <Empty.Content>
+              <Button asChild>
+                <Link to="/erxes-agent/schedules/new">
+                  <IconPlus /> Create Schedule
+                </Link>
+              </Button>
+            </Empty.Content>
+          </Empty>
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0">
+          <RecordTable.Provider
+            columns={columns}
+            data={schedules}
+            className="m-3"
+            stickyColumns={['more', 'checkbox', 'name']}
+          >
+            <RecordTable.CursorProvider
+              hasPreviousPage={false}
+              hasNextPage={false}
+              loading={loading}
+              dataLength={schedules.length}
+              sessionKey="erxes_agent_schedules"
+            >
+              <RecordTable>
+                <RecordTable.Header />
+                <RecordTable.Body>
+                  {loading && schedules.length === 0 ? (
+                    <RecordTable.RowSkeleton rows={10} />
+                  ) : (
+                    <RecordTable.RowList />
+                  )}
+                </RecordTable.Body>
+              </RecordTable>
+            </RecordTable.CursorProvider>
+          </RecordTable.Provider>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
@@ -41,8 +41,7 @@ export const GeneralSettingsPage = () => {
 
   // Read-only "Advanced memory feature" status — derived from the MASTRA_MEMORY
   // env var on the server. Displayed only; not editable from the UI.
-  const advancedMemory: boolean =
-    !!settingsData?.mastraSettings?.advancedMemory;
+  const advancedMemory = Boolean(settingsData?.mastraSettings?.advancedMemory);
   const memStatus = settingsData?.mastraSettings?.advancedMemoryStatus;
 
   // Read-only "Company knowledge" status — derived from ERXES_AGENT_KNOWLEDGE.
@@ -147,8 +146,8 @@ export const GeneralSettingsPage = () => {
               {!attachmentStorage?.configured
                 ? 'No storage'
                 : form.attachmentsEnabled
-                  ? 'On'
-                  : 'Off'}
+                ? 'On'
+                : 'Off'}
             </Badge>
           </div>
 
@@ -222,16 +221,16 @@ export const GeneralSettingsPage = () => {
                   memStatus.qdrantReachable === true
                     ? 'bg-green-500'
                     : memStatus.qdrantReachable === false
-                      ? 'bg-red-500'
-                      : 'bg-muted-foreground/40'
+                    ? 'bg-red-500'
+                    : 'bg-muted-foreground/40'
                 }`}
               />
               <span>
                 {memStatus.qdrantReachable === true
                   ? 'reachable'
                   : memStatus.qdrantReachable === false
-                    ? 'unreachable'
-                    : 'unknown'}
+                  ? 'unreachable'
+                  : 'unknown'}
               </span>
             </div>
             <div>
@@ -276,16 +275,16 @@ export const GeneralSettingsPage = () => {
                   knowledgeStatus.qdrantReachable === true
                     ? 'bg-green-500'
                     : knowledgeStatus.qdrantReachable === false
-                      ? 'bg-red-500'
-                      : 'bg-muted-foreground/40'
+                    ? 'bg-red-500'
+                    : 'bg-muted-foreground/40'
                 }`}
               />
               <span>
                 {knowledgeStatus.qdrantReachable === true
                   ? 'reachable'
                   : knowledgeStatus.qdrantReachable === false
-                    ? 'unreachable'
-                    : 'unknown'}
+                  ? 'unreachable'
+                  : 'unknown'}
               </span>
             </div>
             <div>
@@ -301,7 +300,9 @@ export const GeneralSettingsPage = () => {
             <div>
               Last sweep:{' '}
               {knowledgeStatus.lastSweepAt
-                ? `${new Date(knowledgeStatus.lastSweepAt).toLocaleString()} — ${
+                ? `${new Date(
+                    knowledgeStatus.lastSweepAt,
+                  ).toLocaleString()} — ${
                     knowledgeStatus.pointCount ?? 0
                   } points`
                 : 'not yet run'}

--- a/frontend/plugins/erxes-agent_ui/src/pages/workflows/WorkflowFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/workflows/WorkflowFormPage.tsx
@@ -11,7 +11,6 @@ import {
   Alert,
   Breadcrumb,
   Button,
-  Card,
   Input,
   Label,
   Separator,
@@ -26,6 +25,7 @@ import {
   MASTRA_WORKFLOW_UPDATE,
   MASTRA_WORKFLOW_VALIDATE,
 } from '~/graphql/mutations';
+import { Field, FormSection } from '~/components/FormLayout';
 import { WorkflowGraph } from './graph/WorkflowGraph';
 
 // Minimal valid starter so a hand-authored workflow begins from a runnable shape.
@@ -43,40 +43,6 @@ type ValidationResult = {
   ok: boolean;
   errors?: { path?: string; message: string }[];
 } | null;
-
-const FormSection = ({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) => (
-  <Card className="shadow-none">
-    <Card.Header className="pb-3">
-      <Card.Title className="text-base">{title}</Card.Title>
-      {description && <Card.Description>{description}</Card.Description>}
-    </Card.Header>
-    <Card.Content className="space-y-4">{children}</Card.Content>
-  </Card>
-);
-
-const Field = ({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}) => (
-  <div className="space-y-1.5">
-    <Label className="font-medium">{label}</Label>
-    {children}
-    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
-  </div>
-);
 
 export const WorkflowFormPage = () => {
   const { id } = useParams();

--- a/frontend/plugins/erxes-agent_ui/src/pages/workflows/WorkflowsIndexPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/workflows/WorkflowsIndexPage.tsx
@@ -11,10 +11,7 @@ import {
   IconListNumbers,
   IconPencil,
   IconPlayerPlay,
-  IconTrash,
   IconEye,
-  IconToggleLeft,
-  IconToggleRight,
   IconVersions,
 } from '@tabler/icons-react';
 import {
@@ -39,6 +36,10 @@ import {
   MASTRA_WORKFLOW_RUN_START,
   MASTRA_WORKFLOW_SET_ENABLED,
 } from '~/graphql/mutations';
+import {
+  ToggleDeleteMenuItems,
+  enabledStatusColumn,
+} from '~/components/RecordTableShared';
 import { stepCount, triggerLabel } from './shared';
 
 export interface IWorkflowRow {
@@ -141,41 +142,18 @@ const WorkflowMoreCell = ({
                 <IconPencil className="size-4" /> Edit
               </Button>
             </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8"
-                onClick={() =>
-                  setEnabled({
-                    variables: {
-                      _id: workflow._id,
-                      isEnabled: !workflow.isEnabled,
-                    },
-                  })
-                }
-              >
-                {workflow.isEnabled ? (
-                  <>
-                    <IconToggleLeft className="size-4" /> Disable
-                  </>
-                ) : (
-                  <>
-                    <IconToggleRight className="size-4" /> Enable
-                  </>
-                )}
-              </Button>
-            </Command.Item>
-            <Command.Item asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full h-8 text-destructive"
-                onClick={handleDelete}
-              >
-                <IconTrash className="size-4" /> Delete
-              </Button>
-            </Command.Item>
+            <ToggleDeleteMenuItems
+              isEnabled={workflow.isEnabled}
+              onToggle={() =>
+                setEnabled({
+                  variables: {
+                    _id: workflow._id,
+                    isEnabled: !workflow.isEnabled,
+                  },
+                })
+              }
+              onDelete={handleDelete}
+            />
           </Command.List>
         </Command>
       </Combobox.Content>
@@ -249,24 +227,7 @@ const baseColumns: ColumnDef<IWorkflowRow>[] = [
     ),
     size: 80,
   },
-  {
-    id: 'status',
-    accessorKey: 'isEnabled',
-    header: () => (
-      <RecordTable.InlineHead icon={IconToggleRight} label="Status" />
-    ),
-    cell: ({ cell }) => {
-      const isEnabled = cell.getValue() as boolean;
-      return (
-        <RecordTableInlineCell>
-          <Badge variant={isEnabled ? 'success' : 'secondary'}>
-            {isEnabled ? 'Active' : 'Disabled'}
-          </Badge>
-        </RecordTableInlineCell>
-      );
-    },
-    size: 100,
-  },
+  enabledStatusColumn<IWorkflowRow>(),
   {
     id: 'updatedAt',
     accessorKey: 'updatedAt',


### PR DESCRIPTION
## What

Adds a **schedule** module to the erxes-agent plugin so agents can run prompts on a recurring cron.

## How

**Backend (`erxes-agent_api`)**
- `mastra/schedules/scheduler.ts` — BullMQ job schedulers, one per enabled `MastraSchedule`. A reconcile job fires every 5 minutes and diffs BullMQ's job schedulers against the current set of enabled schedules (upsert/remove). Mongo stays the single source of truth, so the system self-heals after Redis flushes. Multi-tenant aware (per-org in SaaS mode).
- `mastra/schedules/runner.ts` — executes one schedule's prompt against its agent; stale/disabled schedules are skipped.
- `modules/schedule/` — `MastraSchedule` model + definitions, GraphQL schema/queries/mutations, and a cron validation helper with unit tests.
- Invalid cron/timezone on one schedule is isolated so it can't break reconciliation of others.

**Frontend (`erxes-agent_ui`)**
- Schedules index page, create/edit form, and timing fields (cron presets + timezone).
- Wired into the agent plugin navigation.

## Notes
- Builds on the agent plugin introduced in #7985.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent scheduling: cron + timezone support, background tenant-aware scheduler, immediate "Run now"

* **UI**
  * Full schedule management: list, create/edit form, friendly timing controls, enable/disable, run history, navigation entry and routes; deep-link from chat

* **GraphQL**
  * Queries and mutations for schedule CRUD and execution

* **Tests**
  * Cron and timezone validation unit tests

* **Bug Fixes**
  * More robust run recording, error handling and stale-scheduler pruning during scheduled runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->