### PR TITLE
fix(agent): new chat sessions appear immediately and survive a mid-run reload

### DIFF
--- a/backend/plugins/erxes-agent_api/src/modules/agent/prepare.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/prepare.ts
@@ -8,6 +8,7 @@ import { deriveResourceId, augmentConvo, MemoryContext } from '~/mastra/memory';
 import { readLearnedDigest } from '~/mastra/learning/digest';
 import { buildChatUserContent } from '~/mastra/files/chatContent';
 import { IMastraChatAttachment } from '@/session/@types/session';
+import { ensureThreadRegistered } from '@/session/nativeStore';
 import { PreparedTurn, TurnAgent, TurnMessage } from '@/agent/types';
 
 // Turn setup: everything a chat turn needs before the model runs — agent +
@@ -89,6 +90,28 @@ export async function prepareChatTurn(params: {
     if (existing && existing.resourceId !== memoryBinding.resource) {
       throw new ExpectedError('Thread not found');
     }
+  }
+
+  // Register the thread + its agent binding NOW, before the model streams, so
+  // the session is listable the moment the turn starts — not only after it
+  // finishes. This is what lets a refresh WHILE the agent is still running keep
+  // the session: the sidebar query (listOwnedThreads → metadata.agentId) finds
+  // it, and reopening it hydrates the persisted turn. patchNativeTurn re-stamps
+  // the same binding at turn-end. Best-effort: never block the turn on a store
+  // hiccup (the end-of-turn stamp is the backstop).
+  if (memoryBinding) {
+    await ensureThreadRegistered(
+      subdomain,
+      sessionId,
+      memoryBinding.resource,
+      agentId,
+    ).catch((e) =>
+      console.warn(
+        `[native-chat-store] thread pre-register skipped: ${
+          (e as Error)?.message || e
+        }`,
+      ),
+    );
   }
 
   // The tenant's learned digest (shared "Agent knowledge") is woven into the

--- a/backend/plugins/erxes-agent_api/src/modules/session/nativeStore.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/session/nativeStore.ts
@@ -129,6 +129,61 @@ export async function listOwnedThreads(
   );
 }
 
+/**
+ * Register a chat thread in the native store and stamp its erxes↔agent binding
+ * (metadata.agentId + tenant) BEFORE the turn streams — so the session is
+ * immediately listable (listOwnedThreads filters on metadata.agentId) and
+ * survives a reload that happens WHILE the agent is still running.
+ *
+ * Without this the thread is created and tagged only at turn-end: Mastra does
+ * not persist a thread until the run finishes (no savePerStep), and the agentId
+ * tag is written by patchNativeTurn after the stream loop. So refreshing mid-run
+ * — which also aborts the SSE run — left no agentId-tagged thread for the
+ * sidebar query to find, and the in-flight session vanished.
+ *
+ * Idempotent: creates the thread when absent, back-fills the binding when an
+ * existing thread is missing/stale on it, and no-ops otherwise. The caller gates
+ * on a memory binding (advanced memory + known tenant) and treats it as
+ * best-effort — a store hiccup here must never block the turn.
+ */
+export async function ensureThreadRegistered(
+  subdomain: string,
+  threadId: string,
+  resourceId: string,
+  agentId: string,
+): Promise<void> {
+  const memory = await getMastraMemory(subdomain);
+  const existing = (await memory.getThreadById({
+    threadId,
+    resourceId,
+  } as never)) as NativeThread | null;
+
+  if (!existing) {
+    // Empty title keeps native generateTitle eligible (it only fills a blank
+    // title, once, at turn-end). The UI renders a blank title as "New chat".
+    await memory.createThread({
+      threadId,
+      resourceId,
+      title: '',
+      metadata: { agentId, subdomain },
+    } as never);
+    return;
+  }
+
+  const meta = (existing.metadata ?? {}) as {
+    agentId?: string;
+    subdomain?: string;
+  };
+  if (meta.agentId === agentId && meta.subdomain === subdomain) return;
+  // updateThread requires a title — preserve the current one (native
+  // generateTitle / a manual rename own it).
+  await memory.updateThread({
+    id: threadId,
+    title: existing.title ?? '',
+    metadata: { ...(existing.metadata ?? {}), agentId, subdomain },
+  } as never);
+}
+
 /** Ownership-checked transcript for one thread (chronological), UI shape. */
 export async function getOwnedThreadMessages(
   subdomain: string,

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -539,6 +539,21 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       }
       const threadId = agent.activeThreadId!;
 
+      // Surface the session in the sidebar the instant the first message is
+      // sent — don't wait for the turn to finish. The backend registers + tags
+      // the thread at turn start (so a refresh keeps it); this mirrors it into
+      // the list optimistically. The streamed thread_title event fills the real
+      // title, and loadSessions in finishTurn reconciles title/count/order.
+      if (!agent.sessions.some((s) => s.threadId === threadId)) {
+        patchAgent(agentKey, {
+          sessions: [
+            { threadId, title: 'New chat', messageCount: 0 },
+            ...agent.sessions,
+          ],
+          isDraft: false,
+        });
+      }
+
       appendMessage(agentKey, threadId, {
         role: 'user',
         content: message,


### PR DESCRIPTION
## Problem

Two related symptoms in the agent chat UI:

1. **A new session never appears in the sidebar while the agent is working** — and refreshing mid-run loses the conversation entirely.
2. **Even some *completed* chats don't show up** — the sidebar reads "No sessions yet" despite a titled, finished conversation.

### Root cause

A new chat session only becomes durable + listable when the turn *finishes*, and the tag the sidebar filters on is written unreliably:

- The sidebar query is `listThreads({ filter: { resourceId, metadata: { agentId } } })` — a thread is invisible unless `metadata.agentId` is set.
- That tag is stamped only at turn-end by `patchNativeTurn`, *after* the message-patch step. Mastra does not persist a thread until the run completes (no `savePerStep`), and any hiccup in the end-of-turn patch leaves the thread permanently untagged.
- Inspecting a live `erxes_mastra_memory.mastra_threads` collection confirmed it: of 15 threads, several — including the newest, titled, completed one — had `metadata: null` or `metadata: {}`, so they were filtered out of the sidebar forever.
- The frontend compounds it: the session list is refetched only in `finishTurn → loadSessions`, so even a correctly-tagged thread doesn't surface until the whole turn ends, and a refresh mid-run (which also aborts the SSE run via `req.on('close') → controller.abort()`) finds no tagged thread to fall back to.

## Fix

**Backend — `backend/plugins/erxes-agent_api`**
- New idempotent `ensureThreadRegistered` helper (`session/nativeStore.ts`): creates the thread when absent and stamps `metadata.agentId` + tenant; back-fills a stale/missing binding; no-ops otherwise.
- `prepareChatTurn` calls it **before the model streams**, so the thread is tagged up front rather than depending on the fragile end-of-turn patch. Runs for both transports (SSE route + `mastraAgentChat` query). `patchNativeTurn` still re-stamps at turn-end as a backstop. Gated on a memory binding; best-effort — never blocks the turn.

**Frontend — `frontend/plugins/erxes-agent_ui`**
- `sendMessage` optimistically inserts the active thread into the session list the moment the first message is sent, so it appears instantly. The streamed `thread_title` event now fills the real title live (previously dropped, since `setSessionTitle` no-ops for a thread not yet in the list), and `loadSessions` reconciles title/count/order at turn end.

Together: the session appears the instant you start chatting, shows its real title as it streams, and survives a mid-run reload.

## Scope / notes

- Backend additive; frontend is a small optimistic-UI insert. No schema/API changes.
- Backend plugin typechecks clean; frontend plugin has no new type errors (pre-existing `libs/erxes-ui` errors are unrelated).
- Pre-existing threads already written with `metadata: null`/`{}` stay hidden (not retroactively backfilled) — a one-time migration could surface them if desired.
- Out of scope (separate decision): decoupling the agent run from the SSE socket so a client disconnect doesn't abort the run, letting long runs complete in the background.

## Test plan

1. Advanced memory enabled (`ERXES_AGENT_MEMORY=enable`). Open an agent and send a message in a **new** chat.
2. Expected: the session appears in the sidebar immediately (titled "New chat", then the real auto-title as it streams) — previously it appeared only after the turn finished, or not at all.
3. Refresh **while** the agent is still working → the session is still listed and reopens to the (interrupted) turn.
4. Confirm in `erxes_mastra_memory.mastra_threads` that the new thread has `metadata.agentId` set from the start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat threads are now registered earlier so they appear in the sidebar as soon as a conversation starts.
  * The first sent message now creates an optimistic “New chat” entry when needed, improving visibility during live streaming.
  * If native thread registration fails, the conversation proceeds without interrupting the turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->