### PR TITLE
fix(agent-ui): make settings pages scrollable

### DIFF
--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
@@ -158,8 +158,8 @@ export const GeneralSettingsPage = () => {
                       {!attachmentStorage?.configured
                         ? 'No storage'
                         : field.value
-                        ? 'On'
-                        : 'Off'}
+                          ? 'On'
+                          : 'Off'}
                     </Badge>
                   </div>
 

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/GeneralSettingsPage.tsx
@@ -52,193 +52,196 @@ export const GeneralSettingsPage = () => {
   };
 
   return (
-    <div className="p-6 max-w-xl space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold">General Settings</h1>
-        <p className="text-muted-foreground mt-1">
-          Configure the Mastra plugin connection to erxes.
-        </p>
-      </div>
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 max-w-xl space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold">General Settings</h1>
+          <p className="text-muted-foreground mt-1">
+            Configure the Mastra plugin connection to erxes.
+          </p>
+        </div>
 
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-          <Form.Field
-            control={form.control}
-            name="defaultAgentId"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>Default Agent (for bot webhook)</Form.Label>
-                <Form.Control>
-                  <select
-                    className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-                    value={field.value}
-                    onChange={(e) => field.onChange(e.target.value)}
-                  >
-                    <option value="">None</option>
-                    {agents
-                      .filter((a) => a.isEnabled)
-                      .map((a) => (
-                        <option key={a._id} value={a.agentId}>
-                          {a.name} ({a.agentId})
-                        </option>
-                      ))}
-                  </select>
-                </Form.Control>
-                <Form.Description>
-                  This agent handles incoming messages from the erxes messenger
-                  bot endpoint (
-                  <code>POST /pl:erxes-agent/bot/:conversationId</code>). Set
-                  this URL as
-                  <code> botEndpointUrl</code> in your frontline integration.
-                </Form.Description>
-                <Form.Message />
-              </Form.Item>
-            )}
-          />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+            <Form.Field
+              control={form.control}
+              name="defaultAgentId"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Default Agent (for bot webhook)</Form.Label>
+                  <Form.Control>
+                    <select
+                      className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    >
+                      <option value="">None</option>
+                      {agents
+                        .filter((a) => a.isEnabled)
+                        .map((a) => (
+                          <option key={a._id} value={a.agentId}>
+                            {a.name} ({a.agentId})
+                          </option>
+                        ))}
+                    </select>
+                  </Form.Control>
+                  <Form.Description>
+                    This agent handles incoming messages from the erxes
+                    messenger bot endpoint (
+                    <code>POST /pl:erxes-agent/bot/:conversationId</code>). Set
+                    this URL as
+                    <code> botEndpointUrl</code> in your frontline integration.
+                  </Form.Description>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
 
-          <Form.Field
-            control={form.control}
-            name="erxesApiUrl"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>erxes API URL</Form.Label>
-                <Form.Control>
-                  <Input {...field} placeholder="http://localhost:4000" />
-                </Form.Control>
-                <Form.Description>
-                  Used by erxes tools to call the GraphQL gateway
-                </Form.Description>
-                <Form.Message />
-              </Form.Item>
-            )}
-          />
+            <Form.Field
+              control={form.control}
+              name="erxesApiUrl"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>erxes API URL</Form.Label>
+                  <Form.Control>
+                    <Input {...field} placeholder="http://localhost:4000" />
+                  </Form.Control>
+                  <Form.Description>
+                    Used by erxes tools to call the GraphQL gateway
+                  </Form.Description>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
 
-          <Form.Field
-            control={form.control}
-            name="erxesApiToken"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>erxes API Token</Form.Label>
-                <Form.Control>
-                  <Input
-                    {...field}
-                    type="password"
-                    placeholder="Bearer token for erxes gateway calls"
-                  />
-                </Form.Control>
-                <Form.Description>
-                  Also used for GraphQL schema introspection when loading erxes
-                  tools
-                </Form.Description>
-                <Form.Message />
-              </Form.Item>
-            )}
-          />
+            <Form.Field
+              control={form.control}
+              name="erxesApiToken"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>erxes API Token</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      type="password"
+                      placeholder="Bearer token for erxes gateway calls"
+                    />
+                  </Form.Control>
+                  <Form.Description>
+                    Also used for GraphQL schema introspection when loading
+                    erxes tools
+                  </Form.Description>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
 
-          <Form.Field
-            control={form.control}
-            name="attachmentsEnabled"
-            render={({ field }) => (
-              <div className="rounded-lg border p-4 space-y-3">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <IconPaperclip className="size-4 text-muted-foreground" />
-                    <span className="font-medium">Chat file attachments</span>
-                  </div>
-                  <Badge
-                    variant={
-                      attachmentStorage?.configured
-                        ? field.value
-                          ? 'success'
-                          : 'secondary'
-                        : 'destructive'
-                    }
-                  >
-                    {!attachmentStorage?.configured
-                      ? 'No storage'
-                      : field.value
+            <Form.Field
+              control={form.control}
+              name="attachmentsEnabled"
+              render={({ field }) => (
+                <div className="rounded-lg border p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <IconPaperclip className="size-4 text-muted-foreground" />
+                      <span className="font-medium">Chat file attachments</span>
+                    </div>
+                    <Badge
+                      variant={
+                        attachmentStorage?.configured
+                          ? field.value
+                            ? 'success'
+                            : 'secondary'
+                          : 'destructive'
+                      }
+                    >
+                      {!attachmentStorage?.configured
+                        ? 'No storage'
+                        : field.value
                         ? 'On'
                         : 'Off'}
-                  </Badge>
-                </div>
-
-                <div className="text-xs text-muted-foreground space-y-1 pl-6">
-                  <div>
-                    Detected storage:{' '}
-                    <span className="font-mono">
-                      {attachmentStorage?.serviceType || 'unknown'}
-                    </span>{' '}
-                    {attachmentStorage?.configured
-                      ? '(configured)'
-                      : '(not configured)'}
+                    </Badge>
                   </div>
+
+                  <div className="text-xs text-muted-foreground space-y-1 pl-6">
+                    <div>
+                      Detected storage:{' '}
+                      <span className="font-mono">
+                        {attachmentStorage?.serviceType || 'unknown'}
+                      </span>{' '}
+                      {attachmentStorage?.configured
+                        ? '(configured)'
+                        : '(not configured)'}
+                    </div>
+                  </div>
+
+                  <label className="flex items-center gap-2 pl-6 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={field.value}
+                      disabled={!attachmentStorage?.configured}
+                      onChange={(e) => field.onChange(e.target.checked)}
+                    />
+                    Allow file attachments in agent chat (images, PDF, Excel,
+                    Word, …)
+                  </label>
+
+                  <p className="text-xs text-muted-foreground">
+                    Files are stored in this instance's existing upload storage
+                    (configured in <strong>Settings → File upload</strong>: AWS
+                    S3, Cloudflare R2, Azure, GCS or local disk). When no
+                    storage is configured, conversations stay text-only.
+                  </p>
                 </div>
+              )}
+            />
 
-                <label className="flex items-center gap-2 pl-6 text-sm cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={field.value}
-                    disabled={!attachmentStorage?.configured}
-                    onChange={(e) => field.onChange(e.target.checked)}
-                  />
-                  Allow file attachments in agent chat (images, PDF, Excel,
-                  Word, …)
-                </label>
+            <Button type="submit" disabled={saving}>
+              {saved ? (
+                <>
+                  <IconCheck size={16} /> Saved
+                </>
+              ) : saving ? (
+                'Saving...'
+              ) : (
+                'Save Settings'
+              )}
+            </Button>
+          </form>
+        </Form>
 
-                <p className="text-xs text-muted-foreground">
-                  Files are stored in this instance's existing upload storage
-                  (configured in <strong>Settings → File upload</strong>: AWS
-                  S3, Cloudflare R2, Azure, GCS or local disk). When no storage
-                  is configured, conversations stay text-only.
-                </p>
-              </div>
+        <AdvancedMemoryCard enabled={advancedMemory} status={memStatus} />
+
+        <CompanyKnowledgeCard status={knowledgeStatus} />
+
+        <div className="rounded-lg border bg-muted/50 p-4 text-sm space-y-2">
+          <p className="font-semibold">Bot Endpoint Setup</p>
+          <p className="text-muted-foreground">
+            To connect this agent to the erxes messenger widget:
+          </p>
+          <ol className="list-decimal list-inside space-y-1 text-muted-foreground text-xs">
+            <li>
+              Go to <strong>Settings → Integrations → Messenger</strong>
+            </li>
+            <li>
+              Edit an integration and set <strong>Bot Endpoint URL</strong> to:
+            </li>
+          </ol>
+          <CopyText
+            value={BOT_ENDPOINT_URL}
+            className={cn(
+              'block w-full bg-muted px-3 py-2 rounded text-xs font-mono justify-between',
             )}
-          />
-
-          <Button type="submit" disabled={saving}>
-            {saved ? (
-              <>
-                <IconCheck size={16} /> Saved
-              </>
-            ) : saving ? (
-              'Saving...'
-            ) : (
-              'Save Settings'
-            )}
-          </Button>
-        </form>
-      </Form>
-
-      <AdvancedMemoryCard enabled={advancedMemory} status={memStatus} />
-
-      <CompanyKnowledgeCard status={knowledgeStatus} />
-
-      <div className="rounded-lg border bg-muted/50 p-4 text-sm space-y-2">
-        <p className="font-semibold">Bot Endpoint Setup</p>
-        <p className="text-muted-foreground">
-          To connect this agent to the erxes messenger widget:
-        </p>
-        <ol className="list-decimal list-inside space-y-1 text-muted-foreground text-xs">
-          <li>
-            Go to <strong>Settings → Integrations → Messenger</strong>
-          </li>
-          <li>
-            Edit an integration and set <strong>Bot Endpoint URL</strong> to:
-          </li>
-        </ol>
-        <CopyText
-          value={BOT_ENDPOINT_URL}
-          className={cn(
-            'block w-full bg-muted px-3 py-2 rounded text-xs font-mono justify-between',
-          )}
-        >
-          <span>{BOT_ENDPOINT_URL}</span>
-          <IconCopy className="size-3.5 shrink-0 text-muted-foreground" />
-        </CopyText>
-        <p className="text-xs text-muted-foreground">
-          (Replace <code>3312</code> with your actual port. The gateway proxies
-          <code> /pl:erxes-agent/*</code> to port 3312.)
-        </p>
+          >
+            <span>{BOT_ENDPOINT_URL}</span>
+            <IconCopy className="size-3.5 shrink-0 text-muted-foreground" />
+          </CopyText>
+          <p className="text-xs text-muted-foreground">
+            (Replace <code>3312</code> with your actual port. The gateway
+            proxies
+            <code> /pl:erxes-agent/*</code> to port 3312.)
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/ProvidersPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/ProvidersPage.tsx
@@ -152,8 +152,8 @@ export const ProvidersPage = () => {
                         {p.apiKey
                           ? '••••••' + p.apiKey.slice(-4)
                           : p.envKey
-                          ? `env: ${p.envKey}`
-                          : 'No key'}
+                            ? `env: ${p.envKey}`
+                            : 'No key'}
                       </span>
                       {p.baseUrl && (
                         <span className="ml-2 text-xs">· {p.baseUrl}</span>
@@ -217,8 +217,8 @@ export const ProvidersPage = () => {
                     adding === preset.provider
                       ? 'border-primary bg-primary/5'
                       : envOnly
-                      ? 'border-green-500/40 hover:border-green-500/70'
-                      : 'border-border hover:border-primary/50',
+                        ? 'border-green-500/40 hover:border-green-500/70'
+                        : 'border-border hover:border-primary/50',
                   )}
                   role="button"
                   tabIndex={0}

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/ProvidersPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/ProvidersPage.tsx
@@ -112,168 +112,174 @@ export const ProvidersPage = () => {
   );
 
   return (
-    <div className="p-6 max-w-3xl space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold">Providers &amp; Models</h1>
-        <p className="text-muted-foreground mt-1">
-          Configure API keys for LLM providers. Keys are stored in the database
-          and injected at agent runtime.
-        </p>
-      </div>
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 max-w-3xl space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold">Providers &amp; Models</h1>
+          <p className="text-muted-foreground mt-1">
+            Configure API keys for LLM providers. Keys are stored in the
+            database and injected at agent runtime.
+          </p>
+        </div>
 
-      {providers.length > 0 && (
-        <section>
-          <h2 className="text-lg font-semibold mb-3">Configured Providers</h2>
-          <div className="space-y-3">
-            {providers.map((p) => (
-              <div
-                key={p._id}
-                className="rounded-lg border bg-card p-4 flex items-center justify-between"
-              >
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold">
-                      {p.label || p.provider}
-                    </span>
-                    {p.isDefault && <Badge>Default</Badge>}
-                    {!p.isEnabled && (
-                      <Badge variant="secondary">Disabled</Badge>
-                    )}
-                    {p.isOpenAICompatible && (
-                      <Badge variant="secondary" className="text-xs">
-                        OpenAI-compatible
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="text-sm text-muted-foreground mt-0.5 flex items-center gap-1 flex-wrap">
-                    <IconKey size={12} />
-                    <span className="font-mono">
-                      {p.apiKey
-                        ? '••••••' + p.apiKey.slice(-4)
-                        : p.envKey
+        {providers.length > 0 && (
+          <section>
+            <h2 className="text-lg font-semibold mb-3">Configured Providers</h2>
+            <div className="space-y-3">
+              {providers.map((p) => (
+                <div
+                  key={p._id}
+                  className="rounded-lg border bg-card p-4 flex items-center justify-between"
+                >
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">
+                        {p.label || p.provider}
+                      </span>
+                      {p.isDefault && <Badge>Default</Badge>}
+                      {!p.isEnabled && (
+                        <Badge variant="secondary">Disabled</Badge>
+                      )}
+                      {p.isOpenAICompatible && (
+                        <Badge variant="secondary" className="text-xs">
+                          OpenAI-compatible
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="text-sm text-muted-foreground mt-0.5 flex items-center gap-1 flex-wrap">
+                      <IconKey size={12} />
+                      <span className="font-mono">
+                        {p.apiKey
+                          ? '••••••' + p.apiKey.slice(-4)
+                          : p.envKey
                           ? `env: ${p.envKey}`
                           : 'No key'}
-                    </span>
-                    {p.baseUrl && (
-                      <span className="ml-2 text-xs">· {p.baseUrl}</span>
-                    )}
+                      </span>
+                      {p.baseUrl && (
+                        <span className="ml-2 text-xs">· {p.baseUrl}</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleEdit(p)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(p)}
+                    >
+                      <IconTrash className="text-destructive" size={16} />
+                    </Button>
                   </div>
                 </div>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleEdit(p)}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemove(p)}
-                  >
-                    <IconTrash className="text-destructive" size={16} />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+              ))}
+            </div>
+          </section>
+        )}
 
-      {adding && (
+        {adding && (
+          <section>
+            <ProviderForm
+              form={form}
+              title={editingLabel}
+              isEdit={isEdit}
+              isCustom={adding === CUSTOM_KEY}
+              saving={saving}
+              onSubmit={handleSave}
+              onCancel={() => setAdding(null)}
+            />
+          </section>
+        )}
+
         <section>
-          <ProviderForm
-            form={form}
-            title={editingLabel}
-            isEdit={isEdit}
-            isCustom={adding === CUSTOM_KEY}
-            saving={saving}
-            onSubmit={handleSave}
-            onCancel={() => setAdding(null)}
-          />
-        </section>
-      )}
-
-      <section>
-        <h2 className="text-lg font-semibold mb-3">
-          {providers.length > 0 ? 'Add Another Provider' : 'Select a Provider'}
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {presets.map((preset) => {
-            const configured = providers.some(
-              (p) => p.provider === preset.provider,
-            );
-            const envOnly =
-              !configured && catalogMap.get(preset.provider) === true;
-            return (
-              <div
-                key={preset.provider}
-                className={cn(
-                  'rounded-lg border p-4 cursor-pointer transition-colors',
-                  adding === preset.provider
-                    ? 'border-primary bg-primary/5'
-                    : envOnly
+          <h2 className="text-lg font-semibold mb-3">
+            {providers.length > 0
+              ? 'Add Another Provider'
+              : 'Select a Provider'}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {presets.map((preset) => {
+              const configured = providers.some(
+                (p) => p.provider === preset.provider,
+              );
+              const envOnly =
+                !configured && catalogMap.get(preset.provider) === true;
+              return (
+                <div
+                  key={preset.provider}
+                  className={cn(
+                    'rounded-lg border p-4 cursor-pointer transition-colors',
+                    adding === preset.provider
+                      ? 'border-primary bg-primary/5'
+                      : envOnly
                       ? 'border-green-500/40 hover:border-green-500/70'
                       : 'border-border hover:border-primary/50',
-                )}
-                role="button"
-                tabIndex={0}
-                onClick={() => handleAddPreset(preset)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleAddPreset(preset);
-                  }
-                }}
-              >
-                <div className="flex items-center justify-between mb-1">
-                  <span className="font-semibold text-sm">{preset.label}</span>
-                  {configured ? (
-                    <Badge variant="secondary" className="text-xs">
-                      <IconCheck size={10} className="mr-1" /> Configured
-                    </Badge>
-                  ) : envOnly ? (
-                    <Badge variant="success" className="text-xs">
-                      Via env
-                    </Badge>
-                  ) : null}
+                  )}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleAddPreset(preset)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handleAddPreset(preset);
+                    }
+                  }}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="font-semibold text-sm">
+                      {preset.label}
+                    </span>
+                    {configured ? (
+                      <Badge variant="secondary" className="text-xs">
+                        <IconCheck size={10} className="mr-1" /> Configured
+                      </Badge>
+                    ) : envOnly ? (
+                      <Badge variant="success" className="text-xs">
+                        Via env
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {preset.isOpenAICompatible ? 'OpenAI-compatible' : 'Native'}{' '}
+                    · models listed live from the provider
+                  </p>
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  {preset.isOpenAICompatible ? 'OpenAI-compatible' : 'Native'} ·
-                  models listed live from the provider
-                </p>
-              </div>
-            );
-          })}
+              );
+            })}
 
-          <div
-            className={cn(
-              'rounded-lg border border-dashed p-4 cursor-pointer transition-colors',
-              adding === CUSTOM_KEY
-                ? 'border-primary bg-primary/5'
-                : 'border-border hover:border-primary/50',
-            )}
-            role="button"
-            tabIndex={0}
-            onClick={handleAddCustom}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                handleAddCustom();
-              }
-            }}
-          >
-            <div className="flex items-center gap-2 mb-1">
-              <IconPlus size={14} />
-              <span className="font-semibold text-sm">Custom Provider</span>
+            <div
+              className={cn(
+                'rounded-lg border border-dashed p-4 cursor-pointer transition-colors',
+                adding === CUSTOM_KEY
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/50',
+              )}
+              role="button"
+              tabIndex={0}
+              onClick={handleAddCustom}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleAddCustom();
+                }
+              }}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <IconPlus size={14} />
+                <span className="font-semibold text-sm">Custom Provider</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Add any OpenAI-compatible or native provider not listed above.
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Add any OpenAI-compatible or native provider not listed above.
-            </p>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Problem

The **General Settings** and **Providers & Models** pages under `erxes-agent_ui` were impossible to scroll. Content taller than the viewport (the Save button, the Bot Endpoint Setup card, the lower half of the provider catalog) was clipped and unreachable.

### Root cause

The settings shell mounts plugin content inside a fixed-height `overflow-hidden` container (`PageContainer` → `flex flex-col h-full overflow-hidden`). The agent list and agent form pages handle this correctly — they use `flex flex-col h-full` with an inner `flex-1 overflow-auto` scroll region.

But `GeneralSettingsPage` and `ProvidersPage` rendered their content in a bare `<div className="p-6 ...">` with **no height or overflow handling**, so the content overflowed the clipped parent with no scrollbar.

## Fix

Wrap both pages in an `h-full overflow-y-auto` scroll container, matching the existing pattern used elsewhere in the plugin. No behavioural or visual change beyond restoring scroll.

## Test plan

- [x] Open Settings → erxes Agent → General Settings on a short viewport → page scrolls, Save button + Bot Endpoint card reachable
- [x] Open Settings → erxes Agent → Providers & Models with several providers configured → page scrolls to the full catalog
- [x] Prettier-clean, JSX balanced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced General Settings page layout with improved scrollable container for better visual presentation.
  * Updated Providers page layout with scrollable functionality for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->