### PR TITLE
feat(erxes-agent): index Company Knowledge as the requesting user

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -63,4 +63,8 @@
 # ERXES_AGENT_KNOWLEDGE_TOPK=4
 # ERXES_AGENT_KNOWLEDGE_MIN_SCORE=0.5
 # ERXES_AGENT_KNOWLEDGE_OVERFETCH=3         # candidate multiplier for the live post-filter
-# ERXES_AGENT_KNOWLEDGE_SYNC_CRON=0 * * * * # reconciliation sweep schedule (UTC)
+# Indexing runs AS the requesting user (Agent = Person) — triggered by knowledge-
+# tool use and the Settings "Sync now" button; there is no unattended cron, so no
+# standalone service token is needed. (ERXES_AGENT_ERXES_API_TOKEN, if set, is only
+# a Bearer fallback for the user-less customer bot bridge.)
+# ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES=60  # staleness window before a usage-triggered refresh

--- a/backend/plugins/erxes-agent_api/docker-compose.yml
+++ b/backend/plugins/erxes-agent_api/docker-compose.yml
@@ -1,6 +1,7 @@
 # Qdrant — vector store for the Mastra "Advanced memory feature".
 #
-# Only needed when MASTRA_MEMORY=enable. Self-contained to this plugin.
+# Only needed when ERXES_AGENT_MEMORY=enable (or ERXES_AGENT_KNOWLEDGE=enable).
+# Self-contained to this plugin.
 #
 #   docker compose -f backend/plugins/erxes-agent_api/docker-compose.yml up -d
 #   docker compose -f backend/plugins/erxes-agent_api/docker-compose.yml down
@@ -15,9 +16,9 @@ services:
       - "6334:6334" # gRPC API
     volumes:
       - mastra_qdrant_storage:/qdrant/storage
-    # Uncomment to require an API key (also set MASTRA_QDRANT_API_KEY in .env):
+    # Uncomment to require an API key (also set ERXES_AGENT_QDRANT_API_KEY in .env):
     # environment:
-    #   QDRANT__SERVICE__API_KEY: ${MASTRA_QDRANT_API_KEY}
+    #   QDRANT__SERVICE__API_KEY: ${ERXES_AGENT_QDRANT_API_KEY}
     restart: unless-stopped
 
 volumes:

--- a/backend/plugins/erxes-agent_api/docs/COMPANY_KNOWLEDGE_RAG.md
+++ b/backend/plugins/erxes-agent_api/docs/COMPANY_KNOWLEDGE_RAG.md
@@ -2,8 +2,10 @@
 
 > Status: **v2 IMPLEMENTED** (full company data, type-gated) · Plugin: `erxes-agent_api` · Started 2026-06-10
 >
-> **v2 ships:** `ERXES_AGENT_KNOWLEDGE=enable` → BullMQ reconciliation sweep (cron + boot)
-> embeds the content types listed in `ERXES_AGENT_KNOWLEDGE_TYPES` into a dedicated Qdrant
+> **v2 ships:** `ERXES_AGENT_KNOWLEDGE=enable` → a BullMQ reconciliation sweep — triggered by
+> usage (a knowledge-tool call when the index is stale) or the Settings "Sync now" action, and run
+> AS the requesting user (Agent = Person) — embeds the content types listed in
+> `ERXES_AGENT_KNOWLEDGE_TYPES` into a dedicated Qdrant
 > collection (`mastra_knowledge_*`), and a `companyKnowledge` builtin agent tool retrieves
 > them with a tenant-scoped pre-filter + an authoritative live post-filter through the
 > gateway. Supported types (registry in `src/mastra/knowledge/contentTypes.ts`):
@@ -89,7 +91,7 @@ filters → can enforce the `subdomain` filter server-side as defense-in-depth.
 | ----- | --------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **A** | Embedding cost / model strategy   | ✅ Resolved            | **Local-first**: fastembed (`bge-small-en-v1.5`) by default for corpus AND queries; OpenAI embedder remains an explicit operator opt-in (`ERXES_AGENT_EMBEDDER=openai`). Data residency was the real decision, not cost.                                                                                                                                                    |
 | **B** | Permission granularity to enforce | ✅ Resolved            | **Module-level pre-filter + record-level live post-filter.** Coarse payload fields (`subdomain`, `contentType`) gate the Qdrant search; the authoritative check re-fetches every candidate live through the gateway (as the asking user when a session exists) and drops anything not `publish`/public. Stale payloads are never trusted; no `aclVersion` machinery needed. |
-| **C** | How real-time                     | ✅ Resolved            | **Periodic full reconciliation** (BullMQ cron, default hourly, `ERXES_AGENT_KNOWLEDGE_SYNC_CRON`) + one sweep at boot. No change streams — this repo has none, and the sweep self-heals missed deletes. Revocation is still instant via the live post-filter.                                                                                                               |
+| **C** | How real-time                     | ✅ Resolved            | **Usage-driven reconciliation, AS the requesting user** (Agent = Person): a knowledge-tool call refreshes the corpus when it is older than `ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES` (default 60), and a Settings "Sync now" action forces it. No unattended cron and no standalone service token — an unattended job has no person, hence no auth. No change streams (this repo has none); the sweep self-heals missed deletes, and revocation stays instant via the live post-filter. |
 | **D** | Corpus scope                      | ✅ Resolved (v2)       | **Type-gated registry**: kb-article (default), customer, company, product, deal, task, conversation. Default stays KB-only; each additional type is an explicit `ERXES_AGENT_KNOWLEDGE_TYPES` opt-in with the PII/data-residency tradeoff documented at the env key.                                                                                                        |
 | **E** | Reuse Elasticsearch sync          | ✅ Resolved            | **No.** This monorepo has read-only ES query helpers but no Mongo→ES write pipeline to piggyback. Own BullMQ pipeline instead.                                                                                                                                                                                                                                              |
 | **F** | Qdrant security hardening         | ✅ Resolved (v1 scope) | API key support already wired (`ERXES_AGENT_QDRANT_API_KEY`); compose file binds locally, no public exposure. Per-retrieval audit log + JWT-RBAC deferred to the multi-content-type phase.                                                                                                                                                                                  |
@@ -114,8 +116,27 @@ revocation) — out of scope for v1, documented so nobody mistakes it for a post
 
 Qdrant points/filters use `knowledgeTenant()`: the org subdomain in saas mode, and the fixed
 `'os'` tag in non-saas (single tenant; request-derived hostname labels like `localhost` vary and
-background jobs have no request, so both the sweep and the retrieval tool pin the same canonical
-tag).
+sweep jobs carry the triggering user's auth but no request hostname, so both the sweep and the
+retrieval tool pin the same canonical tag).
+
+### Indexing auth — Agent = Person
+
+The reconciliation sweep runs **as the user who triggered it**, never under an unattended service
+token: the sweep job carries `{ userHeader }` (base64 of the user — the gateway's trusted `user`
+header, the same mechanism the chat path and the workflow manual-trigger use), and
+`runKnowledgeSweep` hands it to the gateway client. erxes therefore enforces *that user's*
+permissions on every record the sweep reads — the index can only ever contain rows some real user
+was allowed to fetch, and the query-time post-filter still re-checks per asking user on top.
+
+Two triggers, no cron:
+
+1. **Lazy** — when the `companyKnowledge` tool runs and `knowledgeSyncStatus.lastSweepAt` is older
+   than `ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES` (or missing), it enqueues a refresh carrying the
+   asking user's auth, fire-and-forget, and answers from whatever is already indexed.
+2. **Explicit** — the `mastraKnowledgeSync` mutation (Settings → "Sync now") forces a refresh under
+   the clicking user.
+
+`settings.erxesApiToken` survives only as a Bearer fallback for the user-less customer bot bridge.
 
 ### Decision A — Embedding cost / model strategy
 

--- a/backend/plugins/erxes-agent_api/src/main.ts
+++ b/backend/plugins/erxes-agent_api/src/main.ts
@@ -49,7 +49,7 @@ startPlugin({
         import('~/mastra/knowledge/worker'),
         import('erxes-api-shared/utils'),
       ]);
-      await initKnowledgeSync(redis);
+      initKnowledgeSync(redis);
     }
 
     // Agent learning (opt-in via ERXES_AGENT_LEARNING=enable): distillation +

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/__tests__/config.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/__tests__/config.test.ts
@@ -1,0 +1,91 @@
+import {
+  isKnowledgeEnabled,
+  knowledgeRefreshMinutes,
+  isKnowledgeStale,
+  knowledgeCollectionName,
+  enabledKnowledgeTypes,
+} from '../config';
+
+describe('isKnowledgeEnabled', () => {
+  it('is on ONLY for the exact value "enable"', () => {
+    expect(isKnowledgeEnabled({ ERXES_AGENT_KNOWLEDGE: 'enable' })).toBe(true);
+    expect(isKnowledgeEnabled({ ERXES_AGENT_KNOWLEDGE: ' enable ' })).toBe(true);
+    expect(isKnowledgeEnabled({ ERXES_AGENT_KNOWLEDGE: 'true' })).toBe(false);
+    expect(isKnowledgeEnabled({ ERXES_AGENT_KNOWLEDGE: 'ENABLE' })).toBe(false);
+    expect(isKnowledgeEnabled({})).toBe(false);
+  });
+});
+
+describe('knowledgeRefreshMinutes', () => {
+  it('defaults to 60 and accepts positive-integer overrides', () => {
+    expect(knowledgeRefreshMinutes({})).toBe(60);
+    expect(
+      knowledgeRefreshMinutes({ ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES: '15' }),
+    ).toBe(15);
+  });
+
+  it('ignores non-positive / invalid values', () => {
+    expect(
+      knowledgeRefreshMinutes({ ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES: '0' }),
+    ).toBe(60);
+    expect(
+      knowledgeRefreshMinutes({ ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES: '-5' }),
+    ).toBe(60);
+    expect(
+      knowledgeRefreshMinutes({ ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES: 'abc' }),
+    ).toBe(60);
+  });
+});
+
+describe('isKnowledgeStale', () => {
+  const now = 1_000_000_000_000;
+
+  it('is stale when the corpus was never swept', () => {
+    expect(isKnowledgeStale(null, now, {})).toBe(true);
+    expect(isKnowledgeStale(undefined, now, {})).toBe(true);
+  });
+
+  it('is stale when the last sweep is older than the window', () => {
+    expect(
+      isKnowledgeStale(new Date(now - 61 * 60_000).toISOString(), now, {}),
+    ).toBe(true);
+  });
+
+  it('is fresh within the window', () => {
+    expect(isKnowledgeStale(new Date(now - 59 * 60_000), now, {})).toBe(false);
+  });
+
+  it('honors a custom window', () => {
+    const env = { ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES: '10' };
+    expect(isKnowledgeStale(new Date(now - 11 * 60_000), now, env)).toBe(true);
+    expect(isKnowledgeStale(new Date(now - 9 * 60_000), now, env)).toBe(false);
+  });
+
+  it('treats an unparseable date as stale', () => {
+    expect(isKnowledgeStale('not-a-date', now, {})).toBe(true);
+  });
+});
+
+describe('knowledgeCollectionName', () => {
+  it('encodes model + dimension', () => {
+    expect(knowledgeCollectionName('text-embedding-3-large', 3072)).toBe(
+      'mastra_knowledge_text_embedding_3_large_3072',
+    );
+  });
+});
+
+describe('enabledKnowledgeTypes', () => {
+  it('defaults to kb-article only', () => {
+    expect(enabledKnowledgeTypes(['kb-article', 'customer'], {})).toEqual([
+      'kb-article',
+    ]);
+  });
+
+  it('parses a comma list and drops unknown types', () => {
+    expect(
+      enabledKnowledgeTypes(['kb-article', 'customer'], {
+        ERXES_AGENT_KNOWLEDGE_TYPES: 'kb-article, customer, bogus',
+      }),
+    ).toEqual(['kb-article', 'customer']);
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/config.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/config.ts
@@ -38,7 +38,10 @@ export interface KnowledgeStatus {
   collection: string | null;
 }
 
-const DEFAULT_SYNC_CRON = '0 * * * *'; // hourly, on the hour
+// How long an index stays "fresh" before the next knowledge-tool use triggers
+// a background refresh under the asking user's auth. Replaces the old cron:
+// there is no unattended sweep (Agent = Person), so freshness is usage-driven.
+const DEFAULT_REFRESH_MINUTES = 60;
 
 /** Read one env var as trimmed text (absent → empty string). */
 function val(env: Env, key: string): string {
@@ -91,9 +94,28 @@ export function resolveKnowledgeTuning(
   };
 }
 
-/** Cron pattern for the reconciliation sweep (BullMQ job scheduler). */
-export function knowledgeSyncCron(env: Env = process.env): string {
-  return val(env, 'ERXES_AGENT_KNOWLEDGE_SYNC_CRON') || DEFAULT_SYNC_CRON;
+/**
+ * Staleness window (minutes) for the usage-driven refresh. When the knowledge
+ * tool runs and the last sweep is older than this — or the corpus is empty — a
+ * background sweep is enqueued under the asking user's auth.
+ */
+export function knowledgeRefreshMinutes(env: Env = process.env): number {
+  return parsePositiveInt(
+    val(env, 'ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES'),
+    DEFAULT_REFRESH_MINUTES,
+  );
+}
+
+/** True when a sweep recorded `lastSweepAt` is missing or older than the window. */
+export function isKnowledgeStale(
+  lastSweepAt: Date | string | null | undefined,
+  now: number,
+  env: Env = process.env,
+): boolean {
+  if (!lastSweepAt) return true;
+  const last = new Date(lastSweepAt).getTime();
+  if (!Number.isFinite(last)) return true;
+  return now - last >= knowledgeRefreshMinutes(env) * 60_000;
 }
 
 /**

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/gatewayClient.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/gatewayClient.ts
@@ -6,8 +6,9 @@
 // run under erxes's own permission layer — the authoritative post-filter.
 //
 // Auth: a `user` header (the asking user) when present — erxes resolves the
-// request as that user — otherwise the API token from agent settings (used by
-// the background sweep and the customer bot bridge).
+// request as that user — otherwise a Bearer token. The reconciliation sweep
+// now runs AS the requesting user too (Agent = Person), so the app token is a
+// last-resort fallback (e.g. the customer bot bridge, which has no team user).
 // ---------------------------------------------------------------------------
 
 import { asBearer } from '../tools/erxesTools';

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/indexer.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/indexer.ts
@@ -68,11 +68,28 @@ interface DesiredPoint {
 }
 
 /**
+ * Auth for a sweep. Agent = Person: the index is built AS the requesting user,
+ * so erxes enforces *their* permissions on every record read — never an
+ * unattended privileged service token. `userHeader` is base64(JSON) of the
+ * user (the gateway's trusted `user` header, same mechanism as the chat and
+ * workflow manual-trigger paths); `token` is a Bearer fallback.
+ */
+export interface SweepAuth {
+  userHeader?: string;
+  token?: string;
+}
+
+/**
  * One full reconciliation for one tenant. Returns a result instead of
  * throwing; the caller persists it to settings for the status UI.
+ *
+ * `auth` carries the requesting user's identity (see SweepAuth). The settings
+ * app token (`settings.erxesApiToken`) remains only as a last-resort fallback
+ * for deployments that still configure one.
  */
 export async function runKnowledgeSweep(
   subdomain: string,
+  auth?: SweepAuth,
 ): Promise<SweepResult> {
   const result: SweepResult = {
     ok: false,
@@ -87,7 +104,12 @@ export async function runKnowledgeSweep(
     const settings = await models.MastraSettings.getSettings();
     const gql = makeGqlExec(
       settings.erxesApiUrl || 'http://localhost:4000',
-      buildAuthHeaders({ apiToken: settings.erxesApiToken }),
+      // Index AS the requesting user (erxes enforces their permissions); fall
+      // back to the configured app token only when no user auth is present.
+      buildAuthHeaders({
+        userHeader: auth?.userHeader,
+        apiToken: auth?.token || settings.erxesApiToken,
+      }),
     );
 
     const emb = resolveEmbedderConfig();

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/knowledgeTool.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/knowledgeTool.ts
@@ -78,7 +78,7 @@ export const companyKnowledgeTool = createTool({
         if (
           isKnowledgeStale(settings.knowledgeSyncStatus?.lastSweepAt, Date.now())
         ) {
-          void enqueueKnowledgeSweep({
+          enqueueKnowledgeSweep({
             subdomain,
             auth: { userHeader: auth?.userHeader, token: auth?.token },
           }).catch(() => undefined);

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/knowledgeTool.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/knowledgeTool.ts
@@ -20,6 +20,7 @@ import { getCurrentAuth } from '~/mastra/requestContext';
 import { generateModels } from '~/connectionResolvers';
 import {
   isKnowledgeEnabled,
+  isKnowledgeStale,
   knowledgeCollectionName,
   knowledgeTenant,
   resolveEmbedderConfig,
@@ -33,6 +34,7 @@ import {
   ALL_KNOWLEDGE_TYPE_NAMES,
 } from './contentTypes';
 import { buildAuthHeaders, makeGqlExec } from './gatewayClient';
+import { enqueueKnowledgeSweep } from './worker';
 
 const SNIPPET_MAX = 700;
 
@@ -64,6 +66,25 @@ export const companyKnowledgeTool = createTool({
       const subdomain = knowledgeTenant(auth?.subdomain);
       if (!subdomain) {
         return { results: [], error: 'No tenant context for this request.' };
+      }
+
+      // Agent = Person: keep the corpus fresh without an unattended cron. When
+      // the index is empty or stale, enqueue a refresh AS the asking user (so
+      // erxes indexes only what they may read) — fire-and-forget, so this query
+      // stays fast and simply runs against whatever is already indexed.
+      try {
+        const models = await generateModels(subdomain);
+        const settings = await models.MastraSettings.getSettings();
+        if (
+          isKnowledgeStale(settings.knowledgeSyncStatus?.lastSweepAt, Date.now())
+        ) {
+          void enqueueKnowledgeSweep({
+            subdomain,
+            auth: { userHeader: auth?.userHeader, token: auth?.token },
+          }).catch(() => undefined);
+        }
+      } catch {
+        // a freshness check must never break retrieval
       }
 
       const tuning = resolveKnowledgeTuning();

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/worker.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/worker.ts
@@ -1,80 +1,52 @@
 // ---------------------------------------------------------------------------
-// Company Knowledge RAG — BullMQ sweep scheduling.
+// Company Knowledge RAG — BullMQ sweep worker.
 //
-// Pattern follows posclient_api/src/worker: a repeatable scheduler job fires
-// on a cron, enqueues one sweep job per tenant, and a worker runs the actual
-// reconciliation. One immediate sweep is enqueued at boot so a fresh deploy
-// doesn't wait for the first cron tick.
+// Agent = Person: the index is built AS the requesting user, never under an
+// unattended privileged service token. So reconciliation is triggered by user
+// activity — a chat that uses the knowledge tool (lazy, when the corpus is
+// empty/stale) or the explicit "Sync now" settings action — and each sweep job
+// carries that user's auth, which the worker hands to runKnowledgeSweep so the
+// gateway enforces their permissions. There is no cron: an unattended job has
+// no person, hence no auth.
 // ---------------------------------------------------------------------------
 
-import { Queue } from 'bullmq';
 import {
   createMQWorkerWithListeners,
-  getEnv,
-  getSaasOrganizations,
   sendWorkerQueue,
 } from 'erxes-api-shared/utils';
-import { knowledgeSyncCron } from './config';
-import { runKnowledgeSweep } from './indexer';
+import { runKnowledgeSweep, SweepAuth } from './indexer';
 
 const SERVICE = 'erxes-agent';
 const SWEEP_QUEUE = 'knowledge-sweep';
-const SCHEDULER_QUEUE = 'knowledge-sweep-scheduler';
 
-/** Queue one sweep job per tenant (saas: every org; non-saas: the single tenant). */
-async function enqueueSweepPerTenant() {
-  const VERSION = getEnv({ name: 'VERSION' });
+export interface SweepJobData {
+  subdomain: string;
+  auth?: SweepAuth;
+}
 
-  if (VERSION === 'saas') {
-    const orgs = await getSaasOrganizations();
-    for (const org of orgs) {
-      sendWorkerQueue(SERVICE, SWEEP_QUEUE).add(SWEEP_QUEUE, {
-        subdomain: org.subdomain,
-      });
-    }
-    return;
-  }
-
-  sendWorkerQueue(SERVICE, SWEEP_QUEUE).add(SWEEP_QUEUE, { subdomain: 'os' });
+/**
+ * Enqueue one reconciliation sweep for a tenant, carrying the requesting
+ * user's auth. Call this from a user-authenticated context (the knowledge tool
+ * or the sync mutation) — the worker replays the auth so the sweep reads
+ * company data with exactly that user's permissions.
+ */
+export function enqueueKnowledgeSweep(data: SweepJobData) {
+  return sendWorkerQueue(SERVICE, SWEEP_QUEUE).add(SWEEP_QUEUE, data);
 }
 
 // The shared Redis connection type, extracted from the MQ helper so this
 // module needs no direct ioredis type dependency.
 type RedisConnection = Parameters<typeof createMQWorkerWithListeners>[3];
 
-/** Boot hook: register the sweep scheduler + worker and kick one sweep. */
+/** Boot hook: register the sweep worker. No scheduler — see file header. */
 export async function initKnowledgeSync(redis: RedisConnection): Promise<void> {
-  const schedulerQueue = new Queue(`${SERVICE}-${SCHEDULER_QUEUE}`, {
-    connection: redis,
-  });
-
-  await schedulerQueue.upsertJobScheduler(
-    `${SERVICE}-knowledge-sweep-cron`,
-    { pattern: knowledgeSyncCron(), tz: 'UTC' },
-    { name: SCHEDULER_QUEUE },
-  );
-
-  createMQWorkerWithListeners(
-    SERVICE,
-    SCHEDULER_QUEUE,
-    async () => {
-      await enqueueSweepPerTenant();
-      return 'scheduled';
-    },
-    redis,
-    () => {
-      // eslint-disable-next-line no-console
-      console.log('[erxes-agent:knowledge] sweep scheduler ready');
-    },
-  );
-
   createMQWorkerWithListeners(
     SERVICE,
     SWEEP_QUEUE,
     async (job) => {
-      const { subdomain } = job?.data ?? {};
+      const { subdomain, auth } = (job?.data ?? {}) as SweepJobData;
       if (!subdomain) return 'skipped: no subdomain';
-      const result = await runKnowledgeSweep(subdomain);
+      const result = await runKnowledgeSweep(subdomain, auth);
       const perType = Object.entries(result.types)
         .map(
           ([typeName, st]) =>
@@ -94,7 +66,4 @@ export async function initKnowledgeSync(redis: RedisConnection): Promise<void> {
       console.log('[erxes-agent:knowledge] sweep worker ready');
     },
   );
-
-  // Initial sweep so the corpus exists right after boot.
-  await enqueueSweepPerTenant();
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/knowledge/worker.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/knowledge/worker.ts
@@ -39,7 +39,7 @@ export function enqueueKnowledgeSweep(data: SweepJobData) {
 type RedisConnection = Parameters<typeof createMQWorkerWithListeners>[3];
 
 /** Boot hook: register the sweep worker. No scheduler — see file header. */
-export async function initKnowledgeSync(redis: RedisConnection): Promise<void> {
+export function initKnowledgeSync(redis: RedisConnection): void {
   createMQWorkerWithListeners(
     SERVICE,
     SWEEP_QUEUE,

--- a/backend/plugins/erxes-agent_api/src/modules/settings/graphql/resolvers/mutations/settings.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/settings/graphql/resolvers/mutations/settings.ts
@@ -1,5 +1,7 @@
 import { IContext } from '~/connectionResolvers';
 import { IMastraSettings } from '@/settings/@types/settings';
+import { isKnowledgeEnabled, knowledgeTenant } from '~/mastra/knowledge/config';
+import { enqueueKnowledgeSweep } from '~/mastra/knowledge/worker';
 
 /** Mutations for the plugin-wide Mastra settings document. */
 export const settingsMutations = {
@@ -9,5 +11,31 @@ export const settingsMutations = {
     { models }: IContext,
   ) => {
     return models.MastraSettings.saveSettings(doc);
+  },
+
+  /**
+   * Force a Company Knowledge reindex now — AS the requesting user. Agent =
+   * Person: the sweep reads company data with this user's permissions (the
+   * same `user` header the chat/workflow paths use), never an unattended
+   * service token. It runs in the background worker; the read-only status
+   * block reflects the result on the next settings load.
+   */
+  mastraKnowledgeSync: async (
+    _parent: undefined,
+    _args: unknown,
+    { subdomain, user }: IContext,
+  ) => {
+    if (!user?._id) {
+      throw new Error('Login required');
+    }
+    if (!isKnowledgeEnabled()) {
+      throw new Error('Company knowledge is not enabled on this deployment.');
+    }
+    const userHeader = Buffer.from(JSON.stringify(user)).toString('base64');
+    await enqueueKnowledgeSweep({
+      subdomain: knowledgeTenant(subdomain) ?? subdomain,
+      auth: { userHeader },
+    });
+    return { ok: true, queued: true };
   },
 };

--- a/backend/plugins/erxes-agent_api/src/modules/settings/graphql/schemas/settings.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/settings/graphql/schemas/settings.ts
@@ -22,6 +22,11 @@ export const types = `
     lastError: String
   }
 
+  type MastraKnowledgeSyncResult {
+    ok: Boolean
+    queued: Boolean
+  }
+
   # Where chat attachments land: the instance's existing upload storage,
   # detected from core's file-upload configs. enabled = configured AND the
   # plugin-level toggle is on — when false the chat stays text-only.
@@ -63,4 +68,5 @@ export const queries = `
 
 export const mutations = `
   mastraSettingsSave(doc: MastraSettingsInput!): MastraSettings
+  mastraKnowledgeSync: MastraKnowledgeSyncResult
 `;

--- a/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
+++ b/frontend/plugins/erxes-agent_ui/src/graphql/mutations.ts
@@ -99,6 +99,15 @@ export const MASTRA_SETTINGS_SAVE = gql`
   }
 `;
 
+export const MASTRA_KNOWLEDGE_SYNC = gql`
+  mutation MastraKnowledgeSync {
+    mastraKnowledgeSync {
+      ok
+      queued
+    }
+  }
+`;
+
 export const MASTRA_MESSAGE_FEEDBACK = gql`
   mutation MastraMessageFeedback(
     $messageId: String!

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
@@ -14,15 +14,210 @@ import {
   MASTRA_KNOWLEDGE_SYNC,
 } from '~/graphql/mutations';
 
-export const GeneralSettingsPage = () => {
-  const { data: settingsData } = useQuery(MASTRA_SETTINGS);
-  const { data: agentsData } = useQuery(MASTRA_AGENTS);
-  const [save, { loading }] = useMutation(MASTRA_SETTINGS_SAVE);
+interface AgentOption {
+  _id: string;
+  agentId: string;
+  name: string;
+  isEnabled: boolean;
+}
+
+interface MemoryStatusView {
+  embedder?: string;
+  embedderModel?: string;
+  qdrantUrl?: string;
+  qdrantReachable?: boolean | null;
+  collection?: string;
+}
+
+interface KnowledgeStatusView extends MemoryStatusView {
+  enabled?: boolean;
+  enabledTypes?: string[];
+  lastSweepAt?: string | null;
+  pointCount?: number | null;
+  types?: Record<
+    string,
+    { count: number; points: number; error?: string }
+  > | null;
+  lastError?: string | null;
+}
+
+/** Green/red/grey dot + reachable/unreachable/unknown label for a Qdrant URL. */
+const ReachabilityDot = ({ reachable }: { reachable?: boolean | null }) => (
+  <span className="inline-flex items-center gap-1.5">
+    <span
+      className={`inline-block size-2 rounded-full ${
+        reachable === true
+          ? 'bg-green-500'
+          : reachable === false
+          ? 'bg-red-500'
+          : 'bg-muted-foreground/40'
+      }`}
+    />
+    <span>
+      {reachable === true
+        ? 'reachable'
+        : reachable === false
+        ? 'unreachable'
+        : 'unknown'}
+    </span>
+  </span>
+);
+
+/** Read-only "Advanced memory" status — controlled by ERXES_AGENT_MEMORY env. */
+const AdvancedMemoryCard = ({
+  enabled,
+  status,
+}: {
+  enabled: boolean;
+  status?: MemoryStatusView;
+}) => (
+  <div className="rounded-lg border p-4 space-y-3">
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <IconBrain className="size-4 text-muted-foreground" />
+        <span className="font-medium">Advanced memory feature</span>
+        <IconLock className="size-3.5 text-muted-foreground" />
+      </div>
+      <Badge variant={enabled ? 'success' : 'secondary'}>
+        {enabled ? 'On' : 'Off'}
+      </Badge>
+    </div>
+
+    {enabled && status && (
+      <div className="text-xs text-muted-foreground space-y-1 pl-6">
+        <div>
+          Embedder: <span className="font-mono">{status.embedderModel}</span> (
+          {status.embedder})
+        </div>
+        <div className="flex items-center gap-1.5">
+          Qdrant: <span className="font-mono">{status.qdrantUrl}</span>
+          <ReachabilityDot reachable={status.qdrantReachable} />
+        </div>
+        <div>
+          Collection: <span className="font-mono">{status.collection}</span>
+        </div>
+      </div>
+    )}
+
+    <p className="text-xs text-muted-foreground">
+      Controlled by the <code>ERXES_AGENT_MEMORY</code> environment variable. Set{' '}
+      <code>ERXES_AGENT_MEMORY=enable</code> and restart the plugin to turn it
+      on.
+    </p>
+  </div>
+);
+
+/**
+ * Read-only "Company knowledge" status + a "Sync now" action. Extracted from
+ * GeneralSettingsPage to keep that component small. Indexing runs AS the
+ * clicking user (Agent = Person); erxes enforces their permissions.
+ */
+const CompanyKnowledgeCard = ({ status }: { status?: KnowledgeStatusView }) => {
   const [syncKnowledge, { loading: syncing }] = useMutation(
     MASTRA_KNOWLEDGE_SYNC,
     { refetchQueries: [{ query: MASTRA_SETTINGS }] },
   );
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
+
+  const handleKnowledgeSync = async () => {
+    setSyncMsg(null);
+    try {
+      await syncKnowledge();
+      setSyncMsg(
+        'Indexing started as you — reload in a moment to see updated status.',
+      );
+    } catch (err) {
+      setSyncMsg(
+        err instanceof Error ? err.message : 'Failed to start indexing.',
+      );
+    }
+  };
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <IconBook className="size-4 text-muted-foreground" />
+          <span className="font-medium">Company knowledge</span>
+          <IconLock className="size-3.5 text-muted-foreground" />
+        </div>
+        <Badge variant={status?.enabled ? 'success' : 'secondary'}>
+          {status?.enabled ? 'On' : 'Off'}
+        </Badge>
+      </div>
+
+      {status?.enabled && (
+        <div className="text-xs text-muted-foreground space-y-1 pl-6">
+          <div>
+            Embedder: <span className="font-mono">{status.embedderModel}</span>{' '}
+            ({status.embedder})
+          </div>
+          <div className="flex items-center gap-1.5">
+            Qdrant: <span className="font-mono">{status.qdrantUrl}</span>
+            <ReachabilityDot reachable={status.qdrantReachable} />
+          </div>
+          <div>
+            Collection: <span className="font-mono">{status.collection}</span>
+          </div>
+          <div>
+            Content types:{' '}
+            <span className="font-mono">
+              {(status.enabledTypes || []).join(', ') || '—'}
+            </span>
+          </div>
+          <div>
+            Last sweep:{' '}
+            {status.lastSweepAt
+              ? `${new Date(status.lastSweepAt).toLocaleString()} — ${
+                  status.pointCount ?? 0
+                } points`
+              : 'not yet run'}
+          </div>
+          {status.types && (
+            <div className="font-mono">
+              {Object.entries(status.types)
+                .map(([t, s]) => `${t}: ${s.count}${s.error ? ' ⚠' : ''}`)
+                .join(' · ')}
+            </div>
+          )}
+          {status.lastError && (
+            <div className="text-red-500">Last error: {status.lastError}</div>
+          )}
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Lets agents answer from company data via the{' '}
+        <code>Company Knowledge</code> tool. Controlled by{' '}
+        <code>ERXES_AGENT_KNOWLEDGE</code>; the embedded content types by{' '}
+        <code>ERXES_AGENT_KNOWLEDGE_TYPES</code> (default: kb-article only). The
+        index is built <strong>as the requesting user</strong> — erxes enforces
+        your permissions — and refreshes from usage; there is no unattended
+        sweep.
+      </p>
+
+      {status?.enabled && (
+        <div className="space-y-2 pl-6">
+          <Button
+            type="button"
+            disabled={syncing}
+            onClick={handleKnowledgeSync}
+          >
+            {syncing ? 'Starting…' : 'Sync now'}
+          </Button>
+          {syncMsg && (
+            <p className="text-xs text-muted-foreground">{syncMsg}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const GeneralSettingsPage = () => {
+  const { data: settingsData } = useQuery(MASTRA_SETTINGS);
+  const { data: agentsData } = useQuery(MASTRA_AGENTS);
+  const [save, { loading }] = useMutation(MASTRA_SETTINGS_SAVE);
 
   const [form, setForm] = useState({
     erxesApiUrl: 'http://localhost:4000',
@@ -47,13 +242,9 @@ export const GeneralSettingsPage = () => {
 
   const agents = agentsData?.mastraAgents || [];
 
-  // Read-only "Advanced memory feature" status — derived from the
-  // ERXES_AGENT_MEMORY env var on the server. Displayed only; not editable
-  // from the UI.
+  // Read-only feature statuses — derived from server env vars, display only.
   const advancedMemory = Boolean(settingsData?.mastraSettings?.advancedMemory);
   const memStatus = settingsData?.mastraSettings?.advancedMemoryStatus;
-
-  // Read-only "Company knowledge" status — derived from ERXES_AGENT_KNOWLEDGE.
   const knowledgeStatus = settingsData?.mastraSettings?.knowledgeStatus;
 
   // Detected upload storage (configured in core Settings → File upload).
@@ -67,21 +258,6 @@ export const GeneralSettingsPage = () => {
     await save({ variables: { doc: form } });
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
-  };
-
-  // Re-index company knowledge now, AS the logged-in user (Agent = Person).
-  // The sweep runs in the background; the status block below reflects it once
-  // it finishes (reload the page to refresh).
-  const handleKnowledgeSync = async () => {
-    setSyncMsg(null);
-    try {
-      await syncKnowledge();
-      setSyncMsg(
-        'Indexing started as you — reload in a moment to see updated status.',
-      );
-    } catch (err: any) {
-      setSyncMsg(err?.message || 'Failed to start indexing.');
-    }
   };
 
   return (
@@ -107,8 +283,8 @@ export const GeneralSettingsPage = () => {
           >
             <option value="">None</option>
             {agents
-              .filter((a: any) => a.isEnabled)
-              .map((a: any) => (
+              .filter((a: AgentOption) => a.isEnabled)
+              .map((a: AgentOption) => (
                 <option key={a._id} value={a.agentId}>
                   {a.name} ({a.agentId})
                 </option>
@@ -218,160 +394,9 @@ export const GeneralSettingsPage = () => {
         </Button>
       </form>
 
-      {/* Advanced memory feature — read-only, controlled by ERXES_AGENT_MEMORY env */}
-      <div className="rounded-lg border p-4 space-y-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <IconBrain className="size-4 text-muted-foreground" />
-            <span className="font-medium">Advanced memory feature</span>
-            <IconLock className="size-3.5 text-muted-foreground" />
-          </div>
-          <Badge variant={advancedMemory ? 'success' : 'secondary'}>
-            {advancedMemory ? 'On' : 'Off'}
-          </Badge>
-        </div>
+      <AdvancedMemoryCard enabled={advancedMemory} status={memStatus} />
 
-        {advancedMemory && memStatus && (
-          <div className="text-xs text-muted-foreground space-y-1 pl-6">
-            <div>
-              Embedder:{' '}
-              <span className="font-mono">{memStatus.embedderModel}</span> (
-              {memStatus.embedder})
-            </div>
-            <div className="flex items-center gap-1.5">
-              Qdrant: <span className="font-mono">{memStatus.qdrantUrl}</span>
-              <span
-                className={`inline-block size-2 rounded-full ${
-                  memStatus.qdrantReachable === true
-                    ? 'bg-green-500'
-                    : memStatus.qdrantReachable === false
-                    ? 'bg-red-500'
-                    : 'bg-muted-foreground/40'
-                }`}
-              />
-              <span>
-                {memStatus.qdrantReachable === true
-                  ? 'reachable'
-                  : memStatus.qdrantReachable === false
-                  ? 'unreachable'
-                  : 'unknown'}
-              </span>
-            </div>
-            <div>
-              Collection:{' '}
-              <span className="font-mono">{memStatus.collection}</span>
-            </div>
-          </div>
-        )}
-
-        <p className="text-xs text-muted-foreground">
-          Controlled by the <code>ERXES_AGENT_MEMORY</code> environment variable.
-          Set <code>ERXES_AGENT_MEMORY=enable</code> and restart the plugin to
-          turn it on.
-        </p>
-      </div>
-
-      {/* Company knowledge — read-only, controlled by ERXES_AGENT_KNOWLEDGE env */}
-      <div className="rounded-lg border p-4 space-y-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <IconBook className="size-4 text-muted-foreground" />
-            <span className="font-medium">Company knowledge</span>
-            <IconLock className="size-3.5 text-muted-foreground" />
-          </div>
-          <Badge variant={knowledgeStatus?.enabled ? 'success' : 'secondary'}>
-            {knowledgeStatus?.enabled ? 'On' : 'Off'}
-          </Badge>
-        </div>
-
-        {knowledgeStatus?.enabled && (
-          <div className="text-xs text-muted-foreground space-y-1 pl-6">
-            <div>
-              Embedder:{' '}
-              <span className="font-mono">{knowledgeStatus.embedderModel}</span>{' '}
-              ({knowledgeStatus.embedder})
-            </div>
-            <div className="flex items-center gap-1.5">
-              Qdrant:{' '}
-              <span className="font-mono">{knowledgeStatus.qdrantUrl}</span>
-              <span
-                className={`inline-block size-2 rounded-full ${
-                  knowledgeStatus.qdrantReachable === true
-                    ? 'bg-green-500'
-                    : knowledgeStatus.qdrantReachable === false
-                    ? 'bg-red-500'
-                    : 'bg-muted-foreground/40'
-                }`}
-              />
-              <span>
-                {knowledgeStatus.qdrantReachable === true
-                  ? 'reachable'
-                  : knowledgeStatus.qdrantReachable === false
-                  ? 'unreachable'
-                  : 'unknown'}
-              </span>
-            </div>
-            <div>
-              Collection:{' '}
-              <span className="font-mono">{knowledgeStatus.collection}</span>
-            </div>
-            <div>
-              Content types:{' '}
-              <span className="font-mono">
-                {(knowledgeStatus.enabledTypes || []).join(', ') || '—'}
-              </span>
-            </div>
-            <div>
-              Last sweep:{' '}
-              {knowledgeStatus.lastSweepAt
-                ? `${new Date(
-                    knowledgeStatus.lastSweepAt,
-                  ).toLocaleString()} — ${
-                    knowledgeStatus.pointCount ?? 0
-                  } points`
-                : 'not yet run'}
-            </div>
-            {knowledgeStatus.types && (
-              <div className="font-mono">
-                {Object.entries(
-                  knowledgeStatus.types as Record<
-                    string,
-                    { count: number; points: number; error?: string }
-                  >,
-                )
-                  .map(([t, s]) => `${t}: ${s.count}${s.error ? ' ⚠' : ''}`)
-                  .join(' · ')}
-              </div>
-            )}
-            {knowledgeStatus.lastError && (
-              <div className="text-red-500">
-                Last error: {knowledgeStatus.lastError}
-              </div>
-            )}
-          </div>
-        )}
-
-        <p className="text-xs text-muted-foreground">
-          Lets agents answer from company data via the{' '}
-          <code>Company Knowledge</code> tool. Controlled by{' '}
-          <code>ERXES_AGENT_KNOWLEDGE</code>; the embedded content types by{' '}
-          <code>ERXES_AGENT_KNOWLEDGE_TYPES</code> (default: kb-article only). The
-          index is built <strong>as the requesting user</strong> — erxes enforces
-          your permissions — and refreshes from usage; there is no unattended
-          sweep.
-        </p>
-
-        {knowledgeStatus?.enabled && (
-          <div className="space-y-2 pl-6">
-            <Button type="button" disabled={syncing} onClick={handleKnowledgeSync}>
-              {syncing ? 'Starting…' : 'Sync now'}
-            </Button>
-            {syncMsg && (
-              <p className="text-xs text-muted-foreground">{syncMsg}</p>
-            )}
-          </div>
-        )}
-      </div>
+      <CompanyKnowledgeCard status={knowledgeStatus} />
 
       {/* Bot webhook info box */}
       <div className="rounded-lg border bg-muted/50 p-4 text-sm space-y-2">

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
@@ -9,12 +9,20 @@ import {
 } from '@tabler/icons-react';
 import { Button, Label, Input, Badge } from 'erxes-ui';
 import { MASTRA_SETTINGS, MASTRA_AGENTS } from '~/graphql/queries';
-import { MASTRA_SETTINGS_SAVE } from '~/graphql/mutations';
+import {
+  MASTRA_SETTINGS_SAVE,
+  MASTRA_KNOWLEDGE_SYNC,
+} from '~/graphql/mutations';
 
 export const GeneralSettingsPage = () => {
   const { data: settingsData } = useQuery(MASTRA_SETTINGS);
   const { data: agentsData } = useQuery(MASTRA_AGENTS);
   const [save, { loading }] = useMutation(MASTRA_SETTINGS_SAVE);
+  const [syncKnowledge, { loading: syncing }] = useMutation(
+    MASTRA_KNOWLEDGE_SYNC,
+    { refetchQueries: [{ query: MASTRA_SETTINGS }] },
+  );
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
 
   const [form, setForm] = useState({
     erxesApiUrl: 'http://localhost:4000',
@@ -39,8 +47,9 @@ export const GeneralSettingsPage = () => {
 
   const agents = agentsData?.mastraAgents || [];
 
-  // Read-only "Advanced memory feature" status — derived from the MASTRA_MEMORY
-  // env var on the server. Displayed only; not editable from the UI.
+  // Read-only "Advanced memory feature" status — derived from the
+  // ERXES_AGENT_MEMORY env var on the server. Displayed only; not editable
+  // from the UI.
   const advancedMemory = Boolean(settingsData?.mastraSettings?.advancedMemory);
   const memStatus = settingsData?.mastraSettings?.advancedMemoryStatus;
 
@@ -58,6 +67,21 @@ export const GeneralSettingsPage = () => {
     await save({ variables: { doc: form } });
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
+  };
+
+  // Re-index company knowledge now, AS the logged-in user (Agent = Person).
+  // The sweep runs in the background; the status block below reflects it once
+  // it finishes (reload the page to refresh).
+  const handleKnowledgeSync = async () => {
+    setSyncMsg(null);
+    try {
+      await syncKnowledge();
+      setSyncMsg(
+        'Indexing started as you — reload in a moment to see updated status.',
+      );
+    } catch (err: any) {
+      setSyncMsg(err?.message || 'Failed to start indexing.');
+    }
   };
 
   return (
@@ -194,7 +218,7 @@ export const GeneralSettingsPage = () => {
         </Button>
       </form>
 
-      {/* Advanced memory feature — read-only, controlled by MASTRA_MEMORY env */}
+      {/* Advanced memory feature — read-only, controlled by ERXES_AGENT_MEMORY env */}
       <div className="rounded-lg border p-4 space-y-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -241,9 +265,9 @@ export const GeneralSettingsPage = () => {
         )}
 
         <p className="text-xs text-muted-foreground">
-          Controlled by the <code>MASTRA_MEMORY</code> environment variable. Set{' '}
-          <code>MASTRA_MEMORY=enable</code> and restart the plugin to turn it
-          on.
+          Controlled by the <code>ERXES_AGENT_MEMORY</code> environment variable.
+          Set <code>ERXES_AGENT_MEMORY=enable</code> and restart the plugin to
+          turn it on.
         </p>
       </div>
 
@@ -331,8 +355,22 @@ export const GeneralSettingsPage = () => {
           Lets agents answer from company data via the{' '}
           <code>Company Knowledge</code> tool. Controlled by{' '}
           <code>ERXES_AGENT_KNOWLEDGE</code>; the embedded content types by{' '}
-          <code>ERXES_AGENT_KNOWLEDGE_TYPES</code> (default: kb-article only).
+          <code>ERXES_AGENT_KNOWLEDGE_TYPES</code> (default: kb-article only). The
+          index is built <strong>as the requesting user</strong> — erxes enforces
+          your permissions — and refreshes from usage; there is no unattended
+          sweep.
         </p>
+
+        {knowledgeStatus?.enabled && (
+          <div className="space-y-2 pl-6">
+            <Button type="button" disabled={syncing} onClick={handleKnowledgeSync}>
+              {syncing ? 'Starting…' : 'Sync now'}
+            </Button>
+            {syncMsg && (
+              <p className="text-xs text-muted-foreground">{syncMsg}</p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Bot webhook info box */}


### PR DESCRIPTION
## Problem

Company Knowledge retrieval was correct (the query-time post-filter already re-checks every candidate **as the asking user**), but the **indexing sweep** authenticated to the gateway with a standalone app/service token from settings. The gateway's `userMiddleware` only resolves a `req.user` from a user-session JWT (verified Bearer/cookie that's live in Redis) — it never resolves an opaque app token to a user. So the sweep hit `Login required` on every content type (`content_api/.../cms/utils/permissions.ts` and core permission checks all require `user._id`), the Qdrant collections stayed at **0 points**, and the feature could never answer from company data.

## Fix — Agent = Person

Index **as the user who triggered it**, exactly how the chat path and the workflow manual-trigger already authenticate (`Buffer.from(JSON.stringify(user)).toString('base64')` → the gateway's trusted `user` header). erxes then enforces *that user's* permissions on every record the sweep reads; the index can only ever hold rows a real user was allowed to fetch, and the query-time post-filter still re-checks per asking user on top.

Because an **unattended** job has no person (hence no auth), the hourly cron + boot sweep are removed. Freshness is now usage-driven:

1. **Lazy** — when the `companyKnowledge` tool runs and the index is empty or older than `ERXES_AGENT_KNOWLEDGE_REFRESH_MINUTES` (default 60), it enqueues a refresh carrying the asking user's auth (fire-and-forget; the query answers from whatever is already indexed).
2. **Explicit** — a new `mastraKnowledgeSync` mutation backs a **"Sync now"** button in Settings → General, forcing a refresh under the clicking user.

`settings.erxesApiToken` survives only as a Bearer fallback for the user-less customer bot bridge.

## Changes
- `knowledge/indexer.ts` — `runKnowledgeSweep(subdomain, auth?)`; gateway headers built from the requesting user.
- `knowledge/worker.ts` — remove scheduler/cron/boot sweep; jobs carry `{ subdomain, auth }`; add `enqueueKnowledgeSweep()`.
- `knowledge/knowledgeTool.ts` — lazy, user-authenticated refresh when stale/empty.
- `knowledge/config.ts` — `knowledgeSyncCron` → `knowledgeRefreshMinutes` + `isKnowledgeStale`.
- `settings` schema/resolver — `mastraKnowledgeSync`; UI gets a "Sync now" button.
- Docs (`COMPANY_KNOWLEDGE_RAG.md`), `.env.sample` updated.
- Drive-by: fix stale `MASTRA_MEMORY` references (Settings UI copy + `docker-compose.yml`) — the code reads `ERXES_AGENT_MEMORY`; the old copy told operators to set a var nothing reads.
- Tests: `knowledge/__tests__/config.test.ts` (staleness window, enable contract, type gating).

## Verification
- `tsc --noEmit` on `erxes-agent_api` passes clean.
- New config logic verified (12/12 assertions via `tsx`).
- Manually validated on a live deployment: with the user-auth path the sweep authenticates, the three `mastra_*` collections populate, and the prior `Login required` is gone.

## Note for reviewers
This intentionally drops the unattended background cron — freshness comes from usage + "Sync now", which is the literal consequence of "only ever index under a real user's auth." If a timed refresh is also wanted, it would need a designated service identity (a dedicated user/token), which this PR deliberately avoids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **“Sync now”** button in General Settings to start an on-demand company knowledge refresh.
  * Switched knowledge synchronization to a **usage-driven** model with a configurable **staleness window**.

* **Bug Fixes**
  * Knowledge refresh jobs now run with the **requesting user’s permissions**, falling back to a safe token when needed.

* **Documentation**
  * Updated company knowledge docs and configuration examples to match the new refresh behavior and environment variables.

* **Tests**
  * Added coverage for knowledge enablement, staleness, and configuration handling.

* **Chores**
  * Updated Docker Compose guidance and environment sample variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->