### PR TITLE
ci(erxes-agent): add Dockerfile and image build workflow

### DIFF
--- a/.github/workflows/ci-api-erxes-agent.yml
+++ b/.github/workflows/ci-api-erxes-agent.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -49,21 +49,21 @@ jobs:
         run: pnpm nx build erxes-agent_api
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image (multi-platform)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: backend/plugins/erxes-agent_api/Dockerfile

--- a/.github/workflows/ci-api-erxes-agent.yml
+++ b/.github/workflows/ci-api-erxes-agent.yml
@@ -1,0 +1,74 @@
+name: CI plugin--erxes-agent_api
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/plugins/erxes-agent_api/**'
+      - 'backend/erxes-api-shared/**'
+      - '.github/workflows/ci-api-erxes-agent.yml'
+  pull_request:
+    paths:
+      - 'backend/plugins/erxes-agent_api/**'
+      - 'backend/erxes-api-shared/**'
+      - '.github/workflows/ci-api-erxes-agent.yml'
+
+env:
+  NX_DAEMON: false
+
+jobs:
+  erxes-agent_api-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Set environment variables
+        run: |
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+
+      - name: Build shared module
+        run: pnpm nx build erxes-api-shared
+
+      - name: Build erxes-agent_api
+        run: pnpm nx build erxes-agent_api
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image (multi-platform)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: backend/plugins/erxes-agent_api/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            erxes/erxes-next-erxes-agent_api:latest
+            erxes/erxes-next-erxes-agent_api:${{ env.DATE }}-${{ env.SHORT_SHA }}

--- a/backend/plugins/erxes-agent_api/Dockerfile
+++ b/backend/plugins/erxes-agent_api/Dockerfile
@@ -1,0 +1,57 @@
+# Stage 1: install production deps as flat real directories (no pnpm virtual store)
+FROM node:22-alpine3.22 AS installer
+WORKDIR /app
+RUN npm install -g pnpm@9
+
+COPY pnpm-lock.yaml ./
+COPY backend/plugins/erxes-agent_api/package.json backend/plugins/erxes-agent_api/
+COPY backend/erxes-api-shared/package.json backend/erxes-api-shared/
+RUN node -e "\
+const fs = require('fs'); \
+const shared = require('./backend/erxes-api-shared/package.json'); \
+const service = require('./backend/plugins/erxes-agent_api/package.json'); \
+const dependencies = { \
+  ...(shared.dependencies || {}), \
+  ...(service.dependencies || {}), \
+}; \
+delete dependencies['erxes-api-shared']; \
+fs.writeFileSync( \
+  'package.json', \
+  JSON.stringify( \
+    { name: 'runtime-deps', version: '1.0.0', private: true, dependencies }, \
+    null, \
+    2, \
+  ), \
+); \
+" \
+    && pnpm install --prod --shamefully-hoist --no-frozen-lockfile \
+    && find node_modules -type f \( \
+         -name "*.d.ts" -o -name "*.map" -o -name "*.md" \
+         -o -name "LICENSE*" -o -name "LICENCE*" \
+         -o -name "CHANGELOG*" -o -name "README*" \
+         -o -name "CONTRIBUTING*" -o -name "AUTHORS*" \
+         -o -name ".npmignore" -o -name ".eslintrc*" -o -name "Makefile" \
+       \) -delete \
+    && find node_modules -mindepth 2 -maxdepth 3 -type d \( \
+         -name "test" -o -name "tests" -o -name "__tests__" -o -name "spec" \
+         -o -name "docs" -o -name "doc" -o -name "examples" -o -name "example" \
+         -o -name ".github" -o -name "coverage" \
+       \) -prune -exec rm -rf {} \; 2>/dev/null || true
+# Stage 2: minimal runtime
+FROM node:22-alpine3.22
+WORKDIR /app
+
+COPY --from=installer /app/node_modules ./node_modules
+
+RUN rm -rf ./node_modules/erxes-api-shared
+COPY backend/erxes-api-shared/dist ./node_modules/erxes-api-shared/dist
+COPY backend/erxes-api-shared/utils ./node_modules/erxes-api-shared/utils
+COPY backend/erxes-api-shared/core-types ./node_modules/erxes-api-shared/core-types
+COPY backend/erxes-api-shared/core-modules ./node_modules/erxes-api-shared/core-modules
+COPY backend/erxes-api-shared/package.json ./node_modules/erxes-api-shared/
+
+COPY backend/plugins/erxes-agent_api/dist ./dist
+
+ENV NODE_ENV=production
+USER 1000
+CMD ["node", "dist/src/main.js"]

--- a/backend/plugins/erxes-agent_api/package.json
+++ b/backend/plugins/erxes-agent_api/package.json
@@ -24,6 +24,7 @@
     "erxes-api-shared": "workspace:^",
     "exceljs": "^4.4.0",
     "fastembed": "^2.1.0",
+    "graphql-tag": "^2.12.6",
     "mammoth": "^1.11.0",
     "pdf-parse": "^1.1.1",
     "zod": "^3.25.0"


### PR DESCRIPTION
## What

Adds Docker image publishing for the `erxes-agent` plugin, which currently has no Dockerfile and no CI image workflow — so there is nothing to pull on production servers.

- **`backend/plugins/erxes-agent_api/Dockerfile`** — same two-stage pattern as every other backend plugin (operation_api): flat production-deps installer stage + minimal `node:22-alpine` runtime that copies the prebuilt `dist` artifacts.
- **`.github/workflows/ci-api-erxes-agent.yml`** — mirrors `ci-api-operation.yml`; builds on PRs touching the plugin or `erxes-api-shared`, and on pushes to `main` publishes `erxes/erxes-next-erxes-agent_api:latest` plus a `<date>-<sha>` tag (linux/amd64 + linux/arm64).
- **`package.json`** — declares `graphql-tag`, which `src/apollo/typeDefs.ts` imports but previously only resolved through monorepo hoisting; the flat Docker install crashes at boot without it (`Error: Cannot find module 'graphql-tag'`). All other plugins already declare it.

## How it was verified

Built the image locally from this branch and ran it against live MongoDB/Redis/Qdrant:

- boots clean: `erxes-agent graphql api ready`, joins the gateway as `plugin-erxes-agent-api`
- `[mastra:memory] Advanced memory ready — collection mastra_memory_text_embedding_3_large_3072` (Qdrant collection auto-created)
- knowledge sync, learning sweep, workflow-schedule and agent-schedule workers all start

Without the `graphql-tag` fix the container exits immediately at module load, which is how the missing dependency was caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented a CI workflow to run build and test steps automatically on relevant changes, including automated package installation and project builds.
  * Added automated Docker build and multi-platform image publishing (amd64/arm64) for the plugin, with conditional pushing for main-line releases.
  * Updated runtime dependencies to add GraphQL support for the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->