### PR TITLE
fix(blocknote): gallery concurrent upload race condition and image display

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -7,7 +7,13 @@ import {
   createReactBlockSpec,
   ReactCustomBlockRenderProps,
 } from '@blocknote/react';
-import { IconLayoutGrid, IconPhoto, IconPlus, IconX, IconLoader2 } from '@tabler/icons-react';
+import {
+  IconLayoutGrid,
+  IconPhoto,
+  IconPlus,
+  IconX,
+  IconLoader2,
+} from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
 import { readImage } from '../../../utils/core';
@@ -78,7 +84,9 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
   };
 
   const removeImage = (index: number) => {
-    updateBlock({ images: JSON.stringify(images.filter((_, i) => i !== index)) });
+    updateBlock({
+      images: JSON.stringify(images.filter((_, i) => i !== index)),
+    });
   };
 
   const setColumns = (n: number) => {
@@ -158,7 +166,13 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
               ) : (
                 <IconPlus size={15} />
               )}
-              <span>{uploading ? 'Uploading...' : images.length === 0 ? 'Add images to gallery' : 'Add more'}</span>
+              <span>
+                {uploading
+                  ? 'Uploading...'
+                  : images.length === 0
+                    ? 'Add images to gallery'
+                    : 'Add more'}
+              </span>
             </button>
           ) : (
             images.length === 0 && (
@@ -219,11 +233,20 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
       {images.map((img, i) =>
         img.caption ? (
           <figure key={i} style={{ margin: 0 }}>
-            <img src={img.url} alt={img.caption} style={{ width: '100%', height: 'auto', display: 'block' }} />
+            <img
+              src={img.url}
+              alt={img.caption}
+              style={{ width: '100%', height: 'auto', display: 'block' }}
+            />
             <figcaption>{img.caption}</figcaption>
           </figure>
         ) : (
-          <img key={i} src={img.url} alt="" style={{ width: '100%', height: 'auto', display: 'block' }} />
+          <img
+            key={i}
+            src={img.url}
+            alt=""
+            style={{ width: '100%', height: 'auto', display: 'block' }}
+          />
         ),
       )}
     </div>

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -234,7 +234,7 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
         img.caption ? (
           <figure key={i} style={{ margin: 0 }}>
             <img
-              src={img.url}
+              src={readImage(img.url)}
               alt={img.caption}
               style={{ width: '100%', height: 'auto', display: 'block' }}
             />
@@ -243,7 +243,7 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
         ) : (
           <img
             key={i}
-            src={img.url}
+            src={readImage(img.url)}
             alt=""
             style={{ width: '100%', height: 'auto', display: 'block' }}
           />

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -10,6 +10,7 @@ import {
 import { IconLayoutGrid, IconPhoto, IconPlus, IconX, IconLoader2 } from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
+import { readImage } from '../../../utils/core';
 
 export interface GalleryImage {
   url: string;
@@ -99,7 +100,7 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
               className="relative group aspect-square overflow-hidden rounded-md bg-muted"
             >
               <img
-                src={img.url}
+                src={readImage(img.url)}
                 alt={img.caption ?? ''}
                 className="w-full h-full object-cover"
                 draggable={false}

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -52,8 +52,12 @@ export const useBlockEditor = (args?: {
 
       const promise = queueRef.current.then(runUpload);
       queueRef.current = promise.then(
-        () => { uploadProps.setFiles([]); },
-        () => { uploadProps.setFiles([]); },
+        () => {
+          uploadProps.setFiles([]);
+        },
+        () => {
+          uploadProps.setFiles([]);
+        },
       );
       return promise;
     },

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -14,6 +14,7 @@ export const useBlockEditor = (args?: {
 
   const resolveRef = useRef<(url: string) => void>();
   const rejectRef = useRef<(err: Error) => void>();
+  const queueRef = useRef<Promise<void>>(Promise.resolve());
 
   const uploadProps = useErxesUpload({
     maxFiles: 1,
@@ -38,15 +39,23 @@ export const useBlockEditor = (args?: {
 
   const defaultUploadFile = useCallback(
     (file: File): Promise<string> => {
-      return new Promise((resolve, reject) => {
-        resolveRef.current = resolve;
-        rejectRef.current = reject;
-        const fileWithPreview = Object.assign(file, {
-          preview: URL.createObjectURL(file),
-          errors: [],
-        }) as FileWithPreview;
-        uploadProps.setFiles([fileWithPreview]);
-      });
+      const runUpload = () =>
+        new Promise<string>((resolve, reject) => {
+          resolveRef.current = resolve;
+          rejectRef.current = reject;
+          const fileWithPreview = Object.assign(file, {
+            preview: URL.createObjectURL(file),
+            errors: [],
+          }) as FileWithPreview;
+          uploadProps.setFiles([fileWithPreview]);
+        });
+
+      const promise = queueRef.current.then(runUpload);
+      queueRef.current = promise.then(
+        () => { uploadProps.setFiles([]); },
+        () => { uploadProps.setFiles([]); },
+      );
+      return promise;
     },
     [uploadProps.setFiles],
   );


### PR DESCRIPTION
## Summary by Sourcery

Serialize gallery image uploads in the block editor to avoid race conditions and ensure correct cleanup, and adjust gallery image rendering to use the shared image reader helper.

Bug Fixes:
- Prevent concurrent gallery uploads from interfering with each other by queuing uploads and clearing the upload file list after each completes.
- Ensure gallery block images display correctly by resolving image URLs through the common readImage utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where overlapping upload operations could interfere with each other by serializing uploads in a queue.
  * Improved gallery rendering so inline editor previews load images correctly, and captioned/non-captioned images display appropriate `alt` text and markup consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->