### PR TITLE
feat(agents): single /erxes entry point + feature-map intent routing

### DIFF
--- a/.agents/ROUTER.md
+++ b/.agents/ROUTER.md
@@ -1,0 +1,320 @@
+# .agents/ROUTER.md — THE single entry point for building in erxes
+
+> You were given a user request like **"I want ..."**. This file is your script.
+> **Read it top to bottom and DO each step in order. Do not jump ahead. Do not
+> start coding until STEP 5 says you may.** Every step tells you the exact
+> command to run and the exact decision to make. When a step says STOP, stop.
+>
+> You do NOT need to read any other file to start. This file pulls in what you
+> need, when you need it. Ignore `manifest.yaml`'s longer protocol — it is
+> reference material; THIS file is the procedure.
+
+If you are an experienced agent: this still applies to you. The value is the
+deterministic location lookup in STEP 2 and the confirmation gate in STEP 5.
+
+---
+
+## The whole flow in one picture
+
+```
+"I want ..."
+  STEP 1  Classify the action ........... create | fix | change | new-plugin
+  STEP 2  Resolve WHERE (grep the map) ... plugin + module + frontend/backend
+  STEP 3  Open the reference file ........ a REAL file to copy, not invent
+  STEP 4  Ask 1–3 INTENT questions ....... about the OUTCOME, never "which plugin"
+  STEP 5  Show scope block, WAIT for "yes"  ← the only gate. No coding before this.
+  STEP 6  Load ONLY the rules you need ... tiered by scope, not all 14
+  STEP 7  Build by copying the reference . + run the matching skill
+  STEP 8  Self-check ..................... machine-checkable list, then PR loop
+```
+
+---
+
+## STEP 0 — Load the two always-on rules (takes 1 minute)
+
+Read these two files **in full**. They are short and they are non-negotiable for
+every task:
+
+```bash
+cat .agents/rules/non-negotiable.md
+cat .agents/rules/code-style.md
+```
+
+You are responsible for every MUST/NEVER in `non-negotiable.md`. The most common
+ones a model breaks: no `default` exports, no `any`, no half-built CRUD, no
+cross-plugin imports, named GraphQL operations only. Keep them in mind the whole
+time.
+
+---
+
+## STEP 1 — Classify the action
+
+Read the user's words and pick ONE action. This decides everything downstream.
+
+| The user is saying… | action | typical scope |
+|---|---|---|
+| "I want / add / create / build / new X" | `create` | usually `both` |
+| "X is broken / wrong / not working / slow / looks bad" | `fix` | minimal — where the bug is |
+| "change / update / improve / rename / move X" | `change` | follows the thing changed |
+| "build a whole new plugin / product area for X" | `new-plugin` | full scaffold |
+
+Write down: `action = <one of the four>`. If you genuinely cannot tell create
+vs change, treat it as `change` (it is the safer superset).
+
+---
+
+## STEP 2 — Resolve WHERE this lives (the accuracy step — do not guess)
+
+You will NOT ask the user "which plugin?". You will look it up.
+
+1. Pull the **main nouns** out of the request (the things, not the verbs).
+   Example: "I want customers to see their loyalty points" → nouns:
+   `customers`, `loyalty points`.
+
+2. Grep the feature map for each noun:
+
+```bash
+grep -in "loyalty\|points\|customer" .agents/maps/feature-map.yaml
+```
+
+3. Decide from the matches:
+
+   - **Exactly one entry matches** → that entry is your location. Read its
+     `plugin`, `scope`, `frontend`, `backend`, and any `reference_*` lines.
+     Write down the scope block (see STEP 5). Go to STEP 3.
+
+   - **Zero entries match** → do NOT invent a plugin. Jump to STEP 4 and ask the
+     `disambiguation.unknown` question from the map. After the answer, grep
+     again with the new nouns.
+
+   - **Two or more entries match** (e.g. "customer" hits contacts + insurance +
+     inbox) → open the `disambiguation:` section of the map, find the matching
+     block, and ask its `ask:` question in STEP 4. The answer's `entry:` is your
+     location. **This is still an intent question, not a plugin question** — you
+     are asking what they want to happen, and the map turns that into a plugin.
+
+4. Note the `scope` value:
+   - `frontend` → you will only touch `frontend/plugins/<x>_ui` or `core-ui`.
+   - `backend` → only `backend/plugins/<x>_api` or `core-api`.
+   - `both` → frontend + backend (most "I want a new feature" requests).
+   - `core` → it lives in `core-api` / `core-ui` and is shared by ALL plugins.
+     **Editing core is high-impact. Say so in STEP 5 and get explicit confirm.**
+
+> Rule of thumb the map encodes for you: a brand-new custom field on an existing
+> thing is usually `properties` (core), NOT a new schema field in the plugin.
+> Trust the map's `note:` lines.
+
+---
+
+## STEP 3 — Open the reference file (copy, don't invent)
+
+The matched entry names a real file in `reference_table` / `reference_board` /
+`reference_detail` / `reference_entity_def` / `reference_create`, or you can use
+the generic anchors under `ui_patterns:` in the map.
+
+**Open it and read it fully:**
+
+```bash
+cat <the reference path from the map>
+# also list its siblings to learn the folder shape:
+ls <the module path from the map>
+```
+
+You will COPY this file's structure (imports, exports, hooks, naming) for the new
+code. erxes is highly patterned — the right answer almost always looks like the
+nearest existing sibling. If the entry has no reference, use the `ui_patterns`
+anchor that matches what you're building (table / form / detail).
+
+If you cannot find any sibling pattern in the target plugin, run:
+
+```bash
+.agents/scripts/assemble-context.sh <module path> <skill-name>
+```
+
+---
+
+## STEP 4 — Ask 1–3 INTENT questions (the clarification mechanism)
+
+You now know WHERE. You do NOT yet know exactly WHAT "done" means. Ask the user —
+but **only about the outcome**, and **at most 3 questions**.
+
+**NEVER ask:** which plugin, frontend or backend, which module, what components,
+what file names. You already resolved those in STEP 2. Asking them is a failure.
+
+**DO ask** (pick the template for your action; skip a question if the request
+already answered it):
+
+`action = create`
+1. "Who uses this and what should they be able to *do* with it?"
+2. "What does *done* look like — a list page, a form to add/edit, a board, a
+   widget on another screen, or several of these?"
+3. "Full create + edit + delete, or read-only for now?"
+
+`action = fix`
+1. "What exactly happens now, and what *should* happen instead?"
+2. "Give me one concrete example — a record, a click, or a value — where it goes
+   wrong."
+
+`action = change`
+1. "After the change, what's different for the user compared to today?"
+2. "Should everything that works today keep working unchanged (existing data,
+   existing screens)?"
+
+`action = new-plugin`
+1. "What is the ONE core thing users will manage in this plugin?"
+2. "Is *done* basic create/list/edit/delete, or a specific workflow beyond CRUD?"
+
+If STEP 2 returned **2+ matches**, your FIRST question is the map's
+`disambiguation` `ask:` — framed as outcome, with its options. Then continue
+with the action template above if needed.
+
+For Claude Code: ask these with the **AskUserQuestion** tool (one call, up to the
+allowed options). For other tools: ask in plain text and wait. **Do not proceed
+without answers.**
+
+---
+
+## STEP 5 — Show the scope block and WAIT for confirmation (THE GATE)
+
+This is the only gate. Build NOTHING before the user confirms. Print exactly:
+
+```
+Here's what I'm about to build:
+
+  Action:    <create | fix | change | new-plugin>
+  Plugin:    <plugin name from the map>      (impact: <plugin-local | CORE = all plugins>)
+  Module:    <module path>
+  Scope:     <frontend | backend | both | core>
+  Done when: <one line restating the user's confirmed outcome>
+  Pattern:   I'll copy <reference file from STEP 3>
+  Touches:   <bullet list — e.g. RecordTable, create Sheet, Mongoose entity, GraphQL ops, translations>
+
+Build this? (yes / tell me what to change)
+```
+
+- User says **yes / correct / go** → STEP 6.
+- User changes something → update the block, print it again, wait again.
+- User is unsure → ask ONE more intent question, then re-print. Never start
+  coding on an unconfirmed scope.
+
+> There is no JSON state file and no preflight script in this flow. The printed
+> block + the user's "yes" IS the gate. (Legacy `detect-scope`/`intake` skills
+> and `preflight-check.sh` describe an older mechanism — you do not need them;
+> this step replaces them.)
+
+---
+
+## STEP 6 — Load ONLY the rules this scope needs (tiered)
+
+Do not read all 14 rule files. Read STEP 0's two, plus the rows below that match
+your scope. This keeps your context focused.
+
+| If your scope/touch includes… | also read |
+|---|---|
+| any TypeScript at all | `.agents/rules/typescript-guidelines.md` |
+| frontend (UI, React) | `react-general-guidelines.md`, `react-state-management.md`, `file-structure.md` |
+| user-visible text/labels | `translations.md` |
+| backend (API, resolvers, models) | `architecture.md`, `file-structure.md` |
+| a DB migration / data backfill | `server-migrations.md` |
+| running builds/tests/nx | `nx-rules.md` |
+| writing or touching tests | `testing-guidelines.md` |
+| `.github/workflows/*` | `github-actions-security.md` |
+| a brand-new plugin | read the `create-plugin` skill + `architecture.md` |
+| editing files under `.agents/` | `feedback-incorporation.md` |
+
+Then load the **skill** for what you're building (read its `SKILL.md` and
+`contract.yaml`):
+
+| You are building… | skill |
+|---|---|
+| a list/table screen | `create-table` |
+| a page + route | `create-page` |
+| a create/edit form (sheet/drawer/dialog) | `create-form-drawer` |
+| a popup/dialog/modal | `create-modal` |
+| a GraphQL query/mutation + hook | `create-query` |
+| a Mongoose entity/model | `create-backend-entity` |
+| a data migration/backfill | `create-backend-migration` |
+| a React provider/context | `create-provider-context` |
+| translation keys | `add-translations` |
+| a Module Federation expose | `module-federation-expose` |
+| nav / settings entry | `configure-plugin-navigation` |
+| a whole new plugin | `create-plugin` |
+| fixing lint/TS/Sonar | `fix-sonar` |
+
+```bash
+cat .agents/skills/<skill>/SKILL.md
+cat .agents/skills/<skill>/contract.yaml
+```
+
+A `both`-scope feature usually chains several skills (e.g. create-backend-entity
+→ create-query → create-table → create-form-drawer). The contract's
+`composes_with:` lists the chain.
+
+---
+
+## STEP 7 — Build by copying the reference
+
+1. Make the smallest change that satisfies the confirmed scope. Copy the STEP 3
+   reference's structure; match naming, exports, and folder layout of its
+   siblings.
+2. Backend GraphQL ops MUST be named + plugin-prefixed (`salesDealList`, not
+   `list`). Named exports only. No `any`. No `default` exports in app code.
+3. If you scaffolded anything (`create-plugin`), the generated code VIOLATES the
+   rules on purpose — you MUST fix every default export, `any`, placeholder, and
+   `schemaWrapper` before moving on.
+4. Keep each commit small and one-purpose. Don't refactor unrelated files.
+
+---
+
+## STEP 8 — Self-check before you call it done
+
+Run the validations for what you touched:
+
+```bash
+# frontend plugin
+pnpm nx lint <plugin>_ui && pnpm nx build <plugin>_ui
+# backend plugin
+pnpm nx build erxes-api-shared && pnpm nx build <plugin>_api
+# rules compliance on the files you changed
+.agents/scripts/check-rules.sh <path you edited>
+```
+
+Then walk this list — every box must be true:
+
+- [ ] Scope matches the STEP 5 block the user confirmed (no scope creep).
+- [ ] No `default` export in app code; named exports only.
+- [ ] No `any`; types are real.
+- [ ] CRUD is complete if you started it (list has create+edit+delete, buttons
+      have handlers) — no half-features.
+- [ ] No cross-plugin imports; no new UI system; reused existing components.
+- [ ] GraphQL ops are named + plugin-prefixed.
+- [ ] User-visible strings go through `t('...')` and exist in `locales/en.json`.
+- [ ] Lint + build pass.
+
+If you opened a PR, you are NOT done until the **pr-review-loop** skill settles
+(all AI-reviewer comments addressed, CI green):
+
+```bash
+cat .agents/skills/pr-review-loop/SKILL.md
+```
+
+---
+
+## Hard stops (halt and ask the user)
+
+- The map returns 0 matches AND the `unknown` question didn't clarify it.
+- The change requires editing **core** (`core-api`/`core-ui`) and the user only
+  expected a plugin change.
+- A scaffold or build error you can't fix in 2 attempts.
+- The confirmed scope turns out to need a cross-plugin contract change.
+
+When you halt: say exactly what's blocking and what you tried. Don't guess, don't
+fabricate success, don't invent a PR URL.
+
+---
+
+## One-line summary for the model
+
+**Classify → grep the map for WHERE → open the reference → ask only about the
+OUTCOME → get a "yes" on the scope block → load just the rules you need → copy
+the reference → self-check.** Never ask which plugin; never code before the yes.

--- a/.agents/ROUTER.md
+++ b/.agents/ROUTER.md
@@ -16,7 +16,7 @@ deterministic location lookup in STEP 2 and the confirmation gate in STEP 5.
 
 ## The whole flow in one picture
 
-```
+```text
 "I want ..."
   STEP 1  Classify the action ........... create | fix | change | new-plugin
   STEP 2  Resolve WHERE (grep the map) ... plugin + module + frontend/backend
@@ -30,13 +30,14 @@ deterministic location lookup in STEP 2 and the confirmation gate in STEP 5.
 
 ---
 
-## STEP 0 — Load the two always-on rules (takes 1 minute)
+## STEP 0 — Load the always-on rules (takes 1 minute)
 
-Read these two files **in full**. They are short and they are non-negotiable for
-every task:
+Read these three files **in full**. They are short and they are non-negotiable
+for every task:
 
 ```bash
 cat .agents/rules/non-negotiable.md
+cat .agents/rules/architecture.md
 cat .agents/rules/code-style.md
 ```
 
@@ -92,6 +93,12 @@ grep -in "loyalty\|points\|customer" .agents/maps/feature-map.yaml
      block, and ask its `ask:` question in STEP 4. The answer's `entry:` is your
      location. **This is still an intent question, not a plugin question** — you
      are asking what they want to happen, and the map turns that into a plugin.
+
+   - **The match is a `ui_patterns` anchor (its id starts with `_`)** → it gives
+     you a reference file + skill but NOT a `plugin`/`scope`. The location is
+     still unknown: ask which existing feature or screen this attaches to (an
+     outcome question), grep that noun, and resolve a real entry **before** you
+     fill the STEP 5 scope block.
 
 4. Note the `scope` value:
    - `frontend` → you will only touch `frontend/plugins/<x>_ui` or `core-ui`.
@@ -178,7 +185,7 @@ without answers.**
 
 This is the only gate. Build NOTHING before the user confirms. Print exactly:
 
-```
+```text
 Here's what I'm about to build:
 
   Action:    <create | fix | change | new-plugin>
@@ -206,20 +213,20 @@ Build this? (yes / tell me what to change)
 
 ## STEP 6 — Load ONLY the rules this scope needs (tiered)
 
-Do not read all 14 rule files. Read STEP 0's two, plus the rows below that match
-your scope. This keeps your context focused.
+Do not read all 14 rule files. Read STEP 0's three, plus the rows below that
+match your scope. This keeps your context focused.
 
 | If your scope/touch includes… | also read |
 |---|---|
 | any TypeScript at all | `.agents/rules/typescript-guidelines.md` |
 | frontend (UI, React) | `react-general-guidelines.md`, `react-state-management.md`, `file-structure.md` |
 | user-visible text/labels | `translations.md` |
-| backend (API, resolvers, models) | `architecture.md`, `file-structure.md` |
+| backend (API, resolvers, models) | `file-structure.md` (architecture.md is already always-on from STEP 0) |
 | a DB migration / data backfill | `server-migrations.md` |
 | running builds/tests/nx | `nx-rules.md` |
 | writing or touching tests | `testing-guidelines.md` |
 | `.github/workflows/*` | `github-actions-security.md` |
-| a brand-new plugin | read the `create-plugin` skill + `architecture.md` |
+| a brand-new plugin | read the `create-plugin` skill |
 | editing files under `.agents/` | `feedback-incorporation.md` |
 
 Then load the **skill** for what you're building (read its `SKILL.md` and

--- a/.agents/manifest.yaml
+++ b/.agents/manifest.yaml
@@ -1,7 +1,12 @@
 # .agents/manifest.yaml
 # Agent Manifest Protocol (AMP) v1.0
-# This file is the root contract for all AI agents working in this repository.
-# Agents MUST read this file first before any other .agents/ content.
+# This file is the registry + reference contract for the .agents/ system.
+#
+# >>> THE ENTRY POINT IS .agents/ROUTER.md (run via the /erxes command). <<<
+# Start there. ROUTER is the linear procedure; this manifest is the data it
+# (and humans) reference: rule layers, skill registry, plugin registry. You do
+# NOT need to execute the longer step-by-step "protocol:" block below — ROUTER
+# replaces it. The protocol block is kept for back-compat and tooling.
 
 version: "1.0.0"
 schema: "https://erxes.io/schemas/agent-manifest-v1"
@@ -250,10 +255,9 @@ plugins:
       nx_name: "mongolian_ui"
       path: "frontend/plugins/mongolian_ui"
       status: "active"
-    - name: "agent-assistant"
-      nx_name: "agent-assistant_ui"
-      path: "frontend/plugins/agent-assistant_ui"
-      port: 3015
+    - name: "erxes-agent"
+      nx_name: "erxes-agent_ui"
+      path: "frontend/plugins/erxes-agent_ui"
       status: "active"
   backend:
     - name: "content"
@@ -296,9 +300,9 @@ plugins:
       nx_name: "mongolian_api"
       path: "backend/plugins/mongolian_api"
       status: "active"
-    - name: "agent-assistant"
-      nx_name: "agent-assistant_api"
-      path: "backend/plugins/agent-assistant_api"
+    - name: "erxes-agent"
+      nx_name: "erxes-agent_api"
+      path: "backend/plugins/erxes-agent_api"
       status: "active"
     - name: "posclient"
       nx_name: "posclient_api"
@@ -399,8 +403,13 @@ validation:
 # How agents must behave when using this system.
 
 protocol:
-  # Step 1: ALWAYS read manifest.yaml first
-  entry_point: ".agents/manifest.yaml"
+  # THE entry point. Run this single linear file (via /erxes). It supersedes the
+  # numbered steps below (assemble-context → detect-scope → preflight → intake).
+  entry_point: ".agents/ROUTER.md"
+  command: "/erxes \"I want ...\""
+
+  # Legacy step-by-step protocol (reference only — ROUTER replaces this flow):
+  legacy_entry_point: ".agents/manifest.yaml"
 
   # Step 2: Load base context
   base_context_required: true

--- a/.agents/maps/feature-map.yaml
+++ b/.agents/maps/feature-map.yaml
@@ -1,0 +1,583 @@
+# .agents/maps/feature-map.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# FEATURE MAP — the intent→location lookup table.
+#
+# PURPOSE: turn a user's plain words ("I want customers to see their points")
+# into an exact location (plugin + module + frontend/backend + a real file to
+# copy). This is the accuracy backbone. ROUTER.md greps this file in STEP 2.
+#
+# HOW THE ROUTER USES THIS FILE (do not skip):
+#   grep -in "<noun from user>" .agents/maps/feature-map.yaml
+#   Every entry has a `keywords:` line packed with synonyms so ONE grep hits it.
+#   - 1 entry matched  -> that is the location. Proceed.
+#   - 0 entries matched -> ask ONE intent question (see disambiguation: unknown).
+#   - 2+ entries matched -> ask the outcome-framed question in `disambiguation:`.
+#
+# SCOPE VALUES: frontend | backend | both | core
+#   core = lives in backend/core-api + frontend/core-ui (shared across ALL
+#   plugins). Touching core affects every plugin — confirm before editing.
+#
+# `reference:` is a REAL file that already exists. The model must OPEN it and
+# copy its pattern instead of inventing structure. operation_* is the canonical
+# gold-standard plugin (see manifest.yaml) — prefer its references when unsure.
+#
+# Keep this file in sync with disk. To regenerate the inventory:
+#   for d in frontend/plugins/*_ui backend/plugins/*_api; do
+#     echo "[$d]"; ls "$d/src/modules" 2>/dev/null; done
+# ─────────────────────────────────────────────────────────────────────────────
+
+version: "1.0.0"
+last_synced_to_disk: "2026-06-14"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DISAMBIGUATION — nouns that legitimately map to >1 place.
+# When ROUTER's grep returns more than one candidate, it asks the matching
+# outcome-framed question here. NEVER ask "which plugin" — ask what they want.
+# ─────────────────────────────────────────────────────────────────────────────
+disambiguation:
+  customer:
+    nouns: [customer, client, contact, lead, company]
+    ask: "When you say 'customer', do you mean the central contact record (the person/company directory used everywhere), an insurance policyholder, or the person on the other end of a Frontline conversation?"
+    options:
+      - { label: "Central contact directory", entry: contacts }
+      - { label: "Insurance customer/policyholder", entry: insurance }
+      - { label: "Frontline conversation customer", entry: inbox }
+
+  report:
+    nouns: [report, reporting, dashboard, analytics, metrics]
+    ask: "Which area's numbers do you want to report on — support/Frontline volume, sales performance, accounting, or operations/projects?"
+    options:
+      - { label: "Frontline / support", entry: frontline-reports }
+      - { label: "Sales / deals", entry: deals }
+      - { label: "Accounting", entry: accounting-reports }
+      - { label: "Operations / projects", entry: project }
+
+  form:
+    nouns: [form, fields, popup form, lead form, survey]
+    ask: "Is this a public lead-capture/popup form shown to website visitors, or an internal data form inside the admin UI?"
+    options:
+      - { label: "Public lead/popup form", entry: frontline-forms }
+      - { label: "Core form/field definitions", entry: forms }
+      - { label: "An internal admin form", entry: _ui_form_pattern }
+
+  template:
+    nouns: [template, templates]
+    ask: "A canned reply template for support agents, a project/task template, or a content/document template?"
+    options:
+      - { label: "Support canned response", entry: response-template }
+      - { label: "Project / task template", entry: template-operation }
+      - { label: "Document / content template", entry: documents }
+
+  tags:
+    nouns: [tag, tags, label, labels]
+    ask: "Do you want the global tagging system (tags reused across all modules), or tags specific to CMS posts?"
+    options:
+      - { label: "Global tags (core)", entry: tags }
+      - { label: "CMS post tags", entry: cms }
+
+  pricing:
+    nouns: [pricing, price rule, discount, promotion, price plan]
+    ask: "Is this a discount/promotion rule (loyalty pricing) or a product's base price (products)?"
+    options:
+      - { label: "Discount / promotion rule", entry: pricing-loyalty }
+      - { label: "Product base price", entry: products }
+
+  unknown:
+    # Used when grep returns 0 matches. Do NOT guess a plugin.
+    ask: "I couldn't map that to an existing area yet. In one sentence: what should a user be able to DO when this is done, and who is the user (an admin, a sales rep, a support agent, or an end customer)?"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CORE — backend/core-api + frontend/core-ui. Shared by every plugin.
+# Editing core affects ALL plugins. Confirm scope before changing core.
+# ─────────────────────────────────────────────────────────────────────────────
+core:
+  - id: contacts
+    keywords: customer, customers, client, clients, contact, contacts, lead, leads, company, companies, people, person, directory, audience
+    scope: core
+    backend: backend/core-api/src/modules/contacts
+    frontend: frontend/core-ui/src/modules/contacts
+    note: "The canonical customer/company record. Other plugins REFERENCE contacts; they do not redefine them."
+
+  - id: products
+    keywords: product, products, service, services, item, items, sku, catalog, price, base price
+    scope: core
+    backend: backend/core-api/src/modules/products
+    frontend: frontend/core-ui/src/modules/products
+
+  - id: segments
+    keywords: segment, segments, audience filter, dynamic list, smart list, cohort
+    scope: core
+    backend: backend/core-api/src/modules/segments
+    frontend: frontend/core-ui/src/modules/segments
+
+  - id: tags
+    keywords: tag, tags, label, labels, categorize, categorization
+    scope: core
+    backend: backend/core-api/src/modules/tags
+    frontend: frontend/core-ui/src/modules/properties   # tags surface under properties/settings
+
+  - id: properties
+    keywords: custom field, custom fields, property, properties, attribute, attributes, extra field
+    scope: core
+    backend: backend/core-api/src/modules/properties
+    frontend: frontend/core-ui/src/modules/properties
+    note: "Custom fields are central. To add a field to deals/contacts/etc., extend properties — do NOT add ad-hoc schema fields in the plugin."
+
+  - id: forms
+    keywords: form definition, field definition, form builder fields
+    scope: core
+    backend: backend/core-api/src/modules/forms
+    frontend: frontend/core-ui/src/modules/properties
+
+  - id: documents
+    keywords: document, documents, printable, pdf template, document template
+    scope: core
+    backend: backend/core-api/src/modules/documents
+    frontend: frontend/core-ui/src/modules/documents
+
+  - id: automations
+    keywords: automation, automations, workflow, trigger, triggers, action, actions, when this then that, rule engine
+    scope: core
+    backend: backend/core-api/src/modules/automations
+    frontend: frontend/core-ui/src/modules/automations
+    note: "Plugins REGISTER triggers/actions via their own meta/automations.ts. The engine lives in core."
+
+  - id: import-export
+    keywords: import, importing, export, exporting, csv, spreadsheet, bulk upload, data migration ui
+    scope: core
+    backend: backend/core-api/src/modules/import-export
+    frontend: frontend/core-ui/src/modules/import-export
+
+  - id: notifications
+    keywords: notification, notifications, alert, bell, in-app notify
+    scope: core
+    backend: backend/core-api/src/modules/notifications
+    frontend: frontend/core-ui/src/modules/notification
+
+  - id: permissions
+    keywords: permission, permissions, role, roles, access control, rbac, who can
+    scope: core
+    backend: backend/core-api/src/modules/permissions
+    frontend: frontend/core-ui/src/modules/settings
+
+  - id: organization
+    keywords: organization, org settings, workspace, team members, users, user management, invite, login, auth, authentication, profile
+    scope: core
+    backend: backend/core-api/src/modules/organization
+    frontend: frontend/core-ui/src/modules/organization
+
+  - id: broadcast
+    keywords: broadcast, campaign, email campaign, sms campaign, mass email, engage, newsletter
+    scope: core
+    backend: backend/core-api/src/modules/broadcast
+    frontend: frontend/core-ui/src/modules/broadcast
+
+  - id: clientportal
+    keywords: client portal, customer portal, self-service portal, member portal
+    scope: core
+    backend: backend/core-api/src/modules/clientportal
+    frontend: frontend/core-ui/src/modules/client-portal
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PLUGINS — backend/plugins/<x>_api + frontend/plugins/<x>_ui
+# ─────────────────────────────────────────────────────────────────────────────
+plugins:
+
+  # ── SALES ──────────────────────────────────────────────────────────────────
+  - id: deals
+    keywords: deal, deals, opportunity, opportunities, sales, crm, won, lost, revenue forecast, sales report
+    plugin: sales
+    scope: both
+    frontend: frontend/plugins/sales_ui/src/modules/deals
+    backend: backend/plugins/sales_api/src/modules/sales
+    reference_table: frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
+    related: [pipelines, pos]
+
+  - id: pipelines
+    keywords: pipeline, pipelines, board, kanban, drag and drop, stage, stages, column, columns, deal board, sales stage
+    plugin: sales
+    scope: both
+    frontend: frontend/plugins/sales_ui/src/modules/deals/pipelines
+    backend: backend/plugins/sales_api/src/modules/sales
+    reference_table: frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
+    related: [deals]
+
+  - id: pos
+    keywords: pos, point of sale, cashier, checkout, ecommerce, e-commerce, online store, storefront, cart, order
+    plugin: sales
+    scope: both
+    frontend: frontend/plugins/sales_ui/src/modules/pos
+    backend: backend/plugins/sales_api/src/modules/pos   # also: ecommerce, and posclient_api
+    related: [posclient]
+
+  # ── FRONTLINE (customer service) ─────────────────────────────────────────────
+  - id: inbox
+    keywords: inbox, conversation, conversations, chat, chats, message, messages, live chat, agent inbox, reply, assign conversation
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/inbox
+    backend: backend/plugins/frontline_api/src/modules/inbox
+    related: [channels, integrations, ticket]
+
+  - id: ticket
+    keywords: ticket, tickets, support ticket, helpdesk, issue, sla, ticket status, ticket field, severity, priority
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/ticket
+    backend: backend/plugins/frontline_api/src/modules/ticket
+    related: [inbox]
+
+  - id: channels
+    keywords: channel, channels, team channel, route conversations, channel members
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/channels
+    backend: backend/plugins/frontline_api/src/modules/channel
+    related: [inbox, integrations]
+
+  - id: integrations
+    keywords: integration, integrations, facebook, messenger, instagram, whatsapp, telegram, email integration, imap, sms, twilio, web messenger, widget, callpro, line, viber
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/integrations
+    backend: backend/plugins/frontline_api/src/modules/integrations
+    note: "Adding a NEW provider (LINE/Telegram/Discord) touches integrations registration on both sides — treat as a larger change."
+    related: [inbox, channels]
+
+  - id: frontline-knowledgebase
+    keywords: knowledge base, knowledgebase, kb, help center, help article, faq
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/knowledgebase
+    backend: backend/plugins/frontline_api/src/modules/knowledgebase
+
+  - id: frontline-forms
+    keywords: lead form, popup form, web form, public form, embedded form, survey form, form widget
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/forms
+    backend: backend/plugins/frontline_api/src/modules/form
+
+  - id: response-template
+    keywords: canned response, canned reply, response template, saved reply, quick reply, snippet
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/responseTemplate
+    backend: backend/plugins/frontline_api/src/modules/response
+
+  - id: frontline-reports
+    keywords: support report, frontline report, conversation report, agent performance, response time report
+    plugin: frontline
+    scope: both
+    frontend: frontend/plugins/frontline_ui/src/modules/report
+    backend: backend/plugins/frontline_api/src/modules/reports
+
+  # ── OPERATION (project management — CANONICAL reference plugin) ───────────────
+  - id: task
+    keywords: task, tasks, to-do, todo, checklist item, assignee, sub-task, task board
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/task
+    backend: backend/plugins/operation_api/src/modules/task
+    reference_table: frontend/plugins/operation_ui/src/modules/task/components/TasksRecordTable.tsx
+    reference_board: frontend/plugins/operation_ui/src/modules/task/components/TasksBoard.tsx
+    reference_detail: frontend/plugins/operation_ui/src/modules/task/components/TaskDetailSheet.tsx
+    note: "operation is the gold-standard plugin. Copy these files' patterns for ANY new table/board/detail anywhere."
+
+  - id: project
+    keywords: project, projects, project view, project list, portfolio
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/project
+    backend: backend/plugins/operation_api/src/modules/project
+
+  - id: cycle
+    keywords: cycle, cycles, sprint, sprints, iteration
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/cycle
+    backend: backend/plugins/operation_api/src/modules/cycle
+
+  - id: team-operation
+    keywords: team, teams, squad, team members operation, working group
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/team
+    backend: backend/plugins/operation_api/src/modules/team
+    reference_entity_def: backend/plugins/operation_api/src/modules/team/db/definitions/team.ts
+    reference_entity_model: backend/plugins/operation_api/src/modules/team/db/models/Team.ts
+    note: "Gold-standard backend entity. Copy this definition+model pair for ANY new Mongoose entity."
+
+  - id: milestone
+    keywords: milestone, milestones, goal, deliverable date
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/operation
+    backend: backend/plugins/operation_api/src/modules/milestone
+
+  - id: template-operation
+    keywords: project template, task template, operation template
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/template
+    backend: backend/plugins/operation_api/src/modules/template
+
+  - id: status
+    keywords: status, statuses, workflow status, custom status, state machine, stage status
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/operation
+    backend: backend/plugins/operation_api/src/modules/status
+
+  - id: triage
+    keywords: triage, triage inbox, incoming queue, unassigned queue
+    plugin: operation
+    scope: both
+    frontend: frontend/plugins/operation_ui/src/modules/triage
+    backend: backend/plugins/operation_api/src/modules/task
+
+  # ── LOYALTY ──────────────────────────────────────────────────────────────────
+  - id: loyalty
+    keywords: loyalty, points, reward, rewards, score, loyalty score, member points, earn points, redeem
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/score
+    related: [coupon, voucher, lottery, spin, pricing-loyalty]
+
+  - id: coupon
+    keywords: coupon, coupons, promo code, discount code, redeem code
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/coupon
+
+  - id: voucher
+    keywords: voucher, vouchers, gift card, store credit
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/voucher
+
+  - id: lottery
+    keywords: lottery, lotteries, raffle, prize draw, lucky draw
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/lottery
+
+  - id: spin
+    keywords: spin, spin wheel, wheel of fortune, spin to win
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/spin
+
+  - id: donate
+    keywords: donate, donation, donations, fundraise, give
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/loyalties
+    backend: backend/plugins/loyalty_api/src/modules/donate
+
+  - id: pricing-loyalty
+    keywords: pricing rule, price rule, discount rule, promotion, markup, markdown, dynamic price, price plan
+    plugin: loyalty
+    scope: both
+    frontend: frontend/plugins/loyalty_ui/src/modules/pricing
+    backend: backend/plugins/loyalty_api/src/modules/pricing
+    reference_table: frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
+    reference_create: frontend/plugins/loyalty_ui/src/modules/pricing/create-pricing/PricingCreateSheet.tsx
+
+  # ── CONTENT (CMS / web builder) ──────────────────────────────────────────────
+  - id: cms
+    keywords: cms, post, posts, article, articles, page, pages, blog, category, categories, menu, menus, content management
+    plugin: content
+    scope: both
+    frontend: frontend/plugins/content_ui/src/modules/cms
+    backend: backend/plugins/content_api/src/modules/cms
+    reference_table: frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+
+  - id: web-builder
+    keywords: web builder, website builder, landing page, site, web page builder, drag drop page
+    plugin: content
+    scope: both
+    frontend: frontend/plugins/content_ui/src/modules/web-builder
+    backend: backend/plugins/content_api/src/modules/webbuilder
+
+  - id: content-knowledgebase
+    keywords: content knowledge base, public docs, documentation site
+    plugin: content
+    scope: frontend
+    frontend: frontend/plugins/content_ui/src/modules/knowledgebase
+
+  # ── ACCOUNTING ───────────────────────────────────────────────────────────────
+  - id: accounting-transactions
+    keywords: transaction, transactions, journal entry, ledger, debit, credit, bookkeeping, account, accounts, chart of accounts
+    plugin: accounting
+    scope: both
+    frontend: frontend/plugins/accounting_ui/src/modules/transactions
+    backend: backend/plugins/accounting_api/src/modules/accounting
+    reference_table: frontend/plugins/accounting_ui/src/modules/transactions/components/TrRecordTable.tsx
+
+  - id: accounting-inventories
+    keywords: inventory, inventories, stock, stock count, safe remainder, warehouse stock, on hand
+    plugin: accounting
+    scope: both
+    frontend: frontend/plugins/accounting_ui/src/modules/inventories
+    backend: backend/plugins/accounting_api/src/modules/inventories
+
+  - id: accounting-adjustments
+    keywords: adjustment, adjustments, stock adjustment, balance adjustment
+    plugin: accounting
+    scope: both
+    frontend: frontend/plugins/accounting_ui/src/modules/adjustments
+    backend: backend/plugins/accounting_api/src/modules/accounting
+
+  - id: accounting-reports
+    keywords: accounting report, journal report, balance sheet, financial report, trial balance
+    plugin: accounting
+    scope: both
+    frontend: frontend/plugins/accounting_ui/src/modules/journal-reports
+    backend: backend/plugins/accounting_api/src/modules/accounting
+
+  # ── INSURANCE ────────────────────────────────────────────────────────────────
+  - id: insurance
+    keywords: insurance, policy, policies, policyholder, claim, claims, premium, coverage, vendor, insurance customer
+    plugin: insurance
+    scope: both
+    frontend: frontend/plugins/insurance_ui/src/modules/insurance
+    backend: backend/plugins/insurance_api/src/modules/insurance
+    reference_table: frontend/plugins/insurance_ui/src/modules/insurance/components/customers/CustomersRecordTable.tsx
+
+  # ── TOURISM ──────────────────────────────────────────────────────────────────
+  - id: tourism-pms
+    keywords: pms, property management, hotel, room, rooms, booking, reservation, check-in, check-out, guest
+    plugin: tourism
+    scope: both
+    frontend: frontend/plugins/tourism_ui/src/modules/pms
+    backend: backend/plugins/tourism_api/src/modules/pms
+
+  - id: tourism-tms
+    keywords: tms, tour, tours, itinerary, itineraries, travel, trip, tour package
+    plugin: tourism
+    scope: both
+    frontend: frontend/plugins/tourism_ui/src/modules/tms
+    backend: backend/plugins/tourism_api/src/modules/bms
+    reference_table: frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryRecordTable.tsx
+
+  - id: tourism-ota
+    keywords: ota, channel manager, booking.com, expedia, online travel agency
+    plugin: tourism
+    scope: backend
+    backend: backend/plugins/tourism_api/src/modules/ota
+
+  # ── PAYMENT ──────────────────────────────────────────────────────────────────
+  - id: payment
+    keywords: payment, payments, invoice, invoices, pay, gateway, qpay, stripe, paypal, golomt, socialpay, storepay, transaction payment, checkout payment
+    plugin: payment
+    scope: both
+    frontend: frontend/plugins/payment_ui/src/modules/payment
+    backend: backend/plugins/payment_api/src/modules/payment
+    reference_table: frontend/plugins/payment_ui/src/modules/payment/components/InvoiceRecordTable.tsx
+
+  # ── MONGOLIAN (Mongolia-specific integrations) ───────────────────────────────
+  - id: ebarimt
+    keywords: ebarimt, e-barimt, vat receipt, tax receipt, fiscal receipt, lottery receipt
+    plugin: mongolian
+    scope: both
+    frontend: frontend/plugins/mongolian_ui/src/modules/ebarimt
+    backend: backend/plugins/mongolian_api/src/modules/ebarimt
+
+  - id: erkhet
+    keywords: erkhet, erkhet sync, accounting sync, erp sync mongolian
+    plugin: mongolian
+    scope: both
+    frontend: frontend/plugins/mongolian_ui/src/modules/erkhet-sync
+    backend: backend/plugins/mongolian_api/src/modules/erkhet
+
+  - id: exchange-rates
+    keywords: exchange rate, exchange rates, currency, fx, forex, conversion rate
+    plugin: mongolian
+    scope: both
+    frontend: frontend/plugins/mongolian_ui/src/modules/exchangeRates
+    backend: backend/plugins/mongolian_api/src/modules/exchangeRates
+
+  - id: msdynamic
+    keywords: ms dynamics, msdynamic, microsoft dynamics, dynamics 365, navision
+    plugin: mongolian
+    scope: both
+    frontend: frontend/plugins/mongolian_ui/src/modules/msdynamic
+    backend: backend/plugins/mongolian_api/src/modules/msdynamic
+
+  - id: product-places
+    keywords: product place, product places, store location, branch stock, location stock
+    plugin: mongolian
+    scope: both
+    frontend: frontend/plugins/mongolian_ui/src/modules/productplaces
+    backend: backend/plugins/mongolian_api/src/modules/productPlaces
+
+  # ── ERXES-AGENT (AI agent — formerly "mastra") ───────────────────────────────
+  - id: ai-agent
+    keywords: ai agent, agent, assistant, chatbot, llm, mastra, copilot, ai assistant
+    plugin: erxes-agent
+    scope: both
+    frontend: frontend/plugins/erxes-agent_ui/src/modules/assistants
+    backend: backend/plugins/erxes-agent_api/src/modules/agent
+    related: [ai-provider, ai-tool, ai-workflow]
+
+  - id: ai-provider
+    keywords: llm provider, model provider, openai key, anthropic key, kimi, api key provider
+    plugin: erxes-agent
+    scope: both
+    frontend: frontend/plugins/erxes-agent_ui/src/modules/assistants
+    backend: backend/plugins/erxes-agent_api/src/modules/provider
+
+  - id: ai-tool
+    keywords: agent tool, ai tool, function calling, tool definition
+    plugin: erxes-agent
+    scope: both
+    frontend: frontend/plugins/erxes-agent_ui/src/modules/assistants
+    backend: backend/plugins/erxes-agent_api/src/modules/tool
+
+  - id: ai-workflow
+    keywords: agent workflow, ai workflow, scheduled agent, agent run, agent memory
+    plugin: erxes-agent
+    scope: backend
+    backend: backend/plugins/erxes-agent_api/src/modules/workflow
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SHARED LIBS — reusable code. Build here ONLY when a thing is used by 2+ plugins.
+# ─────────────────────────────────────────────────────────────────────────────
+shared:
+  - id: erxes-ui
+    keywords: ui primitive, design system, button, input, dialog, sheet, base component, shared component, erxes-ui
+    path: frontend/libs/erxes-ui
+    note: "Low-level UI primitives. Add here only if used across plugins. Never fork these into a plugin."
+
+  - id: ui-modules
+    keywords: shared ui module, reusable widget, cross-plugin component, ui-modules
+    path: frontend/libs/ui-modules
+
+  - id: erxes-api-shared
+    keywords: shared backend, backend util, common type, service discovery, redis util, shared resolver, erxes-api-shared
+    path: backend/erxes-api-shared
+    note: "Shared backend. After editing, rebuild: pnpm nx build erxes-api-shared."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UI PATTERN ANCHORS — generic 'how do I build X in the UI' references.
+# Used when the WHAT is clear but there is no domain noun (e.g. "I need a form").
+# ─────────────────────────────────────────────────────────────────────────────
+ui_patterns:
+  _ui_form_pattern:
+    keywords: internal form, admin form, edit form, create form, settings form
+    reference: frontend/plugins/loyalty_ui/src/modules/pricing/create-pricing/PricingCreateSheet.tsx
+    skill: create-form-drawer
+  _ui_table_pattern:
+    keywords: list page, table, record table, grid, data table
+    reference: frontend/plugins/operation_ui/src/modules/task/components/TasksRecordTable.tsx
+    skill: create-table
+  _ui_detail_pattern:
+    keywords: detail page, detail sheet, side panel, drawer detail
+    reference: frontend/plugins/operation_ui/src/modules/task/components/TaskDetailSheet.tsx
+    skill: create-page

--- a/.agents/maps/feature-map.yaml
+++ b/.agents/maps/feature-map.yaml
@@ -58,7 +58,7 @@ disambiguation:
     options:
       - { label: "Public lead/popup form", entry: frontline-forms }
       - { label: "Core form/field definitions", entry: forms }
-      - { label: "An internal admin form", entry: _ui_form_pattern }
+      - { label: "An internal admin form", entry: forms }
 
   template:
     nouns: [template, templates]
@@ -567,6 +567,9 @@ shared:
 # ─────────────────────────────────────────────────────────────────────────────
 # UI PATTERN ANCHORS — generic 'how do I build X in the UI' references.
 # Used when the WHAT is clear but there is no domain noun (e.g. "I need a form").
+# REFERENCE-ONLY: each carries a `reference` file + `skill` but NO plugin/scope.
+# These are never a final STEP 2 location — ROUTER resolves the plugin/scope
+# separately (see ROUTER.md STEP 2, the `_`-prefixed-anchor rule) before STEP 5.
 # ─────────────────────────────────────────────────────────────────────────────
 ui_patterns:
   _ui_form_pattern:

--- a/.agents/references/canonical-examples.yaml
+++ b/.agents/references/canonical-examples.yaml
@@ -1,0 +1,55 @@
+# .agents/references/canonical-examples.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# CANONICAL EXAMPLES — the gold-standard files to copy for each kind of work.
+#
+# When ROUTER.md STEP 3 says "open the reference file", and the feature-map entry
+# has no specific `reference_*`, use the closest match here. These are real,
+# convention-correct files. Copy their structure; do not invent new shapes.
+#
+# operation_* is the reference plugin (see manifest.yaml meta). Prefer it.
+# Keep these paths valid — if a file is moved, update it here.
+# ─────────────────────────────────────────────────────────────────────────────
+
+version: "1.0.0"
+reference_plugin:
+  frontend: frontend/plugins/operation_ui
+  backend: backend/plugins/operation_api
+  why: "Cleanest, most complete implementation of the erxes patterns."
+
+frontend:
+  list_table:
+    file: frontend/plugins/operation_ui/src/modules/task/components/TasksRecordTable.tsx
+    skill: create-table
+    copy: "RecordTable.CursorProvider + useRecordTableCursor + validateFetchMore. Named export. No raw <table>."
+  board_kanban:
+    file: frontend/plugins/operation_ui/src/modules/task/components/TasksBoard.tsx
+    skill: create-table
+    copy: "Column/card board layout with drag handling."
+  detail_sheet:
+    file: frontend/plugins/operation_ui/src/modules/task/components/TaskDetailSheet.tsx
+    skill: create-page
+    copy: "Side sheet detail view bound to a selected record."
+  create_edit_form:
+    file: frontend/plugins/loyalty_ui/src/modules/pricing/create-pricing/PricingCreateSheet.tsx
+    skill: create-form-drawer
+    copy: "Form.Field pattern + Zod schema + success/error toasts. erxes-ui dialog/sheet only."
+  filter_bar:
+    file: frontend/plugins/operation_ui/src/modules/task/components/TasksFilter.tsx
+    skill: create-table
+    copy: "Filter/search bar wired to the record table's query."
+
+backend:
+  entity_definition:
+    file: backend/plugins/operation_api/src/modules/team/db/definitions/team.ts
+    skill: create-backend-entity
+    copy: "Explicit `new Schema({...})` with typed fields. NO schemaWrapper."
+  entity_model:
+    file: backend/plugins/operation_api/src/modules/team/db/models/Team.ts
+    skill: create-backend-entity
+    copy: "loadXClass model with static business methods."
+
+conventions_reminder:
+  - "Named exports only — never `export default` in application code."
+  - "GraphQL operations are named + plugin-prefixed (e.g. operationTaskList)."
+  - "Reuse erxes-ui / ui-modules before building new primitives."
+  - "Keep new code beside the nearest sibling feature in the same plugin."

--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -4,8 +4,16 @@ This directory contains erxes-specific Markdown rules for AI-assisted work in
 this repository. These files should reinforce the monorepo architecture, plugin
 boundaries, and local implementation patterns.
 
+> **You do not read all of these every task.** `.agents/ROUTER.md` (the single
+> entry point, run via `/erxes`) loads them in tiers:
+> **always** → `non-negotiable.md` + `code-style.md`; **then by scope** → the
+> frontend/backend/migration/test/etc. rule only when your change touches it.
+> See ROUTER STEP 0 and STEP 6 for the exact tier table.
+
 ## Rule Files
 
+- `non-negotiable.md` - **ALWAYS-ON.** Zero-tolerance MUST/NEVER rules (no
+  default exports, no `any`, no half-CRUD, plugin isolation, named GraphQL ops).
 - `architecture.md` - erxes monorepo structure, stack, and ownership boundaries.
 - `operation-plugin-reference.md` - operation plugin patterns to use as the
   preferred reference when local plugin patterns are missing or weaker.

--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -6,8 +6,9 @@ boundaries, and local implementation patterns.
 
 > **You do not read all of these every task.** `.agents/ROUTER.md` (the single
 > entry point, run via `/erxes`) loads them in tiers:
-> **always** → `non-negotiable.md` + `code-style.md`; **then by scope** → the
-> frontend/backend/migration/test/etc. rule only when your change touches it.
+> **always** → `non-negotiable.md` + `architecture.md` + `code-style.md`; **then
+> by scope** → the frontend/backend/migration/test/etc. rule only when your
+> change touches it.
 > See ROUTER STEP 0 and STEP 6 for the exact tier table.
 
 ## Rule Files

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,5 +1,11 @@
 # erxes Agent Skills
 
+> **Start here:** the single entry point is **`.agents/ROUTER.md`** (run it via
+> the `/erxes "I want ..."` command). ROUTER classifies the request, resolves the
+> target plugin/module from `.agents/maps/feature-map.yaml`, confirms scope, then
+> loads the right skill below. You rarely pick a skill by hand — ROUTER picks it.
+> The `SEMANTIC_INDEX.md` in this folder maps symptoms/edge-cases to skills.
+
 Use these skills as short task workflows for common erxes changes. Rules in
 `AGENTS.md`, nested `AGENTS.md`, and `.agents/rules/*.md` remain the source of
 truth for architecture and project conventions.
@@ -17,6 +23,17 @@ Skills use one folder per skill:
 the shortest workflow that helps an agent complete the task.
 
 ## Available Skills
+
+Meta / orchestration (ROUTER calls these for you):
+
+- `assemble-context/SKILL.md` - load the applicable rule layers for a path.
+- `create-plugin/SKILL.md` - scaffold a whole new plugin (then fix the scaffold).
+- `pr-review-loop/SKILL.md` - after a PR, drive AI-reviewer comments to zero.
+- `detect-scope/SKILL.md`, `intake/SKILL.md` - the older two-step scope flow,
+  now superseded by `ROUTER.md` STEP 2 + STEP 5. Kept for reference/back-compat;
+  prefer ROUTER for new work.
+
+Feature / task skills:
 
 - `plugin-workflow/SKILL.md` - baseline workflow for plugin changes.
 - `operation-plugin-reference/SKILL.md` - apply operation plugin patterns from

--- a/.agents/skills/create-backend-entity/contract.yaml
+++ b/.agents/skills/create-backend-entity/contract.yaml
@@ -52,10 +52,10 @@ postconditions:
     command: "pnpm nx build {plugin_name}_api"
     required: true
   - description: "Deliverables verified"
-    command: ".agents/evals/check-deliverables.sh {plugin_name}_api {entity_name}"
+    command: ".agents/scripts/check-deliverables.sh {plugin_name}_api {entity_name}"
     required: true
   - description: "Rules compliance verified"
-    command: ".agents/evals/check-rules.sh backend/plugins/{plugin_name}_api/src/modules/{entity_name}"
+    command: ".agents/scripts/check-rules.sh backend/plugins/{plugin_name}_api/src/modules/{entity_name}"
     required: true
 
 composes_with:

--- a/.agents/skills/create-form-drawer/contract.yaml
+++ b/.agents/skills/create-form-drawer/contract.yaml
@@ -55,10 +55,10 @@ postconditions:
     when: "tests_touched"
     required: false
   - description: "Deliverables verified"
-    command: ".agents/evals/check-deliverables.sh {plugin_name}_ui {entity_name}"
+    command: ".agents/scripts/check-deliverables.sh {plugin_name}_ui {entity_name}"
     required: true
   - description: "Rules compliance verified"
-    command: ".agents/evals/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{entity_name}"
+    command: ".agents/scripts/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{entity_name}"
     required: true
 
 composes_with:

--- a/.agents/skills/create-page/contract.yaml
+++ b/.agents/skills/create-page/contract.yaml
@@ -52,10 +52,10 @@ postconditions:
     command: "pnpm nx build {plugin_name}_ui"
     required: true
   - description: "Deliverables verified"
-    command: ".agents/evals/check-deliverables.sh {plugin_name}_ui {module_name}"
+    command: ".agents/scripts/check-deliverables.sh {plugin_name}_ui {module_name}"
     required: true
   - description: "Rules compliance verified"
-    command: ".agents/evals/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{module_name}"
+    command: ".agents/scripts/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{module_name}"
     required: true
 
 composes_with:

--- a/.agents/skills/create-table/contract.yaml
+++ b/.agents/skills/create-table/contract.yaml
@@ -62,10 +62,10 @@ postconditions:
     command: "pnpm nx build {plugin_name}_ui"
     required: true
   - description: "Deliverables verified"
-    command: ".agents/evals/check-deliverables.sh {plugin_name}_ui {entity_name}"
+    command: ".agents/scripts/check-deliverables.sh {plugin_name}_ui {entity_name}"
     required: true
   - description: "Rules compliance verified"
-    command: ".agents/evals/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{entity_name}"
+    command: ".agents/scripts/check-rules.sh frontend/plugins/{plugin_name}_ui/src/modules/{entity_name}"
     required: true
 
 composes_with:

--- a/.gitignore
+++ b/.gitignore
@@ -52,16 +52,26 @@ Thumbs.db
 .agents/*
 !.agents/
 !.agents/README.md
+!.agents/ROUTER.md
+!.agents/manifest.yaml
 !.agents/rules/
 !.agents/rules/*.md
 !.agents/skills/
 !.agents/skills/*.md
+!.agents/skills/*/
+!.agents/skills/*/*
+!.agents/maps/
+!.agents/maps/*.yaml
+!.agents/references/
+!.agents/references/*.yaml
 !.agents/scripts/
 !.agents/scripts/*.sh
 !.agents/state/
 !.agents/state/.gitkeep
+# Runtime-only session/scope state stays local:
 .agents/state/*.json
 .agents/state/*.yaml
+.agents/session.yaml
 .claude
 
 storybook-static

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # erxes AI Operating Rules
 
+## ⟶ Start Here: one entry point
+
+**To build anything from a plain "I want ..." request, run `.agents/ROUTER.md`**
+(Claude Code: the `/erxes "I want ..."` command). ROUTER is the single linear
+procedure — it classifies the request, resolves the exact plugin/module from
+`.agents/maps/feature-map.yaml` (so you never guess or ask "which plugin"), asks
+only about the desired **outcome**, confirms scope, loads just the rules that
+scope needs, and builds by copying a real reference file.
+
+Everything below in this document is the **reference material** ROUTER draws on
+(rules, conventions, architecture). You do not need to execute the older
+"Protocol"/"Workflow" step lists yourself — ROUTER supersedes them. Read the
+specific rule sections when ROUTER's tier table (STEP 6) tells you to.
+
 ## Extended Documentation
 
 For detailed information, see the `.agents/` directory:
@@ -21,8 +35,9 @@ declared in `.agents/manifest.yaml` and enforced through contract-based skills.
 
 ### Entry Point
 
-**ALL agents MUST start by reading `.agents/manifest.yaml`**. This file
-declares:
+**The entry point is `.agents/ROUTER.md` (run via `/erxes`).** `manifest.yaml` is
+the registry/reference it uses — read it when you need the data below, not as a
+first step. This file declares:
 - Rule layers with precedence (constitution → global → category → plugin)
 - Skill registry with contracts
 - Plugin registry
@@ -104,9 +119,15 @@ behavior while keeping changes small.
 
 ## Workflow
 
+> **If you ran `/erxes` / `.agents/ROUTER.md`, you have already done this list** —
+> ROUTER STEP 0–6 *is* this workflow, automated and tiered. The steps below are
+> the manual/reference form (and the canonical detail for the "during" and
+> "after" phases). The `detect-scope → preflight → intake` steps are the legacy
+> scope mechanism; ROUTER STEP 2 + STEP 5 replace them. Don't run both.
+
 Before coding:
 
-1. **Read `.agents/manifest.yaml`** — This is the entry point.
+1. **Read `.agents/ROUTER.md`** — This is the entry point (or run `/erxes`).
 2. **Consult Semantic Index** — Read `.agents/skills/SEMANTIC_INDEX.md` to find the correct skills for your intent or to troubleshoot symptoms (404s, loading errors).
 3. **Assemble context** — Run `.agents/scripts/assemble-context.sh <path> [skill]`
    or follow the `assemble-context` skill to load all applicable rule layers.


### PR DESCRIPTION
## Why

The `.agents/` system was two half-finished generations stacked on each other, and intent resolution was unreliable — especially for small models. Root causes:

- **The accuracy backbone didn't exist.** `detect-scope`'s whole job is "turn words → plugin/module" by grepping `.agents/maps/feature-map.yaml` — a file that was never created **and was git-ignored**. With no map, it fell back to *guessing* the plugin.
- **No single entry point.** The protocol was ~11 hops (read manifest → chain 3 meta-skills → write JSON state → bash preflight gate → intake → read rules) before any code. Weak models fall off that chain.
- **Dangling references everywhere:** `/agents` + `/frontline` pointed at a deleted wish-system; the manifest auto-loaded 2 missing files; 8 contracts called `.agents/evals/check-*.sh` (real path `.agents/scripts/`); the registry said `agent-assistant` (disk: `erxes-agent`); both READMEs omitted half the system (even `non-negotiable.md`).

## What

One entry point → deterministic routing → outcome-only questions → confirm → tiered rules → copy a real reference → self-check.

- **`.agents/ROUTER.md`** (new) — the brain. One linear script (STEP 0→8), no indirection, so a small model reads it top-to-bottom and can't fall off. Never asks "which plugin" (that's a map lookup); only asks about the desired **outcome**, and only after analysis.
- **`.agents/maps/feature-map.yaml`** (new) — the accuracy backbone. 64 entries (14 core + 47 plugin + 3 shared) with synonym-packed `keywords:` lines, real `reference:` files to copy, and 7 `disambiguation:` blocks for ambiguous nouns like "customer".
- **`.agents/references/canonical-examples.yaml`** (new) — gold-standard files (operation_* plugin) to copy per task type.
- **Fixes:** `.gitignore` now lets `maps/`, `references/`, and `ROUTER.md` commit; 8 contract paths `evals/` → `scripts/`; `manifest.yaml` + `AGENTS.md` point at ROUTER as the entry; registry drift `agent-assistant` → `erxes-agent`; both READMEs refreshed.

## Validation

- All YAML parses (`js-yaml`); `validate-manifest.sh` → ALL CHECKS PASSED; 0 remaining broken paths.
- Intent-resolution acceptance test passed on real phrasings — e.g. "add custom fields to a deal" correctly routes to **core `properties`**, not sales.

## Scope notes

- This is generic erxes repo tooling, not personalized — usable by any contributor/model in this repo.
- The `/erxes`, `/agents`, `/frontline` slash commands live in `.claude/commands/` which is git-ignored, so they are **not** in this PR (local-only).
- Deferred (out of scope): deleting the now-superseded `detect-scope`/`intake`/`preflight-check.sh`; merging overlapping rule files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Made the linear `/erxes` router procedure the primary workflow (with explicit hard-stop conditions, scope confirmation, and scope-relevant rule loading).
  * Added a centralized feature-to-location mapping configuration and UI pattern anchors.
  * Introduced canonical “gold-standard” reference mappings to standardize generated implementations.
  * Updated agent, rules, and skills guides to match the new orchestration flow.

* **Chores**
  * Updated skill contract verification commands to use the scripts location (instead of evals).
  * Adjusted git ignore/unignore rules to ensure router, maps, references, and scripts are tracked.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->