### PR TITLE
refactor(erxes-agent): one AgentRunner over the native/legacy provider split

### DIFF
--- a/backend/plugins/erxes-agent_api/src/mastra/__tests__/agentRunner.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/__tests__/agentRunner.test.ts
@@ -1,0 +1,68 @@
+import { makeRunner } from '../agentRunner';
+
+// A spy agent recording which method was called and with what options.
+function spyAgent() {
+  const calls: { method: string; messages: unknown; options: unknown }[] = [];
+  const record = (method: string) => (messages: unknown, options?: unknown) => {
+    calls.push({ method, messages, options });
+    return Promise.resolve(
+      method.startsWith('stream') ? { fullStream: [] } : { text: method },
+    );
+  };
+  return {
+    calls,
+    generate: record('generate'),
+    generateLegacy: record('generateLegacy'),
+    stream: record('stream'),
+    streamLegacy: record('streamLegacy'),
+  };
+}
+
+describe('makeRunner', () => {
+  it('dispatches to the native methods when not legacy', async () => {
+    const agent = spyAgent();
+    const runner = makeRunner(agent, false);
+
+    await runner.generate(['hi']);
+    await runner.stream(['hi']);
+
+    expect(agent.calls.map((c) => c.method)).toEqual(['generate', 'stream']);
+  });
+
+  it('dispatches to the legacy methods when legacy', async () => {
+    const agent = spyAgent();
+    const runner = makeRunner(agent, true);
+
+    await runner.generate(['hi']);
+    await runner.stream(['hi']);
+
+    expect(agent.calls.map((c) => c.method)).toEqual([
+      'generateLegacy',
+      'streamLegacy',
+    ]);
+  });
+
+  // Regression: one-shot synthesis/titler/extractor calls pass { maxSteps: 1 }.
+  // Before the runner, the legacy branch received no options, so those calls ran
+  // with the agent's full step budget and could loop into tool calls.
+  it('forwards options to the legacy path too', async () => {
+    const agent = spyAgent();
+    const runner = makeRunner(agent, true);
+
+    await runner.generate(['hi'], { maxSteps: 1 });
+
+    expect(agent.calls[0].method).toBe('generateLegacy');
+    expect(agent.calls[0].options).toEqual({ maxSteps: 1 });
+  });
+
+  it('forwards the abort signal on the legacy stream path', async () => {
+    const agent = spyAgent();
+    const runner = makeRunner(agent, true);
+    const abortSignal = new AbortController().signal;
+
+    await runner.stream(['hi'], { abortSignal });
+
+    expect(agent.calls[0].method).toBe('streamLegacy');
+    expect(agent.calls[0].options).toEqual({ abortSignal });
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/activity.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/activity.ts
@@ -18,9 +18,9 @@
 // failure never affects the turn itself.
 // ---------------------------------------------------------------------------
 
-import type { Agent } from '@mastra/core/agent';
 import { trimEdgeChars } from '~/mastra/text';
-import type { ProviderDocLike } from '~/mastra/providers';
+import { isLegacyProvider, type ProviderDocLike } from '~/mastra/providers';
+import { AgentRunner, makeRunner } from '~/mastra/agentRunner';
 
 /** Auth context accepted by runWithAuth (the module itself loads lazily). */
 type AuthCtx = Parameters<
@@ -115,26 +115,27 @@ export function sanitizeActivity(
 
 // ── One-shot summarizer ──────────────────────────────────────────────────────
 
-// Tool-less summarizer agents, cached per provider+model.
-const _summarizers = new Map<string, Agent>();
+// Tool-less summarizer runners, cached per provider+model.
+const _summarizers = new Map<string, AgentRunner>();
 
-/** Get (or lazily create and cache) the summarizer agent for a model. */
+/** Get (or lazily create and cache) the summarizer runner for a model. */
 async function summarizerFor(
   provider: string,
   model: string,
   providers: ProviderDocLike[],
-): Promise<Agent> {
+): Promise<AgentRunner> {
   const key = `${provider}:${model}`;
   let summarizer = _summarizers.get(key);
   if (!summarizer) {
     const { Agent: AgentCtor } = await import('@mastra/core/agent');
     const { buildModel } = await import('~/mastra/providers');
-    summarizer = new AgentCtor({
+    const agent = new AgentCtor({
       id: 'mastra-activity-summarizer',
       name: 'Activity Summarizer',
       instructions: ACTIVITY_INSTRUCTIONS,
       model: buildModel(provider, model, providers),
     });
+    summarizer = makeRunner(agent, isLegacyProvider(provider, providers));
     _summarizers.set(key, summarizer);
   }
   return summarizer;
@@ -150,10 +151,9 @@ export async function summarizeActivity(params: {
   model: string;
   providers: ProviderDocLike[];
   authCtx: AuthCtx;
-  isLegacy: boolean;
   snapshot: ActivitySnapshot;
 }): Promise<string | null> {
-  const { provider, model, providers, authCtx, isLegacy, snapshot } = params;
+  const { provider, model, providers, authCtx, snapshot } = params;
   try {
     const context = buildActivityContext(snapshot);
     if (!context) return null;
@@ -161,12 +161,8 @@ export async function summarizeActivity(params: {
     const { runWithAuth } = await import('~/mastra/requestContext');
     const summarizer = await summarizerFor(provider, model, providers);
     const prompt = `${context}\n\nOutput the status line.`;
-    const result = await runWithAuth(
-      authCtx,
-      (): Promise<{ text?: string }> =>
-        isLegacy
-          ? summarizer.generateLegacy(prompt)
-          : summarizer.generate(prompt, { maxSteps: 1 }),
+    const result = await runWithAuth(authCtx, () =>
+      summarizer.generate(prompt, { maxSteps: 1 }),
     );
 
     return sanitizeActivity(result?.text);

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRunner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRunner.ts
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// AgentRunner — one interface over the native vs OpenAI-compatible split.
+//
+// Native providers (OpenAI/Anthropic/Google) drive a Mastra agent through
+// generate()/stream(); OpenAI-compatible ("legacy") providers go through
+// generateLegacy()/streamLegacy(). Every caller used to re-decide which method
+// to call (`isLegacy ? generateLegacy(m) : generate(m, opts)`), so the branch
+// was smeared across the chat turn, the SSE route, the titler, the activity
+// narrator, the working-memory extractor and the workflow judge.
+//
+// makeRunner() binds the agent and its isLegacy flag once and exposes a single
+// generate()/stream() pair. Options (notably maxSteps) are forwarded to BOTH
+// paths — the legacy methods previously received no per-call options, so a
+// one-shot `{ maxSteps: 1 }` synthesis call silently ran with the agent's full
+// step budget and could loop into tool calls.
+// ---------------------------------------------------------------------------
+
+// A tool result as gathered from an agent run — modern and legacy result
+// shapes expose different subsets of these fields, so all stay optional and
+// the payload itself stays unknown.
+export interface ToolResultLike {
+  toolName?: string;
+  name?: string;
+  toolCallId?: string;
+  id?: string;
+  result?: unknown;
+}
+
+// The slice of a Mastra generate() result the turn pipeline reads.
+export interface AgentTurnResult {
+  text?: string;
+  toolResults?: ToolResultLike[];
+  steps?: { toolResults?: ToolResultLike[] }[];
+}
+
+// Per-call options that apply to both provider paths. Kept deliberately small:
+// only the fields the pipeline actually sets. maxSteps caps the tool-call loop;
+// abortSignal cancels a stream when the client disconnects.
+export interface RunOptions {
+  maxSteps?: number;
+  abortSignal?: AbortSignal;
+}
+
+// The uniform surface every caller drives. The native/legacy choice lives
+// behind this interface, not at the call site.
+export interface AgentRunner {
+  generate(messages: unknown, options?: RunOptions): Promise<AgentTurnResult>;
+  stream(
+    messages: unknown,
+    options?: RunOptions,
+  ): Promise<{ fullStream: unknown }>;
+}
+
+// The four methods a Mastra Agent exposes for the two paths. Declared
+// structurally so this module needs no static @mastra/core dependency — the
+// lazily-built helper agents (titler, extractor, judge) satisfy it too.
+interface LegacyCapableAgent {
+  generate(messages: unknown, options?: unknown): Promise<AgentTurnResult>;
+  generateLegacy(
+    messages: unknown,
+    options?: unknown,
+  ): Promise<AgentTurnResult>;
+  stream(
+    messages: unknown,
+    options?: unknown,
+  ): Promise<{ fullStream: unknown }>;
+  streamLegacy(
+    messages: unknown,
+    options?: unknown,
+  ): Promise<{ fullStream: unknown }>;
+}
+
+/**
+ * Bind a Mastra agent and its provider kind into one runner. `isLegacy` is
+ * resolved once (from the provider, via isLegacyProvider) and never travels
+ * with the call again.
+ */
+export function makeRunner(agent: unknown, isLegacy: boolean): AgentRunner {
+  const mastraAgent = agent as LegacyCapableAgent;
+  return {
+    generate: (messages, options) =>
+      isLegacy
+        ? mastraAgent.generateLegacy(messages, options)
+        : mastraAgent.generate(messages, options),
+    stream: (messages, options) =>
+      isLegacy
+        ? mastraAgent.streamLegacy(messages, options)
+        : mastraAgent.stream(messages, options),
+  };
+}

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -3,7 +3,8 @@ import type { ToolsInput } from '@mastra/core/agent';
 import type { IModels } from '~/connectionResolvers';
 import type { IMastraAgentDocument } from '@/agent/@types/agent';
 import { BUILTIN_TOOLS } from './tools/builtins';
-import { buildModel } from './providers';
+import { buildModel, isLegacyProvider } from './providers';
+import { AgentRunner, makeRunner } from './agentRunner';
 import { buildSystemPrompt, ToolInfo } from './instructions/routing';
 import { getOperationRegistry } from './tools/operationRegistry';
 import { buildErxesMetaTools } from './tools/metaTools';
@@ -26,7 +27,9 @@ const toolsCache = new Map<string, ToolsInput>();
 const ROUTING_VERSION = 24;
 
 export interface AgentWithTools {
-  agent: Agent;
+  // The provider-agnostic runner: callers drive generate()/stream() without
+  // knowing whether this agent is native or OpenAI-compatible.
+  runner: AgentRunner;
   tools: ToolsInput;
 }
 
@@ -39,6 +42,9 @@ export async function getOrCreateAgent(
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),
   ]);
+
+  // Resolved once here; the runner carries it so no call site re-decides.
+  const isLegacy = isLegacyProvider(agentConfig.provider, providers);
 
   // The agent's reach: 'all' (every erxes operation + builtin) by default, or a
   // restricted allowlist. The two meta-tools enforce this at execution time.
@@ -58,7 +64,7 @@ export async function getOrCreateAgent(
   const cached = agentCache.get(cacheKey);
   if (cached) {
     return {
-      agent: cached,
+      runner: makeRunner(cached, isLegacy),
       tools: toolsCache.get(cacheKey) ?? {},
     };
   }
@@ -163,7 +169,7 @@ export async function getOrCreateAgent(
 
   agentCache.set(cacheKey, agent);
   toolsCache.set(cacheKey, tools);
-  return { agent, tools };
+  return { runner: makeRunner(agent, isLegacy), tools };
 }
 
 /** Drop every cached agent built from the given stored config id. */

--- a/backend/plugins/erxes-agent_api/src/mastra/learning/extractor.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/learning/extractor.ts
@@ -12,6 +12,7 @@
 
 import { MastraLearningType } from '@/learning/@types/learning';
 import type { ProviderDocLike } from '~/mastra/providers';
+import { AgentRunner, makeRunner } from '~/mastra/agentRunner';
 
 export interface CandidateLearning {
   type: MastraLearningType;
@@ -135,16 +136,9 @@ export function parseCandidates(raw: string): CandidateLearning[] {
 
 // ── Stateless agent plumbing (lazy, cached per provider+model) ───────────────
 
-// The minimal surface this module needs from a Mastra Agent. Keeping it local
-// avoids a static @mastra/core type dependency in a lazily-loaded path.
-interface StatelessAgent {
-  generate(msgs: unknown, opts?: unknown): Promise<{ text?: string }>;
-  generateLegacy(msgs: unknown): Promise<{ text?: string }>;
-}
+const _agents = new Map<string, AgentRunner>();
 
-const _agents = new Map<string, StatelessAgent>();
-
-/** Lazily build (and cache per provider+model) a tool-less one-shot agent. */
+/** Lazily build (and cache per provider+model) a tool-less one-shot runner. */
 async function statelessAgent(
   id: string,
   name: string,
@@ -152,18 +146,19 @@ async function statelessAgent(
   provider: string,
   model: string,
   providers: ProviderDocLike[],
-): Promise<StatelessAgent> {
+): Promise<AgentRunner> {
   const key = `${id}:${provider}:${model}`;
   let cached = _agents.get(key);
   if (!cached) {
     const { Agent } = await import('@mastra/core/agent');
-    const { buildModel } = await import('~/mastra/providers');
-    cached = new Agent({
+    const { buildModel, isLegacyProvider } = await import('~/mastra/providers');
+    const agent = new Agent({
       id,
       name,
       instructions,
       model: buildModel(provider, model, providers),
-    }) as unknown as StatelessAgent;
+    });
+    cached = makeRunner(agent, isLegacyProvider(provider, providers));
     _agents.set(key, cached);
   }
   return cached;
@@ -174,21 +169,18 @@ export interface ExtractionRuntime {
   model: string;
   providers: ProviderDocLike[];
   authCtx: { userHeader?: string; token?: string; subdomain?: string };
-  isLegacy: boolean;
 }
 
 /** One single-turn generate under the request's auth context; returns text. */
 async function runStateless(
-  agent: StatelessAgent,
+  runner: AgentRunner,
   userContent: string,
   rt: ExtractionRuntime,
 ): Promise<string> {
   const { runWithAuth } = await import('~/mastra/requestContext');
   const msgs = [{ role: 'user', content: userContent }];
   const result = await runWithAuth(rt.authCtx, () =>
-    rt.isLegacy
-      ? agent.generateLegacy(msgs)
-      : agent.generate(msgs, { maxSteps: 1 }),
+    runner.generate(msgs, { maxSteps: 1 }),
   );
   return result?.text ?? '';
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/learning/worker.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/learning/worker.ts
@@ -15,7 +15,6 @@ import {
   sendWorkerQueue,
 } from 'erxes-api-shared/utils';
 import { generateModels, IModels } from '~/connectionResolvers';
-import { isLegacyProvider } from '~/mastra/providers';
 import {
   learningSweepCron,
   learningTenant,
@@ -67,7 +66,6 @@ async function resolveRuntime(
       model: agentConfig.model,
       providers,
       authCtx: { token: settings?.erxesApiToken, subdomain },
-      isLegacy: isLegacyProvider(agentConfig.provider, providers),
     },
   };
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/workingMemory.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/workingMemory.ts
@@ -17,6 +17,9 @@ import type { IModels } from '~/connectionResolvers';
 import type { ProviderDocLike } from '~/mastra/providers';
 import type { MemoryContext } from './semanticRecall';
 import type { ConvoMessage } from './convo';
+// agentRunner is dependency-light (types + a thin dispatcher, no @mastra/core),
+// so it stays a static import; the heavy provider builder loads lazily below.
+import { AgentRunner, makeRunner } from '~/mastra/agentRunner';
 
 export const WM_EXTRACTOR_INSTRUCTIONS = `You maintain a concise, durable profile of a single user for an AI assistant.
 Given the current profile and the latest exchange, output the COMPLETE updated profile in markdown.
@@ -103,34 +106,28 @@ export async function readWorkingMemory(
   }
 }
 
-// The minimal surface used from a Mastra Agent — typed locally so the lazy
-// import keeps this module free of a static @mastra/core type dependency.
-interface ExtractorAgent {
-  generate(msgs: unknown, opts?: unknown): Promise<{ text?: string }>;
-  generateLegacy(msgs: unknown): Promise<{ text?: string }>;
-}
-
-// Tool-less extractor agents, cached per provider+model. Built lazily so the
+// Tool-less extractor runners, cached per provider+model. Built lazily so the
 // Mastra Agent / provider deps are only loaded when a refresh actually runs.
-const _extractors = new Map<string, ExtractorAgent>();
+const _extractors = new Map<string, AgentRunner>();
 
-/** Lazily build (and cache per provider+model) the profile extractor agent. */
+/** Lazily build (and cache per provider+model) the profile extractor runner. */
 async function extractorFor(
   provider: string,
   model: string,
   providers: ProviderDocLike[],
-): Promise<ExtractorAgent> {
+): Promise<AgentRunner> {
   const key = `${provider}:${model}`;
   let cached = _extractors.get(key);
   if (!cached) {
     const { Agent } = await import('@mastra/core/agent');
-    const { buildModel } = await import('~/mastra/providers');
-    cached = new Agent({
+    const { buildModel, isLegacyProvider } = await import('~/mastra/providers');
+    const agent = new Agent({
       id: 'mastra-wm-extractor',
       name: 'Working Memory Extractor',
       instructions: WM_EXTRACTOR_INSTRUCTIONS,
       model: buildModel(provider, model, providers),
-    }) as unknown as ExtractorAgent;
+    });
+    cached = makeRunner(agent, isLegacyProvider(provider, providers));
     _extractors.set(key, cached);
   }
   return cached;
@@ -148,18 +145,9 @@ export async function refreshWorkingMemory(params: {
   model: string;
   providers: ProviderDocLike[];
   authCtx: { userHeader?: string; token?: string; subdomain?: string };
-  isLegacy: boolean;
 }): Promise<void> {
-  const {
-    models,
-    ctx,
-    exchange,
-    provider,
-    model,
-    providers,
-    authCtx,
-    isLegacy,
-  } = params;
+  const { models, ctx, exchange, provider, model, providers, authCtx } =
+    params;
   try {
     const existing = await models.MastraWorkingMemory.getContent(
       ctx.resourceId,
@@ -171,9 +159,7 @@ export async function refreshWorkingMemory(params: {
       { role: 'user', content: buildRefreshUserContent(existing, exchange) },
     ];
     const result = await runWithAuth(authCtx, () =>
-      isLegacy
-        ? extractor.generateLegacy(msgs)
-        : extractor.generate(msgs, { maxSteps: 1 }),
+      extractor.generate(msgs, { maxSteps: 1 }),
     );
     const updated = mergeWorkingMemory(existing, result?.text);
     if (updated.trim() && updated !== existing) {

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
@@ -10,14 +10,8 @@
 
 import type { IModels } from '~/connectionResolvers';
 import type { IMastraScheduleDocument } from '@/schedule/@types/schedule';
-import {
-  HISTORY_LIMIT,
-  runAgentTurn,
-  TurnAgent,
-  TurnMessage,
-} from '@/agent/turn';
+import { HISTORY_LIMIT, runAgentTurn, TurnMessage } from '@/agent/turn';
 import { getOrCreateAgent } from '~/mastra/agentRuntime';
-import { isLegacyProvider } from '~/mastra/providers';
 import { runWithAuth } from '~/mastra/requestContext';
 
 /** The dedicated output thread of one schedule — derived, never stored. */
@@ -76,8 +70,7 @@ export async function runSchedule(args: {
     }
 
     const settings = await models.MastraSettings.findOne({});
-    const providers = await models.MastraProvider.find({ isEnabled: true });
-    const { agent, tools } = await getOrCreateAgent(agentConfig, models);
+    const { runner, tools } = await getOrCreateAgent(agentConfig, models);
 
     const threadId = scheduleThreadId(schedule._id);
     await models.MastraThread.ensureThread(
@@ -99,17 +92,13 @@ export async function runSchedule(args: {
     ];
 
     const authCtx = { token: settings?.erxesApiToken, subdomain };
-    const isLegacy = isLegacyProvider(agentConfig.provider, providers);
 
     const reply = await runWithAuth(authCtx, () =>
       runAgentTurn({
-        // Same narrowing as chat turns (turn.ts): Mastra's generate() output
-        // is wider than the slice TurnAgent consumes.
-        agent: agent as unknown as TurnAgent, // NOSONAR typescript:S4325 — removing it fails tsc
+        runner,
         tools,
         convo,
         message: schedule.prompt,
-        isLegacy,
         authCtx,
       }),
     );

--- a/backend/plugins/erxes-agent_api/src/mastra/titler.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/titler.ts
@@ -13,7 +13,8 @@
 
 import { IModels } from '~/connectionResolvers';
 import { trimEdgeChars } from '~/mastra/text';
-import type { ProviderDocLike } from '~/mastra/providers';
+import { isLegacyProvider, type ProviderDocLike } from '~/mastra/providers';
+import { AgentRunner, makeRunner } from '~/mastra/agentRunner';
 
 export const TITLER_INSTRUCTIONS = `You name chat conversations.
 Given a transcript, output a short title (3-6 words) that captures what the conversation is about.
@@ -77,33 +78,28 @@ export function sanitizeTitle(raw: string | null | undefined): string | null {
 
 // ── Orchestration ─────────────────────────────────────────────────────────────
 
-// The minimal surface used from a Mastra Agent — typed locally so the lazy
-// import keeps this module free of a static @mastra/core type dependency.
-interface TitlerAgent {
-  generate(msgs: unknown, opts?: unknown): Promise<{ text?: string }>;
-  generateLegacy(msgs: unknown): Promise<{ text?: string }>;
-}
+// Tool-less titler runners, cached per provider+model. The runner binds the
+// provider kind, so this module never branches on legacy/native itself.
+const _titlers = new Map<string, AgentRunner>();
 
-// Tool-less titler agents, cached per provider+model.
-const _titlers = new Map<string, TitlerAgent>();
-
-/** Lazily build (and cache per provider+model) the titler agent. */
+/** Lazily build (and cache per provider+model) the titler runner. */
 async function titlerFor(
   provider: string,
   model: string,
   providers: ProviderDocLike[],
-): Promise<TitlerAgent> {
+): Promise<AgentRunner> {
   const key = `${provider}:${model}`;
   let cached = _titlers.get(key);
   if (!cached) {
     const { Agent } = await import('@mastra/core/agent');
     const { buildModel } = await import('~/mastra/providers');
-    cached = new Agent({
+    const agent = new Agent({
       id: 'mastra-thread-titler',
       name: 'Thread Titler',
       instructions: TITLER_INSTRUCTIONS,
       model: buildModel(provider, model, providers),
-    }) as unknown as TitlerAgent;
+    });
+    cached = makeRunner(agent, isLegacyProvider(provider, providers));
     _titlers.set(key, cached);
   }
   return cached;
@@ -120,10 +116,8 @@ export async function maybeGenerateThreadTitle(params: {
   model: string;
   providers: ProviderDocLike[];
   authCtx: { userHeader?: string; token?: string; subdomain?: string };
-  isLegacy: boolean;
 }): Promise<string | null> {
-  const { models, threadId, provider, model, providers, authCtx, isLegacy } =
-    params;
+  const { models, threadId, provider, model, providers, authCtx } = params;
   // Reject non-string ids so a crafted object can never become a Mongo
   // query operator (NoSQL injection).
   if (typeof threadId !== 'string' || !threadId) return null;
@@ -150,9 +144,7 @@ export async function maybeGenerateThreadTitle(params: {
       },
     ];
     const result = await runWithAuth(authCtx, () =>
-      isLegacy
-        ? titler.generateLegacy(msgs)
-        : titler.generate(msgs, { maxSteps: 1 }),
+      titler.generate(msgs, { maxSteps: 1 }),
     );
 
     const title = sanitizeTitle(result?.text);

--- a/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/workflows/runtime.ts
@@ -206,15 +206,17 @@ export async function buildRunDeps(
       const judge = getJudgeAgent(agentConfig, providers);
       // Lazy import — providers.ts pulls AI-SDK chunks Jest cannot load.
       const { isLegacyProvider } = await import('../providers');
-      const legacy = isLegacyProvider(agentConfig.provider, providers);
+      const { makeRunner } = await import('../agentRunner');
+      const runner = makeRunner(
+        judge,
+        isLegacyProvider(agentConfig.provider, providers),
+      );
 
       const convo = [
         { role: 'system', content: judgmentInstruction(outputSpec) },
         { role: 'user', content: prompt },
       ];
-      const res = legacy
-        ? await judge.generateLegacy(convo)
-        : await judge.generate(convo);
+      const res = await runner.generate(convo);
       return extractJsonObject(String(res?.text ?? ''));
     },
   };

--- a/backend/plugins/erxes-agent_api/src/modules/agent/graphql/resolvers/queries/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/graphql/resolvers/queries/agent.ts
@@ -46,13 +46,12 @@ export const agentQueries = {
       threadId,
     });
 
-    const { agent, tools, convo, authCtx, isLegacy } = prepared;
+    const { runner, tools, convo, authCtx } = prepared;
     const reply = await runAgentTurn({
-      agent,
+      runner,
       tools,
       convo,
       message,
-      isLegacy,
       authCtx,
     });
 

--- a/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
@@ -2,7 +2,7 @@ import type { ToolsInput } from '@mastra/core/agent';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import { IModels } from '~/connectionResolvers';
 import { getOrCreateAgent } from '~/mastra/agentRuntime';
-import { isLegacyProvider } from '~/mastra/providers';
+import { AgentRunner, ToolResultLike } from '~/mastra/agentRunner';
 import { runWithAuth } from '~/mastra/requestContext';
 import { isAdvancedMemoryEnabled } from '~/mastra/memory/config';
 import {
@@ -38,16 +38,9 @@ import {
 // 12 covers most conversations; reduces DB load + LLM token overhead per turn.
 export const HISTORY_LIMIT = 12;
 
-// A tool result as gathered from an agent run — modern and legacy result
-// shapes expose different subsets of these fields, so all stay optional and
-// the payload itself stays unknown.
-export interface ToolResultLike {
-  toolName?: string;
-  name?: string;
-  toolCallId?: string;
-  id?: string;
-  result?: unknown;
-}
+// Re-exported from the runner module so existing importers (routes, schedules,
+// tests) keep their `@/agent/turn` import path.
+export type { AgentTurnResult, ToolResultLike } from '~/mastra/agentRunner';
 
 // The auth context a turn propagates to tools and follow-up LLM calls.
 export interface TurnAuthCtx {
@@ -61,32 +54,6 @@ export interface TurnAuthCtx {
 export interface TurnMessage {
   role: string;
   content: string | unknown[];
-}
-
-// The slice of a Mastra generate() result the turn pipeline reads.
-export interface AgentTurnResult {
-  text?: string;
-  toolResults?: ToolResultLike[];
-  steps?: { toolResults?: ToolResultLike[] }[];
-}
-
-// The minimal Mastra agent surface the chat pipeline drives. Declared as
-// loose methods so the concrete @mastra/core Agent — whose generics this
-// pipeline never relies on — satisfies it structurally.
-export interface TurnAgent {
-  generate(messages: unknown, options?: unknown): Promise<AgentTurnResult>;
-  generateLegacy(
-    messages: unknown,
-    options?: unknown,
-  ): Promise<AgentTurnResult>;
-  stream(
-    messages: unknown,
-    options?: unknown,
-  ): Promise<{ fullStream: unknown }>;
-  streamLegacy(
-    messages: unknown,
-    options?: unknown,
-  ): Promise<{ fullStream: unknown }>;
 }
 
 // A search_erxes_operations result is navigational (it lists candidate ops),
@@ -281,12 +248,11 @@ export interface PreparedTurn {
   agentConfig: IMastraAgentDocument;
   settings: IMastraSettingsDocument | null;
   providers: IMastraProviderDocument[];
-  agent: TurnAgent;
+  runner: AgentRunner;
   tools: ToolsInput;
   sessionId: string;
   convo: TurnMessage[];
   authCtx: TurnAuthCtx;
-  isLegacy: boolean;
   advanced: boolean;
   memCtx: MemoryContext;
   attachments?: IMastraChatAttachment[];
@@ -324,7 +290,7 @@ export async function prepareChatTurn(params: {
 
   const settings = await models.MastraSettings.findOne({});
   const providers = await models.MastraProvider.find({ isEnabled: true });
-  const { agent, tools } = await getOrCreateAgent(agentConfig, models);
+  const { runner, tools } = await getOrCreateAgent(agentConfig, models);
 
   // Stable session id — the persisted thread this turn belongs to.
   // typeof guard keeps crafted non-string payloads out of Mongo queries
@@ -401,21 +367,16 @@ export async function prepareChatTurn(params: {
     ? Buffer.from(JSON.stringify(user)).toString('base64')
     : undefined;
   const authCtx = { userHeader, token: settings?.erxesApiToken, subdomain };
-  const isLegacy = isLegacyProvider(agentConfig.provider, providers);
 
   return {
     agentConfig,
     settings,
     providers,
-    // The published Agent generics type tool results as wire chunks; the
-    // runtime objects this pipeline reads are the duck-typed legacy/modern
-    // shapes in ToolResultLike, hence the structural cast (cf. titler.ts).
-    agent: agent as unknown as TurnAgent,
+    runner,
     tools,
     sessionId,
     convo,
     authCtx,
-    isLegacy,
     advanced,
     memCtx,
     attachments,
@@ -453,7 +414,6 @@ export async function persistTurn(params: {
     agentConfig,
     providers,
     authCtx,
-    isLegacy,
     attachments,
   } = prepared;
 
@@ -491,7 +451,6 @@ export async function persistTurn(params: {
         model: agentConfig.model,
         providers,
         authCtx,
-        isLegacy,
       })
     : Promise.resolve<string | null>(null);
 
@@ -526,7 +485,6 @@ export async function persistTurn(params: {
         model: agentConfig.model,
         providers,
         authCtx,
-        isLegacy,
       });
     }
   }
@@ -543,20 +501,17 @@ export async function persistTurn(params: {
 // reply text (or null). Holds the tool-call extraction / synthesis / fallback
 // logic; throws a user-facing message on hard failures.
 export async function runAgentTurn(params: {
-  agent: TurnAgent;
+  runner: AgentRunner;
   tools: ToolsInput;
   convo: TurnMessage[];
   message: string;
-  isLegacy: boolean;
   authCtx: TurnAuthCtx;
   depth?: number;
 }): Promise<string | null> {
-  const { agent, tools, convo, message, isLegacy, authCtx, depth = 0 } = params;
+  const { runner, tools, convo, message, authCtx, depth = 0 } = params;
 
   try {
-    const result = await runWithAuth(authCtx, () =>
-      isLegacy ? agent.generateLegacy(convo) : agent.generate(convo),
-    );
+    const result = await runWithAuth(authCtx, () => runner.generate(convo));
 
     if (result.text) {
       const trimmed = result.text.trimStart();
@@ -567,11 +522,10 @@ export async function runAgentTurn(params: {
       const extracted = extractTextToolCall(trimmed);
       if (extracted) {
         const handled = await executeTextToolCall({
-          agent,
+          runner,
           tools,
           convo,
           message,
-          isLegacy,
           authCtx,
           depth,
           extracted,
@@ -604,9 +558,8 @@ export async function runAgentTurn(params: {
     logToolResults(uniqueResults);
 
     return await synthesizeFromToolResults({
-      agent,
+      runner,
       message,
-      isLegacy,
       authCtx,
       toolResults: uniqueResults,
     });
@@ -674,13 +627,12 @@ export function logToolResults(uniqueResults: ToolResultLike[]) {
 // Turn a set of tool results into a one-or-two sentence human answer. Skips
 // synthesis when nothing real came back (synthesis would fabricate success).
 export async function synthesizeFromToolResults(params: {
-  agent: TurnAgent;
+  runner: AgentRunner;
   message: string;
-  isLegacy: boolean;
   authCtx: TurnAuthCtx;
   toolResults: ToolResultLike[];
 }): Promise<string> {
-  const { agent, message, isLegacy, authCtx, toolResults } = params;
+  const { runner, message, authCtx, toolResults } = params;
 
   // search_erxes_operations is navigational; only execute (action) results
   // decide whether the turn produced something real to report.
@@ -715,9 +667,7 @@ export async function synthesizeFromToolResults(params: {
 
   try {
     const synthesis = await runWithAuth(authCtx, () =>
-      isLegacy
-        ? agent.generateLegacy(synthesisMessages)
-        : agent.generate(synthesisMessages, { maxSteps: 1 }),
+      runner.generate(synthesisMessages, { maxSteps: 1 }),
     );
     return synthesis.text || fallback || 'Done.';
   } catch {
@@ -736,11 +686,10 @@ interface ExecutableToolLike {
 // null (caller's fallback applies), or undefined when the tool wasn't found /
 // failed and the original model text should be returned as-is.
 export async function executeTextToolCall(params: {
-  agent: TurnAgent;
+  runner: AgentRunner;
   tools: ToolsInput;
   convo: TurnMessage[];
   message: string;
-  isLegacy: boolean;
   authCtx: TurnAuthCtx;
   depth: number;
   extracted: TextToolCall;
@@ -754,11 +703,10 @@ export async function executeTextToolCall(params: {
   }) => void;
 }): Promise<string | null | undefined> {
   const {
-    agent,
+    runner,
     tools,
     convo,
     message,
-    isLegacy,
     authCtx,
     depth,
     extracted,
@@ -833,11 +781,10 @@ export async function executeTextToolCall(params: {
         },
       ];
       return await runAgentTurn({
-        agent,
+        runner,
         tools,
         convo: followup,
         message,
-        isLegacy,
         authCtx,
         depth: depth + 1,
       });
@@ -861,9 +808,7 @@ export async function executeTextToolCall(params: {
     ];
     try {
       const synthesis = await runWithAuth(authCtx, () =>
-        isLegacy
-          ? agent.generateLegacy(synthesisMessages)
-          : agent.generate(synthesisMessages, { maxSteps: 1 }),
+        runner.generate(synthesisMessages, { maxSteps: 1 }),
       );
       return synthesis.text || fallback || 'Done.';
     } catch {
@@ -873,4 +818,89 @@ export async function executeTextToolCall(params: {
     // Tool execution failed — let the caller return the original text
     return undefined;
   }
+}
+
+// ─── Streamed-reply finalization (SSE) ───────────────────────────────────────
+
+// What the SSE route emits after finalization. `replaceText` swaps the raw JSON
+// the client already streamed for the executed answer; `appendText` is the
+// synthesized summary when the model streamed only tool calls.
+export interface StreamedReplyOutcome {
+  reply: string | null;
+  replaceText?: string;
+  appendText?: string;
+}
+
+// After the stream drains, a turn still needs the same fallback decision the
+// blocking path makes: a tool call emitted as text must be executed, and a turn
+// that produced only tool calls (no answer text) needs a synthesized summary.
+// This used to live inline in the SSE route; keeping it here means streaming and
+// blocking (runAgentTurn) share one description of how a turn finishes.
+export async function finalizeStreamedReply(params: {
+  runner: AgentRunner;
+  tools: ToolsInput;
+  convo: TurnMessage[];
+  message: string;
+  authCtx: TurnAuthCtx;
+  streamedText: string;
+  toolResults: ToolResultLike[];
+  streamError: string | null;
+  onToolEvent?: (event: {
+    phase: 'call' | 'result';
+    toolName: string;
+    args?: Record<string, unknown>;
+    result?: unknown;
+    isError?: boolean;
+  }) => void;
+}): Promise<StreamedReplyOutcome> {
+  const {
+    runner,
+    tools,
+    convo,
+    message,
+    authCtx,
+    streamedText,
+    toolResults,
+    streamError,
+    onToolEvent,
+  } = params;
+
+  const trimmed = streamedText.trimStart();
+
+  // Text-emitted tool call (models without native tool_calls): execute it, then
+  // replace the raw JSON the client already saw with the real answer.
+  const extracted = trimmed ? extractTextToolCall(trimmed) : null;
+  if (extracted) {
+    const handled = await executeTextToolCall({
+      runner,
+      tools,
+      convo,
+      message,
+      authCtx,
+      depth: 0,
+      extracted,
+      rawText: trimmed,
+      onToolEvent,
+    });
+    if (handled !== undefined && handled !== null) {
+      return { reply: handled, replaceText: handled };
+    }
+    return { reply: streamedText || null };
+  }
+
+  // No answer text streamed — synthesize from tool results, or surface the error.
+  if (!streamedText) {
+    if (toolResults.length) {
+      const reply = await synthesizeFromToolResults({
+        runner,
+        message,
+        authCtx,
+        toolResults,
+      });
+      return { reply, appendText: reply };
+    }
+    if (streamError) throw new Error(streamError);
+  }
+
+  return { reply: streamedText || null };
 }

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -8,7 +8,6 @@ import {
   createActivityTracker,
   summarizeActivity,
 } from './mastra/activity';
-import { isLegacyProvider } from './mastra/providers';
 import { runWithAuth } from './mastra/requestContext';
 import { isAdvancedMemoryEnabled } from './mastra/memory/config';
 import {
@@ -24,11 +23,8 @@ import { readLearnedDigest } from './mastra/learning/digest';
 import {
   prepareChatTurn,
   persistTurn,
-  executeTextToolCall,
-  extractTextToolCall,
-  synthesizeFromToolResults,
+  finalizeStreamedReply,
   toUserFacingError,
-  TurnAgent,
 } from '@/agent/turn';
 import {
   IMastraChatAttachment,
@@ -197,6 +193,10 @@ function sanitizeAttachments(raw: unknown): IMastraChatAttachment[] | null {
   return out;
 }
 
+// skipcq: JS-R1005 — SSE orchestration: request validation, header setup,
+// stream consumption, the shared reply-finalization fallback, persistence and
+// the title race necessarily live in one handler. Decomposing it into a
+// streaming turn adapter is tracked separately (the event-sink turn).
 router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
   const user = extractUserFromHeader(req.headers);
   if (!user?._id) {
@@ -334,7 +334,7 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
       threadId,
       attachments,
     });
-    const { agent, tools, convo, authCtx, isLegacy } = prepared;
+    const { runner, tools, convo, authCtx } = prepared;
 
     // Narrates "what is the agent doing" while the turn runs — throttled
     // summaries of the live reasoning/tool signals, pushed as activity events.
@@ -347,7 +347,6 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
           model: prepared.agentConfig.model,
           providers: prepared.providers,
           authCtx,
-          isLegacy,
           snapshot,
         }),
     });
@@ -356,9 +355,9 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
 
     try {
       await runWithAuth(authCtx, async () => {
-        const stream = await (isLegacy
-          ? agent.streamLegacy(convo, { abortSignal: controller.signal })
-          : agent.stream(convo, { abortSignal: controller.signal }));
+        const stream = await runner.stream(convo, {
+          abortSignal: controller.signal,
+        });
 
         for await (const chunk of stream.fullStream as AsyncIterable<unknown>) {
           const ev = normalizeChunk(chunk);
@@ -393,67 +392,48 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     let reply: string | null = acc.text || null;
 
     if (!interrupted) {
-      const trimmed = acc.text.trimStart();
-
-      // Text-emitted tool call (models without native tool_calls): execute it
-      // and replace the raw JSON the client already saw with the real answer.
-      const extracted = trimmed ? extractTextToolCall(trimmed) : null;
-      if (extracted) {
-        const handled = await executeTextToolCall({
-          agent,
-          tools,
-          convo,
-          message,
-          isLegacy,
-          authCtx,
-          depth: 0,
-          extracted,
-          rawText: trimmed,
-          onToolEvent: (toolEvent) => {
-            const ev: StreamEvent =
-              toolEvent.phase === 'call'
-                ? {
-                    type: 'tool_call',
-                    toolName: toolEvent.toolName,
-                    args: toolEvent.args,
-                  }
-                : {
-                    type: 'tool_result',
-                    toolName: toolEvent.toolName,
-                    result: toolEvent.result,
-                    isError: toolEvent.isError,
-                  };
-            recordToolCall(ev);
-            send(ev);
-          },
-        });
-        if (handled !== undefined && handled !== null) {
-          reply = handled;
-          send({ type: 'text_replace', text: handled });
-        }
-      } else if (!acc.text) {
-        // No text streamed — synthesize from tool results, or report the error.
-        const toolResults = acc.toolCalls
+      // The fallback decision (execute a text-emitted tool call, or synthesize
+      // when only tool calls streamed) lives in the turn pipeline so streaming
+      // and the blocking path share it.
+      const outcome = await finalizeStreamedReply({
+        runner,
+        tools,
+        convo,
+        message,
+        authCtx,
+        streamedText: acc.text,
+        streamError,
+        toolResults: acc.toolCalls
           .filter((tc) => tc.result !== undefined)
           .map((tc) => ({
             toolCallId: tc.toolCallId,
             toolName: tc.toolName,
             result: tc.result,
-          }));
+          })),
+        onToolEvent: (toolEvent) => {
+          const ev: StreamEvent =
+            toolEvent.phase === 'call'
+              ? {
+                  type: 'tool_call',
+                  toolName: toolEvent.toolName,
+                  args: toolEvent.args,
+                }
+              : {
+                  type: 'tool_result',
+                  toolName: toolEvent.toolName,
+                  result: toolEvent.result,
+                  isError: toolEvent.isError,
+                };
+          recordToolCall(ev);
+          send(ev);
+        },
+      });
 
-        if (toolResults.length) {
-          reply = await synthesizeFromToolResults({
-            agent,
-            message,
-            isLegacy,
-            authCtx,
-            toolResults,
-          });
-          send({ type: 'text', text: reply });
-        } else if (streamError) {
-          throw new Error(streamError);
-        }
-      }
+      reply = outcome.reply;
+      if (outcome.replaceText !== undefined)
+        send({ type: 'text_replace', text: outcome.replaceText });
+      if (outcome.appendText !== undefined)
+        send({ type: 'text', text: outcome.appendText });
     }
 
     const { titlePromise, assistantMessageId } = await persistTurn({
@@ -530,7 +510,7 @@ router.post('/bot/:conversationId', llmRouteLimiter, async (req, res) => {
     }
 
     const providers = await models.MastraProvider.find({ isEnabled: true });
-    const { agent } = await getOrCreateAgent(agentConfig, models);
+    const { runner } = await getOrCreateAgent(agentConfig, models);
 
     // Conversation memory is Mongo-backed, keyed by the frontline conversationId.
     const userText = text || '';
@@ -574,14 +554,7 @@ router.post('/bot/:conversationId', llmRouteLimiter, async (req, res) => {
 
     // Bot requests use the static app token from settings (no user session available)
     const authCtx = { token: settings?.erxesApiToken, subdomain };
-    const isLegacy = isLegacyProvider(agentConfig.provider, providers);
-    // The published Agent generics type tool results as wire chunks; this
-    // text-only webhook path reads only `.text`, hence the structural cast
-    // (same idiom as prepareChatTurn in @/agent/turn).
-    const turnAgent = agent as unknown as TurnAgent;
-    const result = await runWithAuth(authCtx, () =>
-      isLegacy ? turnAgent.generateLegacy(convo) : turnAgent.generate(convo),
-    );
+    const result = await runWithAuth(authCtx, () => runner.generate(convo));
 
     const reply = result.text || '';
 
@@ -629,7 +602,8 @@ router.post('/bot/:conversationId', llmRouteLimiter, async (req, res) => {
       await indexMessages(memCtx, toIndex);
 
       if (reply) {
-        void refreshWorkingMemory({
+        // Fire-and-forget (best-effort, self-catching) — same as persistTurn.
+        refreshWorkingMemory({
           models,
           ctx: memCtx,
           exchange: { user: userText, assistant: reply },
@@ -637,7 +611,6 @@ router.post('/bot/:conversationId', llmRouteLimiter, async (req, res) => {
           model: agentConfig.model,
           providers,
           authCtx,
-          isLegacy,
         });
       }
     }


### PR DESCRIPTION
## What

Two changes in `backend/plugins/erxes-agent_api`, plus an unrelated frontend scroll fix (separate commit).

### 1. `AgentRunner` — collapse the native/legacy provider dual-path
The agent runtime talks to two provider kinds that need different methods: native (`generate`/`stream`) and OpenAI-compatible/"legacy" (`generateLegacy`/`streamLegacy`). The `isLegacy ? generateLegacy(m) : generate(m, opts)` branch was repeated across **9 call sites in 7 files**, `isLegacyProvider()` was recomputed at 5 sites, an `isLegacy` flag was threaded through ~12 signatures, and 5 files each redeclared their own duck-typed agent interface.

`makeRunner(agent, isLegacy)` binds the provider kind **once** and exposes a single `generate()`/`stream()`. `getOrCreateAgent` and each lazily-built helper agent (titler, activity narrator, working-memory extractor, learning extractor, workflow judge) now resolve `isLegacy` internally and hand back a runner.

**Fixes a latent bug:** one-shot calls pass `{ maxSteps: 1 }`, but the option was only forwarded on the native path — so on a legacy provider those calls ran with the agent's full step budget and could loop into tool calls. `makeRunner` forwards options to **both** paths.

### 2. Share the streamed-reply finalization
The SSE fallback decision (execute a tool call emitted as text, or synthesize when only tool calls streamed) was inlined in `routes.ts` and duplicated inside `runAgentTurn`. It now lives once in the turn module as `finalizeStreamedReply`, so the streaming route and the blocking path share one description of how a turn finishes.

## Why
- **Locality:** the native/legacy decision and the turn-finalization decision each live in one place.
- **Leverage:** one small interface across all call sites; a new provider kind or per-call option is a single edit.
- **Correctness:** fixes the `maxSteps`-dropped-on-legacy bug.
- **Testability:** the pipeline now depends on a 2-method `AgentRunner`; a fake agent is a handful of spies.

## Testing
- `tsc --noEmit` clean.
- Full jest suite green (197 existing tests).
- Adds `agentRunner.test.ts` covering dispatch direction and the maxSteps-on-legacy regression.

## Notes
- Behavior-preserving aside from the intended `maxSteps` fix.
- The second commit (`fix(erxes-agent-ui): make settings pages scroll`) is an unrelated layout fix bundled at the author's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined how the system runs AI across different provider modes, using a single unified execution path.
  * Chat streaming, bot replies, auto-titling, activity summaries, and working memory extraction now follow the same consistent generation flow.
* **Tests**
  * Added regression coverage to ensure legacy vs modern routing and option/abort handling behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->