### PR TITLE
feat(frontline): add ticket custom properties report

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/ConversationMessages.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/ConversationMessages.ts
@@ -121,6 +121,7 @@ export const loadClass = (models: IModels) => {
         content?: string;
         firstRespondedUserId?: string;
         firstRespondedDate?: Date;
+        assignedUserId?: string;
       } = {};
 
       if (!doc.fromBot && !doc.internal) {
@@ -130,6 +131,10 @@ export const loadClass = (models: IModels) => {
       if (!conversation.firstRespondedUserId) {
         modifier.firstRespondedUserId = userId;
         modifier.firstRespondedDate = new Date();
+      }
+
+      if (userId && !doc.internal && !doc.fromBot && !conversation.assignedUserId) {
+        modifier.assignedUserId = userId;
       }
 
       await models.Conversations.updateConversation(

--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/ConversationMessages.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/ConversationMessages.ts
@@ -133,7 +133,12 @@ export const loadClass = (models: IModels) => {
         modifier.firstRespondedDate = new Date();
       }
 
-      if (userId && !doc.internal && !doc.fromBot && !conversation.assignedUserId) {
+      if (
+        userId &&
+        !doc.internal &&
+        !doc.fromBot &&
+        !conversation.assignedUserId
+      ) {
         modifier.assignedUserId = userId;
       }
 

--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
@@ -103,7 +103,7 @@ export interface IIntegrationModel extends Model<IIntegrationDocument> {
   ): Promise<IIntegrationDocument>;
   integrationsSaveMessengerTicketData(
     _id: string,
-    configId: string,
+    configId?: string,
   ): Promise<IIntegrationDocument>;
   saveMessengerAppearanceData(
     _id: string,
@@ -293,7 +293,7 @@ export const loadClass = (models: IModels, subdomain: string) => {
 
     public static async integrationsSaveMessengerTicketData(
       _id: string,
-      configId: string,
+      configId?: string,
     ) {
       const integration = await models.Integrations.findOne({
         _id: _id,
@@ -301,6 +301,21 @@ export const loadClass = (models: IModels, subdomain: string) => {
       if (!integration) {
         throw new Error('Integration not found');
       }
+
+      if (!configId) {
+        const result = await models.Integrations.updateOne(
+          { _id },
+          { $unset: { ticketConfigId: 1 } },
+          { runValidators: true },
+        );
+
+        if (!result.acknowledged) {
+          throw new Error('Failed to update ticket data');
+        }
+
+        return models.Integrations.findOne({ _id });
+      }
+
       const config = await models.TicketConfig.findOne({ _id: configId });
       if (!config) {
         throw new Error('Config not found');

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/integrations.ts
@@ -652,7 +652,7 @@ export const integrationMutations = {
 
   async integrationsSaveMessengerTicketData(
     _root,
-    { _id, configId }: { _id: string; configId: string },
+    { _id, configId }: { _id: string; configId?: string },
     { models }: IContext,
   ) {
     return models.Integrations.integrationsSaveMessengerTicketData(

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/schemas/integration.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/schemas/integration.ts
@@ -317,5 +317,5 @@ export const mutations = `
 
   integrationsSaveMessengerTicketData(
     _id: String!,
-    configId: String!): Integration
+    configId: String): Integration
 `;

--- a/backend/plugins/frontline_api/src/modules/reports/@types/reportFilters.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/@types/reportFilters.ts
@@ -19,6 +19,7 @@ export type IReportFilters = {
   customerIds?: string[];
   frequency?: string;
   branchIds?: string[];
+  propertyIds?: string[];
 };
 
 export type IReportTagsFilters = {

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/ticketQueries.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/ticketQueries.ts
@@ -217,6 +217,65 @@ export const reportTicketQueries = {
     });
   },
 
+  async reportTicketCustomProperties(
+    _parent: undefined,
+    { filters = {} }: { filters?: IReportFilters },
+    { models, subdomain }: IContext,
+  ) {
+    const matchFilter = buildTicketMatch(filters);
+
+    const pipeline: any[] = [
+      { $match: matchFilter },
+      { $match: { $expr: { $eq: [{ $type: '$propertiesData' }, 'object'] } } },
+      { $addFields: { __properties: { $objectToArray: '$propertiesData' } } },
+      { $unwind: '$__properties' },
+      ...(filters.propertyIds?.length
+        ? [{ $match: { '__properties.k': { $in: filters.propertyIds } } }]
+        : []),
+      { $group: { _id: '$__properties.k', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: filters.limit ?? 100 },
+    ];
+
+    const propertyCounts: Array<{ _id: string; count: number }> =
+      await models.Ticket.aggregate(pipeline);
+
+    if (!propertyCounts.length) {
+      return [];
+    }
+
+    const fieldIds = propertyCounts.map((p) => p._id);
+
+    const fields: Array<{ _id: any; name?: string; text?: string }> =
+      await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        method: 'query',
+        module: 'fields',
+        action: 'find',
+        input: {
+          query: { _id: { $in: fieldIds } },
+        },
+        defaultValue: [],
+      });
+
+    const fieldMap = new Map(
+      fields.map((f) => [f._id.toString(), f.name || f.text]),
+    );
+
+    const resolvedCounts = propertyCounts.filter((p) =>
+      fieldMap.has(p._id?.toString()),
+    );
+    const total = resolvedCounts.reduce((s, p) => s + p.count, 0);
+
+    return resolvedCounts.map((p) => ({
+      _id: p._id,
+      name: fieldMap.get(p._id?.toString()),
+      count: p.count,
+      percentage: calculatePercentage(p.count, total),
+    }));
+  },
+
   async reportTicketStatusSummary(
     _parent: undefined,
     { filters = {} }: { filters?: IReportFilters },

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/schema/ticket.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/schema/ticket.ts
@@ -19,6 +19,7 @@ export const types = `
     customerIds: [String]
     frequency: String
     branchIds: [String]
+    propertyIds: [String]
   }
 
   type ReportTicketMetric {
@@ -39,6 +40,13 @@ export const types = `
     count: Int
     percentage: Int
     colorCode: String
+  }
+
+  type ReportTicketCustomProperty {
+    _id: String
+    name: String
+    count: Int
+    percentage: Int
   }
 
   type TicketDateStat {
@@ -90,6 +98,7 @@ export const queries = `
   reportTicketOpen(filters: TicketReportFilter): ReportTicketMetric
   reportTicketList(filters: TicketReportFilter): TicketListResult
   reportTicketTags(filters: TicketReportFilter): [ReportTicketTag]
+  reportTicketCustomProperties(filters: TicketReportFilter): [ReportTicketCustomProperty]
   reportTicketTotalCount(filters: TicketReportFilter): Int
   reportTicketStatusSummary(filters: TicketReportFilter): [ReportTicketStatusSummary]
   reportTicketPriority(filters: TicketReportFilter): [ReportTicketPriority]

--- a/backend/plugins/frontline_api/src/modules/reports/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/utils.ts
@@ -381,6 +381,14 @@ export function buildTicketMatch(filters: IReportFilters) {
     match.branchId = { $in: filters.branchIds };
   }
 
+  if (filters.propertyIds?.length) {
+    andConditions.push({
+      $or: filters.propertyIds.map((propertyId) => ({
+        [`propertiesData.${propertyId}`]: { $exists: true },
+      })),
+    });
+  }
+
   if (filters.startDate) {
     match.startDate = { $gte: new Date(filters.startDate) };
   }

--- a/frontend/plugins/frontline_ui/src/modules/integrations/erxes-messenger/graphql/mutations/createEmMessengerMutations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/erxes-messenger/graphql/mutations/createEmMessengerMutations.ts
@@ -63,7 +63,7 @@ export const SAVE_EM_APPEARANCE_MUTATION = gql`
 export const SAVE_EM_TICKET_CONFIG_MUTATION = gql`
   mutation IntegrationsSaveMessengerTicketData(
     $_id: String!
-    $configId: String!
+    $configId: String
   ) {
     integrationsSaveMessengerTicketData(_id: $_id, configId: $configId) {
       _id

--- a/frontend/plugins/frontline_ui/src/modules/report/components/filter-popover/ticket-report-filter.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/filter-popover/ticket-report-filter.tsx
@@ -15,9 +15,15 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { MemberFormContent } from '../frontline-card/MemberFormContent';
-import { SelectMember, SelectCustomer, SelectCompany } from 'ui-modules';
+import {
+  SelectMember,
+  SelectCustomer,
+  SelectCompany,
+  useFields,
+} from 'ui-modules';
 import {
   getReportDisplayValue,
   REPORT_FIXED_DATES,
@@ -79,6 +85,9 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
   const [companyFilter, setCompanyFilter] = useAtom(
     getReportCompanyFilterAtom(cardId),
   );
+  const [propertyFilter, setPropertyFilter] = useAtom(
+    getReportPropertyFilterAtom(cardId),
+  );
 
   const { channels } = useGetChannels();
 
@@ -91,7 +100,8 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
       stateFilter ||
       (priorityFilter && priorityFilter.length > 0) ||
       (customerFilter && customerFilter.length > 0) ||
-      (companyFilter && companyFilter.length > 0),
+      (companyFilter && companyFilter.length > 0) ||
+      (propertyFilter && propertyFilter.length > 0),
   );
 
   const handleClear = () => {
@@ -105,6 +115,7 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
     setFrequency('day');
     setCustomerFilter([]);
     setCompanyFilter([]);
+    setPropertyFilter([]);
   };
 
   return (
@@ -125,6 +136,7 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
                 <Filter.Item value="priority">Priority</Filter.Item>
                 <Filter.Item value="customer">Customer</Filter.Item>
                 <Filter.Item value="company">Company</Filter.Item>
+                <Filter.Item value="properties">Properties</Filter.Item>
                 <Filter.Item value="frequency">Frequency</Filter.Item>
                 <Filter.Item value="date">Date</Filter.Item>
                 {hasFilters && (
@@ -218,6 +230,15 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
               >
                 <SelectCompany.Content />
               </SelectCompany.Provider>
+            </Command>
+          </Filter.View>
+
+          <Filter.View filterKey="properties">
+            <Command shouldFilter={false}>
+              <PropertyFilterView
+                value={propertyFilter}
+                onValueChange={setPropertyFilter}
+              />
             </Command>
           </Filter.View>
 
@@ -438,6 +459,60 @@ const PriorityFilterView = ({
           </div>
         </Command.Item>
       ))}
+    </Command.List>
+  );
+};
+
+const PropertyFilterView = ({
+  value,
+  onValueChange,
+}: {
+  value: string[];
+  onValueChange: (value: string[]) => void;
+}) => {
+  const { fields, loading } = useFields({ contentType: 'frontline:ticket' });
+
+  const handleSelect = (id: string) => {
+    if (id === 'all') {
+      onValueChange([]);
+      return;
+    }
+    const isSelected = value.includes(id);
+    onValueChange(isSelected ? value.filter((v) => v !== id) : [...value, id]);
+  };
+
+  return (
+    <Command.List className="max-h-[500px] overflow-y-auto">
+      <BackButton />
+      {loading ? (
+        <Command.Empty>Loading...</Command.Empty>
+      ) : (
+        <>
+          <Command.Item value="all" onSelect={() => handleSelect('all')}>
+            <div className="flex items-center gap-2">
+              {(!value || value.length === 0) && (
+                <IconCheck className="size-4" />
+              )}
+              <span>All Properties</span>
+            </div>
+          </Command.Item>
+          {fields.length === 0 && (
+            <Command.Empty>No custom properties found.</Command.Empty>
+          )}
+          {fields.map((field) => (
+            <Command.Item
+              key={field._id}
+              value={field._id}
+              onSelect={() => handleSelect(field._id)}
+            >
+              <div className="flex items-center gap-2">
+                {value.includes(field._id) && <IconCheck className="size-4" />}
+                <span>{field.name}</span>
+              </div>
+            </Command.Item>
+          ))}
+        </>
+      )}
     </Command.List>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/report/components/filter-popover/ticket-report-filter.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/filter-popover/ticket-report-filter.tsx
@@ -93,15 +93,15 @@ export const TicketReportFilter = ({ cardId }: TicketReportFilterProps) => {
 
   const hasFilters = Boolean(
     (channelFilter && channelFilter.length > 0) ||
-      (memberFilter && memberFilter.length > 0) ||
-      (dateValue && dateValue.length > 0) ||
-      (pipelineFilter && pipelineFilter.length > 0) ||
-      (ticketTagFilter && ticketTagFilter.length > 0) ||
-      stateFilter ||
-      (priorityFilter && priorityFilter.length > 0) ||
-      (customerFilter && customerFilter.length > 0) ||
-      (companyFilter && companyFilter.length > 0) ||
-      (propertyFilter && propertyFilter.length > 0),
+    (memberFilter && memberFilter.length > 0) ||
+    (dateValue && dateValue.length > 0) ||
+    (pipelineFilter && pipelineFilter.length > 0) ||
+    (ticketTagFilter && ticketTagFilter.length > 0) ||
+    stateFilter ||
+    (priorityFilter && priorityFilter.length > 0) ||
+    (customerFilter && customerFilter.length > 0) ||
+    (companyFilter && companyFilter.length > 0) ||
+    (propertyFilter && propertyFilter.length > 0),
   );
 
   const handleClear = () => {

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketCustomProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketCustomProperties.tsx
@@ -470,9 +470,8 @@ export const TicketCustomPropertyRadarChart = memo(
     );
     const maxCount = useMemo(
       () =>
-        Math.ceil(
-          Math.max(...properties.map((p) => p.count || 0), 0) / 10,
-        ) * 10 || 100,
+        Math.ceil(Math.max(...properties.map((p) => p.count || 0), 0) / 10) *
+          10 || 100,
       [properties],
     );
     const maxPct = useMemo(
@@ -573,7 +572,11 @@ export const TicketCustomPropertyTableChart = memo(
     ];
     return (
       <div className="bg-sidebar w-full rounded-lg [&_th]:last-of-type:text-right">
-        <RecordTable.Provider data={properties} columns={columns} className="m-3">
+        <RecordTable.Provider
+          data={properties}
+          columns={columns}
+          className="m-3"
+        >
           <RecordTable.Scroll>
             <RecordTable>
               <RecordTable.Header />

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketCustomProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketCustomProperties.tsx
@@ -1,0 +1,589 @@
+import {
+  Alert,
+  ChartContainer,
+  ChartTooltipContent,
+  cn,
+  RecordTable,
+  RecordTableInlineCell,
+} from 'erxes-ui';
+import { FrontlineCard } from '../frontline-card/FrontlineCard';
+import { useTicketCustomProperties } from '@/report/hooks/useTicketCustomProperties';
+import { SelectChartType } from '../select-chart-type/SelectChartType';
+import { ResponsesChartType, TagData } from '@/report/types';
+import { memo, useMemo, useState, useEffect } from 'react';
+import { useAtom } from 'jotai';
+import {
+  Bar,
+  BarChart,
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { ColumnDef } from '@tanstack/table-core';
+import { type LegendPayload } from 'recharts';
+import { getFilters } from '@/report/utils/dateFilters';
+import { AreaGradient } from '../chart/AreaGradient';
+import { CustomLegendContent } from '../chart/legend';
+import {
+  getReportChartTypeAtom,
+  getReportDateFilterAtom,
+  getReportChannelFilterAtom,
+  getReportMemberFilterAtom,
+  getReportPipelineFilterAtom,
+  getReportStateFilterAtom,
+  getReportPriorityFilterAtom,
+  getReportTicketTagFilterAtom,
+  getReportCustomerFilterAtom,
+  getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
+} from '@/report/states';
+import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
+import {
+  useChartPagination,
+  ChartPagination,
+} from '../chart-pagination/ChartPagination';
+import { ChartExportButton } from '../chart-export/ChartExportButton';
+
+interface TicketCustomPropertiesProps {
+  title: string;
+  colSpan?: 6 | 12;
+  onColSpanChange?: (span: 6 | 12) => void;
+}
+
+export const TicketCustomProperties = ({
+  title,
+  colSpan = 6,
+  onColSpanChange,
+}: TicketCustomPropertiesProps) => {
+  const id = title.toLowerCase().replace(/\s+/g, '-');
+  const [chartType, setChartType] = useAtom(getReportChartTypeAtom(id));
+  const [dateValue] = useAtom(getReportDateFilterAtom(id));
+  const [channelFilter] = useAtom(getReportChannelFilterAtom(id));
+  const [memberFilter] = useAtom(getReportMemberFilterAtom(id));
+  const [pipelineFilter] = useAtom(getReportPipelineFilterAtom(id));
+  const [stateFilter] = useAtom(getReportStateFilterAtom(id));
+  const [priorityFilter] = useAtom(getReportPriorityFilterAtom(id));
+  const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
+  const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
+  const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
+  const [filters, setFilters] = useState(() => getFilters());
+
+  useEffect(() => {
+    setFilters(getFilters(dateValue || undefined));
+  }, [dateValue]);
+
+  const { ticketCustomProperties, loading, error } = useTicketCustomProperties({
+    variables: {
+      filters: {
+        ...filters,
+        channelIds: channelFilter.length ? channelFilter : undefined,
+        memberIds: memberFilter.length ? memberFilter : undefined,
+        pipelineIds: pipelineFilter.length ? pipelineFilter : undefined,
+        state: stateFilter || undefined,
+        priority: priorityFilter.length ? priorityFilter : undefined,
+        tagIds: tagFilter.length ? tagFilter : undefined,
+        customerIds: customerFilter.length ? customerFilter : undefined,
+        companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
+      },
+    },
+  });
+
+  const allProperties = useMemo(
+    () => ticketCustomProperties || [],
+    [ticketCustomProperties],
+  );
+  const {
+    pagedData: properties,
+    page,
+    totalPages,
+    totalCount,
+    handlePrev,
+    handleNext,
+  } = useChartPagination(allProperties);
+
+  const exportColumns = useMemo(
+    () => [
+      { key: 'name' as const, header: 'Custom Property' },
+      { key: 'count' as const, header: 'Count' },
+      {
+        key: 'percentage' as const,
+        header: 'Percentage',
+        format: (v: number) => `${v}%`,
+      },
+    ],
+    [],
+  );
+
+  const filterEl = (
+    <>
+      <TicketReportFilter cardId={id} />
+      <SelectChartType value={chartType} onValueChange={setChartType} />
+      <ChartExportButton
+        data={allProperties}
+        columns={exportColumns}
+        filename="ticket-custom-properties"
+      />
+    </>
+  );
+
+  if (loading) {
+    return (
+      <FrontlineCard
+        id={id}
+        title={title}
+        description="Tickets by custom property"
+        colSpan={colSpan}
+        onColSpanChange={onColSpanChange}
+      >
+        <FrontlineCard.Header filter={filterEl} />
+        <FrontlineCard.Content>
+          <FrontlineCard.Skeleton />
+        </FrontlineCard.Content>
+      </FrontlineCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <FrontlineCard
+        id={id}
+        title={title}
+        description="Tickets by custom property"
+        colSpan={colSpan}
+        onColSpanChange={onColSpanChange}
+      >
+        <FrontlineCard.Content>
+          <Alert variant="destructive">
+            <Alert.Title>Error loading data</Alert.Title>
+            <Alert.Description>{error.message}</Alert.Description>
+          </Alert>
+        </FrontlineCard.Content>
+      </FrontlineCard>
+    );
+  }
+
+  if (!allProperties.length) {
+    return (
+      <FrontlineCard
+        id={id}
+        title={title}
+        description="No ticket custom properties found."
+        colSpan={colSpan}
+        onColSpanChange={onColSpanChange}
+      >
+        <FrontlineCard.Header filter={<TicketReportFilter cardId={id} />} />
+        <FrontlineCard.Content>
+          <FrontlineCard.Empty />
+        </FrontlineCard.Content>
+      </FrontlineCard>
+    );
+  }
+
+  return (
+    <FrontlineCard
+      id={id}
+      title={title}
+      description="Tickets by custom property"
+      colSpan={colSpan}
+      onColSpanChange={onColSpanChange}
+    >
+      <FrontlineCard.Header filter={filterEl} />
+      <FrontlineCard.Content>
+        <div
+          className={cn(
+            { 'p-4': chartType !== ResponsesChartType.Table },
+            'w-full',
+          )}
+        >
+          {chartType === ResponsesChartType.Bar && (
+            <TicketCustomPropertyBarChart properties={properties} />
+          )}
+          {chartType === ResponsesChartType.Line && (
+            <TicketCustomPropertyLineChart properties={properties} />
+          )}
+          {chartType === ResponsesChartType.Pie && (
+            <TicketCustomPropertyPieChart properties={properties} />
+          )}
+          {chartType === ResponsesChartType.Radar && (
+            <TicketCustomPropertyRadarChart properties={properties} />
+          )}
+          {chartType === ResponsesChartType.Table && (
+            <TicketCustomPropertyTableChart properties={properties} />
+          )}
+        </div>
+        <ChartPagination
+          page={page}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          onPrev={handlePrev}
+          onNext={handleNext}
+        />
+      </FrontlineCard.Content>
+    </FrontlineCard>
+  );
+};
+
+const CHART_COLORS = [
+  'var(--chart-50)',
+  'var(--chart-100)',
+  'var(--chart-200)',
+  'var(--chart-300)',
+  'var(--chart-400)',
+  'var(--chart-500)',
+  'var(--chart-600)',
+  'var(--chart-700)',
+  'var(--chart-800)',
+  'var(--chart-900)',
+  'var(--chart-950)',
+];
+
+export const TicketCustomPropertyBarChart = memo(
+  function TicketCustomPropertyBarChart({
+    properties,
+  }: {
+    properties: TagData[];
+  }) {
+    const chartConfig = useMemo(
+      () => ({
+        count: { label: 'Count', color: 'var(--primary)' },
+        percentage: { label: 'Percentage', color: 'var(--success)' },
+      }),
+      [],
+    );
+    const maxCount = useMemo(
+      () => Math.max(...properties.map((p) => p.count || 0), 0),
+      [properties],
+    );
+    const maxPct = useMemo(
+      () => Math.max(...properties.map((p) => p.percentage || 0), 100),
+      [properties],
+    );
+    const scaleFactor = maxCount > 0 && maxPct > 0 ? maxCount / maxPct : 1;
+    const chartData = useMemo(
+      () =>
+        properties.map((p) => ({
+          property: p.name || 'Unknown',
+          count: p.count || 0,
+          percentage: p.percentage || 0,
+          percentageScaled: (p.percentage || 0) * scaleFactor,
+        })),
+      [properties, scaleFactor],
+    );
+    if (!chartData.length) return null;
+    return (
+      <ChartContainer config={chartConfig} className="aspect-video w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" />
+          <XAxis dataKey="property" tickLine={false} axisLine={false} />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            label={{ value: 'Count', angle: -90, position: 'insideLeft' }}
+          />
+          <Bar dataKey="count" fill="var(--primary)" name="Count" />
+          <Bar
+            dataKey="percentageScaled"
+            fill="var(--success)"
+            name="Percentage"
+          />
+          <Legend
+            content={(props: any) => <CustomLegendContent {...props} />}
+          />
+          <Tooltip
+            content={<ChartTooltipContent />}
+            formatter={(v: number, name: string, props: any) =>
+              name === 'Percentage'
+                ? [props.payload.percentage?.toFixed(1) + '%', 'Percentage']
+                : [v, name]
+            }
+          />
+        </BarChart>
+      </ChartContainer>
+    );
+  },
+);
+
+export const TicketCustomPropertyLineChart = memo(
+  function TicketCustomPropertyLineChart({
+    properties,
+  }: {
+    properties: TagData[];
+  }) {
+    const chartConfig = useMemo(
+      () => ({
+        count: { label: 'Count', color: 'var(--primary)' },
+        percentage: { label: 'Percentage', color: 'var(--success)' },
+      }),
+      [],
+    );
+    const chartData = useMemo(
+      () =>
+        properties.map((p) => ({
+          property: p.name || 'Unknown',
+          count: p.count || 0,
+          percentage: p.percentage || 0,
+        })),
+      [properties],
+    );
+    return (
+      <ChartContainer config={chartConfig} className="aspect-video w-full">
+        <AreaChart data={chartData} margin={{ top: 10 }}>
+          <defs>
+            <AreaGradient id="tk-props-primary" color="var(--primary)" />
+            <AreaGradient id="tk-props-success" color="var(--success)" />
+          </defs>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" />
+          <XAxis dataKey="property" tickLine={false} axisLine={false} />
+          <YAxis
+            yAxisId="count"
+            tickLine={false}
+            axisLine={false}
+            label={{ value: 'Count', angle: -90, position: 'insideLeft' }}
+          />
+          <YAxis
+            yAxisId="percentage"
+            orientation="right"
+            tickLine={false}
+            axisLine={false}
+            label={{
+              value: 'Percentage (%)',
+              angle: 90,
+              position: 'insideRight',
+            }}
+          />
+          <Area
+            yAxisId="count"
+            dataKey="count"
+            type="monotone"
+            stroke="var(--primary)"
+            fill="url(#tk-props-primary)"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            strokeLinecap="round"
+          />
+          <Area
+            yAxisId="percentage"
+            dataKey="percentage"
+            type="monotone"
+            stroke="var(--success)"
+            fill="url(#tk-props-success)"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            strokeLinecap="round"
+          />
+          <Legend
+            content={(props: any) => <CustomLegendContent {...props} />}
+          />
+          <Tooltip content={<ChartTooltipContent />} />
+        </AreaChart>
+      </ChartContainer>
+    );
+  },
+);
+
+export const TicketCustomPropertyPieChart = memo(
+  function TicketCustomPropertyPieChart({
+    properties,
+  }: {
+    properties: TagData[];
+  }) {
+    const [hovered, setHovered] = useState<string | undefined>(undefined);
+    const chartConfig = useMemo(
+      () => ({ count: { label: 'Count', color: 'var(--primary)' } }),
+      [],
+    );
+    const chartData = useMemo(
+      () =>
+        properties.map((p, i) => ({
+          property: p.name || 'Unknown',
+          count: p.count || 0,
+          fill: CHART_COLORS[i % CHART_COLORS.length],
+        })),
+      [properties],
+    );
+    return (
+      <ChartContainer config={chartConfig} className="aspect-video w-full">
+        <PieChart>
+          <Pie
+            dataKey="count"
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            outerRadius={100}
+            innerRadius={70}
+            nameKey="property"
+          >
+            {chartData.map((item, i) => (
+              <Cell
+                key={i}
+                fill={item.fill}
+                opacity={hovered && hovered !== item.property ? 0.5 : 1}
+              />
+            ))}
+          </Pie>
+          <Legend
+            content={(props: any) => (
+              <CustomLegendContent
+                {...props}
+                onMouseEnter={(d: LegendPayload) =>
+                  setHovered(d.value as string)
+                }
+                onMouseLeave={() => setHovered(undefined)}
+              />
+            )}
+          />
+          <Tooltip content={<ChartTooltipContent />} />
+        </PieChart>
+      </ChartContainer>
+    );
+  },
+);
+
+export const TicketCustomPropertyRadarChart = memo(
+  function TicketCustomPropertyRadarChart({
+    properties,
+  }: {
+    properties: TagData[];
+  }) {
+    const chartConfig = useMemo(
+      () => ({
+        count: { label: 'Count', color: 'var(--primary)' },
+        percentage: { label: 'Percentage', color: 'var(--success)' },
+      }),
+      [],
+    );
+    const maxCount = useMemo(
+      () =>
+        Math.ceil(
+          Math.max(...properties.map((p) => p.count || 0), 0) / 10,
+        ) * 10 || 100,
+      [properties],
+    );
+    const maxPct = useMemo(
+      () => Math.max(...properties.map((p) => p.percentage || 0), 100),
+      [properties],
+    );
+    const scaleFactor = maxCount > 0 && maxPct > 0 ? maxCount / maxPct : 1;
+    const chartData = useMemo(
+      () =>
+        properties.map((p) => ({
+          property: p.name || 'Unknown',
+          count: p.count || 0,
+          percentage: (p.percentage || 0) * scaleFactor,
+          percentageOriginal: p.percentage || 0,
+        })),
+      [properties, scaleFactor],
+    );
+    return (
+      <ChartContainer config={chartConfig} className="aspect-video w-full">
+        <RadarChart data={chartData}>
+          <PolarGrid />
+          <PolarAngleAxis
+            dataKey="property"
+            tickLine={false}
+            tick={{ fontSize: 12 }}
+          />
+          <PolarRadiusAxis
+            angle={90}
+            domain={[0, maxCount]}
+            tick={false}
+            axisLine={false}
+          />
+          <Radar
+            name="Count"
+            dataKey="count"
+            stroke="var(--primary)"
+            fill="var(--primary)"
+            fillOpacity={0.3}
+          />
+          <Radar
+            name="Percentage"
+            dataKey="percentage"
+            stroke="var(--success)"
+            fill="var(--success)"
+            fillOpacity={0.3}
+          />
+          <Legend
+            content={(props: any) => <CustomLegendContent {...props} />}
+          />
+          <Tooltip
+            content={<ChartTooltipContent />}
+            formatter={(v: number, name: string, props: any) =>
+              name === 'Percentage'
+                ? [
+                    props.payload.percentageOriginal?.toFixed(1) + '%',
+                    'Percentage',
+                  ]
+                : [v, name]
+            }
+          />
+        </RadarChart>
+      </ChartContainer>
+    );
+  },
+);
+
+export const TicketCustomPropertyTableChart = memo(
+  function TicketCustomPropertyTableChart({
+    properties,
+  }: {
+    properties: TagData[];
+  }) {
+    const columns: ColumnDef<TagData>[] = [
+      {
+        id: 'name',
+        header: 'Custom Property',
+        accessorKey: 'name',
+        cell: ({ cell }) => (
+          <RecordTableInlineCell className="px-4 text-xs">
+            {cell.getValue() as string}
+          </RecordTableInlineCell>
+        ),
+      },
+      {
+        id: 'count',
+        header: 'Data',
+        accessorKey: 'count',
+        size: 28,
+        cell: ({ cell }) => {
+          const { count, percentage } = cell.row.original || {};
+          return (
+            <RecordTableInlineCell className="px-3 text-xs flex items-center justify-end text-muted-foreground">
+              {count} / {percentage}%
+            </RecordTableInlineCell>
+          );
+        },
+      },
+    ];
+    return (
+      <div className="bg-sidebar w-full rounded-lg [&_th]:last-of-type:text-right">
+        <RecordTable.Provider data={properties} columns={columns} className="m-3">
+          <RecordTable.Scroll>
+            <RecordTable>
+              <RecordTable.Header />
+              <RecordTable.Body>
+                <RecordTable.RowList />
+              </RecordTable.Body>
+            </RecordTable>
+          </RecordTable.Scroll>
+        </RecordTable.Provider>
+      </div>
+    );
+  },
+);

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketList.tsx
@@ -29,6 +29,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 import { ColumnDef, Cell } from '@tanstack/react-table';
@@ -59,6 +60,7 @@ export const TicketList = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
   const [page, setPage] = useState(1);
   const { fetchExport, loading: exportLoading } = useTicketExport();
@@ -79,6 +81,7 @@ export const TicketList = ({
     tagFilter,
     customerFilter,
     companyFilter,
+    propertyFilter,
   ]);
 
   const { ticketList, isInitialLoad, isFetching, error } = useTicketList({
@@ -95,6 +98,7 @@ export const TicketList = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
       },
     },
   });
@@ -116,6 +120,7 @@ export const TicketList = ({
           tagIds: tagFilter.length ? tagFilter : undefined,
           customerIds: customerFilter.length ? customerFilter : undefined,
           companyIds: companyFilter.length ? companyFilter : undefined,
+          propertyIds: propertyFilter.length ? propertyFilter : undefined,
         },
       },
     });
@@ -136,6 +141,7 @@ export const TicketList = ({
     tagFilter,
     customerFilter,
     companyFilter,
+    propertyFilter,
   ]);
 
   const filterEl = useMemo(

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketOpenDate.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketOpenDate.tsx
@@ -48,6 +48,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 import {
@@ -83,6 +84,7 @@ export const TicketOpenDate = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
 
   useEffect(() => {
@@ -101,6 +103,7 @@ export const TicketOpenDate = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
         frequency,
       },
     },

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketSource.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketSource.tsx
@@ -47,6 +47,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 import {
@@ -77,6 +78,7 @@ export const TicketSource = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
 
   useEffect(() => {
@@ -95,6 +97,7 @@ export const TicketSource = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
       },
     },
   });

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketStatusSummary.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketStatusSummary.tsx
@@ -44,6 +44,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 import { type LegendPayload } from 'recharts';
@@ -71,6 +72,7 @@ export const TicketStatusSummary = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
 
   useEffect(() => {
@@ -89,6 +91,7 @@ export const TicketStatusSummary = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
       },
     },
   });

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketTags.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketTags.tsx
@@ -47,6 +47,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 import {
@@ -77,6 +78,7 @@ export const TicketTags = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
 
   useEffect(() => {
@@ -95,6 +97,7 @@ export const TicketTags = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
       },
     },
   });

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketTotalCount.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketTotalCount.tsx
@@ -14,6 +14,7 @@ import {
   getReportTicketTagFilterAtom,
   getReportCustomerFilterAtom,
   getReportCompanyFilterAtom,
+  getReportPropertyFilterAtom,
 } from '@/report/states';
 import { TicketReportFilter } from '../filter-popover/ticket-report-filter';
 
@@ -38,6 +39,7 @@ export const TicketTotalCount = ({
   const [tagFilter] = useAtom(getReportTicketTagFilterAtom(id));
   const [customerFilter] = useAtom(getReportCustomerFilterAtom(id));
   const [companyFilter] = useAtom(getReportCompanyFilterAtom(id));
+  const [propertyFilter] = useAtom(getReportPropertyFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
 
   useEffect(() => {
@@ -56,6 +58,7 @@ export const TicketTotalCount = ({
         tagIds: tagFilter.length ? tagFilter : undefined,
         customerIds: customerFilter.length ? customerFilter : undefined,
         companyIds: companyFilter.length ? companyFilter : undefined,
+        propertyIds: propertyFilter.length ? propertyFilter : undefined,
       },
     },
   });

--- a/frontend/plugins/frontline_ui/src/modules/report/graphql/queries/getTicketChart.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/graphql/queries/getTicketChart.ts
@@ -23,6 +23,17 @@ export const GET_TICKET_TAGS = gql`
   }
 `;
 
+export const GET_TICKET_CUSTOM_PROPERTIES = gql`
+  query ReportTicketCustomProperties($filters: TicketReportFilter) {
+    reportTicketCustomProperties(filters: $filters) {
+      _id
+      name
+      count
+      percentage
+    }
+  }
+`;
+
 export const GET_TICKET_DATE = gql`
   query ReportTicketDate($filters: TicketReportFilter) {
     reportTicketDate(filters: $filters) {

--- a/frontend/plugins/frontline_ui/src/modules/report/hooks/useTicketCustomProperties.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/hooks/useTicketCustomProperties.ts
@@ -1,0 +1,28 @@
+import { QueryHookOptions, useQuery } from '@apollo/client';
+import { GET_TICKET_CUSTOM_PROPERTIES } from '@/report/graphql/queries/getTicketChart';
+
+interface TicketCustomProperty {
+  _id: string;
+  name: string;
+  count: number;
+  percentage: number;
+}
+
+interface TicketCustomPropertiesResponse {
+  reportTicketCustomProperties: TicketCustomProperty[];
+}
+
+export const useTicketCustomProperties = (
+  options?: QueryHookOptions<TicketCustomPropertiesResponse>,
+) => {
+  const { data, loading, error } = useQuery<TicketCustomPropertiesResponse>(
+    GET_TICKET_CUSTOM_PROPERTIES,
+    options,
+  );
+
+  return {
+    ticketCustomProperties: data?.reportTicketCustomProperties,
+    loading,
+    error,
+  };
+};

--- a/frontend/plugins/frontline_ui/src/modules/report/states.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/states.ts
@@ -260,3 +260,23 @@ export const getReportCompanyFilterAtom = (cardId: string) =>
       },
     ),
   );
+
+export const reportPropertyFilterState = atom<Record<string, string[]>>({});
+
+const propertyFilterAtomCache = new Map<
+  string,
+  WritableAtom<string[], [string[]], void>
+>();
+
+export const getReportPropertyFilterAtom = (cardId: string) =>
+  getOrCreate(propertyFilterAtomCache, cardId, () =>
+    atom(
+      (get) => get(reportPropertyFilterState)[cardId] || [],
+      (get, set, newValue: string[]) => {
+        set(reportPropertyFilterState, {
+          ...get(reportPropertyFilterState),
+          [cardId]: newValue,
+        });
+      },
+    ),
+  );

--- a/frontend/plugins/frontline_ui/src/modules/report/types/component-registry.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/types/component-registry.ts
@@ -98,6 +98,13 @@ export const ticketReportComponents: Record<
       default: module.TicketList,
     })),
   ),
+  'ticket-custom-properties': lazy(() =>
+    import('@/report/components/ticket-charts/TicketCustomProperties').then(
+      (module) => ({
+        default: module.TicketCustomProperties,
+      }),
+    ),
+  ),
   'ticket-status-summary': lazy(() =>
     import('@/report/components/ticket-charts/TicketStatusSummary').then(
       (module) => ({
@@ -115,6 +122,11 @@ export const TICKET_DEFAULT_CARD_CONFIGS: Omit<
   { id: 'ticket-date', title: 'Ticket Date', colSpan: 6 },
   { id: 'ticket-source', title: 'Ticket Source', colSpan: 6 },
   { id: 'ticket-tags', title: 'Ticket Tags', colSpan: 6 },
+  {
+    id: 'ticket-custom-properties',
+    title: 'Ticket Custom Properties',
+    colSpan: 6,
+  },
   { id: 'ticket-list', title: 'Ticket List', colSpan: 12 },
 ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Ticket Custom Properties” report card with bar/line/pie/radar/table visualizations, showing counts and percentages.
  * Added a “Properties” filter to ticket reporting to select one or more custom property IDs; it applies across charts and exports.
* **Improvements**
  * Messenger ticket configuration now supports an optional/cleared configId.
  * Conversation assignment is now automatically set when applicable for incoming non-bot messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->