### PR TITLE
feat(erxes-agent): destructive-op guard + mutation audit log

### DIFF
--- a/backend/core-api/src/apollo/resolvers/mutations.ts
+++ b/backend/core-api/src/apollo/resolvers/mutations.ts
@@ -29,6 +29,7 @@ import { commentMutations } from '@/clientportal/graphql/resolvers/mutations/com
 import { cpNotificationMutations } from '@/clientportal/graphql/resolvers/mutations/cpNotification';
 import { bundleMutations } from '@/bundle/graphql/resolvers/mutations';
 import { templateMutations } from '@/template/graphql/mutations';
+import { logMutations } from '@/logs/graphql/resolvers/mutations';
 
 export const mutations = {
   ...contactMutations,
@@ -60,4 +61,5 @@ export const mutations = {
   ...cpNotificationMutations,
   ...bundleMutations,
   ...templateMutations,
+  ...logMutations,
 };

--- a/backend/core-api/src/apollo/schema/schema.ts
+++ b/backend/core-api/src/apollo/schema/schema.ts
@@ -126,6 +126,7 @@ import {
 } from '@/automations/graphql/schema';
 
 import {
+  mutations as LogsMutations,
   queries as LogsQueries,
   types as LogsTypes,
 } from '@/logs/graphql/schema';
@@ -328,6 +329,7 @@ export const mutations = `
     ${BroadcastMutations}
     ${bundleMutations}
     ${templateMutations}
+    ${LogsMutations}
   `;
 
 export default { types, queries, mutations };

--- a/backend/core-api/src/main.ts
+++ b/backend/core-api/src/main.ts
@@ -12,7 +12,9 @@ import {
   isDev,
   joinErxesGateway,
   leaveErxesGateway,
+  registerRevertContentTypeResolver,
 } from 'erxes-api-shared/utils';
+import { logs as coreLogsConfig } from './meta/logs';
 import express from 'express';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import * as http from 'http';
@@ -36,6 +38,20 @@ Sentry.getGlobalScope().setTags({
 });
 
 dotenv.config();
+
+// Seed the dynamic revert-capture content-type resolver from core's meta/logs, so
+// auto-journaled deletes (captured generically in the shared schemaWrapper) carry
+// the same `plugin:module.collection` contentType the revert engine already maps
+// to a permission + model. No per-collection wiring needed beyond this one map.
+const collectionToContentType = new Map<string, string>(
+  coreLogsConfig.contentTypes.map((c) => [
+    c.collectionName,
+    `${PLUGIN_NAME}:${c.moduleName}.${c.collectionName}`,
+  ]),
+);
+registerRevertContentTypeResolver((collectionName) =>
+  collectionToContentType.get(collectionName),
+);
 
 const { DOMAIN, ALLOWED_ORIGINS, WIDGETS_DOMAIN, ALLOWED_DOMAINS } =
   process.env;

--- a/backend/core-api/src/meta/logs.ts
+++ b/backend/core-api/src/meta/logs.ts
@@ -1,54 +1,83 @@
 import { LogsConfigs } from 'erxes-api-shared/core-modules';
 
+// `permission` names the action that gates point-in-time revert of the entity
+// (admin/owner bypasses) — the destructive REMOVE/manage action for that
+// collection. `mongooseName` is the model name the raw revert applier resolves
+// via connection.model(mongooseName); it matches the names registered in
+// connectionResolvers.ts. Entities without a `permission` are revertible by
+// owners/admins only (fail-closed).
 export const logs: LogsConfigs = {
   contentTypes: [
     {
       moduleName: 'contacts',
       collectionName: 'customers',
+      permission: 'contactsDelete',
+      mongooseName: 'customers',
     },
     {
       moduleName: 'contacts',
       collectionName: 'companies',
+      permission: 'contactsDelete',
+      mongooseName: 'companies',
     },
     {
       moduleName: 'organization',
       collectionName: 'users',
+      permission: 'teamMembersRemove',
+      mongooseName: 'users',
     },
     {
       moduleName: 'organization',
       collectionName: 'brands',
+      permission: 'brandsDelete',
+      mongooseName: 'brands',
     },
     {
       moduleName: 'organization',
       collectionName: 'configs',
+      mongooseName: 'configs',
     },
     {
       moduleName: 'tags',
       collectionName: 'tags',
+      permission: 'tagsDelete',
+      mongooseName: 'tags',
     },
     {
       moduleName: 'internalNote',
       collectionName: 'internal_notes',
+      permission: 'internalNotesManage',
+      mongooseName: 'internal_notes',
     },
     {
       moduleName: 'products',
       collectionName: 'products',
+      permission: 'productsDelete',
+      mongooseName: 'products',
     },
     {
       moduleName: 'products',
       collectionName: 'uoms',
+      permission: 'uomsManage',
+      mongooseName: 'uoms',
     },
     {
       moduleName: 'products',
       collectionName: 'products_configs',
+      permission: 'productsConfigsManage',
+      mongooseName: 'products_configs',
     },
     {
       moduleName: 'products',
       collectionName: 'product_categories',
+      permission: 'productCategoriesManage',
+      mongooseName: 'product_categories',
     },
     {
       moduleName: 'app_tokens',
       collectionName: 'app_tokens',
+      permission: 'appsManage',
+      mongooseName: 'app_tokens',
     },
   ],
 };

--- a/backend/core-api/src/modules/contacts/db/models/Companies.ts
+++ b/backend/core-api/src/modules/contacts/db/models/Companies.ts
@@ -171,12 +171,18 @@ export const loadCompanyClass = (
      * Remove company
      */
     public static async removeCompanies(companyIds: string[]) {
+      // Snapshot before deletion so the removal is revertable (point-in-time).
+      const prevDocuments = await models.Companies.find({
+        _id: { $in: companyIds },
+      }).lean();
+
       const deletedCompanies = await models.Companies.deleteMany({
         _id: { $in: companyIds },
       });
       sendDbEventLog({
         action: 'deleteMany',
         docIds: companyIds,
+        prevDocuments,
       });
       return deletedCompanies;
     }

--- a/backend/core-api/src/modules/contacts/db/models/Customers.ts
+++ b/backend/core-api/src/modules/contacts/db/models/Customers.ts
@@ -260,6 +260,11 @@ export const loadCustomerClass = (
      * Remove customers
      */
     public static async removeCustomers(customerIds: string[]) {
+      // Snapshot before deletion so the removal is revertable (point-in-time).
+      const prevDocuments = await models.Customers.find({
+        _id: { $in: customerIds },
+      }).lean();
+
       const response = await models.Customers.deleteMany({
         _id: { $in: customerIds },
       });
@@ -267,6 +272,7 @@ export const loadCustomerClass = (
       sendDbEventLog({
         action: 'deleteMany',
         docIds: customerIds,
+        prevDocuments,
       });
       return response;
     }

--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -1,0 +1,85 @@
+# Logs module — point-in-time revert (undo)
+
+This module owns the event log **and** the point-in-time revert ("undo") feature:
+any create/update/delete made through erxes can be journaled and later reverted,
+dynamically, with no per-entity code.
+
+## Mechanism, end to end
+
+1. **Correlate** — every request carries one `processId` (AsyncLocalStorage,
+   `erxes-api-shared/.../runtimeContext.ts`); the apollo layer honors an inbound
+   `x-erxes-process-id` header (so the AI agent can stamp its actions).
+2. **Capture (dynamic, zero per-call-site)** — a global hook lives in the shared
+   `schemaWrapper` (`erxes-api-shared/src/utils/mongo/revertCapture.ts`), which
+   EVERY model schema runs through. It auto-journals:
+   - **deletes** (`deleteOne`/`deleteMany`/`findOneAndDelete`) with the pre-image,
+   - **edits** (`updateOne`/`updateMany`/`findOneAndUpdate` + `doc.save()`) as a
+     before→after diff.
+   Creates are intentionally NOT captured (revert of a new record = delete it).
+   Each entry records `mongooseName` + `dbName`. It posts to the SAME `put_log`
+   BullMQ queue the manual `sendDbEventLog` uses, so the existing pipeline stores
+   it in `{subdomain}_logs`.
+   - **Gated** behind `REVERT_AUTO_JOURNAL=enable` — a complete no-op when off
+     (zero risk to the ~124 wrapped schemas). Must be set on EVERY writing
+     service, and is off by default (changes before enabling are unrecoverable).
+   - Every hook is wrapped so a capture failure can never block/throw out of a
+     write. Bulk capture is capped at `REVERT_AUTO_JOURNAL_MAX` (default 1000).
+3. **Invert** — `revert/computeInverse.ts` (pure): create→delete,
+   delete→re-insert (keep `_id`), update→restore prior field values.
+4. **Revert** — `logsRevertProcess(processId, dryRun, force, skipConflicts,
+   resolutions)` GraphQL mutation → `revert/revertByProcessId.ts` reverse-replays
+   the process's entries.
+
+## Revert engine (`revert/`)
+
+- `revertByProcessId.ts` — orchestrator: load entries (newest-first), **dedup**
+  exact duplicates, **authorize**, plan inverses, detect conflicts, dry-run or
+  apply, write a marker.
+- `computeInverse.ts` — pure inverse per entry. `conflict.ts` — field-level
+  conflict detection (volatile fields like `updatedAt`/`searchText` are excluded).
+- `applyWrite.ts` — raw mongoose write (NOT audited statics) + whole-doc guards +
+  ES re-sync. `applyInverse.ts` — dispatch core/`auto:` in-process vs remote TRPC.
+- `contentTypeConfig.ts` / `../sanitize.ts` / `trpc.ts` / `types.ts`.
+
+### Zero-config
+An entity needs **no `meta/logs` entry**: the model is resolved from
+`config.mongooseName || payload.mongooseName || payload.collectionName`, and
+authz is **actor-or-admin** (owner, or the user who made every change). A
+`meta/logs` entry is still honored (gives a configured permission/contentType).
+
+### Authorization
+Actor-or-admin: an admin/owner, or the user who made every change in the process.
+No per-entity permission setup required.
+
+## Safety guards
+- **Multi-connection**: capture records the DB it wrote to; revert refuses an
+  entry whose model resolves to a DIFFERENT database (`dbName` mismatch) instead
+  of silently writing to the wrong DB → surfaced as `unrevertable`.
+- **Conflicts → merge**: if a record changed since, the field-level diff is
+  surfaced (revertValue vs currentValue) and the caller passes `resolutions`
+  (`restore`/`keep`/`custom`) — not a blind overwrite. `force` (admin only) blind-
+  restores.
+- **Idempotent**: a complete revert writes a marker (`payload.complete`); re-runs
+  return `alreadyReverted`. Re-inserts are idempotent.
+
+## UI (`frontend/core-ui/src/modules/logs`)
+On the **System Logs** screen, the log-detail sheet renders `LogRevertPanel`
+(shown for Mongo data-change logs AND the GraphQL mutation log of the same
+request — they share the processId; the `logsRevertProcess` log itself is
+excluded). Flow: "Revert this action" → dry-run preview → "Confirm revert", or a
+side-by-side field-level merge chooser ("Keep current" vs "Restore previous",
+with "Restore all"/"Keep all") when there are conflicts. `useRevertProcess`
+(`preview`/`apply`) + `LOGS_REVERT_PROCESS`.
+
+## Known gaps (not production-done)
+- Cascade completeness untested (a delete may restore the parent but not related
+  docs unless they pass through hooked ops).
+- Standalone Mongo = no transactions → a multi-doc revert can partially apply
+  (the result reports `reverted` vs `conflicts`).
+- Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates without a marker yet.
+- The old `MongoLogDetailContent` panel may still show "No document snapshot"
+  even when one was captured (cosmetic).
+- UI doesn't auto-refetch lists after a revert; System Logs is admin-only.
+- Org/separate-connection entities are *guarded* (refused), not yet revertable.
+- Branch `feat/erxes-agent-process-correlation`; not yet in a PR (stacked on
+  #8023). `REVERT_AUTO_JOURNAL` off by default.

--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -2,84 +2,131 @@
 
 This module owns the event log **and** the point-in-time revert ("undo") feature:
 any create/update/delete made through erxes can be journaled and later reverted,
-dynamically, with no per-entity code.
+**dynamically, with no per-entity code**. Built on branch
+`feat/erxes-agent-process-correlation` (stacked on PR #8023; the revert work is
+NOT yet in its own PR). Original driver: make the AI `erxes-agent`'s mistakes
+recoverable — but it's auth-agnostic (agent and human run under the same user).
+
+---
 
 ## Mechanism, end to end
 
-1. **Correlate** — every request carries one `processId` (AsyncLocalStorage,
-   `erxes-api-shared/.../runtimeContext.ts`); the apollo layer honors an inbound
-   `x-erxes-process-id` header (so the AI agent can stamp its actions).
+1. **Correlate** — every request carries one `processId` via AsyncLocalStorage
+   (`erxes-api-shared/.../eventHandlers/runtimeContext.ts`); the apollo layer
+   honors an inbound `x-erxes-process-id` header
+   (`erxes-api-shared/.../apollo/utils.ts`), so the agent can stamp its actions.
 2. **Capture (dynamic, zero per-call-site)** — a global hook lives in the shared
-   `schemaWrapper` (`erxes-api-shared/src/utils/mongo/revertCapture.ts`), which
-   EVERY model schema runs through. It auto-journals:
-   - **deletes** (`deleteOne`/`deleteMany`/`findOneAndDelete`) with the pre-image,
-   - **edits** (`updateOne`/`updateMany`/`findOneAndUpdate` + `doc.save()`) as a
-     before→after diff.
-   Creates are intentionally NOT captured (revert of a new record = delete it).
-   Each entry records `mongooseName` + `dbName`. It posts to the SAME `put_log`
-   BullMQ queue the manual `sendDbEventLog` uses, so the existing pipeline stores
-   it in `{subdomain}_logs`.
-   - **Gated** behind `REVERT_AUTO_JOURNAL=enable` — a complete no-op when off
-     (zero risk to the ~124 wrapped schemas). Must be set on EVERY writing
-     service, and is off by default (changes before enabling are unrecoverable).
-   - Every hook is wrapped so a capture failure can never block/throw out of a
-     write. Bulk capture is capped at `REVERT_AUTO_JOURNAL_MAX` (default 1000).
-3. **Invert** — `revert/computeInverse.ts` (pure): create→delete,
-   delete→re-insert (keep `_id`), update→restore prior field values.
+   `schemaWrapper` (every model schema runs through it). It auto-journals
+   **deletes** (with pre-image) and **edits** (before→after diff), recording
+   `mongooseName` + `dbName`, onto the same `put_log` BullMQ queue the manual
+   `sendDbEventLog` uses → stored in `{subdomain}_logs`. Creates are NOT captured
+   (revert of a new record = delete it).
+3. **Invert** — `revert/computeInverse.ts` (pure): create→delete, delete→re-insert
+   (keep `_id`), update→restore prior field values.
 4. **Revert** — `logsRevertProcess(processId, dryRun, force, skipConflicts,
-   resolutions)` GraphQL mutation → `revert/revertByProcessId.ts` reverse-replays
-   the process's entries.
+   resolutions)` → `revert/revertByProcessId.ts` reverse-replays the process's
+   entries (dedup → authorize → plan → conflicts → dry-run/apply → marker).
 
-## Revert engine (`revert/`)
+### Flag
+Capture is gated behind **`REVERT_AUTO_JOURNAL=enable`** — a complete no-op when
+off (zero risk to the ~124 wrapped schemas). Must be set on EVERY writing service;
+off by default (changes before enabling are unrecoverable). Bulk capture capped at
+`REVERT_AUTO_JOURNAL_MAX` (default 1000). Every hook is wrapped so a capture
+failure can never block/throw out of a write.
 
-- `revertByProcessId.ts` — orchestrator: load entries (newest-first), **dedup**
-  exact duplicates, **authorize**, plan inverses, detect conflicts, dry-run or
-  apply, write a marker.
-- `computeInverse.ts` — pure inverse per entry. `conflict.ts` — field-level
-  conflict detection (volatile fields like `updatedAt`/`searchText` are excluded).
-- `applyWrite.ts` — raw mongoose write (NOT audited statics) + whole-doc guards +
-  ES re-sync. `applyInverse.ts` — dispatch core/`auto:` in-process vs remote TRPC.
-- `contentTypeConfig.ts` / `../sanitize.ts` / `trpc.ts` / `types.ts`.
+### Zero-config + authz
+No `meta/logs` entry needed: model resolved from
+`config.mongooseName || payload.mongooseName || payload.collectionName`; authz is
+**actor-or-admin** (owner, or the user who made every change). A `meta/logs` entry
+is still honored when present.
 
-### Zero-config
-An entity needs **no `meta/logs` entry**: the model is resolved from
-`config.mongooseName || payload.mongooseName || payload.collectionName`, and
-authz is **actor-or-admin** (owner, or the user who made every change). A
-`meta/logs` entry is still honored (gives a configured permission/contentType).
+---
 
-### Authorization
-Actor-or-admin: an admin/owner, or the user who made every change in the process.
-No per-entity permission setup required.
+## File map (all packages)
+
+**Capture (shared):** `backend/erxes-api-shared/src/utils/mongo/`
+- `revertCapture.ts` — the auto-capture: `installRevertCaptureHooks(schema)`
+  (pre/post hooks for delete*/update*/save), `journalDeletes`/`journalUpdates`,
+  `registerRevertContentTypeResolver`. Gated by `REVERT_AUTO_JOURNAL`.
+- `mongoose-utils.ts` — `schemaWrapper` calls `installRevertCaptureHooks`.
+- `index.ts` — re-exports revertCapture. ⚠️ After editing shared, **`pnpm build`**
+  it and **restart** consumers (it's loaded as built dist, not via tsx-watch).
+
+**Journal consumer:** `backend/services/logs/src/bullmq/mongo.ts`
+- `handleDelete`/`handleDeleteMany`/`handleUpdate` + dispatcher. Stores
+  `prevDocument(s)` / `updateDescription` + `mongooseName` + `dbName`. (Fixed: the
+  single-`delete` path used to drop `prevDocument`.)
+
+**Engine:** `backend/core-api/src/modules/logs/revert/`
+- `revertByProcessId.ts` — orchestrator (load newest-first, dedup, actor-or-admin
+  authz, multi-connection guard, plan, conflicts, dry-run/apply, marker).
+- `computeInverse.ts` (pure inverse) · `conflict.ts` (field conflicts; volatile
+  fields excluded) · `applyWrite.ts` (raw write + whole-doc guards + ES re-sync) ·
+  `applyInverse.ts` (core/`auto:` in-process vs remote TRPC) ·
+  `contentTypeConfig.ts` · `trpc.ts` · `types.ts`.
+- `../sanitize.ts` (mask PII in previews) · `../graphql/{schema,resolvers}` —
+  `logsRevertProcess` mutation + `Log` type exposes `processId`/`contentType` ·
+  `../../../meta/logs.ts` (optional per-entity config) ·
+  `erxes-api-shared/.../elasticsearch/saveEs.ts`.
+
+**UI:** `frontend/core-ui/src/modules/logs/`
+- `components/LogRevertPanel.tsx` — the Undo surface in the log-detail sheet (shown
+  for Mongo data-change logs AND the GraphQL mutation log of the same request;
+  excludes the `logsRevertProcess` log). Dry-run preview → confirm, or a
+  side-by-side field-level merge chooser (Keep current / Restore previous, with
+  Restore-all/Keep-all) on conflict.
+- `hooks/useRevertProcess.tsx` (`preview`/`apply`) · `graphql/revertMutations.ts`
+  (`LOGS_REVERT_PROCESS`) · `components/LogDetailView.tsx` (renders the panel) ·
+  `components/LogDetailPrimitives.tsx` (JSON viewer made dark-theme-readable).
+
+---
 
 ## Safety guards
-- **Multi-connection**: capture records the DB it wrote to; revert refuses an
-  entry whose model resolves to a DIFFERENT database (`dbName` mismatch) instead
-  of silently writing to the wrong DB → surfaced as `unrevertable`.
-- **Conflicts → merge**: if a record changed since, the field-level diff is
-  surfaced (revertValue vs currentValue) and the caller passes `resolutions`
-  (`restore`/`keep`/`custom`) — not a blind overwrite. `force` (admin only) blind-
-  restores.
-- **Idempotent**: a complete revert writes a marker (`payload.complete`); re-runs
-  return `alreadyReverted`. Re-inserts are idempotent.
+- **Multi-connection**: revert refuses an entry whose model resolves to a
+  different database than the recorded `dbName` (→ `unrevertable`), never silently
+  writes to the wrong DB.
+- **Conflicts → merge** (not blind overwrite): field-level diff + `resolutions`
+  (`restore`/`keep`/`custom`); `force` (admin only) blind-restores.
+- **Idempotent**: complete revert writes `payload.complete` marker; re-runs return
+  `alreadyReverted`; re-inserts are idempotent. Dedup collapses exact duplicates
+  (manual + auto double-logging).
 
-## UI (`frontend/core-ui/src/modules/logs`)
-On the **System Logs** screen, the log-detail sheet renders `LogRevertPanel`
-(shown for Mongo data-change logs AND the GraphQL mutation log of the same
-request — they share the processId; the `logsRevertProcess` log itself is
-excluded). Flow: "Revert this action" → dry-run preview → "Confirm revert", or a
-side-by-side field-level merge chooser ("Keep current" vs "Restore previous",
-with "Restore all"/"Keep all") when there are conflicts. `useRevertProcess`
-(`preview`/`apply`) + `LOGS_REVERT_PROCESS`.
+---
 
-## Known gaps (not production-done)
-- Cascade completeness untested (a delete may restore the parent but not related
+## Run & test locally
+- Stack: Docker Mongo + Redis (+ ES). Services: core-api (`:3300`), logs-service
+  (`cd backend/services/logs && pnpm dev` — NOT in the default `nx serve` set, but
+  it's what writes `{subdomain}_logs`), gateway (`:4000`) + apollo-router
+  (`:50000`), core-ui (`:3001`).
+- **Cloud-vs-local trap**: root `.env` `MONGO_URL` points at cloud Atlas; force
+  `MONGO_URL=mongodb://127.0.0.1:27017/erxes` for local. Verify the boot log says
+  `Connected to the database: mongodb://127.0.0.1...`.
+- Enable capture: `REVERT_AUTO_JOURNAL=enable` on core-api (and any writing svc).
+- Adding a `Log` GraphQL field needs core-api restart **and** a gateway
+  recompose (kill `:4000` + `:50000` + the router, relaunch gateway).
+- Smoke test: create+delete a tag/department (no `meta/logs` entry → zero-config)
+  → `logsRevertProcess(processId)` → verify restored. UI: System Logs → open the
+  log → "Revert this action".
+
+---
+
+## Known gaps (NOT production-done)
+- Cascade completeness untested (delete may restore the parent but not related
   docs unless they pass through hooked ops).
-- Standalone Mongo = no transactions → a multi-doc revert can partially apply
-  (the result reports `reverted` vs `conflicts`).
-- Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates without a marker yet.
-- The old `MongoLogDetailContent` panel may still show "No document snapshot"
-  even when one was captured (cosmetic).
-- UI doesn't auto-refetch lists after a revert; System Logs is admin-only.
-- Org/separate-connection entities are *guarded* (refused), not yet revertable.
-- Branch `feat/erxes-agent-process-correlation`; not yet in a PR (stacked on
-  #8023). `REVERT_AUTO_JOURNAL` off by default.
+- Standalone Mongo = no transactions → multi-doc revert can partially apply
+  (result reports `reverted` vs `conflicts`).
+- Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates with no marker yet.
+- `.save()` capture coded but not independently live-verified.
+- Old `MongoLogDetailContent` panel may still show "No document snapshot" even
+  when one was captured (cosmetic).
+- UI doesn't auto-refetch lists after revert; System Logs is admin-only.
+- Org/separate-connection entities are *guarded* (refused), not yet revertable
+  (needs connection-aware applyWrite).
+- No automated tests; perf of the extra read-per-write is unmeasured; not human-
+  reviewed/CI'd; not in a PR.
+
+## Commit trail (branch feat/erxes-agent-process-correlation)
+`d61d4bbde9` engine (Phase 3b) · `bd6242ec8e` pitfall fixes · `5b2d545975`
+dynamic delete capture · `6ea1c9db10` zero-config · `e4200f70bb` edit capture ·
+`c0ab1d5560` Undo UI · `58673e8495` .save + multi-conn guard · `656dea0cbe`
+dedup · `39c9af1a49`/`5e3a742c5f`/`bedda42486`/`3e05fa3892` UI fixes.

--- a/backend/core-api/src/modules/logs/graphql/resolvers/mutations.ts
+++ b/backend/core-api/src/modules/logs/graphql/resolvers/mutations.ts
@@ -1,0 +1,37 @@
+import { IContext } from '~/connectionResolvers';
+import { revertByProcessId } from '../../revert/revertByProcessId';
+import { RevertDocResolution } from '../../revert/types';
+
+export interface LogsRevertProcessArgs {
+  processId: string;
+  dryRun?: boolean;
+  force?: boolean;
+  skipConflicts?: boolean;
+  resolutions?: RevertDocResolution[];
+}
+
+export const logMutations = {
+  /**
+   * Point-in-time revert of every change carrying `processId`.
+   *
+   * Per-entity authorization (each distinct contentType's gating permission, or
+   * admin/owner) is enforced inside the orchestrator BEFORE any write — a caller
+   * lacking permission for any entity in the process gets the whole revert
+   * refused. dryRun returns a preview (wouldRevert + field-level conflicts +
+   * unrevertable) without mutating; conflicts can then be resolved via the merge
+   * style `resolutions` input.
+   */
+  async logsRevertProcess(
+    _root: unknown,
+    args: LogsRevertProcessArgs,
+    context: IContext,
+  ) {
+    return await revertByProcessId(context, {
+      processId: args.processId,
+      dryRun: args.dryRun,
+      force: args.force,
+      skipConflicts: args.skipConflicts,
+      resolutions: args.resolutions,
+    });
+  },
+};

--- a/backend/core-api/src/modules/logs/graphql/resolvers/queries.ts
+++ b/backend/core-api/src/modules/logs/graphql/resolvers/queries.ts
@@ -2,6 +2,7 @@ import { ILogContentTypeConfig } from 'erxes-api-shared/core-modules';
 import { ILogDocument } from 'erxes-api-shared/core-types';
 import { cursorPaginate, getPlugin, getPlugins } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
+import { sanitizeLogValue } from '../../sanitize';
 
 const operatorMap = {
   ne: '$ne',
@@ -25,90 +26,6 @@ const getCollectionTypeFromContentType = (contentType?: string) => {
 
   const [, , collectionType = ''] = contentType.replace(':', '.').split('.');
   return collectionType;
-};
-
-const SECRET_KEY_PATTERNS = [
-  /password/i,
-  /passcode/i,
-  /token/i,
-  /secret/i,
-  /authorization/i,
-  /cookie/i,
-  /api[-_]?key/i,
-  /private[-_]?key/i,
-];
-
-const EMAIL_KEY_PATTERNS = [/email/i];
-const IP_KEY_PATTERNS = [/(^|[_-])ip$/i, /ipAddress/i];
-const PHONE_KEY_PATTERNS = [/phone/i, /mobile/i];
-
-const isSecretKey = (key: string) =>
-  SECRET_KEY_PATTERNS.some((pattern) => pattern.test(key));
-
-const isIdLikeKey = (key: string) =>
-  key === '__v' ||
-  /^_id$/i.test(key) ||
-  /^id$/i.test(key) ||
-  /Id(s)?$/.test(key) ||
-  /[_-]id(s)?$/i.test(key) ||
-  /^(createdBy|updatedBy)$/i.test(key);
-
-const isEmailKey = (key: string) =>
-  EMAIL_KEY_PATTERNS.some((pattern) => pattern.test(key));
-
-const isIpKey = (key: string) =>
-  IP_KEY_PATTERNS.some((pattern) => pattern.test(key));
-
-const isPhoneKey = (key: string) =>
-  PHONE_KEY_PATTERNS.some((pattern) => pattern.test(key));
-
-const maskIdentifier = (value: string) => {
-  if (!value) {
-    return '••••••';
-  }
-
-  if (value.length <= 8) {
-    return '••••••';
-  }
-
-  return `${value.slice(0, 4)}••••••••${value.slice(-4)}`;
-};
-
-const maskEmail = (value: string) => {
-  const [local = '', domain = ''] = value.split('@');
-
-  if (!local || !domain) {
-    return '••••••';
-  }
-
-  const visibleLocal = local.slice(0, Math.min(2, local.length));
-  return `${visibleLocal}••••@${domain}`;
-};
-
-const maskIpAddress = (value: string) => {
-  if (value.includes('.')) {
-    const [first = '*', second = '*'] = value.split('.');
-    return `${first}.${second}.***.***`;
-  }
-
-  if (value.includes(':')) {
-    const [head = '****'] = value.split(':');
-    return `${head}:****:****`;
-  }
-
-  return '••••••';
-};
-
-const maskPhone = (value: string) => {
-  if (value.length <= 4) {
-    return '••••';
-  }
-
-  return `${'•'.repeat(Math.max(4, value.length - 2))}${value.slice(-2)}`;
-};
-
-type SanitizeLogOptions = {
-  exposeEmail?: boolean;
 };
 
 type PayloadFilterInput = {
@@ -144,71 +61,6 @@ type LeanLogDetail = Record<string, unknown> & {
   source: string;
   payload?: unknown;
   prevObject?: unknown;
-};
-
-const sanitizeLogValue = (
-  value: unknown,
-  key?: string,
-  options: SanitizeLogOptions = {},
-): unknown => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    if (key && isIdLikeKey(key)) {
-      return value.map((item) =>
-        typeof item === 'string'
-          ? maskIdentifier(item)
-          : sanitizeLogValue(item, undefined, options),
-      );
-    }
-
-    return value.map((item) => sanitizeLogValue(item, key, options));
-  }
-
-  if (typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>).reduce<
-      Record<string, unknown>
-    >((acc, [childKey, childValue]) => {
-      acc[childKey] = sanitizeLogValue(childValue, childKey, options);
-      return acc;
-    }, {});
-  }
-
-  if (!key || typeof value !== 'string') {
-    return value;
-  }
-
-  if (isSecretKey(key)) {
-    return '••••••';
-  }
-
-  if (key === '__v') {
-    return '[hidden]';
-  }
-
-  if (isIdLikeKey(key)) {
-    return maskIdentifier(value);
-  }
-
-  if (isEmailKey(key)) {
-    if (options.exposeEmail) {
-      return value;
-    }
-
-    return maskEmail(value);
-  }
-
-  if (isIpKey(key)) {
-    return maskIpAddress(value);
-  }
-
-  if (isPhoneKey(key)) {
-    return maskPhone(value);
-  }
-
-  return value;
 };
 
 const generateValue = (field: string, value: unknown, operator: string) => {

--- a/backend/core-api/src/modules/logs/graphql/schema/index.ts
+++ b/backend/core-api/src/modules/logs/graphql/schema/index.ts
@@ -8,6 +8,8 @@ export const types = `
       status:String,
       userId:String,
       cursor:String,
+      processId:String,
+      contentType:String,
 
       user:User
       prevObject:JSON

--- a/backend/core-api/src/modules/logs/graphql/schema/index.ts
+++ b/backend/core-api/src/modules/logs/graphql/schema/index.ts
@@ -45,6 +45,54 @@ export const types = `
         changes: JSON
         metadata: JSON
     }
+
+    type LogRevertField {
+        field: String!
+        revertValue: JSON
+        currentValue: JSON
+    }
+
+    type LogRevertConflict {
+        contentType: String!
+        docId: String!
+        mongooseName: String!
+        fields: [LogRevertField!]!
+    }
+
+    type LogRevertApplied {
+        contentType: String!
+        docId: String!
+        kind: String!
+    }
+
+    type LogRevertUnrevertable {
+        contentType: String
+        docId: String
+        action: String!
+        reason: String!
+    }
+
+    type LogRevertResult {
+        processId: String!
+        requestProcessId: String!
+        dryRun: Boolean!
+        alreadyReverted: Boolean!
+        reverted: [LogRevertApplied!]!
+        conflicts: [LogRevertConflict!]!
+        unrevertable: [LogRevertUnrevertable!]!
+    }
+
+    input LogRevertFieldResolutionInput {
+        field: String!
+        mode: String!
+        value: JSON
+    }
+
+    input LogRevertDocResolutionInput {
+        contentType: String!
+        docId: String!
+        fields: [LogRevertFieldResolutionInput!]!
+    }
 `;
 
 const cursorParams = `
@@ -89,4 +137,15 @@ export const queries = `
     logsGetContentTypes: [LogContentType!]!
     logDetail(_id:String!):Log
 `;
-export default { types, queries };
+
+export const mutations = `
+    logsRevertProcess(
+      processId: String!
+      dryRun: Boolean
+      force: Boolean
+      skipConflicts: Boolean
+      resolutions: [LogRevertDocResolutionInput!]
+    ): LogRevertResult
+`;
+
+export default { types, queries, mutations };

--- a/backend/core-api/src/modules/logs/revert/applyInverse.ts
+++ b/backend/core-api/src/modules/logs/revert/applyInverse.ts
@@ -30,7 +30,11 @@ export const applyInverse = async (args: {
 
   const pluginName = pluginNameOf(input.contentType);
 
-  if (pluginName === 'core') {
+  // `core` = first-party entities; `auto` = entities captured generically by the
+  // shared schemaWrapper hooks (which run in THIS process on THIS connection).
+  // Both apply in-process via applyWrite. Only a genuinely remote plugin entity
+  // is dispatched over TRPC.
+  if (pluginName === 'core' || pluginName === 'auto') {
     return await applyWrite({
       connection,
       subdomain,

--- a/backend/core-api/src/modules/logs/revert/applyInverse.ts
+++ b/backend/core-api/src/modules/logs/revert/applyInverse.ts
@@ -1,0 +1,64 @@
+import { Connection } from 'mongoose';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { applyWrite } from './applyWrite';
+import { ApplyWriteInput, ApplyWriteResult } from './types';
+
+/**
+ * Dispatch one inverse op to the plugin that owns the entity.
+ *
+ * - core entities  -> apply in-process via applyWrite (same connection).
+ * - remote entities -> sendTRPCMessage to the owning plugin's revert.applyWrite
+ *   procedure, forwarding context:{processId,userId} so the reverted write logs
+ *   under the request's processId (TRPC does NOT auto-forward processId unless
+ *   the context is passed explicitly).
+ *
+ * The pluginName is the first segment of the contentType (`plugin:module.coll`).
+ */
+
+const pluginNameOf = (contentType: string): string => {
+  return contentType.split(':')[0] || 'core';
+};
+
+export const applyInverse = async (args: {
+  connection: Connection;
+  subdomain: string;
+  input: ApplyWriteInput;
+  requestProcessId: string;
+  userId: string;
+}): Promise<ApplyWriteResult> => {
+  const { connection, subdomain, input, requestProcessId, userId } = args;
+
+  const pluginName = pluginNameOf(input.contentType);
+
+  if (pluginName === 'core') {
+    return await applyWrite({
+      connection,
+      subdomain,
+      input,
+    });
+  }
+
+  const result = (await sendTRPCMessage({
+    subdomain,
+    pluginName,
+    method: 'mutation',
+    module: 'revert',
+    action: 'applyWrite',
+    input,
+    context: {
+      processId: requestProcessId,
+      userId,
+    },
+    defaultValue: null,
+  })) as ApplyWriteResult | null;
+
+  if (!result) {
+    return {
+      ok: false,
+      conflict: true,
+      reason: `Plugin "${pluginName}" did not apply the revert write (unreachable or revert.applyWrite not mounted)`,
+    };
+  }
+
+  return result;
+};

--- a/backend/core-api/src/modules/logs/revert/applyWrite.ts
+++ b/backend/core-api/src/modules/logs/revert/applyWrite.ts
@@ -1,0 +1,162 @@
+import { isEqual } from 'lodash';
+import { Connection, Model } from 'mongoose';
+import { saveEsDoc, deleteEsDoc } from 'erxes-api-shared/utils';
+import { ApplyWriteInput, ApplyWriteResult } from './types';
+
+/**
+ * Apply a single inverse op via RAW mongoose model methods (create / updateOne /
+ * deleteOne), NEVER the audited statics (createCustomer, etc.) — raw writes
+ * avoid double-logging, recursion and dedup-rejection, while the schema still
+ * casts types (string -> ObjectId, dates, defaults). The original _id is always
+ * preserved so references pointing at a restored doc are made whole again.
+ *
+ * Whole-doc conflict guards (field-level update conflicts are detected upstream):
+ *   - insert (undo a delete): live must be ABSENT — never overwrite a doc that
+ *     was re-created in the interim.
+ *   - delete (undo a create): live must still MATCH the created snapshot — never
+ *     delete a doc that diverged since creation.
+ *   - update: applied directly; its conflicts were resolved by the orchestrator.
+ *
+ * After a successful Mongo write the change is mirrored into Elasticsearch
+ * (gated on isUsingElk inside the helper), since there is no in-process
+ * Mongo->ES pipeline at the model layer.
+ */
+
+type RawDoc = Record<string, unknown>;
+
+const resolveModel = (
+  connection: Connection,
+  mongooseName: string,
+): Model<RawDoc> => {
+  return connection.model<RawDoc>(mongooseName);
+};
+
+/**
+ * Whole-doc guard for a delete-inverse (undo a create): the live doc must still
+ * match the snapshot the create produced (ignoring volatile bookkeeping fields).
+ */
+export const createSnapshotMatchesLive = (
+  createdDoc: RawDoc | null | undefined,
+  liveDoc: RawDoc | null | undefined,
+): boolean => {
+  if (!createdDoc || !liveDoc) {
+    return false;
+  }
+  const strip = (d: RawDoc) => {
+    const { updatedAt: _u, __v: _v, ...rest } = d;
+    return rest;
+  };
+  return isEqual(strip(createdDoc), strip(liveDoc));
+};
+
+export const applyWrite = async (args: {
+  connection: Connection;
+  subdomain: string;
+  input: ApplyWriteInput;
+}): Promise<ApplyWriteResult> => {
+  const { connection, subdomain, input } = args;
+  const model = resolveModel(connection, input.mongooseName);
+
+  if (input.kind === 'insert') {
+    const existing = (await model.findById(input.docId).lean()) as RawDoc | null;
+    if (existing) {
+      // Idempotency: if the live doc already equals what we'd restore, a prior
+      // revert (or a re-call carrying merge resolutions) already did this — treat
+      // it as applied, not a conflict, so the merge re-call flow converges.
+      if (createSnapshotMatchesLive(input.document, existing)) {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        conflict: true,
+        reason: 'A document with this _id already exists (re-created in the interim)',
+        liveState: existing,
+      };
+    }
+
+    // Re-insert preserving the original _id so references re-resolve. Provenance
+    // (which revert restored it) is recorded in the revert marker log under
+    // requestProcessId — entity schemas are strict, so an inline restoredFrom
+    // stamp would be silently dropped and is intentionally omitted here.
+    const document: RawDoc = {
+      ...input.document,
+      _id: input.docId,
+    };
+
+    await model.create(document);
+
+    await saveEsDoc({
+      subdomain,
+      contentType: input.contentType,
+      _id: input.docId,
+      document,
+    });
+
+    return { ok: true };
+  }
+
+  if (input.kind === 'delete') {
+    const existing = (await model
+      .findById(input.docId)
+      .lean()) as RawDoc | null;
+    if (!existing) {
+      // Already gone — the desired post-state holds. Treat as applied.
+      return { ok: true };
+    }
+
+    // Undo-a-create guard: only delete if the live doc still matches the snapshot
+    // the create produced. An intervening change means deleting would destroy it.
+    if (
+      input.expectDocument &&
+      !createSnapshotMatchesLive(input.expectDocument, existing)
+    ) {
+      return {
+        ok: false,
+        conflict: true,
+        reason:
+          'Document changed since it was created; refusing to delete (undo-create conflict)',
+        liveState: existing,
+      };
+    }
+
+    await model.deleteOne({ _id: input.docId });
+
+    await deleteEsDoc({
+      subdomain,
+      contentType: input.contentType,
+      _id: input.docId,
+    });
+
+    return { ok: true };
+  }
+
+  // update
+  const update: Record<string, unknown> = {};
+  if (Object.keys(input.set).length) {
+    update.$set = input.set;
+  }
+  if (input.unset.length) {
+    update.$unset = input.unset.reduce<Record<string, ''>>((acc, path) => {
+      acc[path] = '';
+      return acc;
+    }, {});
+  }
+
+  if (!Object.keys(update).length) {
+    return { ok: true };
+  }
+
+  await model.updateOne({ _id: input.docId }, update);
+
+  const fresh = (await model.findById(input.docId).lean()) as RawDoc | null;
+  if (fresh) {
+    await saveEsDoc({
+      subdomain,
+      contentType: input.contentType,
+      _id: input.docId,
+      document: fresh,
+    });
+  }
+
+  return { ok: true };
+};

--- a/backend/core-api/src/modules/logs/revert/computeInverse.ts
+++ b/backend/core-api/src/modules/logs/revert/computeInverse.ts
@@ -1,0 +1,176 @@
+/**
+ * The pure heart of point-in-time revert: given one event-log entry, compute the
+ * inverse operation that undoes it. No DB access — callers read the current doc
+ * and apply the returned op. Keeping this pure makes the safety-critical logic
+ * exhaustively testable.
+ *
+ * Inverses (see getDiffObjects for the diff shape stored on updates):
+ *   create            -> delete the created doc
+ *   delete/deleteMany -> re-insert the snapshot, preserving its original _id
+ *   update            -> $set changed fields back to prev, restore removed
+ *                        fields, unset added fields
+ *   updateMany/bulkWrite -> NOT auto-reverted (the aggregate diff lacks reliable
+ *                        per-doc prev state); flagged for manual review instead
+ *                        of risking a wrong write.
+ */
+
+export interface RevertableLogEntry {
+  _id?: string;
+  action:
+    | 'create'
+    | 'update'
+    | 'delete'
+    | 'deleteMany'
+    | 'updateMany'
+    | 'bulkWrite';
+  docId?: string;
+  contentType?: string;
+  payload?: {
+    collectionName?: string;
+    collectionType?: string;
+    fullDocument?: Record<string, unknown> | null;
+    prevDocument?: Record<string, unknown> | null;
+    updateDescription?: {
+      added?: Record<string, unknown>;
+      removed?: Record<string, unknown>;
+      updated?: Record<string, unknown>;
+    };
+  };
+}
+
+export type InverseOp =
+  | {
+      kind: 'insert';
+      contentType?: string;
+      docId: string;
+      document: Record<string, unknown>;
+    }
+  | { kind: 'delete'; contentType?: string; docId: string }
+  | {
+      kind: 'update';
+      contentType?: string;
+      docId: string;
+      set: Record<string, unknown>;
+      unset: string[];
+    }
+  | { kind: 'skip'; reason: string };
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null &&
+  typeof v === 'object' &&
+  !Array.isArray(v) &&
+  !(v instanceof Date);
+
+/** A node is a diff leaf when it is exactly a { prev, current } pair. */
+const isDiffLeaf = (v: unknown): v is { prev: unknown; current: unknown } =>
+  isPlainObject(v) &&
+  Object.prototype.hasOwnProperty.call(v, 'prev') &&
+  Object.prototype.hasOwnProperty.call(v, 'current') &&
+  Object.keys(v).length === 2;
+
+/**
+ * Flatten a diff accumulator (added/removed/updated) into dot-path → value.
+ * `pick` extracts the value to emit at each leaf; recursion descends only
+ * through plain non-leaf objects, so nested field paths are preserved exactly
+ * as MongoDB $set/$unset expect them.
+ */
+function flattenLeaves(
+  node: unknown,
+  pick: (leaf: unknown) => unknown,
+  isLeaf: (v: unknown) => boolean,
+  prefix = '',
+  out: Record<string, unknown> = {},
+): Record<string, unknown> {
+  if (isLeaf(node)) {
+    out[prefix] = pick(node);
+    return out;
+  }
+  if (isPlainObject(node)) {
+    for (const key of Object.keys(node)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      flattenLeaves(node[key], pick, isLeaf, path, out);
+    }
+    return out;
+  }
+  // A bare primitive/array/Date at the top with no key — nothing addressable.
+  return out;
+}
+
+/** Compute the inverse of one log entry. Never throws; returns a skip on doubt. */
+export function computeInverse(entry: RevertableLogEntry): InverseOp {
+  const { action, contentType } = entry;
+  const payload = entry.payload || {};
+  const docId = entry.docId;
+
+  if (action === 'create') {
+    if (!docId) return { kind: 'skip', reason: 'create log has no docId' };
+    // Undo a creation by deleting the doc.
+    return { kind: 'delete', contentType, docId };
+  }
+
+  if (action === 'delete' || action === 'deleteMany') {
+    if (!docId) return { kind: 'skip', reason: 'delete log has no docId' };
+    const snapshot = payload.prevDocument;
+    if (!isPlainObject(snapshot)) {
+      return {
+        kind: 'skip',
+        reason: 'delete has no prevDocument snapshot (pre-snapshot deletion)',
+      };
+    }
+    // Re-insert exactly as it was, preserving the original _id so references
+    // pointing at this doc are made whole again.
+    return {
+      kind: 'insert',
+      contentType,
+      docId,
+      document: { ...snapshot, _id: snapshot._id ?? docId },
+    };
+  }
+
+  if (action === 'update') {
+    if (!docId) return { kind: 'skip', reason: 'update log has no docId' };
+    const diff = payload.updateDescription || {};
+
+    const set: Record<string, unknown> = {};
+    const unset: string[] = [];
+
+    // updated: restore each changed leaf to its prev value.
+    if (diff.updated) {
+      flattenLeaves(
+        diff.updated,
+        (leaf) => (leaf as { prev: unknown }).prev,
+        isDiffLeaf,
+        '',
+        set,
+      );
+    }
+
+    // removed: the field existed before with this value — set it back.
+    if (diff.removed) {
+      flattenLeaves(diff.removed, (leaf) => leaf, (v) => !isPlainObject(v), '', set);
+    }
+
+    // added: the field did not exist before — unset it.
+    if (diff.added) {
+      const addedPaths = flattenLeaves(
+        diff.added,
+        () => true,
+        (v) => !isPlainObject(v),
+        '',
+        {},
+      );
+      unset.push(...Object.keys(addedPaths));
+    }
+
+    if (Object.keys(set).length === 0 && unset.length === 0) {
+      return { kind: 'skip', reason: 'update diff is empty' };
+    }
+    return { kind: 'update', contentType, docId, set, unset };
+  }
+
+  // updateMany / bulkWrite: the diff is an aggregate, not per-doc prev state.
+  return {
+    kind: 'skip',
+    reason: `${action} is not auto-revertible (no reliable per-document prior state)`,
+  };
+}

--- a/backend/core-api/src/modules/logs/revert/conflict.ts
+++ b/backend/core-api/src/modules/logs/revert/conflict.ts
@@ -1,0 +1,150 @@
+import { get as lodashGet, isEqual } from 'lodash';
+import { RevertableLogEntry } from './computeInverse';
+import { FieldConflict } from './types';
+
+/**
+ * Optimistic conflict detection for point-in-time revert.
+ *
+ * A revert is safe only if nothing changed the doc between the forward write we
+ * are undoing and now. We compare the LIVE doc against the recorded after-image
+ * (what the forward op produced) over EXACTLY the fields the forward op touched.
+ * If a touched field's live value diverges from the recorded after-image value,
+ * the field is in conflict: an intervening change would be silently clobbered by
+ * a blind restore.
+ *
+ * Returns one FieldConflict per diverged field:
+ *   - revertValue  = the value the revert would restore (recorded prev)
+ *   - currentValue = the intervening live value
+ *
+ * No DB access — the caller supplies the live doc.
+ */
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null &&
+  typeof v === 'object' &&
+  !Array.isArray(v) &&
+  !(v instanceof Date);
+
+const isDiffLeaf = (v: unknown): v is { prev: unknown; current: unknown } =>
+  isPlainObject(v) &&
+  Object.prototype.hasOwnProperty.call(v, 'prev') &&
+  Object.prototype.hasOwnProperty.call(v, 'current') &&
+  Object.keys(v).length === 2;
+
+interface FlatLeaf {
+  path: string;
+  prev: unknown;
+  current: unknown;
+}
+
+/** Flatten an updated/removed/added accumulator into dot-path leaves. */
+function flattenUpdated(
+  node: unknown,
+  prefix: string,
+  out: FlatLeaf[],
+): void {
+  if (isDiffLeaf(node)) {
+    out.push({ path: prefix, prev: node.prev, current: node.current });
+    return;
+  }
+  if (isPlainObject(node)) {
+    for (const key of Object.keys(node)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      flattenUpdated(node[key], path, out);
+    }
+  }
+}
+
+function flattenLeafValues(
+  node: unknown,
+  prefix: string,
+  out: Array<{ path: string; value: unknown }>,
+): void {
+  if (!isPlainObject(node)) {
+    if (prefix) {
+      out.push({ path: prefix, value: node });
+    }
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    flattenLeafValues(node[key], path, out);
+  }
+}
+
+const FIELD_ABSENT = Symbol('absent');
+
+/**
+ * Detect field-level conflicts between an update log entry and the live doc.
+ * Only meaningful for `update` entries; create/delete inverses use the
+ * whole-doc conflict checks in applyWrite (live-must-match / live-must-be-absent).
+ */
+export function detectUpdateConflicts(
+  entry: RevertableLogEntry,
+  liveDoc: Record<string, unknown> | null,
+): FieldConflict[] {
+  if (entry.action !== 'update') {
+    return [];
+  }
+
+  const diff = entry.payload?.updateDescription || {};
+  const conflicts: FieldConflict[] = [];
+
+  // updated: forward op changed prev -> current. Conflict if live !== current.
+  const updatedLeaves: FlatLeaf[] = [];
+  if (diff.updated) {
+    flattenUpdated(diff.updated, '', updatedLeaves);
+  }
+  for (const leaf of updatedLeaves) {
+    const liveValue = liveDoc ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT) : FIELD_ABSENT;
+    if (liveValue === FIELD_ABSENT || !isEqual(liveValue, leaf.current)) {
+      conflicts.push({
+        field: leaf.path,
+        revertValue: leaf.prev,
+        currentValue: liveValue === FIELD_ABSENT ? undefined : liveValue,
+      });
+    }
+  }
+
+  // added: forward op added a field (after-image has it, prev did not). The
+  // revert unsets it; conflict if the live value diverged from what was added.
+  if (diff.added) {
+    const addedLeaves: Array<{ path: string; value: unknown }> = [];
+    flattenLeafValues(diff.added, '', addedLeaves);
+    for (const leaf of addedLeaves) {
+      const liveValue = liveDoc
+        ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT)
+        : FIELD_ABSENT;
+      if (liveValue !== FIELD_ABSENT && !isEqual(liveValue, leaf.value)) {
+        conflicts.push({
+          field: leaf.path,
+          // Revert removes the field — express "restore to absent" as undefined.
+          revertValue: undefined,
+          currentValue: liveValue,
+        });
+      }
+    }
+  }
+
+  // removed: forward op removed a field that previously held `value`. The revert
+  // restores it; conflict if the live doc now holds a DIFFERENT value at that
+  // path (something re-added it differently).
+  if (diff.removed) {
+    const removedLeaves: Array<{ path: string; value: unknown }> = [];
+    flattenLeafValues(diff.removed, '', removedLeaves);
+    for (const leaf of removedLeaves) {
+      const liveValue = liveDoc
+        ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT)
+        : FIELD_ABSENT;
+      if (liveValue !== FIELD_ABSENT && !isEqual(liveValue, leaf.value)) {
+        conflicts.push({
+          field: leaf.path,
+          revertValue: leaf.value,
+          currentValue: liveValue,
+        });
+      }
+    }
+  }
+
+  return conflicts;
+}

--- a/backend/core-api/src/modules/logs/revert/conflict.ts
+++ b/backend/core-api/src/modules/logs/revert/conflict.ts
@@ -19,6 +19,25 @@ import { FieldConflict } from './types';
  * No DB access — the caller supplies the live doc.
  */
 
+// Bookkeeping / derived fields that change as a side effect of every write and
+// carry no user intent. They must NOT be reported as conflicts: a merge UI would
+// ask the user to reconcile `updatedAt` (which always differs), and because they
+// differ on essentially every intervening write, including them would make nearly
+// every update-revert look conflicted. The revert's inverse still restores them;
+// we only suppress them from the human-facing conflict surface. Matching is on
+// the field's root segment so nested paths under these are covered too.
+const VOLATILE_FIELD_ROOTS = new Set<string>([
+  'updatedAt',
+  'modifiedAt',
+  'createdAt',
+  '__v',
+  'searchText',
+]);
+
+const isVolatilePath = (path: string): boolean =>
+  VOLATILE_FIELD_ROOTS.has(path) ||
+  VOLATILE_FIELD_ROOTS.has(path.split('.')[0]);
+
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   v !== null &&
   typeof v === 'object' &&
@@ -96,6 +115,9 @@ export function detectUpdateConflicts(
     flattenUpdated(diff.updated, '', updatedLeaves);
   }
   for (const leaf of updatedLeaves) {
+    if (isVolatilePath(leaf.path)) {
+      continue;
+    }
     const liveValue = liveDoc ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT) : FIELD_ABSENT;
     if (liveValue === FIELD_ABSENT || !isEqual(liveValue, leaf.current)) {
       conflicts.push({
@@ -112,6 +134,9 @@ export function detectUpdateConflicts(
     const addedLeaves: Array<{ path: string; value: unknown }> = [];
     flattenLeafValues(diff.added, '', addedLeaves);
     for (const leaf of addedLeaves) {
+      if (isVolatilePath(leaf.path)) {
+        continue;
+      }
       const liveValue = liveDoc
         ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT)
         : FIELD_ABSENT;
@@ -133,6 +158,9 @@ export function detectUpdateConflicts(
     const removedLeaves: Array<{ path: string; value: unknown }> = [];
     flattenLeafValues(diff.removed, '', removedLeaves);
     for (const leaf of removedLeaves) {
+      if (isVolatilePath(leaf.path)) {
+        continue;
+      }
       const liveValue = liveDoc
         ? lodashGet(liveDoc, leaf.path, FIELD_ABSENT)
         : FIELD_ABSENT;

--- a/backend/core-api/src/modules/logs/revert/contentTypeConfig.ts
+++ b/backend/core-api/src/modules/logs/revert/contentTypeConfig.ts
@@ -1,0 +1,60 @@
+import { ILogContentTypeConfig } from 'erxes-api-shared/core-modules';
+import { getPlugin, getPlugins } from 'erxes-api-shared/utils';
+
+/**
+ * Resolved revert config for one entity's contentType, keyed `plugin:module.collection`.
+ */
+export interface ResolvedContentTypeConfig {
+  contentType: string;
+  pluginName: string;
+  moduleName: string;
+  collectionName: string;
+  permission?: string;
+  mongooseName?: string;
+}
+
+/**
+ * Build a map of contentType -> revert config across all active plugins, reading
+ * each plugin's meta.logs.contentTypes (the same source logsGetContentTypes uses).
+ * Used by the revert orchestrator to look up the gating permission and the
+ * mongoose model name for every entity touched by a process.
+ */
+export const buildContentTypeConfigMap = async (): Promise<
+  Map<string, ResolvedContentTypeConfig>
+> => {
+  const map = new Map<string, ResolvedContentTypeConfig>();
+  const pluginNames = await getPlugins();
+
+  await Promise.all(
+    pluginNames.map(async (pluginName) => {
+      try {
+        const plugin = await getPlugin(pluginName);
+        const meta = plugin.config?.meta || {};
+        const serviceContentTypes = (meta.logs?.contentTypes ||
+          []) as ILogContentTypeConfig[];
+
+        for (const ct of serviceContentTypes) {
+          if (!ct.moduleName || !ct.collectionName) {
+            continue;
+          }
+          const contentType = `${pluginName}:${ct.moduleName}.${ct.collectionName}`;
+          map.set(contentType, {
+            contentType,
+            pluginName,
+            moduleName: ct.moduleName,
+            collectionName: ct.collectionName,
+            permission: ct.permission,
+            mongooseName: ct.mongooseName,
+          });
+        }
+      } catch (error) {
+        console.error(
+          `Failed to load logs config from plugin ${pluginName}:`,
+          error,
+        );
+      }
+    }),
+  );
+
+  return map;
+};

--- a/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
+++ b/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
@@ -223,6 +223,11 @@ export const revertByProcessId = async (
   // models are registered on this connection.
   const simulated = new Map<string, Record<string, unknown> | null>();
 
+  // Collapse exact-duplicate entries (e.g. an entity that BOTH manually logs and
+  // is auto-captured produces two identical entries for one change). Keyed by the
+  // change content, so genuinely-distinct chained updates to one doc are kept.
+  const seenEntries = new Set<string>();
+
   for (const entry of entries) {
     // Skip non-data audit/meta entries (e.g. the per-mutation `mutation` wrapper
     // log) — they change no document, so they are neither revertable nor a real
@@ -230,6 +235,19 @@ export const revertByProcessId = async (
     if (!DATA_CHANGE_ACTIONS.has(entry.action)) {
       continue;
     }
+
+    const dedupKey = `${entry.contentType}::${entry.docId}::${entry.action}::${
+      entry.action === 'update'
+        ? JSON.stringify(
+            (entry.payload as { updateDescription?: unknown } | undefined)
+              ?.updateDescription || {},
+          )
+        : 'x'
+    }`;
+    if (seenEntries.has(dedupKey)) {
+      continue;
+    }
+    seenEntries.add(dedupKey);
 
     const contentType = entry.contentType;
     const config: ResolvedContentTypeConfig | undefined = contentType

--- a/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
+++ b/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
@@ -255,6 +255,30 @@ export const revertByProcessId = async (
       continue;
     }
 
+    // Multi-connection safety: the auto-capture records which database the write
+    // actually hit. If the model we can resolve here lives on a DIFFERENT database
+    // (e.g. an org-scoped entity captured from another connection), refuse rather
+    // than silently writing the revert into the wrong database.
+    const recordedDbName = (entry.payload as { dbName?: string } | undefined)
+      ?.dbName;
+    if (recordedDbName) {
+      let localDbName: string | undefined;
+      try {
+        localDbName = mainConnection.model(mongooseName)?.db?.name;
+      } catch {
+        localDbName = undefined;
+      }
+      if (localDbName && localDbName !== recordedDbName) {
+        unrevertable.push({
+          contentType,
+          docId: entry.docId,
+          action: entry.action,
+          reason: `Entity lives on a different database (${recordedDbName}); cannot revert it from here.`,
+        });
+        continue;
+      }
+    }
+
     const inverse = computeInverse(entry);
 
     if (inverse.kind === 'skip') {

--- a/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
+++ b/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
@@ -1,0 +1,485 @@
+import {
+  set as lodashSet,
+  unset as lodashUnset,
+  cloneDeep,
+} from 'lodash';
+import { IContext } from '~/connectionResolvers';
+import { applyInverse } from './applyInverse';
+import { computeInverse, RevertableLogEntry } from './computeInverse';
+import { detectUpdateConflicts } from './conflict';
+import {
+  buildContentTypeConfigMap,
+  ResolvedContentTypeConfig,
+} from './contentTypeConfig';
+import { sanitizeLogValue } from '../sanitize';
+import {
+  ApplyWriteInput,
+  DocConflict,
+  RevertDocResolution,
+  RevertProcessResult,
+  UnrevertableEntry,
+} from './types';
+
+const REVERT_SOURCE = 'revert';
+const REVERT_ACTION = 'revertProcess';
+
+interface LeanLogEntry extends RevertableLogEntry {
+  createdAt?: Date;
+  userId?: string;
+}
+
+const resolutionKey = (contentType: string, docId: string) =>
+  `${contentType}::${docId}`;
+
+const sanitizeConflict = (conflict: DocConflict): DocConflict => ({
+  ...conflict,
+  fields: conflict.fields.map((field) => ({
+    field: field.field,
+    revertValue: sanitizeLogValue(field.revertValue, field.field),
+    currentValue: sanitizeLogValue(field.currentValue, field.field),
+  })),
+});
+
+/**
+ * Apply a doc's field-level resolutions onto a computed update inverse op.
+ * For each resolved field:
+ *   - restore -> keep the revert's prev value (already in set/unset)
+ *   - keep    -> drop the field from set/unset (leave the live value)
+ *   - custom  -> $set the supplied value
+ */
+const mergeResolutionIntoUpdate = (
+  op: Extract<ApplyWriteInput, { kind: 'update' }>,
+  resolution: RevertDocResolution | undefined,
+): Extract<ApplyWriteInput, { kind: 'update' }> => {
+  if (!resolution) {
+    return op;
+  }
+
+  const set: Record<string, unknown> = { ...op.set };
+  let unset = [...op.unset];
+
+  for (const field of resolution.fields) {
+    if (field.mode === 'keep') {
+      delete set[field.field];
+      unset = unset.filter((p) => p !== field.field);
+    } else if (field.mode === 'custom') {
+      set[field.field] = field.value;
+      unset = unset.filter((p) => p !== field.field);
+    }
+    // 'restore' -> leave as computed.
+  }
+
+  return { ...op, set, unset };
+};
+
+/**
+ * Advance a simulated doc state by an update inverse we just planned, so an older
+ * (chained) update to the SAME doc is conflict-checked against the correct
+ * intermediate state — not a single stale live read. Without this, a process with
+ * two updates to one field (1->2, 2->3; live=3) would match the newer entry but
+ * raise a false conflict on the older one and leave the doc at 2 instead of 1.
+ */
+const advanceSimulated = (
+  doc: Record<string, unknown>,
+  op: Extract<ApplyWriteInput, { kind: 'update' }>,
+): Record<string, unknown> => {
+  const next = cloneDeep(doc);
+  for (const [path, value] of Object.entries(op.set)) {
+    lodashSet(next, path, value);
+  }
+  for (const path of op.unset) {
+    lodashUnset(next, path);
+  }
+  return next;
+};
+
+/**
+ * Orchestrate a point-in-time revert of every change carrying `processId`.
+ *
+ * Reverse-replays the process's log entries (newest -> oldest), per-entity
+ * authorized, conflict-aware. Clean entries always apply; conflicted docs apply
+ * only when a resolution is supplied. Hard deletes without a snapshot are
+ * surfaced as unrevertable. The revert's own writes (and its marker) log under
+ * the CURRENT request's processId, never the target — so the revert is itself
+ * auditable and never self-cancels.
+ */
+export const revertByProcessId = async (
+  context: IContext,
+  args: {
+    processId: string;
+    dryRun?: boolean;
+    force?: boolean;
+    skipConflicts?: boolean;
+    resolutions?: RevertDocResolution[];
+  },
+): Promise<RevertProcessResult> => {
+  const { models, subdomain, user, checkPermission } = context;
+  const { processId } = args;
+  const dryRun = args.dryRun ?? false;
+  // force: apply the recorded prev value even over an intervening change
+  // (blind restore). Admin/owner only — non-owners get the merge-first flow.
+  const force = (args.force ?? false) && !!user?.isOwner;
+  // skipConflicts: the caller acknowledges conflicts and wants the clean
+  // entries reverted while conflicted docs are reported (partial-apply). In the
+  // merge-first model this is already the default; the flag is recorded for
+  // auditability of the caller's intent.
+  const skipConflicts = args.skipConflicts ?? false;
+  const resolutions = args.resolutions || [];
+
+  const requestProcessId = context.processId;
+
+  if (!processId) {
+    throw new Error('processId is required');
+  }
+
+  // The revert writes under the REQUEST processId — never reuse the target.
+  if (processId === requestProcessId) {
+    throw new Error('Refusing to revert the current request process');
+  }
+
+  // 1. Load the process's entries, newest first (reverse-replay order).
+  const entries = (await models.Logs.find({ processId })
+    .sort({ createdAt: -1 })
+    .lean()) as unknown as LeanLogEntry[];
+
+  if (!entries.length) {
+    throw new Error(`No log entries found for process ${processId}`);
+  }
+
+  // 2. Resolve each entry's contentType config and gate per-entity.
+  const configMap = await buildContentTypeConfigMap();
+
+  const distinctContentTypes = Array.from(
+    new Set(entries.map((e) => e.contentType).filter((c): c is string => !!c)),
+  );
+
+  const unauthorized: string[] = [];
+  const requiredActions = new Set<string>();
+
+  for (const contentType of distinctContentTypes) {
+    const config = configMap.get(contentType);
+
+    // Owners bypass everything (matches checkPermission's isOwner short-circuit).
+    if (user?.isOwner) {
+      continue;
+    }
+
+    if (!config?.permission) {
+      // Fail closed: an entity with no declared gate is revertible by owners only.
+      unauthorized.push(contentType);
+      continue;
+    }
+
+    requiredActions.add(config.permission);
+  }
+
+  // Enforce each distinct gating action (throws FORBIDDEN on deny). Collect the
+  // ones the caller lacks so the whole-revert refusal can list every entity.
+  for (const action of requiredActions) {
+    try {
+      await checkPermission(action);
+    } catch {
+      const blockedContentTypes = distinctContentTypes.filter(
+        (ct) => configMap.get(ct)?.permission === action,
+      );
+      unauthorized.push(...blockedContentTypes);
+    }
+  }
+
+  if (unauthorized.length) {
+    const unique = Array.from(new Set(unauthorized)).sort();
+    throw new Error(
+      `Not authorized to revert these entities: ${unique.join(', ')}. ` +
+        `A revert requires the gating permission for every entity in the process.`,
+    );
+  }
+
+  // 3. Idempotency: was this process already reverted successfully?
+  // Only a COMPLETE marker locks idempotency — a partial revert (conflicts left
+  // for a merge-resolution re-call) must not short-circuit the follow-up.
+  const existingMarker = await models.Logs.findOne({
+    source: REVERT_SOURCE,
+    action: REVERT_ACTION,
+    'payload.revertedProcessId': processId,
+    'payload.complete': true,
+  }).lean();
+
+  if (existingMarker && !dryRun) {
+    return {
+      processId,
+      requestProcessId,
+      dryRun,
+      reverted: [],
+      conflicts: [],
+      unrevertable: [],
+      alreadyReverted: true,
+    };
+  }
+
+  // 4. Plan: compute inverses, detect conflicts, classify unrevertables.
+  const mainConnection = models.Customers.db;
+
+  const resolutionMap = new Map<string, RevertDocResolution>();
+  for (const r of resolutions) {
+    resolutionMap.set(resolutionKey(r.contentType, r.docId), r);
+  }
+
+  const cleanOps: ApplyWriteInput[] = [];
+  const conflicts: DocConflict[] = [];
+  const unrevertable: UnrevertableEntry[] = [];
+
+  // Simulated post-inverse state per doc (key = contentType::docId), seeded from
+  // the live doc and advanced as each update inverse is planned. `null` = the doc
+  // is (or becomes) absent in the simulation. Only used for core entities, whose
+  // models are registered on this connection.
+  const simulated = new Map<string, Record<string, unknown> | null>();
+
+  for (const entry of entries) {
+    const contentType = entry.contentType;
+    const config: ResolvedContentTypeConfig | undefined = contentType
+      ? configMap.get(contentType)
+      : undefined;
+
+    if (!contentType || !config?.mongooseName) {
+      unrevertable.push({
+        contentType,
+        docId: entry.docId,
+        action: entry.action,
+        reason: 'No mongoose model configured for this contentType',
+      });
+      continue;
+    }
+
+    const inverse = computeInverse(entry);
+
+    if (inverse.kind === 'skip') {
+      unrevertable.push({
+        contentType,
+        docId: entry.docId,
+        action: entry.action,
+        reason: inverse.reason,
+      });
+      continue;
+    }
+
+    const mongooseName = config.mongooseName;
+    const pluginName = contentType.split(':')[0];
+    const simKey = resolutionKey(contentType, inverse.docId);
+
+    if (inverse.kind === 'insert') {
+      // A hard delete lacking a snapshot would have skipped in computeInverse;
+      // reaching here means we have the document to re-insert.
+      cleanOps.push({
+        kind: 'insert',
+        contentType,
+        docId: inverse.docId,
+        mongooseName,
+        document: inverse.document,
+      });
+      // After re-insert the doc exists again as its restored snapshot.
+      simulated.set(simKey, inverse.document);
+      continue;
+    }
+
+    if (inverse.kind === 'delete') {
+      // The snapshot the original `create` produced — lets applyWrite refuse to
+      // delete a doc that changed since creation (undo-create conflict guard).
+      const expectDocument =
+        entry.payload?.fullDocument &&
+        typeof entry.payload.fullDocument === 'object'
+          ? (entry.payload.fullDocument as Record<string, unknown>)
+          : undefined;
+
+      cleanOps.push({
+        kind: 'delete',
+        contentType,
+        docId: inverse.docId,
+        mongooseName,
+        expectDocument,
+      });
+      // After delete the doc is absent in the simulation.
+      simulated.set(simKey, null);
+      continue;
+    }
+
+    // update.
+    const resolution = resolutionMap.get(simKey);
+
+    // Field-level conflict detection must read the live doc, which only works for
+    // models registered on THIS (core) connection. v1 limitation: remote-plugin
+    // entities are applied via TRPC without a local field-level preview (the
+    // in-plugin applyWrite still guards inserts/deletes). Reachable only once a
+    // plugin declares meta.logs contentTypes — none do today.
+    if (pluginName !== 'core') {
+      cleanOps.push(
+        mergeResolutionIntoUpdate(
+          {
+            kind: 'update',
+            contentType,
+            docId: inverse.docId,
+            mongooseName,
+            set: inverse.set,
+            unset: inverse.unset,
+          },
+          resolution,
+        ),
+      );
+      continue;
+    }
+
+    // Seed the simulated state from the live doc on first touch, then reuse it so
+    // chained updates to the same doc compare against the correct intermediate
+    // state (not a single stale read — see advanceSimulated).
+    let simDoc: Record<string, unknown> | null;
+    if (simulated.has(simKey)) {
+      simDoc = simulated.get(simKey) ?? null;
+    } else {
+      simDoc = (await mainConnection
+        .model<Record<string, unknown>>(mongooseName)
+        .findById(inverse.docId)
+        .lean()) as Record<string, unknown> | null;
+      simulated.set(simKey, simDoc);
+    }
+
+    if (!simDoc) {
+      unrevertable.push({
+        contentType,
+        docId: entry.docId,
+        action: entry.action,
+        reason: 'Target document no longer exists; cannot revert an update',
+      });
+      continue;
+    }
+
+    const fieldConflicts = detectUpdateConflicts(entry, simDoc);
+
+    if (fieldConflicts.length && !force) {
+      // Which conflicted fields remain unresolved by the supplied resolutions?
+      const resolvedFields = new Set(
+        (resolution?.fields || []).map((f) => f.field),
+      );
+      const unresolved = fieldConflicts.filter(
+        (c) => !resolvedFields.has(c.field),
+      );
+
+      // Any unresolved conflict means this doc is NOT applied (whether the caller
+      // is in skipConflicts mode or awaiting a resolution) — it is only reported.
+      // The simulation is left unchanged so an older update to the same doc is
+      // checked against the same unreverted state. (force, admin-only, blind-restores.)
+      if (unresolved.length) {
+        conflicts.push({
+          contentType,
+          docId: inverse.docId,
+          mongooseName,
+          fields: fieldConflicts,
+        });
+        continue;
+      }
+    }
+
+    const updateOp = mergeResolutionIntoUpdate(
+      {
+        kind: 'update',
+        contentType,
+        docId: inverse.docId,
+        mongooseName,
+        set: inverse.set,
+        unset: inverse.unset,
+      },
+      resolution,
+    );
+
+    cleanOps.push(updateOp);
+    // Advance the simulated state by the inverse we just planned.
+    simulated.set(simKey, advanceSimulated(simDoc, updateOp));
+  }
+
+  // 5. Dry-run: preview only, sanitize snapshots returned to the client.
+  if (dryRun) {
+    return {
+      processId,
+      requestProcessId,
+      dryRun: true,
+      reverted: cleanOps.map((op) => ({
+        contentType: op.contentType,
+        docId: op.docId,
+        kind: op.kind,
+      })),
+      conflicts: conflicts.map(sanitizeConflict),
+      unrevertable,
+      alreadyReverted: !!existingMarker,
+    };
+  }
+
+  // 6. Apply clean + resolved ops. Each applyInverse forwards the REQUEST
+  //    processId so the reverted writes log under it (never the target).
+  const applied: Array<{ contentType: string; docId: string; kind: string }> =
+    [];
+  const applyConflicts: DocConflict[] = [...conflicts];
+
+  for (const op of cleanOps) {
+    const result = await applyInverse({
+      connection: mainConnection,
+      subdomain,
+      input: op,
+      requestProcessId,
+      userId: user?._id || '',
+    });
+
+    if (result.ok) {
+      applied.push({
+        contentType: op.contentType,
+        docId: op.docId,
+        kind: op.kind,
+      });
+    } else {
+      applyConflicts.push({
+        contentType: op.contentType,
+        docId: op.docId,
+        mongooseName: op.mongooseName,
+        fields: [
+          {
+            field: '*',
+            revertValue: undefined,
+            currentValue: result.liveState,
+          },
+        ],
+      });
+    }
+  }
+
+  // 7. Audit + idempotency marker under the REQUEST processId. The marker LOCKS
+  //    idempotency only when the revert is complete (no conflicts awaiting a merge
+  //    resolution): `payload.complete` gates the step-3 short-circuit, so a re-call
+  //    carrying `resolutions` can still finish a partially-applied revert. (status
+  //    stays enum-valid 'success' — the apply itself succeeded for what it could.)
+  const complete = applyConflicts.length === 0;
+
+  await models.Logs.create({
+    source: REVERT_SOURCE,
+    action: REVERT_ACTION,
+    status: 'success',
+    createdAt: new Date(),
+    userId: user?._id,
+    processId: requestProcessId,
+    payload: {
+      revertedProcessId: processId,
+      complete,
+      appliedCount: applied.length,
+      conflictCount: applyConflicts.length,
+      unrevertableCount: unrevertable.length,
+      force,
+      skipConflicts,
+    },
+  });
+
+  return {
+    processId,
+    requestProcessId,
+    dryRun: false,
+    reverted: applied,
+    conflicts: applyConflicts.map(sanitizeConflict),
+    unrevertable,
+    alreadyReverted: !!existingMarker,
+  };
+};

--- a/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
+++ b/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
@@ -127,7 +127,7 @@ export const revertByProcessId = async (
     resolutions?: RevertDocResolution[];
   },
 ): Promise<RevertProcessResult> => {
-  const { models, subdomain, user, checkPermission } = context;
+  const { models, subdomain, user } = context;
   const { processId } = args;
   const dryRun = args.dryRun ?? false;
   // force: apply the recorded prev value even over an intervening change
@@ -160,52 +160,27 @@ export const revertByProcessId = async (
     throw new Error(`No log entries found for process ${processId}`);
   }
 
-  // 2. Resolve each entry's contentType config and gate per-entity.
+  // 2. Build the content-type config (used for model resolution + display) and
+  // authorize with a zero-config rule: ACTOR-OR-ADMIN. A revert is allowed only
+  // for an admin/owner, or for the user who themselves made EVERY change in the
+  // process. The actor is recorded on each journal entry, so an entity needs no
+  // per-entity permission setup to be revertible.
   const configMap = await buildContentTypeConfigMap();
 
-  const distinctContentTypes = Array.from(
-    new Set(entries.map((e) => e.contentType).filter((c): c is string => !!c)),
-  );
+  if (!user?.isOwner) {
+    const actorIds = entries
+      .filter((e) => DATA_CHANGE_ACTIONS.has(e.action))
+      .map((e) => e.userId)
+      .filter((id): id is string => !!id);
 
-  const unauthorized: string[] = [];
-  const requiredActions = new Set<string>();
+    const allMadeByMe =
+      actorIds.length > 0 && actorIds.every((id) => id === user?._id);
 
-  for (const contentType of distinctContentTypes) {
-    const config = configMap.get(contentType);
-
-    // Owners bypass everything (matches checkPermission's isOwner short-circuit).
-    if (user?.isOwner) {
-      continue;
-    }
-
-    if (!config?.permission) {
-      // Fail closed: an entity with no declared gate is revertible by owners only.
-      unauthorized.push(contentType);
-      continue;
-    }
-
-    requiredActions.add(config.permission);
-  }
-
-  // Enforce each distinct gating action (throws FORBIDDEN on deny). Collect the
-  // ones the caller lacks so the whole-revert refusal can list every entity.
-  for (const action of requiredActions) {
-    try {
-      await checkPermission(action);
-    } catch {
-      const blockedContentTypes = distinctContentTypes.filter(
-        (ct) => configMap.get(ct)?.permission === action,
+    if (!allMadeByMe) {
+      throw new Error(
+        'Not authorized: only an admin, or the user who made these changes, can revert them.',
       );
-      unauthorized.push(...blockedContentTypes);
     }
-  }
-
-  if (unauthorized.length) {
-    const unique = Array.from(new Set(unauthorized)).sort();
-    throw new Error(
-      `Not authorized to revert these entities: ${unique.join(', ')}. ` +
-        `A revert requires the gating permission for every entity in the process.`,
-    );
   }
 
   // 3. Idempotency: was this process already reverted successfully?
@@ -261,12 +236,21 @@ export const revertByProcessId = async (
       ? configMap.get(contentType)
       : undefined;
 
-    if (!contentType || !config?.mongooseName) {
+    // Zero-config model resolution: prefer a configured mongooseName, else the
+    // model name the auto-capture recorded on the entry, else the collection name
+    // (which is the registered model name for core collections). This is what lets
+    // ANY captured entity be reverted without a meta/logs entry.
+    const mongooseName =
+      config?.mongooseName ||
+      (entry.payload as { mongooseName?: string } | undefined)?.mongooseName ||
+      (entry.payload as { collectionName?: string } | undefined)?.collectionName;
+
+    if (!mongooseName) {
       unrevertable.push({
         contentType,
         docId: entry.docId,
         action: entry.action,
-        reason: 'No mongoose model configured for this contentType',
+        reason: 'Could not resolve a model for this entry',
       });
       continue;
     }
@@ -283,16 +267,18 @@ export const revertByProcessId = async (
       continue;
     }
 
-    const mongooseName = config.mongooseName;
-    const pluginName = contentType.split(':')[0];
-    const simKey = resolutionKey(contentType, inverse.docId);
+    // A stable, always-defined contentType for the write/simulation layer
+    // (auto-derived from the model when an entry carried none).
+    const ct: string = contentType || `auto:${mongooseName}.${mongooseName}`;
+    const pluginName = ct.split(':')[0];
+    const simKey = resolutionKey(ct, inverse.docId);
 
     if (inverse.kind === 'insert') {
       // A hard delete lacking a snapshot would have skipped in computeInverse;
       // reaching here means we have the document to re-insert.
       cleanOps.push({
         kind: 'insert',
-        contentType,
+        contentType: ct,
         docId: inverse.docId,
         mongooseName,
         document: inverse.document,
@@ -313,7 +299,7 @@ export const revertByProcessId = async (
 
       cleanOps.push({
         kind: 'delete',
-        contentType,
+        contentType: ct,
         docId: inverse.docId,
         mongooseName,
         expectDocument,
@@ -331,12 +317,12 @@ export const revertByProcessId = async (
     // entities are applied via TRPC without a local field-level preview (the
     // in-plugin applyWrite still guards inserts/deletes). Reachable only once a
     // plugin declares meta.logs contentTypes — none do today.
-    if (pluginName !== 'core') {
+    if (pluginName !== 'core' && pluginName !== 'auto') {
       cleanOps.push(
         mergeResolutionIntoUpdate(
           {
             kind: 'update',
-            contentType,
+            contentType: ct,
             docId: inverse.docId,
             mongooseName,
             set: inverse.set,
@@ -389,7 +375,7 @@ export const revertByProcessId = async (
       // checked against the same unreverted state. (force, admin-only, blind-restores.)
       if (unresolved.length) {
         conflicts.push({
-          contentType,
+          contentType: ct,
           docId: inverse.docId,
           mongooseName,
           fields: fieldConflicts,
@@ -401,7 +387,7 @@ export const revertByProcessId = async (
     const updateOp = mergeResolutionIntoUpdate(
       {
         kind: 'update',
-        contentType,
+        contentType: ct,
         docId: inverse.docId,
         mongooseName,
         set: inverse.set,

--- a/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
+++ b/backend/core-api/src/modules/logs/revert/revertByProcessId.ts
@@ -23,6 +23,20 @@ import {
 const REVERT_SOURCE = 'revert';
 const REVERT_ACTION = 'revertProcess';
 
+// Log actions that represent an actual document change (and so can be inverted).
+// Every mutation ALSO writes a generic `action:'mutation'` audit entry that
+// carries no contentType and changes nothing; such non-data entries must be
+// skipped outright, never surfaced as phantom "unrevertable" items on a revert
+// that otherwise fully succeeded.
+const DATA_CHANGE_ACTIONS = new Set<string>([
+  'create',
+  'update',
+  'delete',
+  'deleteMany',
+  'updateMany',
+  'bulkWrite',
+]);
+
 interface LeanLogEntry extends RevertableLogEntry {
   createdAt?: Date;
   userId?: string;
@@ -235,6 +249,13 @@ export const revertByProcessId = async (
   const simulated = new Map<string, Record<string, unknown> | null>();
 
   for (const entry of entries) {
+    // Skip non-data audit/meta entries (e.g. the per-mutation `mutation` wrapper
+    // log) — they change no document, so they are neither revertable nor a real
+    // gap. Surfacing them as "unrevertable" wrongly implies data was left behind.
+    if (!DATA_CHANGE_ACTIONS.has(entry.action)) {
+      continue;
+    }
+
     const contentType = entry.contentType;
     const config: ResolvedContentTypeConfig | undefined = contentType
       ? configMap.get(contentType)

--- a/backend/core-api/src/modules/logs/revert/trpc.ts
+++ b/backend/core-api/src/modules/logs/revert/trpc.ts
@@ -1,0 +1,39 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { CoreTRPCContext } from '~/init-trpc';
+import { applyWrite } from './applyWrite';
+import { applyWriteInputSchema } from './types';
+
+const t = initTRPC.context<CoreTRPCContext>().create();
+
+/**
+ * revert.applyWrite — the per-plugin write applier for point-in-time revert.
+ *
+ * For remote plugins the orchestrator dispatches the computed inverse op here
+ * over TRPC (with context:{processId,userId}); core also calls applyWrite()
+ * in-process. The procedure validates the inverse op, then performs the raw
+ * model write + ES sync with the same conflict guards, returning a structured
+ * {ok} | {conflict} result rather than throwing on a benign conflict.
+ */
+export const revertTrpcRouter = t.router({
+  revert: t.router({
+    applyWrite: t.procedure
+      .input(applyWriteInputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const { models, subdomain } = ctx;
+
+        if (!subdomain) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing subdomain' });
+        }
+
+        // Entity models share the MAIN connection (Logs lives on a separate
+        // `${db}_logs` connection, so reach the main one through an entity model).
+        const connection = models.Customers.db;
+
+        return await applyWrite({
+          connection,
+          subdomain,
+          input,
+        });
+      }),
+  }),
+});

--- a/backend/core-api/src/modules/logs/revert/types.ts
+++ b/backend/core-api/src/modules/logs/revert/types.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+/**
+ * Shared shapes for point-in-time revert. The InverseOp here mirrors the union
+ * produced by computeInverse, re-expressed as a zod schema so it can cross the
+ * TRPC boundary (remote plugins) with validation and so the same applier can be
+ * driven locally and remotely.
+ */
+
+export const inverseInsertSchema = z.object({
+  kind: z.literal('insert'),
+  contentType: z.string(),
+  docId: z.string(),
+  mongooseName: z.string(),
+  document: z.record(z.unknown()),
+});
+
+export const inverseDeleteSchema = z.object({
+  kind: z.literal('delete'),
+  contentType: z.string(),
+  docId: z.string(),
+  mongooseName: z.string(),
+  // The snapshot the original `create` produced. When present, the delete-inverse
+  // only removes the doc if the live doc still matches it — never destroys an
+  // intervening change. Absent => delete unconditionally (best effort).
+  expectDocument: z.record(z.unknown()).optional(),
+});
+
+export const inverseUpdateSchema = z.object({
+  kind: z.literal('update'),
+  contentType: z.string(),
+  docId: z.string(),
+  mongooseName: z.string(),
+  set: z.record(z.unknown()),
+  unset: z.array(z.string()),
+});
+
+export const applyWriteInputSchema = z.discriminatedUnion('kind', [
+  inverseInsertSchema,
+  inverseDeleteSchema,
+  inverseUpdateSchema,
+]);
+
+export type ApplyWriteInput = z.infer<typeof applyWriteInputSchema>;
+
+/** Result of applying (or attempting to apply) one inverse op. */
+export type ApplyWriteResult =
+  | { ok: true }
+  | { ok: false; conflict: true; reason: string; liveState?: unknown };
+
+/** Field-level conflict surfaced for the merge-style resolution UX. */
+export interface FieldConflict {
+  field: string;
+  // The value the revert wants to restore (from the recorded prev state).
+  revertValue: unknown;
+  // The intervening live value that diverged from the recorded after-image.
+  currentValue: unknown;
+}
+
+export interface DocConflict {
+  contentType: string;
+  docId: string;
+  mongooseName: string;
+  fields: FieldConflict[];
+}
+
+/** An entry that cannot be reverted automatically (surfaced, never applied). */
+export interface UnrevertableEntry {
+  contentType?: string;
+  docId?: string;
+  action: string;
+  reason: string;
+}
+
+/**
+ * Per-field resolution choice for a conflicted doc. Modeled on the existing
+ * erxes merge flow (customersMerge/companiesMerge), but typed for a 3-way
+ * revert: restore the recorded prev, keep the live value, or use a custom one.
+ */
+export type RevertResolutionMode = 'restore' | 'keep' | 'custom';
+
+export interface RevertFieldResolution {
+  field: string;
+  mode: RevertResolutionMode;
+  // Required only when mode === 'custom'.
+  value?: unknown;
+}
+
+export interface RevertDocResolution {
+  contentType: string;
+  docId: string;
+  fields: RevertFieldResolution[];
+}
+
+export interface RevertProcessResult {
+  processId: string;
+  requestProcessId: string;
+  dryRun: boolean;
+  // Inverse ops that would apply / did apply cleanly.
+  reverted: Array<{ contentType: string; docId: string; kind: string }>;
+  // Conflicted docs awaiting a resolution (skipped unless resolved).
+  conflicts: DocConflict[];
+  // Entries that cannot be auto-reverted (e.g. hard delete with no snapshot).
+  unrevertable: UnrevertableEntry[];
+  // True when the process was already reverted (idempotency marker found).
+  alreadyReverted: boolean;
+}

--- a/backend/core-api/src/modules/logs/sanitize.ts
+++ b/backend/core-api/src/modules/logs/sanitize.ts
@@ -1,0 +1,158 @@
+/**
+ * Sanitizes log values before they leave the API: masks secrets, ids, emails,
+ * IPs and phone numbers. Shared by the logs queries (log detail) and the
+ * point-in-time revert resolver (conflict snapshots returned to the client).
+ */
+
+const SECRET_KEY_PATTERNS = [
+  /password/i,
+  /passcode/i,
+  /token/i,
+  /secret/i,
+  /authorization/i,
+  /cookie/i,
+  /api[-_]?key/i,
+  /private[-_]?key/i,
+];
+
+const EMAIL_KEY_PATTERNS = [/email/i];
+const IP_KEY_PATTERNS = [/(^|[_-])ip$/i, /ipAddress/i];
+const PHONE_KEY_PATTERNS = [/phone/i, /mobile/i];
+
+const isSecretKey = (key: string) =>
+  SECRET_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const isIdLikeKey = (key: string) =>
+  key === '__v' ||
+  /^_id$/i.test(key) ||
+  /^id$/i.test(key) ||
+  /Id(s)?$/.test(key) ||
+  /[_-]id(s)?$/i.test(key) ||
+  /^(createdBy|updatedBy)$/i.test(key);
+
+const isEmailKey = (key: string) =>
+  EMAIL_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const isIpKey = (key: string) =>
+  IP_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const isPhoneKey = (key: string) =>
+  PHONE_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const maskIdentifier = (value: string) => {
+  if (!value) {
+    return '••••••';
+  }
+
+  if (value.length <= 8) {
+    return '••••••';
+  }
+
+  return `${value.slice(0, 4)}••••••••${value.slice(-4)}`;
+};
+
+const maskEmail = (value: string) => {
+  const [local = '', domain = ''] = value.split('@');
+
+  if (!local || !domain) {
+    return '••••••';
+  }
+
+  const visibleLocal = local.slice(0, Math.min(2, local.length));
+  return `${visibleLocal}••••@${domain}`;
+};
+
+const maskIpAddress = (value: string) => {
+  if (value.includes('.')) {
+    const [first = '*', second = '*'] = value.split('.');
+    return `${first}.${second}.***.***`;
+  }
+
+  if (value.includes(':')) {
+    const [head = '****'] = value.split(':');
+    return `${head}:****:****`;
+  }
+
+  return '••••••';
+};
+
+const maskPhone = (value: string) => {
+  if (value.length <= 4) {
+    return '••••';
+  }
+
+  return `${'•'.repeat(Math.max(4, value.length - 2))}${value.slice(-2)}`;
+};
+
+export type SanitizeLogOptions = {
+  exposeEmail?: boolean;
+};
+
+export const sanitizeLogValue = (
+  value: unknown,
+  key?: string,
+  options: SanitizeLogOptions = {},
+): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    if (key && isIdLikeKey(key)) {
+      return value.map((item) =>
+        typeof item === 'string'
+          ? maskIdentifier(item)
+          : sanitizeLogValue(item, undefined, options),
+      );
+    }
+
+    return value.map((item) => sanitizeLogValue(item, key, options));
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).reduce<
+      Record<string, unknown>
+    >((acc, [childKey, childValue]) => {
+      acc[childKey] = sanitizeLogValue(childValue, childKey, options);
+      return acc;
+    }, {});
+  }
+
+  if (!key || typeof value !== 'string') {
+    return value;
+  }
+
+  if (isSecretKey(key)) {
+    return '••••••';
+  }
+
+  if (key === '__v') {
+    return '[hidden]';
+  }
+
+  if (isIdLikeKey(key)) {
+    return maskIdentifier(value);
+  }
+
+  if (isEmailKey(key)) {
+    if (options.exposeEmail) {
+      return value;
+    }
+
+    return maskEmail(value);
+  }
+
+  if (isIpKey(key)) {
+    return maskIpAddress(value);
+  }
+
+  if (isPhoneKey(key)) {
+    return maskPhone(value);
+  }
+
+  return value;
+};

--- a/backend/core-api/src/modules/logs/sanitize.ts
+++ b/backend/core-api/src/modules/logs/sanitize.ts
@@ -18,6 +18,20 @@ const SECRET_KEY_PATTERNS = [
 const EMAIL_KEY_PATTERNS = [/email/i];
 const IP_KEY_PATTERNS = [/(^|[_-])ip$/i, /ipAddress/i];
 const PHONE_KEY_PATTERNS = [/phone/i, /mobile/i];
+const NAME_KEY_PATTERNS = [
+  /^firstName$/i,
+  /^lastName$/i,
+  /^middleName$/i,
+  /fullName/i,
+];
+// Denormalized search blobs concatenate names/emails/phones for indexing. They
+// are PII magnets and meaningless as a merge value, so redact them wholesale.
+const DERIVED_BLOB_KEY_PATTERNS = [/^searchText$/i];
+
+// Value-level fallback: an email embedded ANYWHERE in a string (e.g. a search
+// blob, a note, a username field) is masked regardless of its key name, so the
+// masking can't be defeated by PII hiding in an unexpected field.
+const EMBEDDED_EMAIL_REGEX = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
 const isSecretKey = (key: string) =>
   SECRET_KEY_PATTERNS.some((pattern) => pattern.test(key));
@@ -38,6 +52,12 @@ const isIpKey = (key: string) =>
 
 const isPhoneKey = (key: string) =>
   PHONE_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const isNameKey = (key: string) =>
+  NAME_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const isDerivedBlobKey = (key: string) =>
+  DERIVED_BLOB_KEY_PATTERNS.some((pattern) => pattern.test(key));
 
 const maskIdentifier = (value: string) => {
   if (!value) {
@@ -83,6 +103,17 @@ const maskPhone = (value: string) => {
 
   return `${'•'.repeat(Math.max(4, value.length - 2))}${value.slice(-2)}`;
 };
+
+const maskName = (value: string) => {
+  if (value.length <= 1) {
+    return '•';
+  }
+
+  return `${value.slice(0, 1)}${'•'.repeat(Math.max(3, value.length - 1))}`;
+};
+
+const redactEmbeddedEmails = (value: string) =>
+  value.replace(EMBEDDED_EMAIL_REGEX, (match) => maskEmail(match));
 
 export type SanitizeLogOptions = {
   exposeEmail?: boolean;
@@ -154,5 +185,15 @@ export const sanitizeLogValue = (
     return maskPhone(value);
   }
 
-  return value;
+  if (isNameKey(key)) {
+    return maskName(value);
+  }
+
+  if (isDerivedBlobKey(key)) {
+    return '[redacted]';
+  }
+
+  // Value-level fallback: mask any email embedded in an otherwise-unremarkable
+  // field, unless the caller has explicitly opted to expose emails.
+  return options.exposeEmail ? value : redactEmbeddedEmails(value);
 };

--- a/backend/core-api/src/modules/logs/trpc/index.ts
+++ b/backend/core-api/src/modules/logs/trpc/index.ts
@@ -2,7 +2,12 @@ import { initTRPC } from '@trpc/server';
 import { CoreTRPCContext } from '~/init-trpc';
 import { logsRouter } from './logs';
 import { activityLogRouter } from './activityLog';
+import { revertTrpcRouter } from '../revert/trpc';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
-export const logsTrpcRouter = t.mergeRouters(logsRouter, activityLogRouter);
+export const logsTrpcRouter = t.mergeRouters(
+  logsRouter,
+  activityLogRouter,
+  revertTrpcRouter,
+);

--- a/backend/erxes-api-shared/src/core-modules/common/eventHandlers/schemas.ts
+++ b/backend/erxes-api-shared/src/core-modules/common/eventHandlers/schemas.ts
@@ -17,11 +17,17 @@ const UpdateLogSchema = z.object({
 const DeleteLogSchema = z.object({
   action: z.literal('delete'),
   docId: z.string(),
+  // The document as it was just before deletion. Optional for backward
+  // compatibility; when supplied it makes the delete reversible (point-in-time
+  // revert re-inserts it, preserving the original _id).
+  prevDocument: z.any().optional(),
 });
 
 const DeleteManyLogSchema = z.object({
   action: z.literal('deleteMany'),
   docIds: z.array(z.string()),
+  // Prior documents, aligned by index with docIds. Optional; enables revert.
+  prevDocuments: z.array(z.any()).optional(),
 });
 
 const UpdateManyLogSchema = z.object({

--- a/backend/erxes-api-shared/src/core-modules/common/eventHandlers/schemas.ts
+++ b/backend/erxes-api-shared/src/core-modules/common/eventHandlers/schemas.ts
@@ -26,7 +26,8 @@ const DeleteLogSchema = z.object({
 const DeleteManyLogSchema = z.object({
   action: z.literal('deleteMany'),
   docIds: z.array(z.string()),
-  // Prior documents, aligned by index with docIds. Optional; enables revert.
+  // Prior documents (any order; matched to docIds by _id). Optional; enables
+  // revert by re-inserting each deleted doc with its original _id.
   prevDocuments: z.array(z.any()).optional(),
 });
 

--- a/backend/erxes-api-shared/src/core-modules/common/eventHandlers/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/common/eventHandlers/utils.ts
@@ -57,9 +57,9 @@ export const generateDbEventPayload = (
   }
   if (input.action === 'delete') {
     return {
-      ...input,
       collectionName: collectionName,
       docId: input.docId,
+      prevDocument: input.prevDocument,
     };
   }
   if (input.action === 'updateMany') {
@@ -77,6 +77,7 @@ export const generateDbEventPayload = (
   if (input.action === 'deleteMany') {
     return {
       collectionName: collectionName,
+      prevDocuments: input.prevDocuments,
     };
   }
 };

--- a/backend/erxes-api-shared/src/core-modules/logs/definitions/logs.ts
+++ b/backend/erxes-api-shared/src/core-modules/logs/definitions/logs.ts
@@ -38,3 +38,9 @@ logsSchema.index(
   { contentType: 1, createdAt: -1 },
   { partialFilterExpression: { contentType: { $exists: true } } },
 );
+
+// Point-in-time revert reads every change in one request's cascade by processId.
+logsSchema.index(
+  { processId: 1, createdAt: -1 },
+  { partialFilterExpression: { processId: { $exists: true } } },
+);

--- a/backend/erxes-api-shared/src/core-modules/logs/types.ts
+++ b/backend/erxes-api-shared/src/core-modules/logs/types.ts
@@ -9,6 +9,14 @@ export enum TAfterProcessProducers {
 export interface ILogContentTypeConfig {
   moduleName: string;
   collectionName: string;
+  // Gating action for point-in-time revert of this entity; admin/owner bypasses.
+  // Defaults conceptually to the entity's destructive REMOVE action — the
+  // strongest single proxy for "trusted to destructively mutate this entity".
+  permission?: string;
+  // Mongoose model name used to resolve the raw model when applying a revert
+  // write (e.g. connection.model(mongooseName)). Lets the revert applier reach
+  // the live collection without importing a plugin's model classes.
+  mongooseName?: string;
 }
 
 export interface LogsConfigs {

--- a/backend/erxes-api-shared/src/utils/apollo/utils.ts
+++ b/backend/erxes-api-shared/src/utils/apollo/utils.ts
@@ -34,7 +34,13 @@ export const generateApolloContext =
 
     const subdomain = getSubdomain(req);
 
-    const processInfo = generateRequestProcess();
+    // Honor a caller-supplied correlation id (e.g. the AI agent stamps each
+    // action) so a request's DB changes can be traced/reverted together; the
+    // router propagates this header to every subgraph. Falls back to a fresh id.
+    const incomingProcessId = req.headers['x-erxes-process-id'];
+    const processInfo = generateRequestProcess(
+      Array.isArray(incomingProcessId) ? incomingProcessId[0] : incomingProcessId,
+    );
 
     const __ = (doc: any) => ({ ...processInfo, ...doc });
     setEventHandlerRuntimeContext(subdomain, {

--- a/backend/erxes-api-shared/src/utils/elasticsearch/index.ts
+++ b/backend/erxes-api-shared/src/utils/elasticsearch/index.ts
@@ -1,1 +1,2 @@
 export * from './utils';
+export * from './saveEs';

--- a/backend/erxes-api-shared/src/utils/elasticsearch/saveEs.ts
+++ b/backend/erxes-api-shared/src/utils/elasticsearch/saveEs.ts
@@ -1,0 +1,115 @@
+import {
+  client,
+  generateElkId,
+  getEsIndexByContentType,
+  getIndexPrefix,
+} from './utils';
+import { getEnv } from '../utils';
+
+/**
+ * Write-side Elasticsearch helpers for point-in-time revert.
+ *
+ * Normally entity indices are filled by the external elkSyncer (an oplog
+ * tailer): there is NO in-process Mongo->ES pipeline. A model-layer revert
+ * therefore does not auto-sync ES, so these helpers mirror the reverted write
+ * into the entity index explicitly. They are gated on isUsingElk(): when the
+ * syncer is disabled, ES is not the source of truth and these become no-ops.
+ *
+ * The document index/id resolution reuses the same primitives the read path
+ * uses (getEsIndexByContentType + getIndexPrefix via the client default index
+ * prefix; generateElkId for saas id namespacing).
+ */
+
+const isUsingElk = (): boolean => {
+  const ELK_SYNCER = getEnv({ name: 'ELK_SYNCER', defaultValue: 'true' });
+  return ELK_SYNCER !== 'false';
+};
+
+const resolveEsIndex = async (contentType: string): Promise<string | null> => {
+  const esIndex = await getEsIndexByContentType(contentType);
+  if (!esIndex) {
+    return null;
+  }
+  // getIndexPrefix derives the db-name prefix from the mongo connection string,
+  // matching how the read path (fetchEs) names indices.
+  const connectionString = getEnv({ name: 'MONGO_URL' });
+  return `${getIndexPrefix(connectionString)}${esIndex}`;
+};
+
+/**
+ * Upsert a single document into its entity index. No-op when ELK is disabled
+ * or the contentType has no resolvable ES index.
+ */
+export const saveEsDoc = async (args: {
+  subdomain: string;
+  contentType: string;
+  _id: string;
+  document: Record<string, unknown>;
+}): Promise<boolean> => {
+  const { subdomain, contentType, _id, document } = args;
+
+  if (!isUsingElk()) {
+    return false;
+  }
+
+  const index = await resolveEsIndex(contentType);
+  if (!index) {
+    return false;
+  }
+
+  const id = await generateElkId(_id, subdomain);
+
+  // Strip Mongo's _id from the body; ES carries it as the document id.
+  const { _id: _omit, ...body } = document;
+
+  await client.index({
+    index,
+    id,
+    body,
+    refresh: true,
+  });
+
+  return true;
+};
+
+/**
+ * Remove a single document from its entity index. No-op when ELK is disabled
+ * or the contentType has no resolvable ES index. A missing document is treated
+ * as success (the desired post-state — absent — already holds).
+ */
+export const deleteEsDoc = async (args: {
+  subdomain: string;
+  contentType: string;
+  _id: string;
+}): Promise<boolean> => {
+  const { subdomain, contentType, _id } = args;
+
+  if (!isUsingElk()) {
+    return false;
+  }
+
+  const index = await resolveEsIndex(contentType);
+  if (!index) {
+    return false;
+  }
+
+  const id = await generateElkId(_id, subdomain);
+
+  try {
+    await client.delete({
+      index,
+      id,
+      refresh: true,
+    });
+  } catch (e) {
+    // A 404 (already absent) is the intended end state — swallow it; re-throw
+    // anything else so a genuine ES failure surfaces to the revert orchestrator.
+    const statusCode = (e as { meta?: { statusCode?: number } })?.meta
+      ?.statusCode;
+    if (statusCode !== 404) {
+      throw e;
+    }
+  }
+
+  return true;
+};

--- a/backend/erxes-api-shared/src/utils/mongo/index.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/index.ts
@@ -2,3 +2,4 @@ export * from './mongoose-types';
 export * from './mongoose-utils';
 export * from './mongo-connection';
 export * from './generate-models';
+export * from './revertCapture';

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -5,6 +5,7 @@ import mongoose, {
   Schema,
 } from 'mongoose';
 import { nanoid } from 'nanoid';
+import { installRevertCaptureHooks } from './revertCapture';
 
 import {
   buildCursorQuery,
@@ -264,6 +265,11 @@ export const checkCollectionCodeDuplication = async (
 export const schemaWrapper = (schema: Schema) => {
   schema.add({ _id: mongooseStringRandomId });
   schema.add({ processId: { type: String, optional: true } });
+
+  // Dynamic point-in-time-revert capture: auto-journal destructive writes for
+  // every wrapped schema with no per-model code. No-op unless REVERT_AUTO_JOURNAL
+  // is enabled (so the default behaviour of every schema is unchanged).
+  installRevertCaptureHooks(schema);
 
   return schema;
 };

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -233,7 +233,7 @@ const journalUpdates = (
       const after = afterById.get(id);
       if (!after) continue;
 
-      const updateDescription = getDiffObjects(before, after);
+      const updateDescription = getDiffObjects(before as any, after as any);
       if (!hasChanges(updateDescription)) continue;
 
       emitPutLog({
@@ -277,6 +277,39 @@ const makeUpdatePostHook = () => {
       /* never disturb the write path */
     }
   };
+};
+
+// Document middleware for `doc.save()` edits (a common erxes update path that
+// query middleware does NOT see). Creates (isNew) are skipped on purpose.
+const SNAP_SAVE = Symbol('revertCaptureSaveSnapshot');
+const WAS_NEW = Symbol('revertCaptureWasNew');
+
+const savePreHook = async function (this: any) {
+  try {
+    this[WAS_NEW] = !!this.isNew;
+    this[SNAP_SAVE] = undefined;
+    if (this.isNew) return;
+    this[SNAP_SAVE] = await this.constructor.findById(this._id).lean();
+  } catch {
+    this[SNAP_SAVE] = undefined;
+  }
+};
+
+const savePostHook = function (this: any) {
+  try {
+    if (this[WAS_NEW]) return;
+    const before = this[SNAP_SAVE];
+    if (!before) return;
+    const after =
+      typeof this.toObject === 'function' ? this.toObject() : this;
+    journalUpdates(
+      this.constructor,
+      [before],
+      new Map([[toIdString(before._id), after]]),
+    );
+  } catch {
+    /* never disturb the write path */
+  }
 };
 
 /**
@@ -324,4 +357,8 @@ export const installRevertCaptureHooks = (schema: Schema): void => {
 
   schema.pre('findOneAndUpdate', makeUpdatePreHook());
   schema.post('findOneAndUpdate', makeUpdatePostHook());
+
+  // Document-level edit via doc.save().
+  schema.pre('save', savePreHook);
+  schema.post('save', savePostHook);
 };

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'mongoose';
 import { sendWorkerQueue } from '../mq-worker';
 import { getEventHandlerRuntimeContext } from '../../core-modules/common/eventHandlers/runtimeContext';
+import { getDiffObjects } from '../utils';
 
 /**
  * Dynamic, zero-per-call-site capture for point-in-time revert.
@@ -11,9 +12,12 @@ import { getEventHandlerRuntimeContext } from '../../core-modules/common/eventHa
  * journal entries are the SAME shape the manual `sendDbEventLog` emits, so the
  * existing revert engine consumes them unchanged.
  *
- * Scope (increment 1): DELETES (deleteOne / deleteMany / findOneAndDelete) — the
- * irreversible operations. A `pre` hook snapshots the matching documents before
- * they are gone; a `post` hook journals them only after the delete succeeds.
+ * Scope: DELETES (deleteOne / deleteMany / findOneAndDelete) and EDITS
+ * (updateOne / updateMany / findOneAndUpdate). A `pre` hook snapshots the matching
+ * documents before the write; a `post` hook journals only after it succeeds —
+ * deletes carry the prior snapshot (to re-insert), edits carry the per-document
+ * before→after diff (to restore prior field values). Creates are intentionally
+ * NOT captured: reverting a new record is just deleting it.
  *
  * Safety: the whole thing is gated behind REVERT_AUTO_JOURNAL=enable (a complete
  * no-op otherwise, so the 124 schemas are untouched when disabled), and every
@@ -167,6 +171,114 @@ const makePostHook = (kind: DeleteKind) => {
   };
 };
 
+const hasChanges = (ud: {
+  added?: Record<string, unknown>;
+  removed?: Record<string, unknown>;
+  updated?: Record<string, unknown>;
+}): boolean =>
+  !!ud &&
+  (Object.keys(ud.added || {}).length > 0 ||
+    Object.keys(ud.removed || {}).length > 0 ||
+    Object.keys(ud.updated || {}).length > 0);
+
+/**
+ * Journal one `update` event per changed document, carrying the before→after
+ * diff (updateDescription) the revert engine inverts. A bulk updateMany thus
+ * becomes N per-document revertable updates rather than one un-revertable
+ * aggregate. No-op for documents whose content did not actually change.
+ */
+const journalUpdates = (
+  model: any,
+  beforeDocs: Array<Record<string, unknown>>,
+  afterById: Map<string, Record<string, unknown>>,
+): void => {
+  try {
+    if (!beforeDocs || !beforeDocs.length) return;
+
+    let ctx;
+    try {
+      ctx = getEventHandlerRuntimeContext();
+    } catch {
+      ctx = undefined;
+    }
+
+    const collectionName: string =
+      model?.collection?.name || model?.modelName || '';
+    const mongooseName: string = model?.modelName || '';
+    let dbName = '';
+    try {
+      dbName = model?.db?.name || '';
+    } catch {
+      dbName = '';
+    }
+
+    const contentType =
+      (contentTypeResolver && contentTypeResolver(collectionName)) ||
+      `auto:${collectionName}.${collectionName}`;
+
+    const base = {
+      subdomain: ctx?.subdomain || '',
+      source: 'mongo',
+      status: 'success',
+      contentType,
+      processId: ctx?.processId || '',
+      userId: ctx?.userId || '',
+      autoJournal: true,
+      mongooseName,
+      dbName,
+    };
+
+    for (const before of beforeDocs) {
+      const id = toIdString(before._id);
+      const after = afterById.get(id);
+      if (!after) continue;
+
+      const updateDescription = getDiffObjects(before, after);
+      if (!hasChanges(updateDescription)) continue;
+
+      emitPutLog({
+        ...base,
+        action: 'update',
+        docId: id,
+        payload: { collectionName, updateDescription, mongooseName, dbName },
+      });
+    }
+  } catch {
+    /* capture is best-effort and must never disturb the write */
+  }
+};
+
+const makeUpdatePreHook = () => {
+  return async function (this: any) {
+    try {
+      const filter =
+        typeof this.getFilter === 'function' ? this.getFilter() : {};
+      this[SNAP] = await this.model.find(filter).limit(MAX_SNAPSHOT).lean();
+    } catch {
+      this[SNAP] = undefined;
+    }
+  };
+};
+
+const makeUpdatePostHook = () => {
+  return async function (this: any) {
+    try {
+      const before = this[SNAP];
+      if (!before || !before.length) return;
+      const ids = before.map((d: Record<string, unknown>) => d._id);
+      const after = (await this.model
+        .find({ _id: { $in: ids } })
+        .lean()) as Array<Record<string, unknown>>;
+      const afterById = new Map<string, Record<string, unknown>>(
+        after.map((d) => [toIdString(d._id), d]),
+      );
+      journalUpdates(this.model, before, afterById);
+    } catch {
+      /* never disturb the write path */
+    }
+  };
+};
+
 /**
  * Install the delete-capture hooks on a schema. Called from `schemaWrapper`, so
  * every wrapped schema gets them. No-op unless REVERT_AUTO_JOURNAL=enable.
@@ -193,4 +305,23 @@ export const installRevertCaptureHooks = (schema: Schema): void => {
 
   schema.pre('findOneAndDelete', makePreHook('delete'));
   schema.post('findOneAndDelete', makePostHook('delete'));
+
+  // Edit capture (Model.updateMany / Model.updateOne / findOneAndUpdate). Each
+  // produces one revertable per-document update carrying the before→after diff.
+  schema.pre('updateMany', makeUpdatePreHook());
+  schema.post('updateMany', makeUpdatePostHook());
+
+  schema.pre(
+    'updateOne',
+    { query: true, document: false },
+    makeUpdatePreHook(),
+  );
+  schema.post(
+    'updateOne',
+    { query: true, document: false },
+    makeUpdatePostHook(),
+  );
+
+  schema.pre('findOneAndUpdate', makeUpdatePreHook());
+  schema.post('findOneAndUpdate', makeUpdatePostHook());
 };

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -1,0 +1,196 @@
+import { Schema } from 'mongoose';
+import { sendWorkerQueue } from '../mq-worker';
+import { getEventHandlerRuntimeContext } from '../../core-modules/common/eventHandlers/runtimeContext';
+
+/**
+ * Dynamic, zero-per-call-site capture for point-in-time revert.
+ *
+ * Installed once into the shared `schemaWrapper` (which every model schema runs
+ * through), so EVERY collection — current or future, any plugin/connection — has
+ * its destructive writes journaled automatically, with no per-model code. The
+ * journal entries are the SAME shape the manual `sendDbEventLog` emits, so the
+ * existing revert engine consumes them unchanged.
+ *
+ * Scope (increment 1): DELETES (deleteOne / deleteMany / findOneAndDelete) — the
+ * irreversible operations. A `pre` hook snapshots the matching documents before
+ * they are gone; a `post` hook journals them only after the delete succeeds.
+ *
+ * Safety: the whole thing is gated behind REVERT_AUTO_JOURNAL=enable (a complete
+ * no-op otherwise, so the 124 schemas are untouched when disabled), and every
+ * hook is wrapped so a capture failure can NEVER block or throw out of the write.
+ */
+
+const AUTO_JOURNAL_ENABLED = process.env.REVERT_AUTO_JOURNAL === 'enable';
+
+// Bound the extra read a bulk delete triggers. Beyond this many matches we keep
+// the ids but skip the snapshot (still audited; the overflow is not auto-revertable).
+const MAX_SNAPSHOT = Number(process.env.REVERT_AUTO_JOURNAL_MAX || 1000);
+
+const toIdString = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  return String(v);
+};
+
+/**
+ * Optional map from a collection name to its revert contentType
+ * (`plugin:module.collection`). The host service seeds this from its meta/logs so
+ * auto-captured entries reuse the existing contentType registry (permission +
+ * model resolution). When unresolved, a fallback contentType is recorded and the
+ * entry is still revertable by its mongooseName downstream.
+ */
+let contentTypeResolver:
+  | ((collectionName: string) => string | undefined)
+  | undefined;
+
+export const registerRevertContentTypeResolver = (
+  fn: (collectionName: string) => string | undefined,
+): void => {
+  contentTypeResolver = fn;
+};
+
+const emitPutLog = (payload: Record<string, unknown>): void => {
+  try {
+    sendWorkerQueue('logs', 'put_log')
+      .add('put_log', payload, { removeOnComplete: true })
+      .catch(() => {
+        /* best-effort journal; never surface to the write path */
+      });
+  } catch {
+    /* never break a write because journaling failed */
+  }
+};
+
+type DeleteKind = 'delete' | 'deleteMany';
+
+const journalDeletes = (
+  model: any,
+  docs: Array<Record<string, unknown>>,
+  kind: DeleteKind,
+): void => {
+  try {
+    if (!docs || !docs.length) return;
+
+    let ctx;
+    try {
+      ctx = getEventHandlerRuntimeContext();
+    } catch {
+      ctx = undefined;
+    }
+
+    const collectionName: string =
+      model?.collection?.name || model?.modelName || '';
+    const mongooseName: string = model?.modelName || '';
+    let dbName = '';
+    try {
+      dbName = model?.db?.name || '';
+    } catch {
+      dbName = '';
+    }
+
+    const contentType =
+      (contentTypeResolver && contentTypeResolver(collectionName)) ||
+      `auto:${collectionName}.${collectionName}`;
+
+    const base = {
+      subdomain: ctx?.subdomain || '',
+      source: 'mongo',
+      status: 'success',
+      contentType,
+      processId: ctx?.processId || '',
+      userId: ctx?.userId || '',
+      // Markers for the (dynamic) revert path: resolve the model generically even
+      // when no meta/logs contentType is configured for this collection.
+      autoJournal: true,
+      mongooseName,
+      dbName,
+    };
+
+    if (kind === 'deleteMany') {
+      emitPutLog({
+        ...base,
+        action: 'deleteMany',
+        docIds: docs.map((d) => toIdString(d._id)),
+        payload: { collectionName, prevDocuments: docs, mongooseName, dbName },
+      });
+    } else {
+      const doc = docs[0];
+      emitPutLog({
+        ...base,
+        action: 'delete',
+        docId: toIdString(doc._id),
+        payload: {
+          collectionName,
+          docId: toIdString(doc._id),
+          prevDocument: doc,
+          mongooseName,
+          dbName,
+        },
+      });
+    }
+  } catch {
+    /* capture is best-effort and must never disturb the write */
+  }
+};
+
+// Stash key for the pre-image snapshot carried from the `pre` to the `post` hook
+// on the same Query instance.
+const SNAP = Symbol('revertCaptureSnapshot');
+
+const makePreHook = (kind: DeleteKind) => {
+  return async function (this: any) {
+    try {
+      const filter = typeof this.getFilter === 'function' ? this.getFilter() : {};
+      const query = this.model.find(filter).lean();
+      if (kind === 'delete') {
+        query.limit(1);
+      } else {
+        query.limit(MAX_SNAPSHOT);
+      }
+      this[SNAP] = await query;
+    } catch {
+      this[SNAP] = undefined;
+    }
+  };
+};
+
+const makePostHook = (kind: DeleteKind) => {
+  return function (this: any) {
+    try {
+      const docs = this[SNAP];
+      if (docs && docs.length) {
+        journalDeletes(this.model, docs, kind);
+      }
+    } catch {
+      /* never disturb the write path */
+    }
+  };
+};
+
+/**
+ * Install the delete-capture hooks on a schema. Called from `schemaWrapper`, so
+ * every wrapped schema gets them. No-op unless REVERT_AUTO_JOURNAL=enable.
+ */
+export const installRevertCaptureHooks = (schema: Schema): void => {
+  if (!AUTO_JOURNAL_ENABLED) {
+    return;
+  }
+
+  // Query-level middleware (Model.deleteMany / Model.deleteOne / findOneAndDelete).
+  schema.pre('deleteMany', makePreHook('deleteMany'));
+  schema.post('deleteMany', makePostHook('deleteMany'));
+
+  schema.pre(
+    'deleteOne',
+    { query: true, document: false },
+    makePreHook('delete'),
+  );
+  schema.post(
+    'deleteOne',
+    { query: true, document: false },
+    makePostHook('delete'),
+  );
+
+  schema.pre('findOneAndDelete', makePreHook('delete'));
+  schema.post('findOneAndDelete', makePostHook('delete'));
+};

--- a/backend/erxes-api-shared/src/utils/utils.ts
+++ b/backend/erxes-api-shared/src/utils/utils.ts
@@ -451,8 +451,20 @@ export const checkServiceRunning = async (
   }
 };
 
-export const generateRequestProcess = () => {
-  const processId = nanoid(12);
+// nanoid's default alphabet, with a length window. A request MAY supply its own
+// correlation id via the x-erxes-process-id header — e.g. the AI agent stamps
+// each action so the resulting DB changes (and their synchronous cascade) share
+// one processId and can be traced/reverted together. Honored only when
+// well-formed; otherwise a fresh id is minted. This is a correlation hint, not a
+// trust boundary: a client can only group the changes of its OWN request.
+const PROCESS_ID_RE = /^[A-Za-z0-9_-]{8,64}$/;
+
+export const generateRequestProcess = (incomingProcessId?: string) => {
+  const processId =
+    typeof incomingProcessId === 'string' &&
+    PROCESS_ID_RE.test(incomingProcessId)
+      ? incomingProcessId
+      : nanoid(12);
 
   return { processId };
 };

--- a/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
+++ b/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
@@ -16,6 +16,11 @@ import {
 } from '@/workflow/@types/workflow';
 import { loadAgentClass, IMastraAgentModel } from '@/agent/db/models/Agent';
 import {
+  loadAgentActionLogClass,
+  IMastraAgentActionLogModel,
+} from '@/agent/db/models/AgentActionLog';
+import { IMastraAgentActionLogDocument } from '@/agent/@types/agentActionLog';
+import {
   loadProviderClass,
   IMastraProviderModel,
 } from '@/provider/db/models/Provider';
@@ -63,6 +68,7 @@ import { IMastraScheduleDocument } from '@/schedule/@types/schedule';
 
 export interface IModels {
   MastraAgent: IMastraAgentModel;
+  MastraAgentActionLog: IMastraAgentActionLogModel;
   MastraProvider: IMastraProviderModel;
   MastraSettings: IMastraSettingsModel;
   MastraThread: IMastraThreadModel;
@@ -89,6 +95,11 @@ export const loadClasses = (db: mongoose.Connection): IModels => {
     'mastra_agents',
     loadAgentClass(models),
   );
+
+  models.MastraAgentActionLog = db.model<
+    IMastraAgentActionLogDocument,
+    IMastraAgentActionLogModel
+  >('mastra_agent_action_logs', loadAgentActionLogClass(models));
 
   models.MastraProvider = db.model<
     IMastraProviderDocument,

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -14,6 +14,7 @@ import {
   scopeSummary,
   capabilityInventory,
 } from './tools/scope';
+import { resolveDestructiveOpsPolicy } from './tools/destructiveGuard';
 
 // Cache agents by config ID + updatedAt + routing version.
 const agentCache = new Map<string, Agent>();
@@ -23,7 +24,7 @@ const agentCache = new Map<string, Agent>();
 const toolsCache = new Map<string, ToolsInput>();
 
 // Increment this whenever routing.ts, the meta-tools, or provider logic changes.
-const ROUTING_VERSION = 24;
+const ROUTING_VERSION = 25;
 
 export interface AgentWithTools {
   agent: Agent;
@@ -43,6 +44,11 @@ export async function getOrCreateAgent(
   // The agent's reach: 'all' (every erxes operation + builtin) by default, or a
   // restricted allowlist. The two meta-tools enforce this at execution time.
   const policy = resolveToolPolicy(agentConfig);
+
+  // Consent for irreversible deletes/merges. Defaults to 'block' (incl. legacy
+  // agents with no field persisted) so the AI cannot remove data by mistake;
+  // the execute meta-tool refuses destructive ops unless this is 'allow'.
+  const destructiveOps = resolveDestructiveOpsPolicy(agentConfig);
 
   // The live, cached schema registry powers search + execute. No per-operation
   // tool docs are bound any more — capabilities are derived from the gateway.
@@ -80,7 +86,10 @@ export async function getOrCreateAgent(
   // one operation (an all-builtins-only restricted agent skips them).
   const hasErxes = hasAnyOperation(registry.list, policy);
   if (hasErxes) {
-    Object.assign(tools, buildErxesMetaTools({ registry, settings, policy }));
+    Object.assign(
+      tools,
+      buildErxesMetaTools({ registry, settings, policy, destructiveOps }),
+    );
   }
 
   // Standalone builtin tools, filtered by policy.

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -15,6 +15,7 @@ import {
   capabilityInventory,
 } from './tools/scope';
 import { resolveDestructiveOpsPolicy } from './tools/destructiveGuard';
+import { writeAgentAction, AgentActionInput } from './auditLog';
 
 // Cache agents by config ID + updatedAt + routing version.
 const agentCache = new Map<string, Agent>();
@@ -84,11 +85,26 @@ export async function getOrCreateAgent(
 
   // erxes search/execute meta-tools — bound only when the policy grants at least
   // one operation (an all-builtins-only restricted agent skips them).
+  // Per-agent audit sink: every mutation the agent runs (or is blocked from)
+  // is recorded against this agent. Fire-and-forget inside writeAgentAction.
+  const recordAction = (entry: AgentActionInput) =>
+    writeAgentAction(models, {
+      ...entry,
+      source: 'chat',
+      agentId: agentConfig.agentId,
+    });
+
   const hasErxes = hasAnyOperation(registry.list, policy);
   if (hasErxes) {
     Object.assign(
       tools,
-      buildErxesMetaTools({ registry, settings, policy, destructiveOps }),
+      buildErxesMetaTools({
+        registry,
+        settings,
+        policy,
+        destructiveOps,
+        recordAction,
+      }),
     );
   }
 

--- a/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
@@ -32,8 +32,9 @@ export function writeAgentAction(
   if (!model?.record) return;
 
   // Fire-and-forget by design: an audit write must never slow down or break the
-  // action it records, so the write is not awaited and a rejection is swallowed.
-  void model.record(entry).catch((err) =>
+  // action it records. Not awaited; the catch swallows a rejected write (and
+  // marks the promise handled so it is not a floating promise).
+  model.record(entry).catch((err) =>
     console.error('writeAgentAction failed', err),
   );
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
@@ -26,14 +26,14 @@ export function writeAgentAction(
   models: IModels,
   entry: AgentActionEntry,
 ): void {
-  // Defensive on every axis: a missing model (e.g. a partial test harness), a
-  // synchronous throw, or a rejected write must never surface to the caller.
-  try {
-    const pending = models?.MastraAgentActionLog?.record?.(entry);
-    if (pending && typeof pending.catch === 'function') {
-      pending.catch((err) => console.error('writeAgentAction failed', err));
-    }
-  } catch (err) {
-    console.error('writeAgentAction failed', err);
-  }
+  // Guard a missing model (e.g. a partial test harness) before touching it, so
+  // the conditional never operates on a promise.
+  const model = models?.MastraAgentActionLog;
+  if (!model?.record) return;
+
+  // Fire-and-forget by design: an audit write must never slow down or break the
+  // action it records, so the write is not awaited and a rejection is swallowed.
+  void model.record(entry).catch((err) =>
+    console.error('writeAgentAction failed', err),
+  );
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
@@ -1,4 +1,15 @@
+import { randomBytes } from 'crypto';
 import type { IModels } from '~/connectionResolvers';
+
+/**
+ * A per-action correlation id sent to erxes as the x-erxes-process-id header so
+ * the resulting DB changes (and their synchronous cascade) share one processId
+ * and can be traced/reverted together. base64url keeps it within the core
+ * validator's `[A-Za-z0-9_-]{8,64}` window; the agt_ prefix marks the origin.
+ */
+export function makeAgentProcessId(): string {
+  return `agt_${randomBytes(9).toString('base64url')}`;
+}
 
 // The fields a tool layer produces about one mutation attempt. The source +
 // principal (agentId / workflowId) are added by the caller that owns them.
@@ -9,6 +20,8 @@ export interface AgentActionInput {
   args?: Record<string, unknown>;
   status: 'success' | 'failed' | 'blocked';
   error?: string;
+  // The x-erxes-process-id stamped on the underlying mutation (executed ops only).
+  processId?: string;
 }
 
 export interface AgentActionEntry extends AgentActionInput {

--- a/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/auditLog.ts
@@ -1,0 +1,39 @@
+import type { IModels } from '~/connectionResolvers';
+
+// The fields a tool layer produces about one mutation attempt. The source +
+// principal (agentId / workflowId) are added by the caller that owns them.
+export interface AgentActionInput {
+  operation: string;
+  operationType: string;
+  destructive: boolean;
+  args?: Record<string, unknown>;
+  status: 'success' | 'failed' | 'blocked';
+  error?: string;
+}
+
+export interface AgentActionEntry extends AgentActionInput {
+  source: 'chat' | 'workflow';
+  agentId?: string;
+  workflowId?: string;
+}
+
+/**
+ * Persist one agent action to the audit trail. Fire-and-forget by design: an
+ * audit write must never slow down or break the action it records, so failures
+ * are logged and swallowed rather than propagated.
+ */
+export function writeAgentAction(
+  models: IModels,
+  entry: AgentActionEntry,
+): void {
+  // Defensive on every axis: a missing model (e.g. a partial test harness), a
+  // synchronous throw, or a rejected write must never surface to the caller.
+  try {
+    const pending = models?.MastraAgentActionLog?.record?.(entry);
+    if (pending && typeof pending.catch === 'function') {
+      pending.catch((err) => console.error('writeAgentAction failed', err));
+    }
+  } catch (err) {
+    console.error('writeAgentAction failed', err);
+  }
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/destructiveGuard.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/destructiveGuard.test.ts
@@ -1,0 +1,72 @@
+import {
+  isDestructiveOperation,
+  resolveDestructiveOpsPolicy,
+  destructiveBlockedResult,
+} from '../destructiveGuard';
+import type { OperationMeta } from '../operationRegistry';
+
+/** Minimal OperationMeta for the guard, which only reads name + type. */
+const op = (
+  operation: string,
+  operationType: 'query' | 'mutation',
+): OperationMeta => ({ operation, operationType }) as OperationMeta;
+
+describe('isDestructiveOperation', () => {
+  it('flags remove/delete/merge/destroy mutations', () => {
+    for (const name of [
+      'dealsRemove',
+      'customersRemove',
+      'customersMerge',
+      'companiesMerge',
+      'segmentsDelete',
+      'conversationsRemove',
+      'productsDestroy',
+    ]) {
+      expect(isDestructiveOperation(op(name, 'mutation'))).toBe(true);
+    }
+  });
+
+  it('does not flag non-destructive mutations', () => {
+    for (const name of [
+      'dealsAdd',
+      'customersEdit',
+      'tasksAdd',
+      'boardItemsArchive', // archive is the reversible, soft alternative
+    ]) {
+      expect(isDestructiveOperation(op(name, 'mutation'))).toBe(false);
+    }
+  });
+
+  it('never flags queries, even when the name contains a destructive verb', () => {
+    expect(isDestructiveOperation(op('customers', 'query'))).toBe(false);
+    expect(isDestructiveOperation(op('removedCustomers', 'query'))).toBe(false);
+  });
+});
+
+describe('resolveDestructiveOpsPolicy', () => {
+  it("returns 'allow' only when explicitly set", () => {
+    expect(resolveDestructiveOpsPolicy({ destructiveOps: 'allow' })).toBe(
+      'allow',
+    );
+  });
+
+  it("defaults to 'block' for missing, invalid, or legacy configs", () => {
+    expect(resolveDestructiveOpsPolicy({ destructiveOps: 'block' })).toBe(
+      'block',
+    );
+    expect(resolveDestructiveOpsPolicy({})).toBe('block');
+    expect(resolveDestructiveOpsPolicy(null)).toBe('block');
+    expect(resolveDestructiveOpsPolicy(undefined)).toBe('block');
+    expect(resolveDestructiveOpsPolicy({ destructiveOps: 'yes' })).toBe('block');
+  });
+});
+
+describe('destructiveBlockedResult', () => {
+  it('is a structured, non-retryable refusal naming the operation', () => {
+    const result = destructiveBlockedResult('customersRemove');
+    expect(result.success).toBe(false);
+    expect(result.blocked).toBe(true);
+    expect(result.error).toContain('customersRemove');
+    expect(result.instruction).toMatch(/do not retry/i);
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/destructiveGuard.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/destructiveGuard.test.ts
@@ -56,7 +56,6 @@ describe('resolveDestructiveOpsPolicy', () => {
     );
     expect(resolveDestructiveOpsPolicy({})).toBe('block');
     expect(resolveDestructiveOpsPolicy(null)).toBe('block');
-    expect(resolveDestructiveOpsPolicy(undefined)).toBe('block');
     expect(resolveDestructiveOpsPolicy({ destructiveOps: 'yes' })).toBe('block');
   });
 });

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/metaTools.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/metaTools.test.ts
@@ -5,7 +5,9 @@
  */
 jest.mock('@mastra/core/tools', () => ({ createTool: (cfg: unknown) => cfg }));
 
-const mockExecute = jest.fn(() => Promise.resolve({ ok: true }));
+const mockExecute = jest.fn((..._args: unknown[]) =>
+  Promise.resolve({ ok: true }),
+);
 jest.mock('../erxesTools', () => ({
   executeErxesOperation: (...args: unknown[]) => mockExecute(...args),
   graphqlTypeToString: () => 'String',
@@ -80,9 +82,11 @@ describe('execute_erxes_operation guard + audit', () => {
       destructive: true,
       status: 'blocked',
     });
+    // Nothing executed → no correlation id.
+    expect(calls[0].processId).toBeUndefined();
   });
 
-  it("records a successful mutation when destructiveOps is 'allow'", async () => {
+  it("records a successful mutation (with a correlation id) when destructiveOps is 'allow'", async () => {
     const calls: AgentActionInput[] = [];
     const tool = build(
       [{ operation: 'customersRemove', operationType: 'mutation' }],
@@ -93,10 +97,14 @@ describe('execute_erxes_operation guard + audit', () => {
     await tool.execute({ operation: 'customersRemove', args: {} });
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
+    // The processId is the 6th arg to executeErxesOperation and is recorded.
+    const sentProcessId = mockExecute.mock.calls[0][5] as string;
+    expect(sentProcessId).toMatch(/^agt_/);
     expect(calls[0]).toMatchObject({
       operation: 'customersRemove',
       destructive: true,
       status: 'success',
+      processId: sentProcessId,
     });
   });
 
@@ -125,6 +133,8 @@ describe('execute_erxes_operation guard + audit', () => {
     await tool.execute({ operation: 'customers', args: {} });
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
+    // Reads get no correlation id (nothing to revert).
+    expect(mockExecute.mock.calls[0][5]).toBeUndefined();
     expect(calls).toHaveLength(0);
   });
 });

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/metaTools.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/metaTools.test.ts
@@ -1,0 +1,130 @@
+/**
+ * execute_erxes_operation: the destructive-ops guard and the audit-trail
+ * recording. Mastra's createTool and the network executor are mocked so the
+ * test drives the tool's own logic directly.
+ */
+jest.mock('@mastra/core/tools', () => ({ createTool: (cfg: unknown) => cfg }));
+
+const mockExecute = jest.fn(() => Promise.resolve({ ok: true }));
+jest.mock('../erxesTools', () => ({
+  executeErxesOperation: (...args: unknown[]) => mockExecute(...args),
+  graphqlTypeToString: () => 'String',
+}));
+
+import { buildErxesMetaTools } from '../metaTools';
+import type {
+  OperationRegistry,
+  OperationMeta,
+} from '../operationRegistry';
+import type { AgentActionInput } from '../auditLog';
+
+const mkRegistry = (ops: Array<Partial<OperationMeta>>): OperationRegistry => {
+  const list = ops.map(
+    (o) =>
+      ({
+        operation: o.operation || 'x',
+        operationType: o.operationType || 'mutation',
+        plugin: o.plugin || 'core',
+        module: o.module || 'customers',
+        description: '',
+        graphqlArgs: [],
+        returnType: null,
+      }) as OperationMeta,
+  );
+  return {
+    operations: new Map(list.map((o) => [o.operation, o])),
+    list,
+    inputTypesMap: {},
+    objectFieldsMap: {},
+  };
+};
+
+interface ToolLike {
+  execute: (input: unknown) => Promise<{ blocked?: boolean } & Record<string, unknown>>;
+}
+
+const build = (
+  ops: Array<Partial<OperationMeta>>,
+  destructiveOps: 'allow' | 'block',
+  calls: AgentActionInput[],
+) =>
+  buildErxesMetaTools({
+    registry: mkRegistry(ops),
+    settings: {},
+    policy: { mode: 'all', allowed: [] },
+    destructiveOps,
+    recordAction: (entry) => calls.push(entry),
+  }).execute_erxes_operation as unknown as ToolLike;
+
+beforeEach(() => mockExecute.mockClear());
+
+describe('execute_erxes_operation guard + audit', () => {
+  it('blocks a destructive op, records it, and never executes it', async () => {
+    const calls: AgentActionInput[] = [];
+    const tool = build(
+      [{ operation: 'customersRemove', operationType: 'mutation' }],
+      'block',
+      calls,
+    );
+
+    const res = await tool.execute({
+      operation: 'customersRemove',
+      args: { _ids: ['c1'] },
+    });
+
+    expect(res.blocked).toBe(true);
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      operation: 'customersRemove',
+      destructive: true,
+      status: 'blocked',
+    });
+  });
+
+  it("records a successful mutation when destructiveOps is 'allow'", async () => {
+    const calls: AgentActionInput[] = [];
+    const tool = build(
+      [{ operation: 'customersRemove', operationType: 'mutation' }],
+      'allow',
+      calls,
+    );
+
+    await tool.execute({ operation: 'customersRemove', args: {} });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(calls[0]).toMatchObject({
+      operation: 'customersRemove',
+      destructive: true,
+      status: 'success',
+    });
+  });
+
+  it('records a failed mutation when the executor returns success:false', async () => {
+    mockExecute.mockResolvedValueOnce({ success: false, error: 'boom' } as never);
+    const calls: AgentActionInput[] = [];
+    const tool = build(
+      [{ operation: 'dealsEdit', operationType: 'mutation' }],
+      'block',
+      calls,
+    );
+
+    await tool.execute({ operation: 'dealsEdit', args: {} });
+
+    expect(calls[0]).toMatchObject({ status: 'failed', error: 'boom' });
+  });
+
+  it('does not record reads (queries)', async () => {
+    const calls: AgentActionInput[] = [];
+    const tool = build(
+      [{ operation: 'customers', operationType: 'query' }],
+      'block',
+      calls,
+    );
+
+    await tool.execute({ operation: 'customers', args: {} });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/destructiveGuard.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/destructiveGuard.ts
@@ -1,0 +1,55 @@
+import { OperationMeta } from './operationRegistry';
+
+// Consent for irreversible mutations, stored per-agent (and per-workflow).
+//   'block' (default) → the agent may NOT run remove/delete/merge operations.
+//   'allow'           → destructive operations are permitted.
+// 'confirm' is intentionally NOT a value yet: a human-in-the-loop approval flow
+// does not exist on the chat/scheduled transports, so anything other than an
+// explicit 'allow' must fall through to 'block' and never silently destroy data.
+export type DestructiveOpsPolicy = 'block' | 'allow';
+
+// erxes mutation names are suffix-based: customersRemove, dealsRemove,
+// segmentsDelete, customersMerge, companiesMerge. Match those verbs anywhere in
+// the operation name. We gate ONLY mutations, so reads are never affected.
+// 'archive' is deliberately excluded — it is the reversible, soft alternative to
+// a hard delete, so blocking it would push the model toward the worse option.
+const DESTRUCTIVE_NAME = /(remove|delete|merge|destroy)/i;
+
+/** True when `op` is a mutation that irreversibly destroys or merges data. */
+export function isDestructiveOperation(op: OperationMeta): boolean {
+  if (op.operationType !== 'mutation') return false;
+  return DESTRUCTIVE_NAME.test(op.operation);
+}
+
+/**
+ * Resolve the destructive-ops consent from a stored config object (an agent
+ * document or a workflow definition). Anything other than an explicit 'allow'
+ * — including a missing field on a legacy agent — resolves to 'block', so the
+ * safe default holds even before the field is persisted.
+ */
+export function resolveDestructiveOpsPolicy(
+  config: unknown,
+): DestructiveOpsPolicy {
+  const value = (config as { destructiveOps?: unknown } | null | undefined)
+    ?.destructiveOps;
+  return value === 'allow' ? 'allow' : 'block';
+}
+
+/**
+ * The structured refusal returned to the model when it attempts a destructive
+ * operation without consent. Deliberately actionable: the model should explain
+ * the limit to the user and offer a safe alternative, NOT silently retry.
+ */
+export function destructiveBlockedResult(operation: string) {
+  return {
+    success: false,
+    blocked: true,
+    error: `Operation "${operation}" deletes or merges data and is blocked for this agent.`,
+    instruction:
+      'Do NOT retry this operation. Tell the user plainly that this agent is not ' +
+      'allowed to delete or merge records, and that an administrator can enable ' +
+      'destructive operations in the agent settings if it is intended. Where it ' +
+      'helps, suggest a non-destructive alternative such as editing or archiving ' +
+      'instead of removing.',
+  };
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/erxesTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/erxesTools.ts
@@ -680,7 +680,10 @@ const isValidObjectId = (value?: string): boolean =>
  * Auth headers for gateway calls: the calling user's request header when
  * present, otherwise the configured app token (bot/no-session calls).
  */
-function buildAuthHeaders(appToken: string): Record<string, string> {
+function buildAuthHeaders(
+  appToken: string,
+  processId?: string,
+): Record<string, string> {
   const reqAuth = getCurrentAuth();
   const authHeaders: Record<string, string> = {};
   if (reqAuth?.userHeader) {
@@ -692,6 +695,11 @@ function buildAuthHeaders(appToken: string): Record<string, string> {
     // The gateway resolves the tenant via getSubdomain(), which reads the
     // 'hostname' header before falling back to the request host.
     authHeaders['hostname'] = reqAuth.subdomain;
+  }
+  if (processId) {
+    // Correlation id honored by the subgraph's request context, so every DB
+    // change this mutation makes is stamped with it (traceable / revertable).
+    authHeaders['x-erxes-process-id'] = processId;
   }
   return authHeaders;
 }
@@ -792,6 +800,7 @@ export async function executeErxesOperation(
   settings: ErxesToolSettings | null,
   inputTypesMap?: Record<string, GqlArgDef[]>,
   objectFieldsMap?: Record<string, GqlFieldDef[]>,
+  processId?: string,
 ): Promise<unknown> {
   // Any internal failure (a malformed introspection shape, an undefined field
   // access, a network blip) must become a STRUCTURED result the model can act
@@ -815,7 +824,7 @@ export async function executeErxesOperation(
       : { ...(rawArgs || {}) };
 
     // Auth must be resolved first — needed for any pre-flight stage lookups.
-    const authHeaders = buildAuthHeaders(token);
+    const authHeaders = buildAuthHeaders(token, processId);
 
     if (erxesOperation === 'dealsAdd') {
       const preflight = await resolveDealsAddStageArg(

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
@@ -12,7 +12,7 @@ import {
   isDestructiveOperation,
   destructiveBlockedResult,
 } from './destructiveGuard';
-import type { AgentActionInput } from '../auditLog';
+import { makeAgentProcessId, type AgentActionInput } from '../auditLog';
 
 // LLMs sometimes pass the args object as a JSON string. Parse it back so the
 // execute tool always receives a real object.
@@ -207,12 +207,17 @@ export function buildErxesMetaTools(params: {
         return destructiveBlockedResult(operation);
       }
 
+      // Stamp a correlation id on mutations so every DB change this op makes is
+      // traceable/revertable as a unit; reads need none.
+      const processId = isMutation ? makeAgentProcessId() : undefined;
+
       const result = await executeErxesOperation(
         op,
         callArgs,
         settings,
         registry.inputTypesMap,
         registry.objectFieldsMap,
+        processId,
       );
 
       // Audit trail: record mutations only (executed or failed); reads are not
@@ -231,6 +236,7 @@ export function buildErxesMetaTools(params: {
           error: failed
             ? String((result as { error?: unknown }).error ?? '')
             : undefined,
+          processId,
         });
       }
 

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
@@ -7,6 +7,11 @@ import {
 } from './erxesTools';
 import { OperationMeta, OperationRegistry } from './operationRegistry';
 import { ToolPolicy, isOperationAllowed } from './scope';
+import {
+  DestructiveOpsPolicy,
+  isDestructiveOperation,
+  destructiveBlockedResult,
+} from './destructiveGuard';
 
 // LLMs sometimes pass the args object as a JSON string. Parse it back so the
 // execute tool always receives a real object.
@@ -76,8 +81,9 @@ export function buildErxesMetaTools(params: {
   registry: OperationRegistry;
   settings: ErxesToolSettings;
   policy: ToolPolicy;
+  destructiveOps: DestructiveOpsPolicy;
 }) {
-  const { registry, settings, policy } = params;
+  const { registry, settings, policy, destructiveOps } = params;
 
   /** Operations visible to this agent after policy filtering. */
   const allowedList = (): OperationMeta[] =>
@@ -178,6 +184,12 @@ export function buildErxesMetaTools(params: {
           success: false,
           error: `Operation "${operation}" is not permitted for this agent.`,
         };
+      }
+      // Safety gate: irreversible deletes/merges are refused unless the agent is
+      // explicitly configured with destructiveOps: 'allow'. Enforced here, beside
+      // the policy check, so the boundary holds even if the model guesses a name.
+      if (destructiveOps !== 'allow' && isDestructiveOperation(op)) {
+        return destructiveBlockedResult(operation);
       }
 
       return await executeErxesOperation(

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
@@ -219,7 +219,7 @@ export function buildErxesMetaTools(params: {
       // logged. Best-effort — never blocks or fails the operation.
       if (isMutation) {
         const failed =
-          !!result &&
+          Boolean(result) &&
           typeof result === 'object' &&
           (result as { success?: unknown }).success === false;
         recordAction?.({

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/metaTools.ts
@@ -12,6 +12,7 @@ import {
   isDestructiveOperation,
   destructiveBlockedResult,
 } from './destructiveGuard';
+import type { AgentActionInput } from '../auditLog';
 
 // LLMs sometimes pass the args object as a JSON string. Parse it back so the
 // execute tool always receives a real object.
@@ -82,8 +83,9 @@ export function buildErxesMetaTools(params: {
   settings: ErxesToolSettings;
   policy: ToolPolicy;
   destructiveOps: DestructiveOpsPolicy;
+  recordAction?: (entry: AgentActionInput) => void;
 }) {
-  const { registry, settings, policy, destructiveOps } = params;
+  const { registry, settings, policy, destructiveOps, recordAction } = params;
 
   /** Operations visible to this agent after policy filtering. */
   const allowedList = (): OperationMeta[] =>
@@ -185,20 +187,54 @@ export function buildErxesMetaTools(params: {
           error: `Operation "${operation}" is not permitted for this agent.`,
         };
       }
+
+      const callArgs = coerceArgs(args);
+      const isMutation = op.operationType === 'mutation';
+
       // Safety gate: irreversible deletes/merges are refused unless the agent is
       // explicitly configured with destructiveOps: 'allow'. Enforced here, beside
       // the policy check, so the boundary holds even if the model guesses a name.
       if (destructiveOps !== 'allow' && isDestructiveOperation(op)) {
+        if (isMutation)
+          recordAction?.({
+            operation,
+            operationType: op.operationType,
+            destructive: true,
+            args: callArgs,
+            status: 'blocked',
+            error: 'blocked by destructive-ops guard',
+          });
         return destructiveBlockedResult(operation);
       }
 
-      return await executeErxesOperation(
+      const result = await executeErxesOperation(
         op,
-        coerceArgs(args),
+        callArgs,
         settings,
         registry.inputTypesMap,
         registry.objectFieldsMap,
       );
+
+      // Audit trail: record mutations only (executed or failed); reads are not
+      // logged. Best-effort — never blocks or fails the operation.
+      if (isMutation) {
+        const failed =
+          !!result &&
+          typeof result === 'object' &&
+          (result as { success?: unknown }).success === false;
+        recordAction?.({
+          operation,
+          operationType: op.operationType,
+          destructive: isDestructiveOperation(op),
+          args: callArgs,
+          status: failed ? 'failed' : 'success',
+          error: failed
+            ? String((result as { error?: unknown }).error ?? '')
+            : undefined,
+        });
+      }
+
+      return result;
     },
   });
 

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/workflowTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/workflowTools.ts
@@ -109,6 +109,7 @@ A workflow is a JSON document:
 {
   "trigger": { "type": "manual" | "automation" | "schedule" | "webhook", "config": {} },
   "policy": { "mode": "all" | "custom", "allowed": ["dealsAdd", "plugin:sales", "module:customers"] },
+  "destructiveOps": "block" | "allow",
   "bindings": { "<name>": { "kind": "agent", "id": "<agent _id>" } },
   "limits": { "maxLlmCalls": 10 },
   "steps": [ ... ]
@@ -154,8 +155,12 @@ TRIGGERS:
 RULES:
 1. Always set the narrowest policy that covers every operation step.
 2. Bind agents through "bindings" — never inline agent ids in steps.
-3. Destructive operations (*Remove, *Delete, *Merge, payment creation): warn the
-   user explicitly before saving, and get their confirmation.
+3. Destructive operations (*Remove, *Delete, *Merge): a step using one is
+   REJECTED by validation unless the workflow sets "destructiveOps": "allow"
+   (default "block"). Only set "allow" when the user has explicitly asked to
+   delete or merge records — warn them and get confirmation before saving, and
+   prefer editing or archiving over removing. Payment creation also warrants an
+   explicit warning even though it is not gated here.
 4. Build flow: validate with workflowValidate and fix every error. Then:
    - If the user ALREADY asked you to create/save the workflow (or already
      confirmed a plan), call workflowSave NOW, in this SAME turn. Do not

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/__tests__/dsl.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/__tests__/dsl.test.ts
@@ -266,3 +266,38 @@ describe('review fixes', () => {
     ).toBe(true);
   });
 });
+
+describe('workflow destructiveOps guard', () => {
+  // validDef()'s second step replaced with an irreversible delete.
+  const destructiveDef = (destructiveOps?: 'allow' | 'block') => {
+    const def = validDef();
+    def.steps[1] = {
+      id: 'create',
+      type: 'operation',
+      operation: 'dealsRemove',
+      args: { _ids: ['{{trigger.payload.id}}'] },
+    };
+    return destructiveOps ? { ...def, destructiveOps } : def;
+  };
+  const registry = mkRegistry([
+    { operation: 'dealsRemove', plugin: 'sales', module: 'deals' },
+  ]);
+
+  it('rejects a destructive operation when destructiveOps is unset (default block)', () => {
+    const result = validateDefinition(destructiveDef(), registry);
+    expect(result.ok).toBe(false);
+    expect(
+      result.errors.some((e) => /deletes or merges data/.test(e.message)),
+    ).toBe(true);
+  });
+
+  it("rejects a destructive operation when destructiveOps is 'block'", () => {
+    expect(validateDefinition(destructiveDef('block'), registry).ok).toBe(
+      false,
+    );
+  });
+
+  it("accepts a destructive operation when destructiveOps is 'allow'", () => {
+    expect(validateDefinition(destructiveDef('allow'), registry).ok).toBe(true);
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/dsl.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/dsl.ts
@@ -3,6 +3,7 @@ import { collectRefs, checkRef, findMalformedRefs } from './refs';
 import { parseExpr, exprRefs } from './expr';
 import type { OperationRegistry } from '../tools/operationRegistry';
 import { isOperationAllowed, ToolPolicy } from '../tools/scope';
+import { isDestructiveOperation } from '../tools/destructiveGuard';
 
 /**
  * The workflow definition DSL — the declarative JSON document the master agent
@@ -160,6 +161,10 @@ export const MAX_STEPS = 30;
 export const workflowDefinitionSchema = z.object({
   trigger: workflowTriggerSchema,
   policy: workflowPolicySchema,
+  // Consent for irreversible deletes/merges, mirroring the chat agent's
+  // destructiveOps. Defaults to 'block': a workflow with a remove/delete/merge
+  // step must explicitly opt in with 'allow' or validation rejects it.
+  destructiveOps: z.enum(['allow', 'block']).default('block'),
   bindings: z.record(bindingSchema).default({}),
   limits: workflowLimitsSchema.default({ maxLlmCalls: 10 }),
   steps: z.array(stepSchema).min(1).max(MAX_STEPS),
@@ -281,6 +286,14 @@ export function validateDefinition(
           errors.push({
             path: at,
             message: `operation "${opName}" is outside this workflow's policy`,
+          });
+        } else if (
+          isDestructiveOperation(meta) &&
+          def.destructiveOps !== 'allow'
+        ) {
+          errors.push({
+            path: at,
+            message: `operation "${opName}" deletes or merges data; set "destructiveOps": "allow" on the workflow to permit it`,
           });
         }
       } else if (def.policy.mode === 'custom') {

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
@@ -12,6 +12,7 @@ import {
   isDestructiveOperation,
   resolveDestructiveOpsPolicy,
 } from '../tools/destructiveGuard';
+import { writeAgentAction } from '../auditLog';
 import { getOperationRegistry } from '../tools/operationRegistry';
 import type { IModels } from '~/connectionResolvers';
 import type { IMastraAgentDocument } from '@/agent/@types/agent';
@@ -168,6 +169,7 @@ function judgmentInstruction(outputSpec: Record<string, string>): string {
 export async function buildRunDeps(
   models: IModels,
   definition: WorkflowDefinition,
+  workflowId?: string,
 ): Promise<{ deps: CompiledDeps; usage: { llmCalls: number } }> {
   const settings = await models.MastraSettings.getSettings();
   const registry = await getOperationRegistry(settings);
@@ -187,6 +189,7 @@ export async function buildRunDeps(
           `operation "${operation}" is outside this workflow's policy`,
         );
       }
+      const isMutation = meta.operationType === 'mutation';
       // Defense-in-depth: validation already rejects destructive ops without
       // consent, but re-check at execution time (a definition could be run
       // without re-validation) so a remove/delete/merge never slips through.
@@ -194,18 +197,51 @@ export async function buildRunDeps(
         isDestructiveOperation(meta) &&
         resolveDestructiveOpsPolicy(definition) !== 'allow'
       ) {
+        if (isMutation)
+          writeAgentAction(models, {
+            source: 'workflow',
+            workflowId,
+            operation,
+            operationType: meta.operationType,
+            destructive: true,
+            args: args || {},
+            status: 'blocked',
+            error: 'blocked by destructive-ops guard',
+          });
         throw new Error(
           `operation "${operation}" deletes or merges data and is blocked for this workflow (set destructiveOps: "allow" to permit)`,
         );
       }
       const { executeErxesOperation } = await import('../tools/erxesTools');
-      return executeErxesOperation(
+      const result = await executeErxesOperation(
         meta,
         args || {},
         settings,
         registry.inputTypesMap,
         registry.objectFieldsMap,
       );
+
+      // Audit trail: mutations only, best-effort.
+      if (isMutation) {
+        const failed =
+          !!result &&
+          typeof result === 'object' &&
+          (result as { success?: unknown }).success === false;
+        writeAgentAction(models, {
+          source: 'workflow',
+          workflowId,
+          operation,
+          operationType: meta.operationType,
+          destructive: isDestructiveOperation(meta),
+          args: args || {},
+          status: failed ? 'failed' : 'success',
+          error: failed
+            ? String((result as { error?: unknown }).error ?? '')
+            : undefined,
+        });
+      }
+
+      return result;
     },
 
     runJudgment: async ({ agentBindingId, prompt, outputSpec }) => {
@@ -273,7 +309,7 @@ export async function runWorkflow(args: {
   const tenant = workflowTenant(subdomain);
   const key = `wf_${workflow._id}_v${workflow.version}`;
 
-  const { deps, usage } = await buildRunDeps(models, definition);
+  const { deps, usage } = await buildRunDeps(models, definition, workflow._id);
   // NOT awaited — the Workflow object is a thenable (see compiler.ts).
   const compiled = compileDefinition(key, definition, deps);
 

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
@@ -12,7 +12,7 @@ import {
   isDestructiveOperation,
   resolveDestructiveOpsPolicy,
 } from '../tools/destructiveGuard';
-import { writeAgentAction } from '../auditLog';
+import { writeAgentAction, makeAgentProcessId } from '../auditLog';
 import { getOperationRegistry } from '../tools/operationRegistry';
 import type { IModels } from '~/connectionResolvers';
 import type { IMastraAgentDocument } from '@/agent/@types/agent';
@@ -212,6 +212,10 @@ export async function buildRunDeps(
           `operation "${operation}" deletes or merges data and is blocked for this workflow (set destructiveOps: "allow" to permit)`,
         );
       }
+      // Stamp a correlation id on mutations so every DB change is traceable/
+      // revertable as a unit; reads need none.
+      const processId = isMutation ? makeAgentProcessId() : undefined;
+
       const { executeErxesOperation } = await import('../tools/erxesTools');
       const result = await executeErxesOperation(
         meta,
@@ -219,6 +223,7 @@ export async function buildRunDeps(
         settings,
         registry.inputTypesMap,
         registry.objectFieldsMap,
+        processId,
       );
 
       // Audit trail: mutations only, best-effort.
@@ -238,6 +243,7 @@ export async function buildRunDeps(
           error: failed
             ? String((result as { error?: unknown }).error ?? '')
             : undefined,
+          processId,
         });
       }
 

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
@@ -8,6 +8,10 @@ import {
 import { TriggerEnvelope } from './envelope';
 import { WorkflowDefinition } from './dsl';
 import { isOperationAllowed, ToolPolicy } from '../tools/scope';
+import {
+  isDestructiveOperation,
+  resolveDestructiveOpsPolicy,
+} from '../tools/destructiveGuard';
 import { getOperationRegistry } from '../tools/operationRegistry';
 import type { IModels } from '~/connectionResolvers';
 import type { IMastraAgentDocument } from '@/agent/@types/agent';
@@ -181,6 +185,17 @@ export async function buildRunDeps(
       if (!isOperationAllowed(meta, definition.policy as ToolPolicy)) {
         throw new Error(
           `operation "${operation}" is outside this workflow's policy`,
+        );
+      }
+      // Defense-in-depth: validation already rejects destructive ops without
+      // consent, but re-check at execution time (a definition could be run
+      // without re-validation) so a remove/delete/merge never slips through.
+      if (
+        isDestructiveOperation(meta) &&
+        resolveDestructiveOpsPolicy(definition) !== 'allow'
+      ) {
+        throw new Error(
+          `operation "${operation}" deletes or merges data and is blocked for this workflow (set destructiveOps: "allow" to permit)`,
         );
       }
       const { executeErxesOperation } = await import('../tools/erxesTools');

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
@@ -224,7 +224,7 @@ export async function buildRunDeps(
       // Audit trail: mutations only, best-effort.
       if (isMutation) {
         const failed =
-          !!result &&
+          Boolean(result) &&
           typeof result === 'object' &&
           (result as { success?: unknown }).success === false;
         writeAgentAction(models, {

--- a/backend/plugins/erxes-agent_api/src/modules/agent/@types/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/@types/agent.ts
@@ -9,6 +9,8 @@ export interface IMastraAgent {
   model: string;
   toolPolicy?: 'all' | 'custom';
   allowedTools?: string[];
+  // Consent for irreversible deletes/merges. Defaults to 'block'.
+  destructiveOps?: 'allow' | 'block';
   memoryEnabled?: boolean;
   maxSteps?: number;
   temperature?: number;

--- a/backend/plugins/erxes-agent_api/src/modules/agent/@types/agentActionLog.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/@types/agentActionLog.ts
@@ -1,0 +1,31 @@
+import { Document } from 'mongoose';
+
+// One record per erxes MUTATION the agent attempted — executed, failed, or
+// blocked by the destructive-ops guard. Reads are intentionally not logged
+// (high volume, nothing to audit or revert). This is both an accountability
+// trail and the seed of the future point-in-time revert journal.
+export interface IMastraAgentActionLog {
+  source: 'chat' | 'workflow';
+  agentId?: string;
+  workflowId?: string;
+  operation: string;
+  operationType: string;
+  destructive?: boolean;
+  // The mutation arguments. May contain business data by nature — it records
+  // exactly what the agent changed.
+  args?: Record<string, unknown>;
+  status: 'success' | 'failed' | 'blocked';
+  error?: string;
+  // Reserved for revert correlation once agent runs are stamped with the erxes
+  // request processId (Phase 2/3). Best-effort / unset for now.
+  userId?: string;
+  processId?: string;
+}
+
+export interface IMastraAgentActionLogDocument
+  extends IMastraAgentActionLog,
+    Document {
+  _id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agent.ts
@@ -20,6 +20,15 @@ export const agentSchema = new Schema(
       label: 'Tool Policy',
     },
     allowedTools: [{ type: String }],
+    // Consent for irreversible deletes/merges (remove/delete/merge mutations).
+    // Defaults to 'block' so the agent cannot destroy data by mistake; set to
+    // 'allow' to opt a specific agent into destructive operations.
+    destructiveOps: {
+      type: String,
+      enum: ['allow', 'block'],
+      default: 'block',
+      label: 'Destructive Operations',
+    },
     memoryEnabled: { type: Boolean, default: true },
     maxSteps: { type: Number, default: 10 },
     // Sampling temperature sent to the model. Unset → the provider/SDK default

--- a/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agentActionLog.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/db/definitions/agentActionLog.ts
@@ -1,0 +1,34 @@
+import { Schema } from 'mongoose';
+import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+
+export const agentActionLogSchema = new Schema(
+  {
+    _id: mongooseStringRandomId,
+    source: {
+      type: String,
+      enum: ['chat', 'workflow'],
+      index: true,
+      label: 'Source',
+    },
+    agentId: { type: String, index: true, label: 'Agent' },
+    workflowId: { type: String, index: true, label: 'Workflow' },
+    operation: { type: String, index: true, label: 'Operation' },
+    operationType: { type: String, label: 'Operation type' },
+    destructive: { type: Boolean, default: false, label: 'Destructive' },
+    // Stored verbatim so the trail shows exactly what the agent changed.
+    args: { type: Schema.Types.Mixed, label: 'Arguments' },
+    status: {
+      type: String,
+      enum: ['success', 'failed', 'blocked'],
+      index: true,
+      label: 'Status',
+    },
+    error: { type: String, label: 'Error' },
+    // Reserved for revert correlation (Phase 2/3); unset for now.
+    userId: { type: String, label: 'User' },
+    processId: { type: String, label: 'Process' },
+  },
+  { timestamps: true, minimize: false },
+);
+
+agentActionLogSchema.index({ createdAt: -1 });

--- a/backend/plugins/erxes-agent_api/src/modules/agent/db/models/AgentActionLog.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/db/models/AgentActionLog.ts
@@ -1,0 +1,57 @@
+import { Model } from 'mongoose';
+import { IModels } from '~/connectionResolvers';
+import { agentActionLogSchema } from '@/agent/db/definitions/agentActionLog';
+import {
+  IMastraAgentActionLog,
+  IMastraAgentActionLogDocument,
+} from '@/agent/@types/agentActionLog';
+
+export interface IMastraAgentActionLogListParams {
+  agentId?: string;
+  source?: string;
+  status?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export interface IMastraAgentActionLogModel
+  extends Model<IMastraAgentActionLogDocument> {
+  record(
+    doc: IMastraAgentActionLog,
+  ): Promise<IMastraAgentActionLogDocument>;
+  getActions(
+    params: IMastraAgentActionLogListParams,
+  ): Promise<IMastraAgentActionLogDocument[]>;
+}
+
+export const loadAgentActionLogClass = (_models: IModels) => {
+  class MastraAgentActionLog {
+    public static async record(doc: IMastraAgentActionLog) {
+      return _models.MastraAgentActionLog.create(doc);
+    }
+
+    public static async getActions({
+      agentId,
+      source,
+      status,
+      page = 1,
+      perPage = 30,
+    }: IMastraAgentActionLogListParams) {
+      const filter: Record<string, unknown> = {};
+      if (agentId) filter.agentId = agentId;
+      if (source) filter.source = source;
+      if (status) filter.status = status;
+
+      const limit = Math.min(Math.max(perPage, 1), 100);
+      const skip = (Math.max(page, 1) - 1) * limit;
+
+      return _models.MastraAgentActionLog.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit);
+    }
+  }
+
+  agentActionLogSchema.loadClass(MastraAgentActionLog);
+  return agentActionLogSchema;
+};

--- a/backend/plugins/erxes-agent_api/src/modules/agent/db/models/AgentActionLog.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/db/models/AgentActionLog.ts
@@ -24,13 +24,18 @@ export interface IMastraAgentActionLogModel
   ): Promise<IMastraAgentActionLogDocument[]>;
 }
 
+/** Bind the MastraAgentActionLog statics onto the schema (mongoose loadClass). */
 export const loadAgentActionLogClass = (_models: IModels) => {
+  /** Static helpers for the agent action audit trail. */
+  // skipcq: JS-0327 — the mongoose loadClass pattern requires a class of statics
   class MastraAgentActionLog {
-    public static async record(doc: IMastraAgentActionLog) {
+    /** Append one action entry to the audit trail. */
+    public static record(doc: IMastraAgentActionLog) {
       return _models.MastraAgentActionLog.create(doc);
     }
 
-    public static async getActions({
+    /** Recorded actions, newest first, optionally filtered and paginated. */
+    public static getActions({
       agentId,
       source,
       status,

--- a/backend/plugins/erxes-agent_api/src/modules/agent/graphql/schemas/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/graphql/schemas/agent.ts
@@ -9,6 +9,7 @@ export const types = `
     model: String
     toolPolicy: String
     allowedTools: [String]
+    destructiveOps: String
     memoryEnabled: Boolean
     maxSteps: Int
     temperature: Float
@@ -26,6 +27,7 @@ export const types = `
     model: String
     toolPolicy: String
     allowedTools: [String]
+    destructiveOps: String
     memoryEnabled: Boolean
     maxSteps: Int
     temperature: Float

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -28,6 +28,10 @@ type EventPayload = {
   processId?: string;
   userId?: string;
   contentType?: string;
+  // Recorded by the dynamic auto-capture so revert can resolve the model and
+  // refuse to apply against the wrong database connection.
+  mongooseName?: string;
+  dbName?: string;
 };
 
 type BulkEventPayload = {
@@ -48,6 +52,8 @@ type DeleteManyEventPayload = {
   processId?: string;
   userId?: string;
   contentType?: string;
+  mongooseName?: string;
+  dbName?: string;
 };
 
 const getCollectionType = (contentType?: string, collectionName?: string) => {
@@ -152,6 +158,8 @@ const handleUpdate = async (
   const logPayload = {
     collectionName: payload.collectionName,
     updateDescription: payload.updateDescription || {},
+    mongooseName: payload.mongooseName,
+    dbName: payload.dbName,
   };
 
   return await createLogDocument(
@@ -178,6 +186,8 @@ const handleDelete = async (
     // The pre-deletion snapshot (when the caller supplied it) — what a revert
     // re-inserts. Absent for callers not yet passing prevDocument.
     prevDocument: payload.prevDocument,
+    mongooseName: payload.mongooseName,
+    dbName: payload.dbName,
   };
 
   return await createLogDocument(
@@ -212,7 +222,12 @@ const handleDeleteMany = async (
     action: LOG_ACTIONS.DELETE_MANY,
     docId: String(docId),
     payload: withCollectionType(
-      { collectionName, prevDocument: snapshotById.get(String(docId)) },
+      {
+        collectionName,
+        prevDocument: snapshotById.get(String(docId)),
+        mongooseName: payload.mongooseName,
+        dbName: payload.dbName,
+      },
       payload.contentType,
       collectionName,
     ),
@@ -355,6 +370,8 @@ export const handleMongoChangeEvent = async (
       processId,
       userId,
       contentType,
+      mongooseName: payload?.mongooseName,
+      dbName: payload?.dbName,
     });
   }
 
@@ -401,6 +418,8 @@ export const handleMongoChangeEvent = async (
     processId,
     userId,
     contentType,
+    mongooseName: (payload as { mongooseName?: string })?.mongooseName,
+    dbName: (payload as { dbName?: string })?.dbName,
   };
 
   const handler = actionMap[logAction];

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -11,6 +11,7 @@ export const LOG_ACTIONS = {
   DELETE: 'delete',
   UPDATE_MANY: 'updateMany',
   BULK_WRITE: 'bulkWrite',
+  DELETE_MANY: 'deleteMany',
 } as const;
 
 type LogAction = (typeof LOG_ACTIONS)[keyof typeof LOG_ACTIONS];
@@ -34,6 +35,16 @@ type BulkEventPayload = {
   docIds: string[];
   collectionName: string;
   updateDescription?: Record<string, unknown>;
+  processId?: string;
+  userId?: string;
+  contentType?: string;
+};
+
+type DeleteManyEventPayload = {
+  collectionName: string;
+  docIds: string[];
+  // Aligned by index with docIds; each is the doc as it was before deletion.
+  prevDocuments?: unknown[];
   processId?: string;
   userId?: string;
   contentType?: string;
@@ -164,6 +175,9 @@ const handleDelete = async (
 
   const logPayload = {
     collectionName: payload.collectionName,
+    // The pre-deletion snapshot (when the caller supplied it) — what a revert
+    // re-inserts. Absent for callers not yet passing prevDocument.
+    prevDocument: payload.prevDocument,
   };
 
   return await createLogDocument(
@@ -175,6 +189,42 @@ const handleDelete = async (
     payload.userId,
     payload.contentType,
   );
+};
+
+const handleDeleteMany = async (
+  Logs: Model<ILogDocument>,
+  payload: DeleteManyEventPayload,
+) => {
+  const { collectionName, docIds, prevDocuments, processId, userId } = payload;
+
+  // One log per deleted doc, each carrying its own snapshot (paired by index
+  // with docIds) so a revert can re-insert every removed document.
+  const entries = docIds.map((docId, index) => ({
+    action: LOG_ACTIONS.DELETE_MANY,
+    docId: String(docId),
+    payload: withCollectionType(
+      { collectionName, prevDocument: prevDocuments?.[index] },
+      payload.contentType,
+      collectionName,
+    ),
+    source: 'mongo',
+    status: LOG_STATUSES.SUCCESS,
+    processId,
+    userId,
+    createdAt: new Date(),
+    contentType: payload.contentType,
+  }));
+
+  if (entries.length > BATCH_SIZE) {
+    const results: ILogDocument[] = [];
+    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+      const inserted = await Logs.insertMany(entries.slice(i, i + BATCH_SIZE));
+      results.push(...inserted);
+    }
+    return results;
+  }
+
+  return await Logs.insertMany(entries);
 };
 
 const handleUpdateMany = async (
@@ -273,6 +323,7 @@ const actionMap: Record<string, Function> = {
   [LOG_ACTIONS.DELETE]: handleDelete,
   [LOG_ACTIONS.UPDATE_MANY]: handleUpdateMany,
   [LOG_ACTIONS.BULK_WRITE]: handleBulkWrite,
+  [LOG_ACTIONS.DELETE_MANY]: handleDeleteMany,
 };
 
 export const handleMongoChangeEvent = async (
@@ -284,6 +335,20 @@ export const handleMongoChangeEvent = async (
   }
 
   const logAction = action as LogAction;
+
+  // deleteMany carries a per-doc snapshot list (prevDocuments) rather than a
+  // shared updateDescription, so it has its own handler/shape.
+  if (logAction === LOG_ACTIONS.DELETE_MANY && docIds && Array.isArray(docIds)) {
+    return await handleDeleteMany(Logs, {
+      collectionName: payload?.collectionName || '',
+      docIds,
+      prevDocuments: (payload as { prevDocuments?: unknown[] })?.prevDocuments,
+      processId,
+      userId,
+      contentType,
+    });
+  }
+
   const isBulkOperation =
     logAction === LOG_ACTIONS.UPDATE_MANY ||
     logAction === LOG_ACTIONS.BULK_WRITE;

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -43,7 +43,7 @@ type BulkEventPayload = {
 type DeleteManyEventPayload = {
   collectionName: string;
   docIds: string[];
-  // Aligned by index with docIds; each is the doc as it was before deletion.
+  // Docs as they were before deletion; matched to docIds by _id (any order).
   prevDocuments?: unknown[];
   processId?: string;
   userId?: string;
@@ -197,13 +197,22 @@ const handleDeleteMany = async (
 ) => {
   const { collectionName, docIds, prevDocuments, processId, userId } = payload;
 
-  // One log per deleted doc, each carrying its own snapshot (paired by index
-  // with docIds) so a revert can re-insert every removed document.
-  const entries = docIds.map((docId, index) => ({
+  // Match each snapshot to its doc by _id, so callers can pass a find() result
+  // in any order — no index alignment with docIds required.
+  const snapshotById = new Map<string, unknown>(
+    (prevDocuments || []).map((doc) => [
+      String((doc as { _id?: unknown } | null)?._id),
+      doc,
+    ]),
+  );
+
+  // One log per deleted doc, each carrying its own snapshot, so a revert can
+  // re-insert every removed document.
+  const entries = docIds.map((docId) => ({
     action: LOG_ACTIONS.DELETE_MANY,
     docId: String(docId),
     payload: withCollectionType(
-      { collectionName, prevDocument: prevDocuments?.[index] },
+      { collectionName, prevDocument: snapshotById.get(String(docId)) },
       payload.contentType,
       collectionName,
     ),

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -394,6 +394,9 @@ export const handleMongoChangeEvent = async (
     collectionName: payload?.collectionName || '',
     docId,
     fullDocument: payload?.fullDocument,
+    // Forward the pre-deletion snapshot for single `delete` ops too — without this
+    // only deleteMany captured prevDocument, so single deletes were unrevertable.
+    prevDocument: (payload as { prevDocument?: unknown })?.prevDocument,
     updateDescription: payload?.updateDescription,
     processId,
     userId,

--- a/frontend/core-ui/src/modules/logs/components/LogDetailPrimitives.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogDetailPrimitives.tsx
@@ -106,6 +106,13 @@ export const LogDetailJsonPanel = ({
 }) => {
   const normalized = normalizeJsonSource(src);
 
+  // react-json-view has no auto theming; its keys render near-black, which is
+  // unreadable on dark mode. Pick a dark base16 theme when the app is in dark
+  // mode (the `dark` class is toggled on <html> by ThemeEffect).
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark');
+
   return (
     <LogDetailPanel
       title={title}
@@ -119,6 +126,8 @@ export const LogDetailJsonPanel = ({
           name={false}
           displayDataTypes={false}
           enableClipboard={false}
+          theme={isDark ? 'twilight' : 'rjv-default'}
+          style={{ backgroundColor: 'transparent', fontSize: 12 }}
         />
       ) : (
         <p className="text-sm text-muted-foreground">{emptyMessage}</p>

--- a/frontend/core-ui/src/modules/logs/components/LogDetailView.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogDetailView.tsx
@@ -175,9 +175,7 @@ export const LogDetailView = ({ logId }: { logId: string }) => {
 
           <Component {...detail} />
 
-          <section className="rounded-3xl border bg-background p-6">
-            <LogRevertPanel detail={detail} />
-          </section>
+          <LogRevertPanel detail={detail} />
         </div>
       </div>
     </Suspense>

--- a/frontend/core-ui/src/modules/logs/components/LogDetailView.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogDetailView.tsx
@@ -5,6 +5,7 @@ import { Badge, RelativeDateDisplay, Spinner, cn } from 'erxes-ui';
 import { LogUserInfo } from '@/logs/components/LogUser';
 import { maskFields } from '../utils/logFormUtils';
 import { LogDetailJsonPanel, LogDetailSection } from './LogDetailPrimitives';
+import { LogRevertPanel } from './LogRevertPanel';
 import { IconClockHour4, IconDatabase } from '@tabler/icons-react';
 
 const MongoContent = lazy(() =>
@@ -173,6 +174,10 @@ export const LogDetailView = ({ logId }: { logId: string }) => {
           </section>
 
           <Component {...detail} />
+
+          <section className="rounded-3xl border bg-background p-6">
+            <LogRevertPanel detail={detail} />
+          </section>
         </div>
       </div>
     </Suspense>

--- a/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Badge, Button, useToast } from 'erxes-ui';
+import { Badge, Button, cn, useToast } from 'erxes-ui';
 import {
   IconHistory,
   IconAlertTriangle,
@@ -31,6 +31,53 @@ const entityLabel = (contentType?: string) => {
   const seg = contentType.split(':')[1] || contentType;
   return seg.split('.').pop() || contentType;
 };
+
+/** One selectable value card in the conflict chooser. */
+const OptionCard = ({
+  selected,
+  onClick,
+  label,
+  value,
+  tone,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  label: string;
+  value: string;
+  tone: 'current' | 'previous';
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={selected}
+    className={cn(
+      'flex flex-col items-start gap-1 rounded-lg border px-3 py-2 text-left transition-colors min-w-0',
+      selected
+        ? 'border-primary bg-primary/5 ring-1 ring-primary'
+        : 'border-border bg-background hover:bg-accent',
+    )}
+  >
+    <span className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+      {selected ? (
+        <IconCircleCheck size={13} className="text-primary" />
+      ) : (
+        <span
+          className={cn(
+            'inline-block size-3 rounded-full border',
+            tone === 'previous' ? 'border-primary/40' : 'border-border',
+          )}
+        />
+      )}
+      {label}
+    </span>
+    <span
+      className="w-full truncate font-mono text-sm text-foreground"
+      title={value}
+    >
+      {value}
+    </span>
+  </button>
+);
 
 /**
  * "Revert this action" surface for a Mongo data-change log. Self-contained:
@@ -124,6 +171,19 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
   const setChoice = (k: string, field: string, mode: 'restore' | 'keep') =>
     setChoices((prev) => ({ ...prev, [k]: { ...prev[k], [field]: mode } }));
 
+  const setAll = (mode: 'restore' | 'keep') => {
+    if (!result) return;
+    const next: Record<string, Record<string, 'restore' | 'keep'>> = {};
+    for (const c of result.conflicts) {
+      next[keyOf(c)] = {};
+      for (const f of c.fields) next[keyOf(c)][f.field] = mode;
+    }
+    setChoices(next);
+  };
+
+  const conflictFieldCount =
+    result?.conflicts.reduce((n, c) => n + c.fields.length, 0) || 0;
+
   return (
     <section className="rounded-3xl border bg-background">
       <div className="flex items-start gap-3 border-b px-6 py-5">
@@ -197,48 +257,63 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
             )}
 
             {result.conflicts.length > 0 && !done && (
-              <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
-                <p className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-destructive">
-                  <IconAlertTriangle size={15} /> Conflicts — choose what to keep
-                </p>
-                <div className="flex flex-col gap-4">
+              <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-4">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <p className="flex items-center gap-1.5 text-sm font-semibold text-destructive">
+                    <IconAlertTriangle size={15} />
+                    {conflictFieldCount} field
+                    {conflictFieldCount === 1 ? '' : 's'} changed since — choose
+                    what to keep
+                  </p>
+                  <div className="flex gap-1.5">
+                    <Button variant="outline" onClick={() => setAll('restore')}>
+                      Restore all
+                    </Button>
+                    <Button variant="outline" onClick={() => setAll('keep')}>
+                      Keep all
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-3">
                   {result.conflicts.map((c) => (
-                    <div key={keyOf(c)}>
+                    <div
+                      key={keyOf(c)}
+                      className="rounded-lg border bg-background p-3"
+                    >
                       <p className="mb-2 text-xs font-medium text-foreground">
                         {entityLabel(c.contentType)}{' '}
                         <span className="font-mono text-muted-foreground">
                           {c.docId}
                         </span>
                       </p>
-                      <div className="flex flex-col gap-2">
+                      <div className="flex flex-col gap-3">
                         {c.fields.map((f) => {
                           const mode = choices[keyOf(c)]?.[f.field] || 'restore';
                           return (
-                            <div
-                              key={f.field}
-                              className="flex flex-wrap items-center gap-2"
-                            >
-                              <span className="min-w-24 text-xs font-medium text-foreground">
+                            <div key={f.field}>
+                              <p className="mb-1.5 text-xs font-semibold text-foreground">
                                 {f.field}
-                              </span>
-                              <Button
-                                variant={mode === 'keep' ? 'default' : 'outline'}
-                                onClick={() =>
-                                  setChoice(keyOf(c), f.field, 'keep')
-                                }
-                              >
-                                Keep: {valueText(f.currentValue)}
-                              </Button>
-                              <Button
-                                variant={
-                                  mode === 'restore' ? 'default' : 'outline'
-                                }
-                                onClick={() =>
-                                  setChoice(keyOf(c), f.field, 'restore')
-                                }
-                              >
-                                Restore: {valueText(f.revertValue)}
-                              </Button>
+                              </p>
+                              <div className="grid grid-cols-2 gap-2">
+                                <OptionCard
+                                  tone="current"
+                                  selected={mode === 'keep'}
+                                  onClick={() =>
+                                    setChoice(keyOf(c), f.field, 'keep')
+                                  }
+                                  label="Keep current"
+                                  value={valueText(f.currentValue)}
+                                />
+                                <OptionCard
+                                  tone="previous"
+                                  selected={mode === 'restore'}
+                                  onClick={() =>
+                                    setChoice(keyOf(c), f.field, 'restore')
+                                  }
+                                  label="Restore previous"
+                                  value={valueText(f.revertValue)}
+                                />
+                              </div>
                             </div>
                           );
                         })}

--- a/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import { Button, useToast } from 'erxes-ui';
+import { Badge, Button, useToast } from 'erxes-ui';
 import {
   IconHistory,
   IconAlertTriangle,
-  IconCheck,
+  IconCircleCheck,
+  IconArrowBackUp,
 } from '@tabler/icons-react';
 import { ILogDoc } from '../types';
-import { LogDetailSection } from './LogDetailPrimitives';
 import {
   useRevertProcess,
   IRevertResult,
@@ -26,10 +26,17 @@ const valueText = (v: unknown): string => {
   }
 };
 
+const entityLabel = (contentType?: string) => {
+  if (!contentType) return 'record';
+  const seg = contentType.split(':')[1] || contentType;
+  return seg.split('.').pop() || contentType;
+};
+
 /**
- * "Revert this action" surface for a Mongo data-change log. Previews the
- * point-in-time revert of the whole processId (dry run), then applies it —
- * offering a field-level merge choice when a record changed in the interim.
+ * "Revert this action" surface for a Mongo data-change log. Self-contained:
+ * renders nothing (no wrapper) for non-revertable logs. Previews the
+ * point-in-time revert of the whole processId, then applies it — offering a
+ * field-level merge choice when a record changed in the interim.
  */
 export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
   const { processId, source } = detail;
@@ -37,13 +44,12 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
   const { toast } = useToast();
 
   const [result, setResult] = useState<IRevertResult | null>(null);
-  // docKey -> field -> chosen mode
   const [choices, setChoices] = useState<
     Record<string, Record<string, 'restore' | 'keep'>>
   >({});
   const [done, setDone] = useState(false);
 
-  // Only Mongo data changes carry a revertable processId.
+  // Only Mongo data changes carry a revertable processId — render nothing else.
   if (source !== 'mongo' || !processId) {
     return null;
   }
@@ -111,119 +117,161 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
     setChoices((prev) => ({ ...prev, [k]: { ...prev[k], [field]: mode } }));
 
   return (
-    <LogDetailSection
-      title="Revert"
-      description="Undo every change made in this action (point-in-time)."
-      icon={IconHistory}
-    >
-      {!result && (
-        <Button onClick={onPreview} disabled={loading} variant="secondary">
-          {loading ? 'Checking…' : 'Revert this action'}
-        </Button>
-      )}
+    <section className="rounded-3xl border bg-background">
+      <div className="flex items-start gap-3 border-b px-6 py-5">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+          <IconHistory size={18} />
+        </div>
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">Revert</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Undo every change made in this action, point-in-time.
+          </p>
+        </div>
+      </div>
 
-      {result && (
-        <div className="flex flex-col gap-3">
-          {result.alreadyReverted && (
-            <p className="text-sm text-muted-foreground">
-              This action was already reverted.
-            </p>
-          )}
+      <div className="px-6 py-5">
+        {!result && (
+          <Button onClick={onPreview} disabled={loading} variant="secondary">
+            <IconArrowBackUp />
+            {loading ? 'Checking…' : 'Revert this action'}
+          </Button>
+        )}
 
-          {result.reverted.length > 0 && (
-            <div className="text-sm">
-              <span className="font-semibold">
-                {done ? 'Restored' : 'Will restore'}:
-              </span>
-              <ul className="mt-1 list-disc pl-5">
-                {result.reverted.map((it, i) => (
-                  <li key={i} className="font-mono text-xs">
-                    {it.kind} · {it.contentType} · {it.docId}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+        {result && (
+          <div className="flex flex-col gap-4">
+            {result.alreadyReverted && (
+              <p className="text-sm text-muted-foreground">
+                This action was already reverted.
+              </p>
+            )}
 
-          {result.unrevertable.length > 0 && (
-            <div className="text-sm text-amber-600">
-              <span className="font-semibold">Cannot revert:</span>
-              <ul className="mt-1 list-disc pl-5">
-                {result.unrevertable.map((it, i) => (
-                  <li key={i} className="text-xs">
-                    {it.action} — {it.reason}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {result.conflicts.length > 0 && !done && (
-            <div className="rounded-lg border p-3">
-              <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-destructive">
-                <IconAlertTriangle size={16} /> Conflicts — choose what to keep
-              </div>
-              {result.conflicts.map((c) => (
-                <div key={keyOf(c)} className="mb-3">
-                  <p className="font-mono text-xs text-muted-foreground">
-                    {c.contentType} · {c.docId}
-                  </p>
-                  {c.fields.map((f) => {
-                    const mode = choices[keyOf(c)]?.[f.field] || 'restore';
-                    return (
-                      <div
-                        key={f.field}
-                        className="mt-1 flex flex-wrap items-center gap-2 text-xs"
-                      >
-                        <span className="font-semibold">{f.field}</span>
-                        <Button
-                          variant={mode === 'keep' ? 'default' : 'outline'}
-                          onClick={() => setChoice(keyOf(c), f.field, 'keep')}
-                        >
-                          Keep current: {valueText(f.currentValue)}
-                        </Button>
-                        <Button
-                          variant={mode === 'restore' ? 'default' : 'outline'}
-                          onClick={() => setChoice(keyOf(c), f.field, 'restore')}
-                        >
-                          Restore: {valueText(f.revertValue)}
-                        </Button>
-                      </div>
-                    );
-                  })}
+            {result.reverted.length > 0 && (
+              <div>
+                <p className="mb-2 text-sm font-medium text-foreground">
+                  {done ? 'Restored' : 'Will restore'}
+                </p>
+                <div className="flex flex-col gap-1.5">
+                  {result.reverted.map((it, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm"
+                    >
+                      <Badge variant="secondary">{it.kind}</Badge>
+                      <span className="font-medium text-foreground">
+                        {entityLabel(it.contentType)}
+                      </span>
+                      <span className="truncate font-mono text-xs text-muted-foreground">
+                        {it.docId}
+                      </span>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          )}
-
-          {!done &&
-            !result.alreadyReverted &&
-            (result.reverted.length > 0 || result.conflicts.length > 0) && (
-              <div className="flex gap-2">
-                <Button onClick={onApply} disabled={loading}>
-                  {loading
-                    ? 'Applying…'
-                    : result.conflicts.length
-                      ? 'Apply & revert'
-                      : 'Confirm revert'}
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => setResult(null)}
-                  disabled={loading}
-                >
-                  Cancel
-                </Button>
               </div>
             )}
 
-          {done && (
-            <div className="flex items-center gap-2 text-sm text-emerald-600">
-              <IconCheck size={16} /> Reverted successfully.
-            </div>
-          )}
-        </div>
-      )}
-    </LogDetailSection>
+            {result.unrevertable.length > 0 && (
+              <div>
+                <p className="mb-2 flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+                  <IconAlertTriangle size={15} /> Cannot revert
+                </p>
+                <div className="flex flex-col gap-1.5">
+                  {result.unrevertable.map((it, i) => (
+                    <p
+                      key={i}
+                      className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+                    >
+                      {it.reason}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {result.conflicts.length > 0 && !done && (
+              <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+                <p className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-destructive">
+                  <IconAlertTriangle size={15} /> Conflicts — choose what to keep
+                </p>
+                <div className="flex flex-col gap-4">
+                  {result.conflicts.map((c) => (
+                    <div key={keyOf(c)}>
+                      <p className="mb-2 text-xs font-medium text-foreground">
+                        {entityLabel(c.contentType)}{' '}
+                        <span className="font-mono text-muted-foreground">
+                          {c.docId}
+                        </span>
+                      </p>
+                      <div className="flex flex-col gap-2">
+                        {c.fields.map((f) => {
+                          const mode = choices[keyOf(c)]?.[f.field] || 'restore';
+                          return (
+                            <div
+                              key={f.field}
+                              className="flex flex-wrap items-center gap-2"
+                            >
+                              <span className="min-w-24 text-xs font-medium text-foreground">
+                                {f.field}
+                              </span>
+                              <Button
+                                variant={mode === 'keep' ? 'default' : 'outline'}
+                                onClick={() =>
+                                  setChoice(keyOf(c), f.field, 'keep')
+                                }
+                              >
+                                Keep: {valueText(f.currentValue)}
+                              </Button>
+                              <Button
+                                variant={
+                                  mode === 'restore' ? 'default' : 'outline'
+                                }
+                                onClick={() =>
+                                  setChoice(keyOf(c), f.field, 'restore')
+                                }
+                              >
+                                Restore: {valueText(f.revertValue)}
+                              </Button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {done && (
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Badge variant="success">
+                  <IconCircleCheck size={14} /> Reverted successfully
+                </Badge>
+              </div>
+            )}
+
+            {!done &&
+              !result.alreadyReverted &&
+              (result.reverted.length > 0 || result.conflicts.length > 0) && (
+                <div className="flex gap-2">
+                  <Button onClick={onApply} disabled={loading}>
+                    {loading
+                      ? 'Applying…'
+                      : result.conflicts.length
+                        ? 'Apply & revert'
+                        : 'Confirm revert'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => setResult(null)}
+                    disabled={loading}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              )}
+          </div>
+        )}
+      </div>
+    </section>
   );
 };

--- a/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
@@ -39,7 +39,7 @@ const entityLabel = (contentType?: string) => {
  * field-level merge choice when a record changed in the interim.
  */
 export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
-  const { processId, source } = detail;
+  const { processId, source, action } = detail;
   const { preview, apply, loading } = useRevertProcess();
   const { toast } = useToast();
 
@@ -49,8 +49,16 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
   >({});
   const [done, setDone] = useState(false);
 
-  // Only Mongo data changes carry a revertable processId — render nothing else.
-  if (source !== 'mongo' || !processId) {
+  // Revertable from the Mongo data-change log OR the GraphQL mutation log of the
+  // same request (both share the processId). Skip non-mutation/no-process logs,
+  // and the revert mutation itself (reverting a revert would be a confusing redo).
+  const isRevertMutation = detail.payload?.mutationName === 'logsRevertProcess';
+  const revertable =
+    !!processId &&
+    !isRevertMutation &&
+    (source === 'mongo' || (source === 'graphql' && action === 'mutation'));
+
+  if (!revertable) {
     return null;
   }
 

--- a/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { Button, useToast } from 'erxes-ui';
+import {
+  IconHistory,
+  IconAlertTriangle,
+  IconCheck,
+} from '@tabler/icons-react';
+import { ILogDoc } from '../types';
+import { LogDetailSection } from './LogDetailPrimitives';
+import {
+  useRevertProcess,
+  IRevertResult,
+  IDocResolution,
+} from '@/logs/hooks/useRevertProcess';
+
+const keyOf = (c: { contentType: string; docId: string }) =>
+  `${c.contentType}::${c.docId}`;
+
+const valueText = (v: unknown): string => {
+  if (v === undefined || v === null) return '—';
+  if (typeof v === 'string') return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+};
+
+/**
+ * "Revert this action" surface for a Mongo data-change log. Previews the
+ * point-in-time revert of the whole processId (dry run), then applies it —
+ * offering a field-level merge choice when a record changed in the interim.
+ */
+export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
+  const { processId, source } = detail;
+  const { preview, apply, loading } = useRevertProcess();
+  const { toast } = useToast();
+
+  const [result, setResult] = useState<IRevertResult | null>(null);
+  // docKey -> field -> chosen mode
+  const [choices, setChoices] = useState<
+    Record<string, Record<string, 'restore' | 'keep'>>
+  >({});
+  const [done, setDone] = useState(false);
+
+  // Only Mongo data changes carry a revertable processId.
+  if (source !== 'mongo' || !processId) {
+    return null;
+  }
+
+  const showError = (e: unknown) =>
+    toast({
+      title: 'Revert failed',
+      description: (e as Error)?.message || 'Unknown error',
+      variant: 'destructive',
+    });
+
+  const onPreview = async () => {
+    try {
+      const r = await preview(processId);
+      setResult(r);
+      const next: Record<string, Record<string, 'restore' | 'keep'>> = {};
+      for (const c of r.conflicts) {
+        next[keyOf(c)] = {};
+        for (const f of c.fields) next[keyOf(c)][f.field] = 'restore';
+      }
+      setChoices(next);
+    } catch (e) {
+      showError(e);
+    }
+  };
+
+  const buildResolutions = (r: IRevertResult): IDocResolution[] =>
+    r.conflicts.map((c) => ({
+      contentType: c.contentType,
+      docId: c.docId,
+      fields: c.fields.map((f) => ({
+        field: f.field,
+        mode: choices[keyOf(c)]?.[f.field] || 'restore',
+      })),
+    }));
+
+  const onApply = async () => {
+    if (!result) return;
+    try {
+      const r = await apply(
+        processId,
+        result.conflicts.length ? buildResolutions(result) : undefined,
+      );
+      setResult(r);
+      if (r.conflicts.length) {
+        toast({
+          title: 'Some changes still conflict',
+          description: 'Resolve the remaining fields and apply again.',
+          variant: 'destructive',
+        });
+      } else {
+        setDone(true);
+        toast({
+          title: 'Reverted',
+          description: `${r.reverted.length} change(s) undone.`,
+          variant: 'success',
+        });
+      }
+    } catch (e) {
+      showError(e);
+    }
+  };
+
+  const setChoice = (k: string, field: string, mode: 'restore' | 'keep') =>
+    setChoices((prev) => ({ ...prev, [k]: { ...prev[k], [field]: mode } }));
+
+  return (
+    <LogDetailSection
+      title="Revert"
+      description="Undo every change made in this action (point-in-time)."
+      icon={IconHistory}
+    >
+      {!result && (
+        <Button onClick={onPreview} disabled={loading} variant="secondary">
+          {loading ? 'Checking…' : 'Revert this action'}
+        </Button>
+      )}
+
+      {result && (
+        <div className="flex flex-col gap-3">
+          {result.alreadyReverted && (
+            <p className="text-sm text-muted-foreground">
+              This action was already reverted.
+            </p>
+          )}
+
+          {result.reverted.length > 0 && (
+            <div className="text-sm">
+              <span className="font-semibold">
+                {done ? 'Restored' : 'Will restore'}:
+              </span>
+              <ul className="mt-1 list-disc pl-5">
+                {result.reverted.map((it, i) => (
+                  <li key={i} className="font-mono text-xs">
+                    {it.kind} · {it.contentType} · {it.docId}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {result.unrevertable.length > 0 && (
+            <div className="text-sm text-amber-600">
+              <span className="font-semibold">Cannot revert:</span>
+              <ul className="mt-1 list-disc pl-5">
+                {result.unrevertable.map((it, i) => (
+                  <li key={i} className="text-xs">
+                    {it.action} — {it.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {result.conflicts.length > 0 && !done && (
+            <div className="rounded-lg border p-3">
+              <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-destructive">
+                <IconAlertTriangle size={16} /> Conflicts — choose what to keep
+              </div>
+              {result.conflicts.map((c) => (
+                <div key={keyOf(c)} className="mb-3">
+                  <p className="font-mono text-xs text-muted-foreground">
+                    {c.contentType} · {c.docId}
+                  </p>
+                  {c.fields.map((f) => {
+                    const mode = choices[keyOf(c)]?.[f.field] || 'restore';
+                    return (
+                      <div
+                        key={f.field}
+                        className="mt-1 flex flex-wrap items-center gap-2 text-xs"
+                      >
+                        <span className="font-semibold">{f.field}</span>
+                        <Button
+                          variant={mode === 'keep' ? 'default' : 'outline'}
+                          onClick={() => setChoice(keyOf(c), f.field, 'keep')}
+                        >
+                          Keep current: {valueText(f.currentValue)}
+                        </Button>
+                        <Button
+                          variant={mode === 'restore' ? 'default' : 'outline'}
+                          onClick={() => setChoice(keyOf(c), f.field, 'restore')}
+                        >
+                          Restore: {valueText(f.revertValue)}
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!done &&
+            !result.alreadyReverted &&
+            (result.reverted.length > 0 || result.conflicts.length > 0) && (
+              <div className="flex gap-2">
+                <Button onClick={onApply} disabled={loading}>
+                  {loading
+                    ? 'Applying…'
+                    : result.conflicts.length
+                      ? 'Apply & revert'
+                      : 'Confirm revert'}
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => setResult(null)}
+                  disabled={loading}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+
+          {done && (
+            <div className="flex items-center gap-2 text-sm text-emerald-600">
+              <IconCheck size={16} /> Reverted successfully.
+            </div>
+          )}
+        </div>
+      )}
+    </LogDetailSection>
+  );
+};

--- a/frontend/core-ui/src/modules/logs/graphql/logQueries.ts
+++ b/frontend/core-ui/src/modules/logs/graphql/logQueries.ts
@@ -82,6 +82,8 @@ export const LOG_DETAIL = gql`
       action
       status
       userId
+      processId
+      contentType
       user {
         _id
         email

--- a/frontend/core-ui/src/modules/logs/graphql/revertMutations.ts
+++ b/frontend/core-ui/src/modules/logs/graphql/revertMutations.ts
@@ -1,0 +1,49 @@
+import { gql } from '@apollo/client';
+
+/**
+ * Point-in-time revert of every change made under a log entry's processId.
+ * dryRun previews the plan (what would be restored, conflicts, unrevertable);
+ * a second call with dryRun:false (and optional field-level resolutions) applies it.
+ */
+export const LOGS_REVERT_PROCESS = gql`
+  mutation LogsRevertProcess(
+    $processId: String!
+    $dryRun: Boolean
+    $force: Boolean
+    $skipConflicts: Boolean
+    $resolutions: [LogRevertDocResolutionInput!]
+  ) {
+    logsRevertProcess(
+      processId: $processId
+      dryRun: $dryRun
+      force: $force
+      skipConflicts: $skipConflicts
+      resolutions: $resolutions
+    ) {
+      processId
+      dryRun
+      alreadyReverted
+      reverted {
+        contentType
+        docId
+        kind
+      }
+      conflicts {
+        contentType
+        docId
+        mongooseName
+        fields {
+          field
+          revertValue
+          currentValue
+        }
+      }
+      unrevertable {
+        contentType
+        docId
+        action
+        reason
+      }
+    }
+  }
+`;

--- a/frontend/core-ui/src/modules/logs/hooks/useRevertProcess.tsx
+++ b/frontend/core-ui/src/modules/logs/hooks/useRevertProcess.tsx
@@ -1,0 +1,71 @@
+import { useMutation } from '@apollo/client';
+import { LOGS_REVERT_PROCESS } from '@/logs/graphql/revertMutations';
+
+export interface IRevertField {
+  field: string;
+  revertValue?: any;
+  currentValue?: any;
+}
+
+export interface IRevertConflict {
+  contentType: string;
+  docId: string;
+  mongooseName: string;
+  fields: IRevertField[];
+}
+
+export interface IRevertApplied {
+  contentType: string;
+  docId: string;
+  kind: string;
+}
+
+export interface IRevertUnrevertable {
+  contentType?: string;
+  docId?: string;
+  action: string;
+  reason: string;
+}
+
+export interface IRevertResult {
+  processId: string;
+  dryRun: boolean;
+  alreadyReverted: boolean;
+  reverted: IRevertApplied[];
+  conflicts: IRevertConflict[];
+  unrevertable: IRevertUnrevertable[];
+}
+
+export interface IFieldResolution {
+  field: string;
+  mode: 'restore' | 'keep' | 'custom';
+  value?: any;
+}
+
+export interface IDocResolution {
+  contentType: string;
+  docId: string;
+  fields: IFieldResolution[];
+}
+
+export const useRevertProcess = () => {
+  const [run, { loading }] = useMutation(LOGS_REVERT_PROCESS);
+
+  const call = async (variables: {
+    processId: string;
+    dryRun?: boolean;
+    resolutions?: IDocResolution[];
+  }): Promise<IRevertResult> => {
+    const { data } = await run({ variables });
+    return data.logsRevertProcess as IRevertResult;
+  };
+
+  /** Preview the plan without writing anything. */
+  const preview = (processId: string) => call({ processId, dryRun: true });
+
+  /** Apply the revert, optionally with per-field merge resolutions. */
+  const apply = (processId: string, resolutions?: IDocResolution[]) =>
+    call({ processId, dryRun: false, resolutions });
+
+  return { preview, apply, loading };
+};

--- a/frontend/core-ui/src/modules/logs/types/index.ts
+++ b/frontend/core-ui/src/modules/logs/types/index.ts
@@ -26,6 +26,8 @@ export interface ILogDoc {
   };
   createdAt: string;
   status?: ILogStatusType;
+  processId?: string;
+  contentType?: string;
 }
 export type LogsMainListQueryResponse = {
   logsMainList: {


### PR DESCRIPTION
## Why

The erxes-agent chat agent can discover and execute **any** mutation in any enabled plugin (default `toolPolicy: 'all'`). That includes irreversible `*Remove` / `*Delete` / `*Merge` operations — with no confirmation, no audit, and no undo. A model mistake could silently delete or merge records.

This PR adds a **secure-by-default guard** plus an **audit trail**, entirely within `erxes-agent_api` (no core changes).

## What changed

**1. Destructive-op guard (chat)** — `execute_erxes_operation` refuses `*Remove`/`*Delete`/`*Merge`/`*Destroy` **mutations** unless the agent is explicitly configured with `destructiveOps: 'allow'`. Reads are never gated; `archive` is excluded (it's the reversible alternative). The refusal is a structured, non-retryable result so the model explains the limit instead of looping. The field persists on the agent (schema + GraphQL + types).

**2. Destructive-op guard (workflows)** — `destructiveOps` added to the workflow definition. `validateDefinition` **rejects** a destructive step at authoring time unless the workflow opts in, with a runtime re-check as defense-in-depth. The DSL guide tells the authoring model to set the flag only when deletion is genuinely intended.

**3. Mutation audit log** — new `MastraAgentActionLog` model records one entry per agent mutation (executed / failed / blocked) on both the chat and workflow paths. Writes are fire-and-forget and defensive — an audit write never slows or breaks the action it records. `userId`/`processId` are reserved for later use.

## Default behavior note

The default is **`block`** (secure-by-default). This is a deliberate behavior change: existing agents that relied on destructive operations will refuse them until opted into `destructiveOps: 'allow'` per agent. Flipping the default is a one-line change if the maintainers prefer non-breaking — flagging it explicitly for review.

## Testing

- `tsc --noEmit` clean.
- 13 new tests (guard classifier, workflow validation, chat guard+audit).
- Full plugin suite green: **210 tests**.

## Scope

Self-contained in `erxes-agent_api`. The audit log is also the foundation for a planned point-in-time revert capability for agent-initiated changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an audit trail for agent actions, capturing operation details, outcome (success/failed/blocked), and related chat/workflow context.
  * Introduced destructive-operations protection for agents and workflows: irreversible deletes/merges are blocked by default and require explicit opt-in (`destructiveOps: "allow"`).
  * Added point-in-time log revert: new “revert this action” UI with dry-run preview, conflict resolution, and apply support.

* **Tests**
  * Added coverage for destructive-operation detection, policy resolution, refusal behavior, and audit logging outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->