### PR TITLE
fix(payment): persist transaction response and tdbOrderId on invoice

### DIFF
--- a/backend/plugins/payment_api/src/apis/ErxesPayment.ts
+++ b/backend/plugins/payment_api/src/apis/ErxesPayment.ts
@@ -74,7 +74,7 @@ class ErxesPayment {
       case 'toki':
         this.api = new TokiAPI(payment.config, this.domain);
         break;
-      case 'tdb':   
+      case 'tdb':
         this.api = new TDBAPI(payment.config, this.domain);
         break;
       default:

--- a/backend/plugins/payment_api/src/apis/ErxesPayment.ts
+++ b/backend/plugins/payment_api/src/apis/ErxesPayment.ts
@@ -111,6 +111,7 @@ class ErxesPayment {
     // clone transaction safely instead of mutating
     const invoicePayload = {
       ...transaction,
+      _id: transaction._id,
       amount: invoiceAmount,
     };
 

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -58,9 +58,13 @@ export const loadInvoiceClass = (models: IModels) => {
         const api = new ErxesPayment(payment);
 
         try {
-          const reponse = await api.createInvoice(transaction.toObject());
-          transaction.response = reponse;
-          await invoice.save();
+          const response = await api.createInvoice(transaction.toObject());
+          transaction.response = response;
+          transaction.details = {
+            ...transaction.details,
+            tdbOrderId: response.order?.id,
+          };
+          await transaction.save();
 
           return invoice;
         } catch (e) {


### PR DESCRIPTION
## Summary by Sourcery

Persist transaction gateway response and related order identifier on the payment transaction record instead of the invoice.

Bug Fixes:
- Store the full invoice creation response and tdbOrderId on the transaction so they are not lost and can be referenced later.

Enhancements:
- Include the transaction identifier in the payload sent to ErxesPayment when creating invoices to maintain traceability between local transactions and remote orders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for TDB as a new payment method option.

* **Bug Fixes**
  * Fixed transaction response handling in payment processing to ensure accurate data persistence.
  * Improved order information tracking to correctly capture and store identifiers from payment provider responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->