### PR TITLE
feat(blocknote): add custom file block, image preview dialog, and file upload support

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditorReadOnly.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditorReadOnly.tsx
@@ -21,7 +21,7 @@ export const BlockEditorReadOnly = React.forwardRef<
   const editor = useCreateBlockNote({
     schema: BLOCK_SCHEMA,
     initialContent: contentBlocks || undefined,
-    resolveFileUrl: async (url) => readImage(url),
+    resolveFileUrl: (url) => Promise.resolve(readImage(url)),
   });
   const theme = useAtomValue(themeState);
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditorReadOnly.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditorReadOnly.tsx
@@ -7,6 +7,7 @@ import { parseBlocks } from '../utils';
 import DOMPurify from 'dompurify';
 import { cn } from 'erxes-ui/lib';
 import React, { useMemo } from 'react';
+import { readImage } from '../../../utils/core';
 
 export const BlockEditorReadOnly = React.forwardRef<
   HTMLDivElement,
@@ -20,6 +21,7 @@ export const BlockEditorReadOnly = React.forwardRef<
   const editor = useCreateBlockNote({
     schema: BLOCK_SCHEMA,
     initialContent: contentBlocks || undefined,
+    resolveFileUrl: async (url) => readImage(url),
   });
   const theme = useAtomValue(themeState);
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
@@ -33,7 +33,11 @@ const CustomFilePreview: FC<Pick<FileRenderProps, 'block'>> = ({ block }) => {
   const url = readImage(block.props.url, undefined, true);
 
   return (
-    <div className="bn-file-name-with-icon" contentEditable={false} draggable={false}>
+    <div
+      className="bn-file-name-with-icon"
+      contentEditable={false}
+      draggable={false}
+    >
       <a
         href={url}
         target="_blank"

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
@@ -1,0 +1,81 @@
+import {
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
+  fileBlockConfig,
+} from '@blocknote/core';
+import {
+  FileBlockWrapper,
+  ReactCustomBlockRenderProps,
+  createReactBlockSpec,
+  useUploadLoading,
+} from '@blocknote/react';
+import { IconFile } from '@tabler/icons-react';
+import { Spinner } from 'erxes-ui/components';
+import { FC } from 'react';
+import { readImage } from '../../../utils/core';
+
+type FileRenderProps = ReactCustomBlockRenderProps<
+  typeof fileBlockConfig,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema
+>;
+
+type FileBlockWrapperProps = Parameters<typeof FileBlockWrapper>[0];
+type FileWrapperRenderProps = Omit<
+  FileBlockWrapperProps,
+  'buttonText' | 'buttonIcon' | 'children'
+>;
+
+const toFileWrapperProps = (props: FileRenderProps): FileWrapperRenderProps =>
+  props as unknown as FileWrapperRenderProps;
+
+const CustomFilePreview: FC<Pick<FileRenderProps, 'block'>> = ({ block }) => {
+  const url = readImage(block.props.url, undefined, true);
+
+  return (
+    <div className="bn-file-name-with-icon" contentEditable={false} draggable={false}>
+      <a
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+        className="flex items-center gap-2 hover:underline"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bn-file-icon">
+          <IconFile size={24} />
+        </div>
+        <p className="bn-file-name">{block.props.name || block.props.url}</p>
+      </a>
+    </div>
+  );
+};
+
+const CustomFileBlockContent: FC<FileRenderProps> = (props) => {
+  const loading = useUploadLoading(props.block.id);
+  const wrapperProps = toFileWrapperProps(props);
+
+  if (loading) {
+    return (
+      <div className="bn-file-block-content-wrapper">
+        <div className="bn-file-loading-preview flex items-center gap-2">
+          <Spinner size="sm" />
+          <span className="text-sm text-muted-foreground">Uploading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <FileBlockWrapper
+      {...wrapperProps}
+      buttonText={props.editor.dictionary.file_blocks.file.add_button_text}
+      buttonIcon={<IconFile size={24} />}
+    >
+      <CustomFilePreview block={props.block} />
+    </FileBlockWrapper>
+  );
+};
+
+export const customFileBlock = createReactBlockSpec(fileBlockConfig, {
+  render: CustomFileBlockContent,
+});

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomFileBlock.tsx
@@ -27,7 +27,7 @@ type FileWrapperRenderProps = Omit<
 >;
 
 const toFileWrapperProps = (props: FileRenderProps): FileWrapperRenderProps =>
-  props as unknown as FileWrapperRenderProps;
+  props;
 
 const CustomFilePreview: FC<Pick<FileRenderProps, 'block'>> = ({ block }) => {
   const url = readImage(block.props.url, undefined, true);

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -106,18 +106,14 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
       )}
       {!isResolving && src && (
         <>
-          <button
-            type="button"
+          <div
             className={cn(
               'bn-visual-media mx-auto cursor-pointer p-0 border-0 bg-transparent',
               getImageStyleClasses(imageStyle),
             )}
             style={imgLoaded ? undefined : { display: 'none' }}
             contentEditable={false}
-            onClick={(e) => {
-              e.stopPropagation();
-              setPreviewOpen(true);
-            }}
+            onDoubleClick={() => setPreviewOpen(true)}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -128,7 +124,7 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
               onLoad={() => setImgLoaded(true)}
               onError={() => setImgLoaded(true)}
             />
-          </button>
+          </div>
           <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
             <Dialog.Content className="bg-transparent shadow-none p-0 border-0 max-w-fit">
               <Dialog.Title className="sr-only">

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -247,7 +247,9 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => { document.getElementById(styleId)?.remove(); };
+    return () => {
+      document.getElementById(styleId)?.remove();
+    };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -244,7 +244,9 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => { document.getElementById(styleId)?.remove(); };
+    return () => {
+      document.getElementById(styleId)?.remove();
+    };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -126,7 +126,6 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
               }
             }}
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               className="w-full h-auto block"
               src={src}
@@ -141,7 +140,6 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
               <Dialog.Title className="sr-only">
                 {block.props.caption || block.props.name || 'Image preview'}
               </Dialog.Title>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={src}
                 alt={block.props.caption || block.props.name || ''}
@@ -194,7 +192,6 @@ const ExternalImageHtml: FC<ImageRenderProps> = ({ block }) => {
   const containerStyle = getFloatContainerStyle(imageStyle, maxWidth);
 
   const img = (
-    // eslint-disable-next-line @next/next/no-img-element
     <img
       src={url}
       alt={caption || name || ''}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -39,13 +39,16 @@ const getImageStyle = (value?: string): ImageStyle =>
 
 const getImageStyleClasses = (imageStyle: ImageStyle) => {
   switch (imageStyle) {
-    case 'wide':        return 'w-full max-w-[1080px]';
-    case 'float-left':  return 'max-w-[400px] w-full';
-    case 'float-right': return 'max-w-[400px] w-full';
-    default:            return 'w-full max-w-[720px]';
+    case 'wide':
+      return 'w-full max-w-[1080px]';
+    case 'float-left':
+      return 'max-w-[400px] w-full';
+    case 'float-right':
+      return 'max-w-[400px] w-full';
+    default:
+      return 'w-full max-w-[720px]';
   }
 };
-
 
 const getImageStyleFromElement = (element: HTMLElement): ImageStyle => {
   const explicitStyle =
@@ -116,7 +119,10 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
             style={imgLoaded ? undefined : { display: 'none' }}
             onLoad={() => setImgLoaded(true)}
             onError={() => setImgLoaded(true)}
-            onClick={(e) => { e.stopPropagation(); setPreviewOpen(true); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              setPreviewOpen(true);
+            }}
           />
           <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
             <Dialog.Content className="bg-transparent shadow-none p-0 border-0 max-w-fit">
@@ -146,9 +152,19 @@ const getFloatContainerStyle = (
     maxWidth: `${maxWidth}px`,
   };
   if (imageStyle === 'float-left')
-    return { ...base, float: 'left', marginRight: '1.25em', marginBottom: '0.5em' };
+    return {
+      ...base,
+      float: 'left',
+      marginRight: '1.25em',
+      marginBottom: '0.5em',
+    };
   if (imageStyle === 'float-right')
-    return { ...base, float: 'right', marginLeft: '1.25em', marginBottom: '0.5em' };
+    return {
+      ...base,
+      float: 'right',
+      marginLeft: '1.25em',
+      marginBottom: '0.5em',
+    };
   return { ...base, margin: '0 auto' };
 };
 
@@ -206,7 +222,10 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
       (props.block.props as { previewWidth?: number }).previewWidth ||
       IMAGE_STYLE_PRESETS[imageStyle].maxWidth;
     const dir = imageStyle === 'float-left' ? 'left' : 'right';
-    const margin = imageStyle === 'float-left' ? 'margin-right:1.25em' : 'margin-left:1.25em';
+    const margin =
+      imageStyle === 'float-left'
+        ? 'margin-right:1.25em'
+        : 'margin-left:1.25em';
 
     const styleEl = document.createElement('style');
     styleEl.id = styleId;
@@ -214,7 +233,11 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     document.head.appendChild(styleEl);
 
     return () => document.getElementById(styleId)?.remove();
-  }, [props.block.id, imageStyle, (props.block.props as { previewWidth?: number }).previewWidth]);
+  }, [
+    props.block.id,
+    imageStyle,
+    (props.block.props as { previewWidth?: number }).previewWidth,
+  ]);
 
   if (loading) {
     return (

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -247,9 +247,7 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => {
-      document.getElementById(styleId)?.remove();
-    };
+    return () => { void document.getElementById(styleId)?.remove(); };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -116,7 +116,6 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
             )}
             style={imgLoaded ? undefined : { display: 'none' }}
             contentEditable={false}
-            role="button"
             tabIndex={0}
             onDoubleClick={() => setPreviewOpen(true)}
             onKeyDown={(e) => {

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -106,24 +106,29 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
       )}
       {!isResolving && src && (
         <>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <button
+            type="button"
             className={cn(
-              'bn-visual-media mx-auto cursor-pointer',
+              'bn-visual-media mx-auto cursor-pointer p-0 border-0 bg-transparent',
               getImageStyleClasses(imageStyle),
             )}
-            src={src}
-            alt={block.props.caption || block.props.name || ''}
-            contentEditable={false}
-            draggable={false}
             style={imgLoaded ? undefined : { display: 'none' }}
-            onLoad={() => setImgLoaded(true)}
-            onError={() => setImgLoaded(true)}
+            contentEditable={false}
             onClick={(e) => {
               e.stopPropagation();
               setPreviewOpen(true);
             }}
-          />
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className="w-full h-auto block"
+              src={src}
+              alt={block.props.caption || block.props.name || ''}
+              draggable={false}
+              onLoad={() => setImgLoaded(true)}
+              onError={() => setImgLoaded(true)}
+            />
+          </button>
           <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
             <Dialog.Content className="bg-transparent shadow-none p-0 border-0 max-w-fit">
               <Dialog.Title className="sr-only">

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -113,7 +113,15 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
             )}
             style={imgLoaded ? undefined : { display: 'none' }}
             contentEditable={false}
+            role="button"
+            tabIndex={0}
             onDoubleClick={() => setPreviewOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setPreviewOpen(true);
+              }
+            }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -244,9 +244,7 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => {
-      void document.getElementById(styleId)?.remove();
-    };
+    return () => { document.getElementById(styleId)?.remove(); };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -50,6 +50,7 @@ const getImageStyleClasses = (imageStyle: ImageStyle) => {
   }
 };
 
+/** Reads the image style from a DOM element's data attribute or class name. */
 const getImageStyleFromElement = (element: HTMLElement): ImageStyle => {
   const explicitStyle =
     element.getAttribute('data-image-style') ||
@@ -83,9 +84,11 @@ type FileBlockRenderProps = Omit<
   'buttonText' | 'buttonIcon' | 'children'
 >;
 
+/** Casts image render props to file block wrapper props. */
 const toFileBlockProps = (props: ImageRenderProps): FileBlockRenderProps =>
   props as unknown as FileBlockRenderProps;
 
+/** Renders the image preview with a double-click to open full-size dialog. */
 const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
   const { loadingState, downloadUrl } = useResolveUrl(block.props.url ?? '');
   const [imgLoaded, setImgLoaded] = useState(false);
@@ -152,6 +155,7 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
   );
 };
 
+/** Returns inline styles for float-left/right image container positioning. */
 const getFloatContainerStyle = (
   imageStyle: ImageStyle,
   maxWidth: number,
@@ -177,6 +181,7 @@ const getFloatContainerStyle = (
   return { ...base, margin: '0 auto' };
 };
 
+/** Renders the image block as external HTML for export. */
 const ExternalImageHtml: FC<ImageRenderProps> = ({ block }) => {
   const { url, caption, name, previewWidth } = block.props;
   const imageStyle = getImageStyle(
@@ -212,6 +217,7 @@ const ExternalImageHtml: FC<ImageRenderProps> = ({ block }) => {
   );
 };
 
+/** Renders the image block content with upload loading state and float style injection. */
 const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
   const loading = useUploadLoading(props.block.id);
   const fileProps = toFileBlockProps(props);
@@ -241,7 +247,7 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => document.getElementById(styleId)?.remove();
+    return () => { document.getElementById(styleId)?.remove(); };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -247,7 +247,9 @@ const CustomImageBlockContent: FC<ImageRenderProps> = (props) => {
     styleEl.textContent = `[data-id="${blockId}"]{float:${dir};max-width:${maxWidth}px;width:100%;${margin};margin-bottom:.75em}`;
     document.head.appendChild(styleEl);
 
-    return () => { void document.getElementById(styleId)?.remove(); };
+    return () => {
+      void document.getElementById(styleId)?.remove();
+    };
   }, [
     props.block.id,
     imageStyle,

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/CustomImageBlock.tsx
@@ -12,7 +12,7 @@ import {
 } from '@blocknote/react';
 import { IconPhoto } from '@tabler/icons-react';
 import { CSSProperties, FC, useEffect, useState } from 'react';
-import { Spinner } from 'erxes-ui/components';
+import { Dialog, Spinner } from 'erxes-ui/components';
 import { cn } from 'erxes-ui/lib';
 
 const IMAGE_STYLES = ['normal', 'wide', 'float-left', 'float-right'] as const;
@@ -86,6 +86,7 @@ const toFileBlockProps = (props: ImageRenderProps): FileBlockRenderProps =>
 const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
   const { loadingState, downloadUrl } = useResolveUrl(block.props.url ?? '');
   const [imgLoaded, setImgLoaded] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const src = downloadUrl ?? block.props.url;
   const isResolving = loadingState === 'loading';
@@ -101,20 +102,36 @@ const CustomImagePreview: FC<FileBlockRenderProps> = ({ block }) => {
         </div>
       )}
       {!isResolving && src && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          className={cn(
-            'bn-visual-media mx-auto',
-            getImageStyleClasses(imageStyle),
-          )}
-          src={src}
-          alt={block.props.caption || block.props.name || ''}
-          contentEditable={false}
-          draggable={false}
-          style={imgLoaded ? undefined : { display: 'none' }}
-          onLoad={() => setImgLoaded(true)}
-          onError={() => setImgLoaded(true)}
-        />
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            className={cn(
+              'bn-visual-media mx-auto cursor-pointer',
+              getImageStyleClasses(imageStyle),
+            )}
+            src={src}
+            alt={block.props.caption || block.props.name || ''}
+            contentEditable={false}
+            draggable={false}
+            style={imgLoaded ? undefined : { display: 'none' }}
+            onLoad={() => setImgLoaded(true)}
+            onError={() => setImgLoaded(true)}
+            onClick={(e) => { e.stopPropagation(); setPreviewOpen(true); }}
+          />
+          <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+            <Dialog.Content className="bg-transparent shadow-none p-0 border-0 max-w-fit">
+              <Dialog.Title className="sr-only">
+                {block.props.caption || block.props.name || 'Image preview'}
+              </Dialog.Title>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={src}
+                alt={block.props.caption || block.props.name || ''}
+                className="shadow-2xl rounded max-w-[90vw] max-h-[85vh] object-contain"
+              />
+            </Dialog.Content>
+          </Dialog>
+        </>
       )}
     </div>
   );

--- a/frontend/libs/erxes-ui/src/modules/blocks/constant/blockEditorSchema.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/constant/blockEditorSchema.ts
@@ -6,6 +6,7 @@ import {
   createStyleSpec,
 } from '@blocknote/core';
 import { Attribute, Mention } from '../components/BlockEditor';
+import { customFileBlock } from '../components/CustomFileBlock';
 import { customImageBlock } from '../components/CustomImageBlock';
 import { galleryBlock } from '../components/GalleryBlock';
 
@@ -29,6 +30,7 @@ export const BLOCK_SCHEMA = BlockNoteSchema.create({
   blockSpecs: {
     ...defaultBlockSpecs,
     image: customImageBlock,
+    file: customFileBlock,
     gallery: galleryBlock,
   },
   inlineContentSpecs: {

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -1,5 +1,8 @@
 import { Block } from '@blocknote/core';
 import { useCreateBlockNote } from '@blocknote/react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useErxesUpload, FileWithPreview } from '../../../hooks/use-upload-new';
+import { readImage } from '../../../utils/core';
 import { BLOCK_SCHEMA, TABLE_SCHEMA } from '../constant';
 
 export const useBlockEditor = (args?: {
@@ -9,13 +12,48 @@ export const useBlockEditor = (args?: {
 }) => {
   const { placeholder, uploadFile, ...restArgs } = args || {};
 
+  const resolveRef = useRef<(url: string) => void>();
+  const rejectRef = useRef<(err: Error) => void>();
+
+  const uploadProps = useErxesUpload({
+    maxFiles: 1,
+    onFilesAdded: (added) => {
+      if (added[0]?.url) {
+        resolveRef.current?.(added[0].url);
+      } else {
+        rejectRef.current?.(new Error('Upload failed'));
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (uploadProps.files.length > 0 && !uploadProps.loading) {
+      void uploadProps.onUpload();
+    }
+  }, [uploadProps.files.length]);
+
+  const defaultUploadFile = useCallback(
+    (file: File): Promise<string> => {
+      return new Promise((resolve, reject) => {
+        resolveRef.current = resolve;
+        rejectRef.current = reject;
+        const fileWithPreview = file as FileWithPreview;
+        fileWithPreview.preview = URL.createObjectURL(file);
+        (fileWithPreview as any).errors = [];
+        uploadProps.setFiles([fileWithPreview]);
+      });
+    },
+    [uploadProps.setFiles],
+  );
+
   const editor = useCreateBlockNote({
     schema: BLOCK_SCHEMA,
     tables: TABLE_SCHEMA,
     placeholders: {
       default: placeholder || "Type '/' for commands...",
     },
-    uploadFile,
+    uploadFile: uploadFile ?? defaultUploadFile,
+    resolveFileUrl: async (url) => readImage(url),
     ...restArgs,
   });
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -46,7 +46,9 @@ export const useBlockEditor = (args?: {
   const defaultUploadFile = useCallback(
     (file: File): Promise<string> => {
       return new Promise((resolve, reject) => {
-        pendingRef.current?.reject(new Error('Previous upload was interrupted'));
+        pendingRef.current?.reject(
+          new Error('Previous upload was interrupted'),
+        );
         pendingRef.current = { resolve, reject };
         const fileWithPreview = Object.assign(file, {
           preview: URL.createObjectURL(file),

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -28,7 +28,7 @@ export const useBlockEditor = (args?: {
 
   useEffect(() => {
     if (uploadProps.files.length > 0 && !uploadProps.loading) {
-      void uploadProps.onUpload();
+      uploadProps.onUpload().catch(() => {});
     }
   }, [uploadProps.files.length]);
 
@@ -37,9 +37,10 @@ export const useBlockEditor = (args?: {
       return new Promise((resolve, reject) => {
         resolveRef.current = resolve;
         rejectRef.current = reject;
-        const fileWithPreview = file as FileWithPreview;
-        fileWithPreview.preview = URL.createObjectURL(file);
-        (fileWithPreview as any).errors = [];
+        const fileWithPreview = Object.assign(file, {
+          preview: URL.createObjectURL(file),
+          errors: [],
+        }) as FileWithPreview;
         uploadProps.setFiles([fileWithPreview]);
       });
     },
@@ -53,7 +54,7 @@ export const useBlockEditor = (args?: {
       default: placeholder || "Type '/' for commands...",
     },
     uploadFile: uploadFile ?? defaultUploadFile,
-    resolveFileUrl: async (url) => readImage(url),
+    resolveFileUrl: (url) => Promise.resolve(readImage(url)),
     ...restArgs,
   });
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -28,7 +28,11 @@ export const useBlockEditor = (args?: {
 
   useEffect(() => {
     if (uploadProps.files.length > 0 && !uploadProps.loading) {
-      uploadProps.onUpload().catch(() => {});
+      uploadProps.onUpload().catch((err: unknown) => {
+        rejectRef.current?.(
+          err instanceof Error ? err : new Error('Upload failed'),
+        );
+      });
     }
   }, [uploadProps.files.length]);
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -12,35 +12,42 @@ export const useBlockEditor = (args?: {
 }) => {
   const { placeholder, uploadFile, ...restArgs } = args || {};
 
-  const resolveRef = useRef<(url: string) => void>();
-  const rejectRef = useRef<(err: Error) => void>();
+  const pendingRef = useRef<{
+    resolve: (url: string) => void;
+    reject: (err: Error) => void;
+  } | null>(null);
 
   const uploadProps = useErxesUpload({
     maxFiles: 1,
     onFilesAdded: (added) => {
+      const pending = pendingRef.current;
+      if (!pending) return;
+
       if (added[0]?.url) {
-        resolveRef.current?.(added[0].url);
+        pending.resolve(added[0].url);
       } else {
-        rejectRef.current?.(new Error('Upload failed'));
+        pending.reject(new Error('Upload failed'));
       }
+      pendingRef.current = null;
     },
   });
 
   useEffect(() => {
     if (uploadProps.files.length > 0 && !uploadProps.loading) {
       uploadProps.onUpload().catch((err: unknown) => {
-        rejectRef.current?.(
+        pendingRef.current?.reject(
           err instanceof Error ? err : new Error('Upload failed'),
         );
+        pendingRef.current = null;
       });
     }
-  }, [uploadProps.files.length]);
+  }, [uploadProps.files[0]]);
 
   const defaultUploadFile = useCallback(
     (file: File): Promise<string> => {
       return new Promise((resolve, reject) => {
-        resolveRef.current = resolve;
-        rejectRef.current = reject;
+        pendingRef.current?.reject(new Error('Previous upload was interrupted'));
+        pendingRef.current = { resolve, reject };
         const fileWithPreview = Object.assign(file, {
           preview: URL.createObjectURL(file),
           errors: [],

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
@@ -1,14 +1,17 @@
-export const getMentionedUserIds = (content: any) => {
+type InlineContent = { type: string; props: Record<string, string> };
+type BlockLike = { content?: InlineContent[] };
+
+export const getMentionedUserIds = (content: BlockLike[]) => {
   if (!content) return [];
   const mentionedUserIds: string[] = [];
   const flatContent = content
-    .map((block: any) =>
+    .map((block) =>
       Array.isArray(block.content) ? [...block.content] : [],
     )
     .flat();
-  flatContent.forEach((content: any) => {
-    if (content.type === 'mention') {
-      mentionedUserIds.push(content.props._id);
+  flatContent.forEach((item) => {
+    if (item.type === 'mention') {
+      mentionedUserIds.push(item.props._id);
     }
   });
   return mentionedUserIds;

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
@@ -4,9 +4,9 @@ type BlockLike = { content?: InlineContent[] };
 export const getMentionedUserIds = (content: BlockLike[]) => {
   if (!content) return [];
   const mentionedUserIds: string[] = [];
-  const flatContent = content
-    .map((block) => (Array.isArray(block.content) ? [...block.content] : []))
-    .flat();
+  const flatContent = content.flatMap((block) =>
+    Array.isArray(block.content) ? block.content : [],
+  );
   flatContent.forEach((item) => {
     if (item.type === 'mention') {
       mentionedUserIds.push(item.props._id);

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
@@ -5,9 +5,7 @@ export const getMentionedUserIds = (content: BlockLike[]) => {
   if (!content) return [];
   const mentionedUserIds: string[] = [];
   const flatContent = content
-    .map((block) =>
-      Array.isArray(block.content) ? [...block.content] : [],
-    )
+    .map((block) => (Array.isArray(block.content) ? [...block.content] : []))
     .flat();
   flatContent.forEach((item) => {
     if (item.type === 'mention') {

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
@@ -1,7 +1,7 @@
 export const getMentionedUserIds = (content: any) => {
   if (!content) return [];
   const mentionedUserIds: string[] = [];
-  const flatContent = content.map((block: any) => [...block.content]).flat();
+  const flatContent = content.map((block: any) => (Array.isArray(block.content) ? [...block.content] : [])).flat();
   flatContent.forEach((content: any) => {
     if (content.type === 'mention') {
       mentionedUserIds.push(content.props._id);

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/getMentionedUserIds.ts
@@ -1,7 +1,11 @@
 export const getMentionedUserIds = (content: any) => {
   if (!content) return [];
   const mentionedUserIds: string[] = [];
-  const flatContent = content.map((block: any) => (Array.isArray(block.content) ? [...block.content] : [])).flat();
+  const flatContent = content
+    .map((block: any) =>
+      Array.isArray(block.content) ? [...block.content] : [],
+    )
+    .flat();
   flatContent.forEach((content: any) => {
     if (content.type === 'mention') {
       mentionedUserIds.push(content.props._id);

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketFields.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketFields.tsx
@@ -66,8 +66,7 @@ export const TicketFields = ({ ticket }: { ticket: ITicket }) => {
             typeof block === 'object' &&
             block !== null &&
             'id' in block &&
-            'type' in block &&
-            'content' in block,
+            'type' in block,
         )
       ) {
         return parsed as Block[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a custom “file” block with an icon, upload-progress state, and an external download link.
  * Added a full-size image preview modal that opens via double-click or Enter/Space.
* **Refactor**
  * Improved image preview behavior and float styling, with cleaner style injection and accessibility updates.
  * Updated block editor rendering and upload/url resolution to consistently handle image/file URLs in both editor and read-only views.
* **Bug Fixes**
  * Improved resilience when extracting mentioned users from block content.
  * Made description JSON parsing more tolerant of persisted block shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->