### PR TITLE
feat(agent-chat): per-conversation thinking level control

### DIFF
--- a/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
@@ -1,0 +1,55 @@
+import { buildReasoningProviderOptions, isReasoningEffort } from '../providers';
+
+describe('isReasoningEffort', () => {
+  it('accepts the four levels', () => {
+    for (const v of ['off', 'low', 'medium', 'high']) {
+      expect(isReasoningEffort(v)).toBe(true);
+    }
+  });
+
+  it('rejects anything else', () => {
+    for (const v of ['auto', 'HIGH', '', 1, null, undefined, {}]) {
+      expect(isReasoningEffort(v)).toBe(false);
+    }
+  });
+});
+
+describe('buildReasoningProviderOptions', () => {
+  it('returns undefined when effort is unset (default behaviour)', () => {
+    expect(buildReasoningProviderOptions('openai')).toBeUndefined();
+    expect(buildReasoningProviderOptions('anthropic')).toBeUndefined();
+  });
+
+  it('returns undefined for providers without a known reasoning knob', () => {
+    expect(buildReasoningProviderOptions('groq', 'high')).toBeUndefined();
+    expect(buildReasoningProviderOptions('kimi', 'high')).toBeUndefined();
+    expect(buildReasoningProviderOptions('mistral', 'low')).toBeUndefined();
+  });
+
+  it('maps OpenAI effort, collapsing off to minimal', () => {
+    expect(buildReasoningProviderOptions('openai', 'high')).toEqual({
+      openai: { reasoningEffort: 'high' },
+    });
+    expect(buildReasoningProviderOptions('openai', 'off')).toEqual({
+      openai: { reasoningEffort: 'minimal' },
+    });
+  });
+
+  it('maps Anthropic to a thinking budget, disabling on off', () => {
+    expect(buildReasoningProviderOptions('anthropic', 'medium')).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 8192 } },
+    });
+    expect(buildReasoningProviderOptions('anthropic', 'off')).toEqual({
+      anthropic: { thinking: { type: 'disabled' } },
+    });
+  });
+
+  it('maps Google to a thinking budget, zero on off', () => {
+    expect(buildReasoningProviderOptions('google', 'low')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 2048 } },
+    });
+    expect(buildReasoningProviderOptions('google', 'off')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 0 } },
+    });
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/providers.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/providers.ts
@@ -135,6 +135,79 @@ export const PROVIDER_PRESETS: Array<{
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Reasoning effort → per-provider stream options.
+//
+// The chat view lets power users dial how hard the model "thinks" per
+// conversation. Each provider exposes this differently, so we translate a
+// single enum into the option each SDK understands. Unset effort (or a
+// provider we don't have a mapping for) yields no options — the agent's
+// configured default stands, exactly as before this feature existed.
+// ---------------------------------------------------------------------------
+export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
+const REASONING_EFFORTS: ReasoningEffort[] = ['off', 'low', 'medium', 'high'];
+
+/** Type guard for the reasoning-effort enum — validates untrusted request input. */
+export function isReasoningEffort(v: unknown): v is ReasoningEffort {
+  return (
+    typeof v === 'string' && REASONING_EFFORTS.includes(v as ReasoningEffort)
+  );
+}
+
+// Anthropic / Google take an explicit thinking-token budget. 'off' disables
+// reasoning where the provider supports it.
+const THINKING_BUDGET: Record<Exclude<ReasoningEffort, 'off'>, number> = {
+  low: 2048,
+  medium: 8192,
+  high: 16384,
+};
+
+/**
+ * Translate a reasoning-effort choice into the `providerOptions` block for the
+ * agent's provider. Returns `undefined` when there's nothing to apply (unset
+ * effort, or a provider without a known reasoning knob) so callers can spread
+ * it without touching the default behaviour.
+ */
+export function buildReasoningProviderOptions(
+  providerName: string,
+  effort?: ReasoningEffort,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!effort) return undefined;
+
+  switch (providerName) {
+    case 'openai':
+      // gpt-5 / o-series accept 'minimal' | 'low' | 'medium' | 'high'.
+      return {
+        openai: { reasoningEffort: effort === 'off' ? 'minimal' : effort },
+      };
+    case 'anthropic':
+      return {
+        anthropic:
+          effort === 'off'
+            ? { thinking: { type: 'disabled' } }
+            : {
+                thinking: {
+                  type: 'enabled',
+                  budgetTokens: THINKING_BUDGET[effort],
+                },
+              },
+      };
+    case 'google':
+      return {
+        google: {
+          thinkingConfig: {
+            thinkingBudget: effort === 'off' ? 0 : THINKING_BUDGET[effort],
+          },
+        },
+      };
+    default:
+      // groq / mistral / cohere / OpenAI-compatible providers (Kimi, NVIDIA):
+      // no portable reasoning knob — leave the model's default in place.
+      return undefined;
+  }
+}
+
 // What buildModel hands to Agent: a Mastra model config. A bare string ref
 // ("openai/gpt-4o") when the registry resolves the key from env, or a config
 // object — `{ id, apiKey }` for native providers with a DB-stored key, or

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -9,6 +9,10 @@ import {
   summarizeActivity,
 } from './mastra/activity';
 import { toolStatusLine } from './mastra/activity-signals';
+import {
+  isReasoningEffort,
+  buildReasoningProviderOptions,
+} from './mastra/providers';
 import { runWithAuth } from './mastra/requestContext';
 import { isAdvancedMemoryEnabled } from './mastra/memory/config';
 import { scopedResource } from './mastra/memory/mastraMemory';
@@ -209,6 +213,14 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     return res.status(400).json({ error: 'threadId must be a string' });
   }
 
+  // Optional per-conversation reasoning override from the chat composer.
+  const reasoningEffort = req.body?.reasoningEffort;
+  if (reasoningEffort !== undefined && !isReasoningEffort(reasoningEffort)) {
+    return res
+      .status(400)
+      .json({ error: 'reasoningEffort must be off | low | medium | high' });
+  }
+
   const attachments = sanitizeAttachments(req.body?.attachments);
   if (attachments === null) {
     return res.status(400).json({ error: 'Invalid attachments payload' });
@@ -350,9 +362,17 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
 
     try {
       await runWithAuth(authCtx, async () => {
+        // Per-conversation reasoning override → provider-specific options.
+        // Providers without a portable reasoning knob yield undefined, so the
+        // model's configured default stands untouched.
+        const reasoningOptions = buildReasoningProviderOptions(
+          prepared.agentConfig.provider,
+          reasoningEffort,
+        );
         const stream = await agent.stream(convo, {
           abortSignal: controller.signal,
           ...(memoryBinding ? { memory: memoryBinding } : {}),
+          ...(reasoningOptions ? { providerOptions: reasoningOptions } : {}),
         });
 
         for await (const chunk of stream.fullStream as AsyncIterable<unknown>) {

--- a/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/chat/ChatPage.tsx
@@ -24,13 +24,16 @@ import {
   IconFileUpload,
   IconThumbUp,
   IconThumbDown,
+  IconBrain,
 } from '@tabler/icons-react';
 import {
   Badge,
   Breadcrumb,
   Button,
   ChatVizMessage,
+  Command,
   Empty,
+  Popover,
   REACT_APP_API_URL,
   Separator,
   Skeleton,
@@ -48,6 +51,8 @@ import {
   ChatAttachment,
   Message,
   ToolCallInfo,
+  ReasoningEffort,
+  REASONING_EFFORT_OPTIONS,
 } from './chatStore';
 import './chat.css';
 
@@ -620,6 +625,134 @@ const WaitingIndicator = () => (
     </div>
   </div>
 );
+
+const REASONING_PICKER_ITEMS: {
+  value?: ReasoningEffort;
+  label: string;
+  hint: string;
+}[] = [
+  { value: undefined, label: 'Auto', hint: "Use the agent's default" },
+  ...REASONING_EFFORT_OPTIONS,
+];
+
+/** One selectable row in the reasoning-level picker (kept separate so the menu
+ * JSX tree stays shallow). */
+const ReasoningOption = ({
+  label,
+  hint,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  hint: string;
+  selected: boolean;
+  onSelect: () => void;
+}) => (
+  <Command.Item
+    value={label}
+    onSelect={onSelect}
+    className="h-auto cursor-pointer items-start gap-2 rounded-lg px-2.5 py-2"
+  >
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <span
+        className={`text-sm leading-none ${
+          selected ? 'font-medium text-foreground' : 'text-foreground/90'
+        }`}
+      >
+        {label}
+      </span>
+      <span className="text-[11px] leading-snug text-muted-foreground">
+        {hint}
+      </span>
+    </div>
+    <IconCheck
+      className={`mt-0.5 shrink-0 text-muted-foreground transition-opacity ${
+        selected ? 'opacity-100' : 'opacity-0'
+      }`}
+    />
+  </Command.Item>
+);
+
+/**
+ * A deliberately low-key composer control: a ghost "brain" icon that opens a
+ * small level picker. Hidden in plain sight — most users never touch it, power
+ * users can dial reasoning up or down per conversation. The choice persists per
+ * agent (localStorage) and is unset by default, leaving the agent's configured
+ * behaviour untouched.
+ */
+const ReasoningEffortControl = ({
+  value,
+  onChange,
+  disabled,
+}: {
+  value?: ReasoningEffort;
+  onChange: (effort?: ReasoningEffort) => void;
+  disabled?: boolean;
+}) => {
+  const [open, setOpen] = useState(false);
+  const active = Boolean(value);
+  const activeLabel = REASONING_EFFORT_OPTIONS.find(
+    (o) => o.value === value,
+  )?.label;
+
+  /** Apply a level and close the popover. */
+  const select = (effort?: ReasoningEffort) => {
+    onChange(effort);
+    setOpen(false);
+  };
+
+  // Extracted so the trigger's own element chain doesn't deepen the tree below.
+  const trigger = (
+    <Popover.Trigger asChild>
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="Thinking level"
+        disabled={disabled}
+        className={`size-9 shrink-0 transition-colors hover:text-foreground ${
+          active ? 'text-foreground' : 'text-muted-foreground'
+        }`}
+      >
+        <IconBrain className="size-4" />
+      </Button>
+    </Popover.Trigger>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip.Provider>
+        <Tooltip>
+          <Tooltip.Trigger asChild>{trigger}</Tooltip.Trigger>
+          <Tooltip.Content>
+            {active ? `Thinking: ${activeLabel}` : 'Thinking level'}
+          </Tooltip.Content>
+        </Tooltip>
+      </Tooltip.Provider>
+      <Popover.Content
+        align="start"
+        sideOffset={8}
+        className="w-60 overflow-hidden p-0"
+      >
+        <div className="px-3 pb-1.5 pt-2.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+          Thinking level
+        </div>
+        <Command shouldFilter={false}>
+          <Command.List className="px-1 pb-1">
+            {REASONING_PICKER_ITEMS.map((opt) => (
+              <ReasoningOption
+                key={opt.value ?? 'auto'}
+                label={opt.label}
+                hint={opt.hint}
+                selected={(opt.value ?? undefined) === (value ?? undefined)}
+                onSelect={() => select(opt.value)}
+              />
+            ))}
+          </Command.List>
+        </Command>
+      </Popover.Content>
+    </Popover>
+  );
+};
 
 // ─── Thinking section ────────────────────────────────────────────────────────
 //
@@ -1695,6 +1828,14 @@ export const ChatPage = () => {
                           </Tooltip.Provider>
                         </>
                       )}
+                      <ReasoningEffortControl
+                        value={state?.reasoningEffort}
+                        disabled={chatLoading}
+                        onChange={(effort) => {
+                          if (agentId)
+                            chatStore.setReasoningEffort(agentId, effort);
+                        }}
+                      />
                       <Textarea
                         ref={textareaRef}
                         value={input}

--- a/frontend/plugins/erxes-agent_ui/src/pages/chat/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/pages/chat/chatStore.ts
@@ -98,11 +98,50 @@ const EMPTY_THREAD: ThreadChatState = {
   messagesLoading: false,
 };
 
+// How hard the model should think before answering. Unset = let the agent's
+// configured default stand (current behaviour). The chat view exposes this
+// behind a low-key composer control for power users; the backend maps it to
+// the right per-provider reasoning option at stream time.
+export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
+export const REASONING_EFFORT_OPTIONS: {
+  value: ReasoningEffort;
+  label: string;
+  hint: string;
+}[] = [
+  { value: 'off', label: 'Off', hint: 'Answer directly, no reasoning' },
+  { value: 'low', label: 'Low', hint: 'Brief reasoning, fastest' },
+  { value: 'medium', label: 'Medium', hint: 'Balanced reasoning' },
+  { value: 'high', label: 'High', hint: 'Deep reasoning, slowest' },
+];
+
+const REASONING_EFFORT_VALUES = REASONING_EFFORT_OPTIONS.map((o) => o.value);
+
+/** localStorage key holding the persisted reasoning choice for one agent. */
+function reasoningEffortStorageKey(agentKey: string) {
+  return `erxes-agent:reasoningEffort:${agentKey}`;
+}
+
+// Best-effort read of the persisted choice — localStorage may be unavailable
+// (private mode / SSR) and may hold stale values from an older enum.
+function loadReasoningEffort(agentKey: string): ReasoningEffort | undefined {
+  try {
+    const raw = localStorage.getItem(reasoningEffortStorageKey(agentKey));
+    return raw && REASONING_EFFORT_VALUES.includes(raw as ReasoningEffort)
+      ? (raw as ReasoningEffort)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export interface AgentChatState {
   sessions: SessionMeta[];
   sessionsLoaded: boolean;
   activeThreadId?: string;
   isDraft: boolean; // active session is new and not yet persisted
+  // Power-user reasoning override for this agent's chat view. Unset = default.
+  reasoningEffort?: ReasoningEffort;
 }
 
 const EMPTY_AGENT: AgentChatState = {
@@ -110,6 +149,7 @@ const EMPTY_AGENT: AgentChatState = {
   sessionsLoaded: false,
   activeThreadId: undefined,
   isDraft: false,
+  reasoningEffort: undefined,
 };
 
 // What ChatPage renders: agent-level session state + the active thread's view.
@@ -173,10 +213,25 @@ class ChatStore {
   private ensureAgent(agentKey: string): AgentChatState {
     let state = this.agents.get(agentKey);
     if (!state) {
-      state = { ...EMPTY_AGENT };
+      state = {
+        ...EMPTY_AGENT,
+        reasoningEffort: loadReasoningEffort(agentKey),
+      };
       this.agents.set(agentKey, state);
     }
     return state;
+  }
+
+  // Persist the power-user reasoning choice for this agent's chat view.
+  setReasoningEffort(agentKey: string, effort: ReasoningEffort | undefined) {
+    try {
+      const key = reasoningEffortStorageKey(agentKey);
+      if (effort) localStorage.setItem(key, effort);
+      else localStorage.removeItem(key);
+    } catch {
+      // localStorage unavailable — the in-memory patch below still applies.
+    }
+    this.patchAgent(agentKey, { reasoningEffort: effort });
   }
 
   private patchAgent(agentKey: string, partial: Partial<AgentChatState>) {
@@ -223,6 +278,8 @@ class ChatStore {
       : EMPTY_THREAD;
     return {
       ...agent,
+      // Surface the persisted choice even before the agent state is created.
+      reasoningEffort: agent.reasoningEffort ?? loadReasoningEffort(agentKey),
       messages: thread.messages,
       loading: thread.loading,
       messagesLoading: thread.messagesLoading,
@@ -528,6 +585,7 @@ class ChatStore {
       agent = this.ensureAgent(agentKey);
     }
     const threadId = agent.activeThreadId!;
+    const reasoningEffort = agent.reasoningEffort;
 
     // Optimistically show the user message — in this thread only.
     this.appendMessage(agentKey, threadId, {
@@ -548,6 +606,7 @@ class ChatStore {
         message,
         abort,
         attachments,
+        reasoningEffort,
       );
       // Stream transport unavailable (older gateway/plugin) — degrade to the
       // blocking GraphQL query.
@@ -606,6 +665,7 @@ class ChatStore {
     message: string,
     abort: AbortController,
     attachments?: ChatAttachment[],
+    reasoningEffort?: ReasoningEffort,
   ): Promise<boolean> {
     let response: Response;
     try {
@@ -620,6 +680,7 @@ class ChatStore {
             message,
             threadId,
             attachments: attachments?.length ? attachments : undefined,
+            reasoningEffort: reasoningEffort || undefined,
           }),
           signal: abort.signal,
         },


### PR DESCRIPTION
## What

Adds a **per-conversation "thinking level"** control to the agent chat composer. A quiet brain icon sits next to the attach button; clicking it opens a small picker where power users can dial how hard the model reasons for the current conversation. It's hidden in plain sight: most users never touch it, and the default behaviour is unchanged.

| Level | Effect |
|-------|--------|
| **Auto** (default) | Use the agent's configured behaviour. No override sent. |
| **Off** | Answer directly, minimal/no reasoning. |
| **Low / Medium / High** | Progressively larger reasoning budget. |

The choice persists per agent in `localStorage` and applies to that agent's chat going forward.

## Why

The agent runtime already streams model reasoning into collapsible "thinking" panes, but there was no way to *influence* how much the model reasons. Reasoning effort trades latency for answer quality, and the right setting is task-dependent, so it belongs to the operator, not a fixed per-agent config. Exposing it as a low-emphasis composer affordance keeps the default chat clean while giving power users control.

## How

**Frontend (`erxes-agent_ui`)**
- `chatStore`: new `ReasoningEffort` type (`off | low | medium | high`), stored per agent and persisted to `localStorage` (unset by default). Threaded into the SSE `chat/stream` request body as `reasoningEffort`.
- `ChatPage`: a ghost brain icon in the composer opens a `Popover` + `Command` picker, built on existing erxes-ui primitives.

**Backend (`erxes-agent_api`)**
- `providers.buildReasoningProviderOptions(provider, effort)` maps the enum to each SDK's knob:
  - OpenAI → `providerOptions.openai.reasoningEffort` (`off` → `minimal`)
  - Anthropic → `providerOptions.anthropic.thinking` budget (`off` → `disabled`)
  - Google → `providerOptions.google.thinkingConfig.thinkingBudget` (`off` → `0`)
  - Other / OpenAI-compatible providers (groq, mistral, cohere, Kimi, NVIDIA) have no portable knob, so the mapping returns `undefined` and the model's default stands.
- `routes`: validates `reasoningEffort` (400 on bad value) and spreads `providerOptions` into the native `agent.stream` call alongside the existing memory binding.
- Added `isReasoningEffort` validator.

## Behavioural guarantees / scope

- **No change by default.** Unset effort sends no `providerOptions`; existing conversations behave exactly as before.
- **Graceful on unsupported providers.** The picker still works, but the level is a no-op where there's no portable reasoning knob (rather than erroring or breaking the stream).
- **GraphQL fallback** (`sendViaQuery`) does not carry the level — it's a degraded text-only transport, so the override only applies over SSE.

## Notes

This reimplements the feature from #8036 on top of the current `erxes-agent` codebase. The provider layer has since dropped its legacy OpenAI-compatible streaming split — everything now runs through the native AI SDK v5 `agent.stream` path — so the backend wiring is simpler than the original (no `isLegacy`/`streamLegacy` branch). The UI and store logic are carried over.

## Testing

- New unit tests: `src/mastra/__tests__/reasoning.test.ts` cover the validator and the per-provider mapping (7 cases, passing via `nx test erxes-agent_api`).
- `tsc --noEmit` clean on both the backend plugin and the frontend plugin.
- `nx lint erxes-agent_ui` reports 0 errors (only pre-existing warnings on untouched lines).

## Summary by Sourcery

Add a per-conversation reasoning level control in agent chat and plumb the selected effort through to provider-specific reasoning options in the backend stream API.

New Features:
- Introduce a per-conversation reasoning level picker in the chat composer allowing users to override the agent's default thinking level.
- Persist each agent's selected reasoning effort in localStorage and apply it automatically to subsequent chats.
- Support a reasoningEffort parameter on the chat streaming endpoint that maps to provider-specific reasoning options for OpenAI, Anthropic, and Google models.

Enhancements:
- Extend the chat store to manage agent-level reasoningEffort state and include it in SSE chat requests.
- Add backend validation and translation utilities for reasoningEffort, defaulting to provider behavior when unset or unsupported.

Tests:
- Add unit tests covering reasoningEffort validation and provider-specific option mapping in the backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Thinking Level" control to the chat interface, allowing users to adjust AI reasoning effort across four levels (off, low, medium, high) on a per-session basis. The setting persists across sessions for enhanced control over AI response depth and quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->