### PR TITLE
fix(erxes-agent): publish plugin UI to CDN and fix dashed remote name

### DIFF
--- a/.github/workflows/ci-ui-erxes-agent.yml
+++ b/.github/workflows/ci-ui-erxes-agent.yml
@@ -1,0 +1,67 @@
+name: CI plugin-erxes-agent_ui
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]*'
+    paths:
+      - 'frontend/plugins/erxes-agent_ui/**'
+      - 'frontend/libs/**'
+      - '.github/workflows/ci-ui-erxes-agent.yml'
+  pull_request:
+    paths:
+      - 'frontend/plugins/erxes-agent_ui/**'
+      - 'frontend/libs/**'
+      - '.github/workflows/ci-ui-erxes-agent.yml'
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  erxes-agent_ui-ci:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Set environment variables
+        run: |
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+      - name: Build erxes-agent UI
+        run: |
+          export NX_DAEMON=false
+          pnpm nx build erxes-agent_ui
+
+      - name: Sync to Cloudflare R2
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            FOLDER="${{ github.ref_name }}"
+          else
+            FOLDER="latest"
+          fi
+          aws s3 sync dist/frontend/plugins/erxes-agent_ui s3://erxes-next/$FOLDER/erxes-agent_ui/ \
+            --endpoint-url https://7c8392aff8ac4518aa06dfa4b6337ef2.r2.cloudflarestorage.com

--- a/backend/core-api/src/modules/organization/routes.ts
+++ b/backend/core-api/src/modules/organization/routes.ts
@@ -77,6 +77,12 @@ router.get('/get-frontend-plugins', async (_req: Request, res: Response) => {
     }
   };
 
+  // Module-federation container names cannot contain dashes — Nx builds
+  // "erxes-agent_ui" as global `erxes_agent_ui` — so the runtime remote name
+  // must use underscores while the CDN path keeps the plugin's real name.
+  const remoteName = (pluginName: string): string =>
+    `${pluginName.replace(/-/g, '_')}_ui`;
+
   if (VERSION === 'saas') {
     const remotes: { name: string; entry: string }[] = [];
     const subdomain = getSubdomain(_req);
@@ -99,7 +105,7 @@ router.get('/get-frontend-plugins', async (_req: Request, res: Response) => {
         if (enabledPluginsArray.includes(pluginName)) {
           const version = await getPluginVersion(pluginName);
           remotes.push({
-            name: `${pluginName}_ui`,
+            name: remoteName(pluginName),
             entry: `https://plugins.erxes.io/${version}/${pluginName}_ui/remoteEntry.js`,
           });
         }
@@ -124,7 +130,7 @@ router.get('/get-frontend-plugins', async (_req: Request, res: Response) => {
       for (const plugin of ENABLED_PLUGINS.split(',')) {
         const version = await getPluginVersion(plugin);
         remotes.push({
-          name: `${plugin}_ui`,
+          name: remoteName(plugin),
           entry: `https://plugins.erxes.io/${version}/${plugin}_ui/remoteEntry.js`,
         });
       }


### PR DESCRIPTION
## What

Two fixes required for the erxes-agent plugin UI to appear in production:

1. **Add `ci-ui-erxes-agent.yml`** (mirrors `ci-ui-operation.yml`, SHA-pinned actions): builds `erxes-agent_ui` and syncs it to the `erxes-next` R2 bucket — `latest/erxes-agent_ui/` on main pushes, `<version>/erxes-agent_ui/` on release tags. Without this the remote entry URL 404s.

2. **Normalize the runtime remote name in `/get-frontend-plugins`**: the endpoint registers the remote as `erxes-agent_ui`, but Nx builds the module-federation container global as `erxes_agent_ui` — dashes are invalid in container names, so `loadRemote` can never resolve it. The remote `name` is now normalized to underscores while the CDN path keeps the dashed plugin folder. No-op for every existing plugin (none contain dashes).

## Why

Together with #8006 (API image) and #8007 (release matrix), this is the last piece needed before a release can ship the erxes-agent plugin to production: API image ✅ → release tagging ✅ → UI bundle + resolvable remote (this PR).

## Testing

- Verified the dashed-name failure and the underscore fix locally against `/get-frontend-plugins`.
- Workflow mirrors the existing UI CI pattern; same secrets (`AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established GitHub Actions CI/CD automation for continuous integration, building, and deployment of frontend plugins to cloud storage infrastructure. The workflow triggers automatically on code pushes to main, tag releases, and pull requests when relevant components change.
  * Standardized Module Federation plugin naming conventions by updating the plugin registration mechanism. This ensures consistent plugin identification across the system and improves overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->