### PR TITLE
fix(permissions): use readImage for member avatar urls

### DIFF
--- a/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
+++ b/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
@@ -1,5 +1,13 @@
 import { IconLock, IconShield, IconUsers } from '@tabler/icons-react';
-import { Avatar, Button, Collapsible, Dialog, readImage, Separator, Spinner } from 'erxes-ui';
+import {
+  Avatar,
+  Button,
+  Collapsible,
+  Dialog,
+  readImage,
+  Separator,
+  Spinner,
+} from 'erxes-ui';
 import { useState } from 'react';
 import { useGetPermissionModules } from '@/settings/permissions/hooks/useGetPermissionModules';
 import {
@@ -163,8 +171,13 @@ export const PermissionGroupDetails = ({
                       className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border bg-background"
                     >
                       <Avatar size="lg">
-                        <Avatar.Image src={readImage(member.details?.avatar || '')} alt={name} />
-                        <Avatar.Fallback>{name.charAt(0).toUpperCase()}</Avatar.Fallback>
+                        <Avatar.Image
+                          src={readImage(member.details?.avatar || '')}
+                          alt={name}
+                        />
+                        <Avatar.Fallback>
+                          {name.charAt(0).toUpperCase()}
+                        </Avatar.Fallback>
                       </Avatar>
                       <div className="min-w-0">
                         <p className="text-sm font-medium truncate">{name}</p>

--- a/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
+++ b/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
@@ -1,5 +1,5 @@
 import { IconLock, IconShield, IconUsers } from '@tabler/icons-react';
-import { Button, Collapsible, Dialog, readImage, Separator, Spinner } from 'erxes-ui';
+import { Avatar, Button, Collapsible, Dialog, readImage, Separator, Spinner } from 'erxes-ui';
 import { useState } from 'react';
 import { useGetPermissionModules } from '@/settings/permissions/hooks/useGetPermissionModules';
 import {
@@ -162,19 +162,10 @@ export const PermissionGroupDetails = ({
                       key={member._id}
                       className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border bg-background"
                     >
-                      {member.details?.avatar ? (
-                        <img
-                          src={readImage(member.details.avatar)}
-                          alt={name}
-                          className="w-8 h-8 rounded-full object-cover shrink-0"
-                        />
-                      ) : (
-                        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0">
-                          <span className="text-xs font-medium text-muted-foreground">
-                            {name.charAt(0).toUpperCase()}
-                          </span>
-                        </div>
-                      )}
+                      <Avatar size="lg">
+                        <Avatar.Image src={readImage(member.details?.avatar || '')} alt={name} />
+                        <Avatar.Fallback>{name.charAt(0).toUpperCase()}</Avatar.Fallback>
+                      </Avatar>
                       <div className="min-w-0">
                         <p className="text-sm font-medium truncate">{name}</p>
                         {name !== member.email && (

--- a/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
+++ b/frontend/core-ui/src/modules/settings/permissions/components/PermissionGroupDetails.tsx
@@ -1,5 +1,5 @@
 import { IconLock, IconShield, IconUsers } from '@tabler/icons-react';
-import { Button, Collapsible, Dialog, Separator, Spinner } from 'erxes-ui';
+import { Button, Collapsible, Dialog, readImage, Separator, Spinner } from 'erxes-ui';
 import { useState } from 'react';
 import { useGetPermissionModules } from '@/settings/permissions/hooks/useGetPermissionModules';
 import {
@@ -164,7 +164,7 @@ export const PermissionGroupDetails = ({
                     >
                       {member.details?.avatar ? (
                         <img
-                          src={member.details.avatar}
+                          src={readImage(member.details.avatar)}
                           alt={name}
                           className="w-8 h-8 rounded-full object-cover shrink-0"
                         />


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix member avatar rendering in permission group details by routing avatar URLs through the readImage helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member avatar rendering in permission group details by enhancing avatar image handling and display consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->