### PR TITLE
ci(release): add erxes-agent_api image to release tag matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           - erxes/erxes-next-mongolian_api
           - erxes/erxes-next-posclient_api
           - erxes/erxes-next-insurance_api
+          - erxes/erxes-next-erxes-agent_api
           - erxes/erxes-next-logs
           - erxes/erxes-next-automations
           - erxes/erxes-next-ui


### PR DESCRIPTION
## What

Adds `erxes/erxes-next-erxes-agent_api` to the Docker image matrix in `release.yml`.

## Why

The erxes-agent_api image build was added in #8006 and is pushed as `:latest` on every main build, but the Release workflow never re-tags it with the release version. Cutting a release today would stamp every other service with the version tag while leaving erxes-agent_api unpinned — deployments pinning to a release version would have no agent image to pull.

## Notes

- Image name matches what `ci-api-erxes-agent.yml` pushes (`erxes/erxes-next-erxes-agent_api:latest`).
- The first release tag after this merge requires at least one main build of the agent image to have completed (so `:latest` exists) — already true since #8006 merged.

## Summary by Sourcery

Build:
- Include erxes/erxes-next-erxes-agent_api in the Docker image matrix used by the release workflow for version tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to support additional deployment images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->