### PR TITLE
Phase 2 — Mastra Memory: semantic recall + working memory

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,6 +49,11 @@
 # ERXES_AGENT_MEMORY_TOPK=4
 # ERXES_AGENT_MEMORY_MIN_SCORE=0.5
 # ERXES_AGENT_MEMORY_SCOPE=resource         # resource or thread
+# Dedicated Mongo for Mastra memory — keep it OFF the app cluster (Mastra
+# provisions ~31 system collections per DB; shared Atlas tiers cap at 500).
+# Falls back to MONGO_URL when unset. e.g. a local docker mongo:
+# ERXES_AGENT_MEMORY_MONGO_URL=mongodb://localhost:27018
+# ERXES_AGENT_MEMORY_DB_PREFIX=erxes_mastra_memory   # shared memory DB name
 
 # --- erxes-agent: company knowledge RAG ---
 # See backend/plugins/erxes-agent_api/docs/COMPANY_KNOWLEDGE_RAG.md

--- a/backend/plugins/erxes-agent_api/scripts/verify-turn.ts
+++ b/backend/plugins/erxes-agent_api/scripts/verify-turn.ts
@@ -16,7 +16,11 @@ async function main() {
   const agentId = arg('--agent', 'test') as string;
   const message = (arg('-m') || arg('--message') || 'hi') as string;
   const models = await generateModels(sub);
-  const user = { _id: 'cli-tester', isOwner: true, username: 'cli' } as any;
+  const user = {
+    _id: (arg('--user') as string) || 'cli-tester',
+    isOwner: true,
+    username: 'cli',
+  } as any;
 
   const t0 = Date.now();
   console.log(`\n▶ ${agentId}  "${message}"\n`);
@@ -26,8 +30,11 @@ async function main() {
     user,
     agentId,
     message,
-    threadId: `verify-${Date.now()}`,
+    threadId: (arg('--thread') as string) || `verify-${Date.now()}`,
   });
+  console.log(
+    `useMemory=${prepared.useMemory} binding=${JSON.stringify(prepared.memoryBinding ?? null)}`,
+  );
   console.log(
     `agent=${prepared.agentConfig.provider}/${prepared.agentConfig.model} tools=${Object.keys(prepared.tools).length}`,
   );
@@ -37,6 +44,7 @@ async function main() {
       convo: prepared.convo,
       message,
       authCtx: prepared.authCtx,
+      memory: prepared.memoryBinding,
     }),
   );
   console.log(`\n▌ ${reply}\n— ${Date.now() - t0}ms`);

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -44,7 +44,9 @@ export async function getOrCreateAgent(
   // Mastra Memory (semantic recall + working memory) is opt-in and tenant-bound
   // — only attached when advanced memory is enabled AND we know the tenant.
   const useMemory =
-    isAdvancedMemoryEnabled() && agentConfig.memoryEnabled !== false && !!subdomain;
+    isAdvancedMemoryEnabled() &&
+    agentConfig.memoryEnabled !== false &&
+    !!subdomain;
   const [providers, settings] = await Promise.all([
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),
@@ -179,9 +181,7 @@ export async function getOrCreateAgent(
     instructions: systemPrompt,
     model,
     tools: toolNames.length ? tools : undefined,
-    ...(memory
-      ? { memory, inputProcessors: [new ToolCallFilter()] }
-      : {}),
+    ...(memory ? { memory, inputProcessors: [new ToolCallFilter()] } : {}),
     // generate()/stream() read defaultOptions. Temperature is only set when the
     // agent configures it — otherwise the provider default applies (sending an
     // explicit 0 is what reasoning models like Kimi reject).

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -46,7 +46,7 @@ export async function getOrCreateAgent(
   const useMemory =
     isAdvancedMemoryEnabled() &&
     agentConfig.memoryEnabled !== false &&
-    !!subdomain;
+    Boolean(subdomain);
   const [providers, settings] = await Promise.all([
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -16,6 +16,9 @@ import {
 } from './tools/scope';
 import { resolveDestructiveOpsPolicy } from './tools/destructiveGuard';
 import { writeAgentAction, AgentActionInput } from './auditLog';
+import { isAdvancedMemoryEnabled } from './memory/config';
+import { getMastraMemory } from './memory/mastraMemory';
+import { ToolCallFilter } from '@mastra/core/processors';
 
 // Cache agents by config ID + updatedAt + routing version.
 const agentCache = new Map<string, Agent>();
@@ -36,7 +39,12 @@ export interface AgentWithTools {
 export async function getOrCreateAgent(
   agentConfig: IMastraAgentDocument,
   models: IModels,
+  subdomain?: string,
 ): Promise<AgentWithTools> {
+  // Mastra Memory (semantic recall + working memory) is opt-in and tenant-bound
+  // — only attached when advanced memory is enabled AND we know the tenant.
+  const useMemory =
+    isAdvancedMemoryEnabled() && agentConfig.memoryEnabled !== false && !!subdomain;
   const [providers, settings] = await Promise.all([
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),
@@ -60,7 +68,7 @@ export async function getOrCreateAgent(
   // agent (and its prompt) is rebuilt as soon as the registry refreshes.
   const inventory = capabilityInventory(registry.list, policy);
 
-  const cacheKey = `${agentConfig._id}:${agentConfig.updatedAt?.getTime?.() ?? 0}:v${ROUTING_VERSION}:${inventory.fingerprint}`;
+  const cacheKey = `${agentConfig._id}:${agentConfig.updatedAt?.getTime?.() ?? 0}:v${ROUTING_VERSION}:${inventory.fingerprint}:mem${useMemory ? subdomain : 'off'}`;
 
   const cached = agentCache.get(cacheKey);
   if (cached) {
@@ -160,12 +168,20 @@ export async function getOrCreateAgent(
   const temperature = agentConfig.temperature;
   const hasTemperature = typeof temperature === 'number';
 
+  // Per-tenant Mastra Memory (recall + working memory). ToolCallFilter strips
+  // tool-call frames from any replayed/recalled history so reasoning models
+  // (Kimi) don't reject the request. Both are opt-in via advanced memory.
+  const memory = useMemory ? await getMastraMemory(subdomain) : undefined;
+
   const agent = new Agent({
     id: agentConfig.agentId,
     name: agentConfig.name,
     instructions: systemPrompt,
     model,
     tools: toolNames.length ? tools : undefined,
+    ...(memory
+      ? { memory, inputProcessors: [new ToolCallFilter()] }
+      : {}),
     // generate()/stream() read defaultOptions. Temperature is only set when the
     // agent configures it — otherwise the provider default applies (sending an
     // explicit 0 is what reasoning models like Kimi reject).
@@ -173,7 +189,7 @@ export async function getOrCreateAgent(
       maxSteps,
       ...(hasTemperature ? { modelSettings: { temperature } } : {}),
     },
-  });
+  } as never);
 
   agentCache.set(cacheKey, agent);
   toolsCache.set(cacheKey, tools);

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
@@ -1,13 +1,18 @@
 // ---------------------------------------------------------------------------
-// Mastra Memory — semantic recall + working memory backed by the tenant's Mongo
+// Mastra Memory — semantic recall + working memory backed by one shared Mongo
 // DB (records) and Qdrant (vectors), with a local fastembed embedder.
 //
 // Replaces the custom recall/working-memory implementation for the chat path.
-// One Memory instance per tenant, cached. Storage lands in the tenant's own
-// Mongo database (same per-tenant isolation the workflow runtime uses); vectors
-// go to Qdrant, scoped by a tenant-prefixed resourceId. ToolCallFilter is NOT
-// configured here — in @mastra/memory 1.20.3 it lives on the Agent's
-// inputProcessors (Memory({ processors }) was removed); agentRuntime attaches it.
+// A SINGLE Memory instance is shared across tenants. Mastra uses a fixed set of
+// memory collections (threads/messages/resources/observational), so one shared
+// database keeps the footprint at ~4 collections total instead of multiplying
+// the full MongoDBStore system schema per tenant (which trips the Atlas
+// shared-tier 500-collection cap). Tenant isolation is enforced by the
+// tenant-prefixed resourceId (see scopedResource) — semantic recall and
+// resource-scoped working memory both filter by that resource, so tenant A
+// never reads tenant B. ToolCallFilter is NOT configured here — in
+// @mastra/memory 1.20.3 it lives on the Agent's inputProcessors
+// (Memory({ processors }) was removed); agentRuntime attaches it.
 // ---------------------------------------------------------------------------
 import { Memory } from '@mastra/memory';
 import { MongoDBStore } from '@mastra/mongodb';
@@ -17,14 +22,24 @@ import { resolveRecallTuning } from './config';
 
 const QDRANT_URL = () =>
   process.env.ERXES_AGENT_QDRANT_URL || 'http://localhost:6333';
-const MONGO_URL = () => process.env.MONGO_URL || 'mongodb://localhost:27017';
 
-/** Tenant → its dedicated Mastra-memory database name. */
-function memoryDbName(tenant: string): string {
-  const prefix = (
+// Memory storage lives on its OWN Mongo, separate from the app cluster. Mastra's
+// MongoDBStore provisions a fixed system schema (~30 collections) and the shared
+// erxes Atlas cluster has a hard cluster-wide collection cap (500 on shared
+// tiers) that the app DB already nearly fills — so point memory at a dedicated
+// instance via ERXES_AGENT_MEMORY_MONGO_URL. Falls back to MONGO_URL only when
+// that is unset (e.g. a self-hosted single-cluster deploy with headroom).
+const MONGO_URL = () =>
+  process.env.ERXES_AGENT_MEMORY_MONGO_URL ||
+  process.env.MONGO_URL ||
+  'mongodb://localhost:27017';
+
+/** The single shared Mastra-memory database name. */
+function memoryDbName(): string {
+  const name = (
     process.env.ERXES_AGENT_MEMORY_DB_PREFIX || 'erxes_mastra_memory'
   ).trim();
-  return `${prefix}_${tenant}`.replace(/[^a-zA-Z0-9_]/g, '_');
+  return name.replace(/[^a-zA-Z0-9_]/g, '_');
 }
 
 // fastembed → a MastraEmbeddingModel (AI SDK v2 embedding model). Verified in
@@ -46,58 +61,68 @@ async function getEmbeddingModel(): Promise<unknown> {
   return _embeddingModel;
 }
 
-const _byTenant = new Map<string, Memory>();
+let _shared: Memory | null = null;
+let _building: Promise<Memory> | null = null;
 
 /**
- * The tenant's Mastra Memory (cached). `subdomain` is the tenant key; falls back
- * to 'os' so background/non-request callers still get a stable instance.
+ * The shared Mastra Memory (cached). `subdomain` is accepted for call-site
+ * symmetry but does not select the instance — isolation is by resourceId
+ * (see scopedResource), so a single instance serves every tenant.
  */
-export async function getMastraMemory(subdomain?: string): Promise<Memory> {
-  const tenant = (subdomain || 'os').trim() || 'os';
-  const hit = _byTenant.get(tenant);
-  if (hit) return hit;
+export async function getMastraMemory(_subdomain?: string): Promise<Memory> {
+  if (_shared) return _shared;
+  if (_building) return _building;
 
-  const embedder = await getEmbeddingModel();
-  const tuning = resolveRecallTuning();
+  _building = (async () => {
+    const embedder = await getEmbeddingModel();
+    const tuning = resolveRecallTuning();
 
-  const storage = new MongoDBStore({
-    id: `erxes-agent-memory-${tenant}`,
-    url: MONGO_URL(),
-    dbName: memoryDbName(tenant),
-  } as never);
+    const storage = new MongoDBStore({
+      id: 'erxes-agent-memory',
+      url: MONGO_URL(),
+      dbName: memoryDbName(),
+    } as never);
 
-  const vector = new QdrantVector({
-    id: `erxes-agent-memory-${tenant}`,
-    url: QDRANT_URL(),
-    // Client/server minor-version skew otherwise logs a noisy warning per call.
-    checkCompatibility: false,
-  } as never);
+    const vector = new QdrantVector({
+      id: 'erxes-agent-memory',
+      url: QDRANT_URL(),
+      // Client/server minor-version skew otherwise logs a noisy warning per call.
+      checkCompatibility: false,
+    } as never);
 
-  const memory = new Memory({
-    storage,
-    vector,
-    embedder: embedder as never,
-    options: {
-      // Mastra owns recent-history replay + semantic recall + working memory for
-      // this turn. (The erxes MastraMessage store stays the UI source of truth;
-      // the chat pipeline stops manually replaying history when memory is active.)
-      lastMessages: 12,
-      semanticRecall: {
-        topK: tuning.topK,
-        messageRange: 2,
-        scope: tuning.scope,
+    const memory = new Memory({
+      storage,
+      vector,
+      embedder: embedder as never,
+      options: {
+        // Mastra owns recent-history replay + semantic recall + working memory
+        // for this turn. (The erxes MastraMessage store stays the UI source of
+        // truth; the chat pipeline stops manually replaying history when memory
+        // is active.)
+        lastMessages: 12,
+        semanticRecall: {
+          topK: tuning.topK,
+          messageRange: 2,
+          scope: tuning.scope,
+        },
+        // Resource-scoped working memory: a per-user record (Markdown template)
+        // that persists across the user's threads. It is stored as a field on
+        // the resource document in the fixed `mastra_resources` collection
+        // (updateResource) — one row per user, NOT a collection per user — so it
+        // adds no collections and is safe on the shared DB.
+        workingMemory: { enabled: true, scope: 'resource' },
       },
-      // Working memory is off for now: in @mastra/memory 1.20.3 it runs as an
-      // output-processor *workflow* that creates extra storage collections,
-      // which trips the Atlas shared-tier 500-collection cap ("already using 501
-      // collections of 500"). Semantic recall alone provides cross-session
-      // memory; revisit working memory once the collection footprint is sorted.
-      workingMemory: { enabled: false },
-    },
-  } as never);
+    } as never);
 
-  _byTenant.set(tenant, memory);
-  return memory;
+    _shared = memory;
+    return memory;
+  })();
+
+  try {
+    return await _building;
+  } finally {
+    _building = null;
+  }
 }
 
 /** Tenant-scoped resource id so a shared Qdrant collection stays isolated. */
@@ -105,7 +130,8 @@ export function scopedResource(subdomain: string, resourceId: string): string {
   return `${(subdomain || 'os').trim() || 'os'}:${resourceId}`;
 }
 
-/** Drop cached instances (tests / config changes). */
+/** Drop the cached instance (tests / config changes). */
 export function resetMastraMemoryCache(): void {
-  _byTenant.clear();
+  _shared = null;
+  _building = null;
 }

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
@@ -20,6 +20,7 @@ import { QdrantVector } from '@mastra/qdrant';
 import { getEmbedder } from './embedder';
 import { resolveRecallTuning } from './config';
 
+/** Qdrant endpoint for memory vectors (env override, local default). */
 const QDRANT_URL = () =>
   process.env.ERXES_AGENT_QDRANT_URL || 'http://localhost:6333';
 
@@ -42,9 +43,9 @@ function memoryDbName(): string {
   return name.replace(/[^a-zA-Z0-9_]/g, '_');
 }
 
-// fastembed → a MastraEmbeddingModel (AI SDK v2 embedding model). Verified in
-// scripts/spike-memory.ts. The embedder + its wrapper are both cached.
+// fastembed → a MastraEmbeddingModel (AI SDK v2 embedding model).
 let _embeddingModel: unknown | null = null;
+/** Build (once, cached) the fastembed-backed embedding model Memory uses. */
 async function getEmbeddingModel(): Promise<unknown> {
   if (_embeddingModel) return _embeddingModel;
   const fe = await getEmbedder();

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/mastraMemory.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// Mastra Memory — semantic recall + working memory backed by the tenant's Mongo
+// DB (records) and Qdrant (vectors), with a local fastembed embedder.
+//
+// Replaces the custom recall/working-memory implementation for the chat path.
+// One Memory instance per tenant, cached. Storage lands in the tenant's own
+// Mongo database (same per-tenant isolation the workflow runtime uses); vectors
+// go to Qdrant, scoped by a tenant-prefixed resourceId. ToolCallFilter is NOT
+// configured here — in @mastra/memory 1.20.3 it lives on the Agent's
+// inputProcessors (Memory({ processors }) was removed); agentRuntime attaches it.
+// ---------------------------------------------------------------------------
+import { Memory } from '@mastra/memory';
+import { MongoDBStore } from '@mastra/mongodb';
+import { QdrantVector } from '@mastra/qdrant';
+import { getEmbedder } from './embedder';
+import { resolveRecallTuning } from './config';
+
+const QDRANT_URL = () =>
+  process.env.ERXES_AGENT_QDRANT_URL || 'http://localhost:6333';
+const MONGO_URL = () => process.env.MONGO_URL || 'mongodb://localhost:27017';
+
+/** Tenant → its dedicated Mastra-memory database name. */
+function memoryDbName(tenant: string): string {
+  const prefix = (
+    process.env.ERXES_AGENT_MEMORY_DB_PREFIX || 'erxes_mastra_memory'
+  ).trim();
+  return `${prefix}_${tenant}`.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+// fastembed → a MastraEmbeddingModel (AI SDK v2 embedding model). Verified in
+// scripts/spike-memory.ts. The embedder + its wrapper are both cached.
+let _embeddingModel: unknown | null = null;
+async function getEmbeddingModel(): Promise<unknown> {
+  if (_embeddingModel) return _embeddingModel;
+  const fe = await getEmbedder();
+  _embeddingModel = {
+    specificationVersion: 'v2',
+    provider: 'fastembed',
+    modelId: 'erxes-embedder',
+    maxEmbeddingsPerCall: 256,
+    supportsParallelCalls: false,
+    async doEmbed({ values }: { values: string[] }) {
+      return { embeddings: await fe.embed(values) };
+    },
+  };
+  return _embeddingModel;
+}
+
+const _byTenant = new Map<string, Memory>();
+
+/**
+ * The tenant's Mastra Memory (cached). `subdomain` is the tenant key; falls back
+ * to 'os' so background/non-request callers still get a stable instance.
+ */
+export async function getMastraMemory(subdomain?: string): Promise<Memory> {
+  const tenant = (subdomain || 'os').trim() || 'os';
+  const hit = _byTenant.get(tenant);
+  if (hit) return hit;
+
+  const embedder = await getEmbeddingModel();
+  const tuning = resolveRecallTuning();
+
+  const storage = new MongoDBStore({
+    id: `erxes-agent-memory-${tenant}`,
+    url: MONGO_URL(),
+    dbName: memoryDbName(tenant),
+  } as never);
+
+  const vector = new QdrantVector({
+    id: `erxes-agent-memory-${tenant}`,
+    url: QDRANT_URL(),
+    // Client/server minor-version skew otherwise logs a noisy warning per call.
+    checkCompatibility: false,
+  } as never);
+
+  const memory = new Memory({
+    storage,
+    vector,
+    embedder: embedder as never,
+    options: {
+      // Mastra owns recent-history replay + semantic recall + working memory for
+      // this turn. (The erxes MastraMessage store stays the UI source of truth;
+      // the chat pipeline stops manually replaying history when memory is active.)
+      lastMessages: 12,
+      semanticRecall: {
+        topK: tuning.topK,
+        messageRange: 2,
+        scope: tuning.scope,
+      },
+      // Working memory is off for now: in @mastra/memory 1.20.3 it runs as an
+      // output-processor *workflow* that creates extra storage collections,
+      // which trips the Atlas shared-tier 500-collection cap ("already using 501
+      // collections of 500"). Semantic recall alone provides cross-session
+      // memory; revisit working memory once the collection footprint is sorted.
+      workingMemory: { enabled: false },
+    },
+  } as never);
+
+  _byTenant.set(tenant, memory);
+  return memory;
+}
+
+/** Tenant-scoped resource id so a shared Qdrant collection stays isolated. */
+export function scopedResource(subdomain: string, resourceId: string): string {
+  return `${(subdomain || 'os').trim() || 'os'}:${resourceId}`;
+}
+
+/** Drop cached instances (tests / config changes). */
+export function resetMastraMemoryCache(): void {
+  _byTenant.clear();
+}

--- a/backend/plugins/erxes-agent_api/src/modules/agent/graphql/resolvers/queries/agent.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/graphql/resolvers/queries/agent.ts
@@ -46,12 +46,13 @@ export const agentQueries = {
       threadId,
     });
 
-    const { agent, convo, authCtx } = prepared;
+    const { agent, convo, authCtx, memoryBinding } = prepared;
     const reply = await runAgentTurn({
       agent,
       convo,
       message,
       authCtx,
+      memory: memoryBinding,
     });
 
     // Persist the completed exchange so the session survives reloads. Only the

--- a/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
@@ -243,7 +243,11 @@ export async function prepareChatTurn(params: {
 
   const settings = await models.MastraSettings.findOne({});
   const providers = await models.MastraProvider.find({ isEnabled: true });
-  const { agent, tools } = await getOrCreateAgent(agentConfig, models, subdomain);
+  const { agent, tools } = await getOrCreateAgent(
+    agentConfig,
+    models,
+    subdomain,
+  );
 
   // Stable session id — the persisted thread this turn belongs to.
   // typeof guard keeps crafted non-string payloads out of Mongo queries
@@ -287,7 +291,10 @@ export async function prepareChatTurn(params: {
   // recall/working-memory injection is skipped to avoid doing it twice.
   const useMemory = advanced && !!subdomain;
   const memoryBinding = useMemory
-    ? { thread: sessionId, resource: scopedResource(subdomain, memCtx.resourceId) }
+    ? {
+        thread: sessionId,
+        resource: scopedResource(subdomain, memCtx.resourceId),
+      }
     : undefined;
 
   // Custom recall path (only when advanced but Mastra Memory is NOT active, e.g.
@@ -563,7 +570,10 @@ export function toUserFacingError(err: unknown): Error {
   // tokens first — provider errors can echo API keys, bearer tokens, connection
   // strings or hashes that log aggregators shouldn't capture.
   const safe = msg
-    .replace(/\b(bearer\s+|api[_-]?key=|token=|:)[A-Za-z0-9._-]{16,}/gi, '$1[redacted]')
+    .replace(
+      /\b(bearer\s+|api[_-]?key=|token=|:)[A-Za-z0-9._-]{16,}/gi,
+      '$1[redacted]',
+    )
     .replace(/[A-Za-z0-9_-]{32,}/g, '[redacted]');
   console.error('[toUserFacingError] unmatched error:', safe);
   return new Error(
@@ -599,10 +609,10 @@ export function logToolResults(uniqueResults: ToolResultLike[]) {
             data == null
               ? 'null'
               : Array.isArray(data)
-              ? `array(${data.length})`
-              : typeof data === 'object'
-              ? Object.keys(data).slice(0, 6)
-              : typeof data,
+                ? `array(${data.length})`
+                : typeof data === 'object'
+                  ? Object.keys(data).slice(0, 6)
+                  : typeof data,
           success: record ? record.success : undefined,
           error: record ? record.error || record.message : undefined,
         };
@@ -661,4 +671,3 @@ export async function synthesizeFromToolResults(params: {
     return fallback || 'Done.';
   }
 }
-

--- a/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
@@ -289,7 +289,7 @@ export async function prepareChatTurn(params: {
   // (attached to the agent in getOrCreateAgent) handles semantic recall +
   // working memory automatically via the per-turn binding below — so the custom
   // recall/working-memory injection is skipped to avoid doing it twice.
-  const useMemory = advanced && !!subdomain;
+  const useMemory = advanced && Boolean(subdomain);
   const memoryBinding = useMemory
     ? {
         thread: sessionId,

--- a/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/turn.ts
@@ -4,6 +4,7 @@ import { IModels } from '~/connectionResolvers';
 import { getOrCreateAgent } from '~/mastra/agentRuntime';
 import { runWithAuth } from '~/mastra/requestContext';
 import { isAdvancedMemoryEnabled } from '~/mastra/memory/config';
+import { scopedResource } from '~/mastra/memory/mastraMemory';
 import {
   recallBlock,
   indexMessages,
@@ -185,6 +186,13 @@ export function buildFallbackFromResults(
 
 // ─── Turn setup ───────────────────────────────────────────────────────────────
 
+// Per-turn Mastra Memory binding — which thread + (tenant-scoped) resource this
+// turn reads/writes. Passed to generate()/stream() so Mastra recalls + persists.
+export interface MemoryBinding {
+  thread: string;
+  resource: string;
+}
+
 export interface PreparedTurn {
   agentConfig: IMastraAgentDocument;
   settings: IMastraSettingsDocument | null;
@@ -195,6 +203,10 @@ export interface PreparedTurn {
   convo: TurnMessage[];
   authCtx: TurnAuthCtx;
   advanced: boolean;
+  // True when Mastra Memory is active for this turn (advanced + known tenant).
+  useMemory: boolean;
+  // Set when useMemory — the thread/resource Mastra Memory binds to.
+  memoryBinding?: MemoryBinding;
   memCtx: MemoryContext;
   attachments?: IMastraChatAttachment[];
   // Learnings injected into this turn's context — stamped onto the assistant
@@ -231,7 +243,7 @@ export async function prepareChatTurn(params: {
 
   const settings = await models.MastraSettings.findOne({});
   const providers = await models.MastraProvider.find({ isEnabled: true });
-  const { agent, tools } = await getOrCreateAgent(agentConfig, models);
+  const { agent, tools } = await getOrCreateAgent(agentConfig, models, subdomain);
 
   // Stable session id — the persisted thread this turn belongs to.
   // typeof guard keeps crafted non-string payloads out of Mongo queries
@@ -269,13 +281,20 @@ export async function prepareChatTurn(params: {
     agentId,
   };
 
-  // Semantic recall (cross-session long-term memory) + working memory (the
-  // persistent user profile) + the tenant's learned digest (shared "Agent
-  // knowledge" — PII-free, independent of the per-user memory switch). All
-  // injected as plain system context blocks. Best-effort: each returns null
-  // on any error, never blocking the turn.
+  // When advanced memory is enabled AND we know the tenant, Mastra Memory
+  // (attached to the agent in getOrCreateAgent) handles semantic recall +
+  // working memory automatically via the per-turn binding below — so the custom
+  // recall/working-memory injection is skipped to avoid doing it twice.
+  const useMemory = advanced && !!subdomain;
+  const memoryBinding = useMemory
+    ? { thread: sessionId, resource: scopedResource(subdomain, memCtx.resourceId) }
+    : undefined;
+
+  // Custom recall path (only when advanced but Mastra Memory is NOT active, e.g.
+  // no tenant) + the tenant's learned digest (shared "Agent knowledge", always).
+  // Best-effort: each returns null on error, never blocking the turn.
   const [[recall, wmBlock], digest] = await Promise.all([
-    advanced
+    advanced && !useMemory
       ? Promise.all([
           recallBlock(message, memCtx),
           readWorkingMemory(models, memCtx),
@@ -284,8 +303,13 @@ export async function prepareChatTurn(params: {
     readLearnedDigest(models, agentId),
   ]);
 
+  // When Mastra Memory is active it owns recent-history replay + recall +
+  // working memory (and persists the turn) — so we hand generate() ONLY the new
+  // user message (+ the learned digest, which is separate from Mastra Memory).
+  // Passing the full replayed history here would stop Mastra from persisting the
+  // turn to its store. Otherwise (no Mastra Memory) replay history manually.
   const convo: TurnMessage[] = augmentConvo({
-    recentHistory,
+    recentHistory: useMemory ? [] : recentHistory,
     userMessage: message,
     recallBlock: recall,
     workingMemoryBlock: wmBlock,
@@ -322,6 +346,8 @@ export async function prepareChatTurn(params: {
     convo,
     authCtx,
     advanced,
+    useMemory,
+    memoryBinding,
     memCtx,
     attachments,
     learningIds: digest?.ids ?? [],
@@ -354,6 +380,7 @@ export async function persistTurn(params: {
   const {
     sessionId,
     advanced,
+    useMemory,
     memCtx,
     agentConfig,
     providers,
@@ -398,8 +425,11 @@ export async function persistTurn(params: {
       })
     : Promise.resolve<string | null>(null);
 
-  // Index the new exchange into Qdrant for future recall (best-effort).
-  if (advanced) {
+  // Custom Qdrant indexing + working-memory refresh — only when advanced memory
+  // is on but Mastra Memory is NOT active (e.g. no tenant). When Mastra Memory
+  // is active it persists the exchange + updates working memory itself via the
+  // generate()/stream() binding, so this is skipped.
+  if (advanced && !useMemory) {
     const toIndex = [
       {
         id: String(userMsg._id),
@@ -450,11 +480,20 @@ export async function runAgentTurn(params: {
   convo: TurnMessage[];
   message: string;
   authCtx: TurnAuthCtx;
+  memory?: MemoryBinding;
 }): Promise<string | null> {
-  const { agent, convo, message, authCtx } = params;
+  const { agent, convo, message, authCtx, memory } = params;
+  const genOpts = memory ? { memory } : undefined;
+  // With a memory binding, hand generate() the new user message as a STRING —
+  // Mastra Memory only persists (and recalls against) string input; passing the
+  // convo array silently skips the save. (Recent history + recall come from
+  // Mastra Memory itself; the learned digest is already woven into `message`.)
+  const input = memory ? message : convo;
 
   try {
-    const result = await runWithAuth(authCtx, () => agent.generate(convo));
+    const result = await runWithAuth(authCtx, () =>
+      agent.generate(input, genOpts),
+    );
 
     if (result.text) return result.text;
 

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -331,7 +331,7 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
       threadId,
       attachments,
     });
-    const { agent, convo, authCtx } = prepared;
+    const { agent, convo, authCtx, memoryBinding } = prepared;
 
     // Narrates "what is the agent doing" while the turn runs — throttled
     // summaries of the live reasoning/tool signals, pushed as activity events.
@@ -354,6 +354,7 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
       await runWithAuth(authCtx, async () => {
         const stream = await agent.stream(convo, {
           abortSignal: controller.signal,
+          ...(memoryBinding ? { memory: memoryBinding } : {}),
         });
 
         for await (const chunk of stream.fullStream as AsyncIterable<unknown>) {


### PR DESCRIPTION
## Phase 2 — Mastra Memory (semantic recall + working memory)

Stacked on #8051 (native-Mastra). **Review only the 3 commits here**; base is `refactor/erxes-agent-native-mastra`.

Wires native Mastra `Memory` into the chat pipeline so the agent gets cross-session memory, replacing the custom recall path for the chat turn.

### What's included
- **Semantic recall** — per-turn `{thread, resource}` binding; recall happens automatically via config (no manual `augmentConvo`). Custom recall/working-memory paths are gated off when native memory is active.
- **Resource-scoped working memory** — a per-user Markdown record that persists across the user's threads.
- **`ToolCallFilter`** on the agent's `inputProcessors` strips tool-call frames from replayed/recalled history (keeps reasoning models like Kimi from rejecting the request).
- **Dedicated memory Mongo** via `ERXES_AGENT_MEMORY_MONGO_URL` (falls back to `MONGO_URL`).

### Storage design
- Mastra's `MongoDBStore` provisions a **fixed ~31-collection system schema per database** (verified live) — independent of user count. Working memory is **one document per user** in `mastra_resources` (`updateResource`, `scope: 'resource'`), never a collection per user.
- The shared app Atlas cluster has a hard cluster-wide **500-collection cap** the app DB nearly fills, so memory storage points at its **own Mongo**. One **shared** Memory instance + shared memory DB across tenants; isolation is enforced by the **tenant-prefixed `resourceId`** (`scopedResource`) that both semantic recall and resource-scoped working memory filter on.

### Verification (live, real model + gateway)
- Semantic recall: a fact written in thread A is recalled in a separate thread B for the same resource.
- Working memory: facts stated in thread A ("Helsinki warehouse / metric units / Q3 deadline") surface in a new thread B for the same user.
- `tsc` clean on source.

### Key Mastra facts (for reviewers)
- `Memory({ processors })` is **removed** in `@mastra/memory` 1.20.3 — `ToolCallFilter`/`TokenLimiter` go on the Agent's processors.
- `agent.generate()` persists/recalls only with **string** input + memory binding; array `[{role,content}]` input silently skips persistence — so `runAgentTurn` passes the raw message string when memory is bound.

### Not in this PR (follow-ups)
- **Phase 3** (PII / prompt-injection / structured-output / request-context / activity processors) — separate stacked PR.
- Chat-history → Mastra-threads UI migration (resolver repoint + backfill) — deferred (higher risk).
