### PR TITLE
feat(agent-chat): in-chat agent editor + per-conversation thinking level

### DIFF
--- a/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
@@ -35,21 +35,41 @@ describe('buildReasoningProviderOptions', () => {
     });
   });
 
-  it('maps Anthropic to a thinking budget, disabling on off', () => {
+  it('maps Anthropic to a thinking budget per level, disabling on off', () => {
+    expect(buildReasoningProviderOptions('anthropic', 'low')).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 2048 } },
+    });
     expect(buildReasoningProviderOptions('anthropic', 'medium')).toEqual({
       anthropic: { thinking: { type: 'enabled', budgetTokens: 8192 } },
+    });
+    expect(buildReasoningProviderOptions('anthropic', 'high')).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 16384 } },
     });
     expect(buildReasoningProviderOptions('anthropic', 'off')).toEqual({
       anthropic: { thinking: { type: 'disabled' } },
     });
   });
 
-  it('maps Google to a thinking budget, zero on off', () => {
+  it('maps Google to a thinking budget per level, zero on off', () => {
     expect(buildReasoningProviderOptions('google', 'low')).toEqual({
       google: { thinkingConfig: { thinkingBudget: 2048 } },
+    });
+    expect(buildReasoningProviderOptions('google', 'medium')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 8192 } },
+    });
+    expect(buildReasoningProviderOptions('google', 'high')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 16384 } },
     });
     expect(buildReasoningProviderOptions('google', 'off')).toEqual({
       google: { thinkingConfig: { thinkingBudget: 0 } },
     });
+  });
+
+  it('maps OpenAI minimal/low/medium/high without a budget', () => {
+    for (const level of ['low', 'medium', 'high'] as const) {
+      expect(buildReasoningProviderOptions('openai', level)).toEqual({
+        openai: { reasoningEffort: level },
+      });
+    }
   });
 });

--- a/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/__tests__/reasoning.test.ts
@@ -1,0 +1,55 @@
+import { buildReasoningProviderOptions, isReasoningEffort } from '../providers';
+
+describe('isReasoningEffort', () => {
+  it('accepts the four levels', () => {
+    for (const v of ['off', 'low', 'medium', 'high']) {
+      expect(isReasoningEffort(v)).toBe(true);
+    }
+  });
+
+  it('rejects anything else', () => {
+    for (const v of ['auto', 'HIGH', '', 1, null, undefined, {}]) {
+      expect(isReasoningEffort(v)).toBe(false);
+    }
+  });
+});
+
+describe('buildReasoningProviderOptions', () => {
+  it('returns undefined when effort is unset (default behaviour)', () => {
+    expect(buildReasoningProviderOptions('openai')).toBeUndefined();
+    expect(buildReasoningProviderOptions('anthropic')).toBeUndefined();
+  });
+
+  it('returns undefined for providers without a known reasoning knob', () => {
+    expect(buildReasoningProviderOptions('groq', 'high')).toBeUndefined();
+    expect(buildReasoningProviderOptions('kimi', 'high')).toBeUndefined();
+    expect(buildReasoningProviderOptions('mistral', 'low')).toBeUndefined();
+  });
+
+  it('maps OpenAI effort, collapsing off to minimal', () => {
+    expect(buildReasoningProviderOptions('openai', 'high')).toEqual({
+      openai: { reasoningEffort: 'high' },
+    });
+    expect(buildReasoningProviderOptions('openai', 'off')).toEqual({
+      openai: { reasoningEffort: 'minimal' },
+    });
+  });
+
+  it('maps Anthropic to a thinking budget, disabling on off', () => {
+    expect(buildReasoningProviderOptions('anthropic', 'medium')).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 8192 } },
+    });
+    expect(buildReasoningProviderOptions('anthropic', 'off')).toEqual({
+      anthropic: { thinking: { type: 'disabled' } },
+    });
+  });
+
+  it('maps Google to a thinking budget, zero on off', () => {
+    expect(buildReasoningProviderOptions('google', 'low')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 2048 } },
+    });
+    expect(buildReasoningProviderOptions('google', 'off')).toEqual({
+      google: { thinkingConfig: { thinkingBudget: 0 } },
+    });
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/providers.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/providers.ts
@@ -183,7 +183,10 @@ const REASONING_BUILDERS: Record<
       effort === 'off'
         ? { thinking: { type: 'disabled' } }
         : {
-            thinking: { type: 'enabled', budgetTokens: THINKING_BUDGET[effort] },
+            thinking: {
+              type: 'enabled',
+              budgetTokens: THINKING_BUDGET[effort],
+            },
           },
   }),
   google: (effort) => ({

--- a/backend/plugins/erxes-agent_api/src/mastra/providers.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/providers.ts
@@ -144,16 +144,20 @@ export const PROVIDER_PRESETS: Array<{
 // provider we don't have a mapping for) yields no options — the agent's
 // configured default stands, exactly as before this feature existed.
 // ---------------------------------------------------------------------------
-export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
-
-const REASONING_EFFORTS: ReasoningEffort[] = ['off', 'low', 'medium', 'high'];
+export const REASONING_EFFORTS = ['off', 'low', 'medium', 'high'] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
 /** Type guard for the reasoning-effort enum — validates untrusted request input. */
 export function isReasoningEffort(v: unknown): v is ReasoningEffort {
   return (
-    typeof v === 'string' && REASONING_EFFORTS.includes(v as ReasoningEffort)
+    typeof v === 'string' &&
+    (REASONING_EFFORTS as readonly string[]).includes(v)
   );
 }
+
+// The `providerOptions` block Mastra forwards to the model SDK — keyed by
+// provider name, each value the option bag that provider understands.
+export type ReasoningProviderOptions = Record<string, Record<string, unknown>>;
 
 // Anthropic / Google take an explicit thinking-token budget. 'off' disables
 // reasoning where the provider supports it.
@@ -161,6 +165,34 @@ const THINKING_BUDGET: Record<Exclude<ReasoningEffort, 'off'>, number> = {
   low: 2048,
   medium: 8192,
   high: 16384,
+};
+
+// Per-provider translators: one entry per provider with a portable reasoning
+// knob. A provider absent from this table has none, so the model's configured
+// default stands (groq / mistral / cohere / OpenAI-compatible Kimi, NVIDIA…).
+const REASONING_BUILDERS: Record<
+  string,
+  (effort: ReasoningEffort) => ReasoningProviderOptions
+> = {
+  // gpt-5 / o-series accept 'minimal' | 'low' | 'medium' | 'high'.
+  openai: (effort) => ({
+    openai: { reasoningEffort: effort === 'off' ? 'minimal' : effort },
+  }),
+  anthropic: (effort) => ({
+    anthropic:
+      effort === 'off'
+        ? { thinking: { type: 'disabled' } }
+        : {
+            thinking: { type: 'enabled', budgetTokens: THINKING_BUDGET[effort] },
+          },
+  }),
+  google: (effort) => ({
+    google: {
+      thinkingConfig: {
+        thinkingBudget: effort === 'off' ? 0 : THINKING_BUDGET[effort],
+      },
+    },
+  }),
 };
 
 /**
@@ -172,40 +204,9 @@ const THINKING_BUDGET: Record<Exclude<ReasoningEffort, 'off'>, number> = {
 export function buildReasoningProviderOptions(
   providerName: string,
   effort?: ReasoningEffort,
-): Record<string, Record<string, unknown>> | undefined {
+): ReasoningProviderOptions | undefined {
   if (!effort) return undefined;
-
-  switch (providerName) {
-    case 'openai':
-      // gpt-5 / o-series accept 'minimal' | 'low' | 'medium' | 'high'.
-      return {
-        openai: { reasoningEffort: effort === 'off' ? 'minimal' : effort },
-      };
-    case 'anthropic':
-      return {
-        anthropic:
-          effort === 'off'
-            ? { thinking: { type: 'disabled' } }
-            : {
-                thinking: {
-                  type: 'enabled',
-                  budgetTokens: THINKING_BUDGET[effort],
-                },
-              },
-      };
-    case 'google':
-      return {
-        google: {
-          thinkingConfig: {
-            thinkingBudget: effort === 'off' ? 0 : THINKING_BUDGET[effort],
-          },
-        },
-      };
-    default:
-      // groq / mistral / cohere / OpenAI-compatible providers (Kimi, NVIDIA):
-      // no portable reasoning knob — leave the model's default in place.
-      return undefined;
-  }
+  return REASONING_BUILDERS[providerName]?.(effort);
 }
 
 // What buildModel hands to Agent: a Mastra model config. A bare string ref

--- a/backend/plugins/erxes-agent_api/src/mastra/providers.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/providers.ts
@@ -135,6 +135,79 @@ export const PROVIDER_PRESETS: Array<{
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Reasoning effort → per-provider stream options.
+//
+// The chat view lets power users dial how hard the model "thinks" per
+// conversation. Each provider exposes this differently, so we translate a
+// single enum into the option each SDK understands. Unset effort (or a
+// provider we don't have a mapping for) yields no options — the agent's
+// configured default stands, exactly as before this feature existed.
+// ---------------------------------------------------------------------------
+export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
+const REASONING_EFFORTS: ReasoningEffort[] = ['off', 'low', 'medium', 'high'];
+
+/** Type guard for the reasoning-effort enum — validates untrusted request input. */
+export function isReasoningEffort(v: unknown): v is ReasoningEffort {
+  return (
+    typeof v === 'string' && REASONING_EFFORTS.includes(v as ReasoningEffort)
+  );
+}
+
+// Anthropic / Google take an explicit thinking-token budget. 'off' disables
+// reasoning where the provider supports it.
+const THINKING_BUDGET: Record<Exclude<ReasoningEffort, 'off'>, number> = {
+  low: 2048,
+  medium: 8192,
+  high: 16384,
+};
+
+/**
+ * Translate a reasoning-effort choice into the `providerOptions` block for the
+ * agent's provider. Returns `undefined` when there's nothing to apply (unset
+ * effort, or a provider without a known reasoning knob) so callers can spread
+ * it without touching the default behaviour.
+ */
+export function buildReasoningProviderOptions(
+  providerName: string,
+  effort?: ReasoningEffort,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!effort) return undefined;
+
+  switch (providerName) {
+    case 'openai':
+      // gpt-5 / o-series accept 'minimal' | 'low' | 'medium' | 'high'.
+      return {
+        openai: { reasoningEffort: effort === 'off' ? 'minimal' : effort },
+      };
+    case 'anthropic':
+      return {
+        anthropic:
+          effort === 'off'
+            ? { thinking: { type: 'disabled' } }
+            : {
+                thinking: {
+                  type: 'enabled',
+                  budgetTokens: THINKING_BUDGET[effort],
+                },
+              },
+      };
+    case 'google':
+      return {
+        google: {
+          thinkingConfig: {
+            thinkingBudget: effort === 'off' ? 0 : THINKING_BUDGET[effort],
+          },
+        },
+      };
+    default:
+      // groq / mistral / cohere / OpenAI-compatible providers (Kimi, NVIDIA):
+      // no portable reasoning knob — leave the model's default in place.
+      return undefined;
+  }
+}
+
 // What buildModel hands to Agent: a Mastra model config. A bare string ref
 // ("openai/gpt-4o") when the registry resolves the key from env, or a config
 // object — `{ id, apiKey }` for native providers with a DB-stored key, or

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -10,6 +10,10 @@ import {
   summarizeActivity,
 } from './mastra/activity';
 import { toolStatusLine } from './mastra/activity-signals';
+import {
+  isReasoningEffort,
+  buildReasoningProviderOptions,
+} from './mastra/providers';
 import { runWithAuth } from './mastra/requestContext';
 import { isAdvancedMemoryEnabled } from './mastra/memory/config';
 import { scopedResource } from './mastra/memory/mastraMemory';
@@ -210,6 +214,14 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     return res.status(400).json({ error: 'threadId must be a string' });
   }
 
+  // Optional per-conversation reasoning override from the chat composer.
+  const reasoningEffort = req.body?.reasoningEffort;
+  if (reasoningEffort !== undefined && !isReasoningEffort(reasoningEffort)) {
+    return res
+      .status(400)
+      .json({ error: 'reasoningEffort must be off | low | medium | high' });
+  }
+
   const attachments = sanitizeAttachments(req.body?.attachments);
   if (attachments === null) {
     return res.status(400).json({ error: 'Invalid attachments payload' });
@@ -365,9 +377,17 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     let langfuseTraceId: string | undefined;
     try {
       await runWithAuth(authCtx, async () => {
+        // Per-conversation reasoning override → provider-specific options.
+        // Providers without a portable reasoning knob yield undefined, so the
+        // model's configured default stands untouched.
+        const reasoningOptions = buildReasoningProviderOptions(
+          prepared.agentConfig.provider,
+          reasoningEffort,
+        );
         const stream = await agent.stream(convo, {
           abortSignal: controller.signal,
           ...(memoryBinding ? { memory: memoryBinding } : {}),
+          ...(reasoningOptions ? { providerOptions: reasoningOptions } : {}),
         });
         const tid = (stream as { traceId?: unknown }).traceId;
         const resolvedTid =

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -13,6 +13,7 @@ import { toolStatusLine } from './mastra/activity-signals';
 import {
   isReasoningEffort,
   buildReasoningProviderOptions,
+  ReasoningEffort,
 } from './mastra/providers';
 import { runWithAuth } from './mastra/requestContext';
 import { isAdvancedMemoryEnabled } from './mastra/memory/config';
@@ -195,37 +196,66 @@ function sanitizeAttachments(raw: unknown): IMastraChatAttachment[] | null {
   return out;
 }
 
-router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
-  const user = extractUserFromHeader(req.headers);
-  if (!user?._id) {
-    return res.status(401).json({ error: 'Login required' });
-  }
+// Validated POST /chat/stream payload. All shape-checking for the untrusted
+// request body lives here so the handler reads as straight-line logic.
+interface ChatStreamRequest {
+  agentId: string;
+  message: string;
+  threadId?: string;
+  reasoningEffort?: ReasoningEffort;
+  attachments: IMastraChatAttachment[];
+}
 
-  const { agentId, message, threadId } = req.body || {};
+type ParseResult =
+  | { ok: true; value: ChatStreamRequest }
+  | { ok: false; error: string };
+
+function parseChatStreamBody(raw: unknown): ParseResult {
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const { agentId, message, threadId, reasoningEffort } = body;
+
   if (
     typeof agentId !== 'string' ||
     !agentId ||
     typeof message !== 'string' ||
     !message.trim()
   ) {
-    return res.status(400).json({ error: 'agentId and message are required' });
+    return { ok: false, error: 'agentId and message are required' };
   }
   if (threadId !== undefined && typeof threadId !== 'string') {
-    return res.status(400).json({ error: 'threadId must be a string' });
+    return { ok: false, error: 'threadId must be a string' };
   }
-
-  // Optional per-conversation reasoning override from the chat composer.
-  const reasoningEffort = req.body?.reasoningEffort;
   if (reasoningEffort !== undefined && !isReasoningEffort(reasoningEffort)) {
-    return res
-      .status(400)
-      .json({ error: 'reasoningEffort must be off | low | medium | high' });
+    return {
+      ok: false,
+      error: 'reasoningEffort must be off | low | medium | high',
+    };
   }
 
-  const attachments = sanitizeAttachments(req.body?.attachments);
+  const attachments = sanitizeAttachments(body.attachments);
   if (attachments === null) {
-    return res.status(400).json({ error: 'Invalid attachments payload' });
+    return { ok: false, error: 'Invalid attachments payload' };
   }
+
+  return {
+    ok: true,
+    value: { agentId, message, threadId, reasoningEffort, attachments },
+  };
+}
+
+router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
+  const user = extractUserFromHeader(req.headers);
+  if (!user?._id) {
+    return res.status(401).json({ error: 'Login required' });
+  }
+
+  const parsed = parseChatStreamBody(req.body);
+  if (!parsed.ok) {
+    return res.status(400).json({ error: parsed.error });
+  }
+  // reasoningEffort is the optional per-conversation override from the composer.
+  const { agentId, message, threadId, reasoningEffort, attachments } =
+    parsed.value;
 
   const subdomain = getSubdomain(req);
 
@@ -352,6 +382,14 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     });
     const { agent, convo, authCtx, memoryBinding } = prepared;
 
+    // Per-conversation reasoning override → provider-specific options, resolved
+    // once against the agent's provider. Providers without a portable reasoning
+    // knob yield undefined, so the model's configured default stands untouched.
+    const reasoningOptions = buildReasoningProviderOptions(
+      prepared.agentConfig.provider,
+      reasoningEffort,
+    );
+
     // Narrates "what is the agent doing" while the turn runs — throttled
     // summaries of the live reasoning/tool signals, pushed as activity events.
     activity = createActivityTracker({
@@ -377,13 +415,6 @@ router.post('/chat/stream', llmRouteLimiter, async (req, res) => {
     let langfuseTraceId: string | undefined;
     try {
       await runWithAuth(authCtx, async () => {
-        // Per-conversation reasoning override → provider-specific options.
-        // Providers without a portable reasoning knob yield undefined, so the
-        // model's configured default stands untouched.
-        const reasoningOptions = buildReasoningProviderOptions(
-          prepared.agentConfig.provider,
-          reasoningEffort,
-        );
         const stream = await agent.stream(convo, {
           abortSignal: controller.signal,
           ...(memoryBinding ? { memory: memoryBinding } : {}),

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -399,9 +399,9 @@ export const ChatPage = () => {
                 uploadsInFlight={attachments.uploadsInFlight}
                 agentName={selectedAgent.name}
                 reasoningEffort={reasoningEffort}
-                onReasoningEffortChange={(effort) => {
-                  if (agentId) chatStore.setReasoningEffort(agentId, effort);
-                }}
+                onReasoningEffortChange={(effort) =>
+                  chatStore.setReasoningEffort(agentId!, effort)
+                }
                 textareaRef={textareaRef}
                 fileInputRef={fileInputRef}
               />

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -44,6 +44,7 @@ export const ChatPage = () => {
     sessionsLoaded,
     activeThreadId,
     isDraft,
+    reasoningEffort,
     messages,
     loading: chatLoading,
     messagesLoading,
@@ -397,6 +398,10 @@ export const ChatPage = () => {
                 onRemoveAttachment={attachments.removeAttachment}
                 uploadsInFlight={attachments.uploadsInFlight}
                 agentName={selectedAgent.name}
+                reasoningEffort={reasoningEffort}
+                onReasoningEffortChange={(effort) => {
+                  if (agentId) chatStore.setReasoningEffort(agentId, effort);
+                }}
                 textareaRef={textareaRef}
                 fileInputRef={fileInputRef}
               />

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
@@ -15,16 +15,17 @@ const AgentRailItem = ({
   agent,
   isActive,
   onSelect,
+  onEdit,
 }: {
   agent: IChatAgent;
   isActive: boolean;
   onSelect: (agentId: string) => void;
+  onEdit: (agent: IChatAgent) => void;
 }) => {
   const isWorking = useAgentWorking(agent._id);
   const hasUnread = useAgentUnread(agent._id) && !isActive;
   const activity = useAgentActivity(agent._id);
   const showActivity = isWorking ? activity : undefined;
-  const [editing, setEditing] = useState(false);
 
   return (
     <div
@@ -53,7 +54,7 @@ const AgentRailItem = ({
               className="absolute right-1 top-1 z-10 size-6 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
               onClick={(e) => {
                 e.stopPropagation();
-                setEditing(true);
+                onEdit(agent);
               }}
             >
               <IconSettings className="size-3.5" />
@@ -62,8 +63,6 @@ const AgentRailItem = ({
           <Tooltip.Content>Edit agent settings</Tooltip.Content>
         </Tooltip>
       </Tooltip.Provider>
-
-      <EditAgentDialog agent={agent} open={editing} onOpenChange={setEditing} />
 
       <div className="flex items-start gap-2">
         <div className="relative shrink-0">
@@ -122,7 +121,12 @@ export const AgentRail = ({
   loading: boolean;
   activeAgentId?: string;
   onSelect: (agentId: string) => void;
-}) => (
+}) => {
+  // A single editor for the whole rail — opened with the row's agent, mounted
+  // only while open so its form/mutation/subscriptions don't exist per row.
+  const [editingAgent, setEditingAgent] = useState<IChatAgent | null>(null);
+
+  return (
   <div className="w-56 border-r flex flex-col shrink-0">
     <div className="px-3 py-2.5 border-b">
       <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
@@ -149,10 +153,22 @@ export const AgentRail = ({
               agent={agent}
               isActive={activeAgentId === agent._id}
               onSelect={onSelect}
+              onEdit={setEditingAgent}
             />
           ))}
         </div>
       )}
     </div>
+
+    {editingAgent && (
+      <EditAgentDialog
+        agent={editingAgent}
+        open
+        onOpenChange={(next) => {
+          if (!next) setEditingAgent(null);
+        }}
+      />
+    )}
   </div>
-);
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
@@ -127,48 +127,48 @@ export const AgentRail = ({
   const [editingAgent, setEditingAgent] = useState<IChatAgent | null>(null);
 
   return (
-  <div className="w-56 border-r flex flex-col shrink-0">
-    <div className="px-3 py-2.5 border-b">
-      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-        Agents
-      </p>
-    </div>
-    <div className="flex-1 overflow-auto">
-      {loading ? (
-        <div className="p-3 space-y-1.5">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-12 w-full rounded-md" />
-          ))}
-        </div>
-      ) : agents.length === 0 ? (
-        <div className="p-4 text-center">
-          <IconRobot className="size-8 text-muted-foreground mx-auto mb-2" />
-          <p className="text-sm text-muted-foreground">No enabled agents.</p>
-        </div>
-      ) : (
-        <div className="p-1.5 space-y-0.5">
-          {agents.map((agent) => (
-            <AgentRailItem
-              key={agent._id}
-              agent={agent}
-              isActive={activeAgentId === agent._id}
-              onSelect={onSelect}
-              onEdit={setEditingAgent}
-            />
-          ))}
-        </div>
+    <div className="w-56 border-r flex flex-col shrink-0">
+      <div className="px-3 py-2.5 border-b">
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Agents
+        </p>
+      </div>
+      <div className="flex-1 overflow-auto">
+        {loading ? (
+          <div className="p-3 space-y-1.5">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-md" />
+            ))}
+          </div>
+        ) : agents.length === 0 ? (
+          <div className="p-4 text-center">
+            <IconRobot className="size-8 text-muted-foreground mx-auto mb-2" />
+            <p className="text-sm text-muted-foreground">No enabled agents.</p>
+          </div>
+        ) : (
+          <div className="p-1.5 space-y-0.5">
+            {agents.map((agent) => (
+              <AgentRailItem
+                key={agent._id}
+                agent={agent}
+                isActive={activeAgentId === agent._id}
+                onSelect={onSelect}
+                onEdit={setEditingAgent}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {editingAgent && (
+        <EditAgentDialog
+          agent={editingAgent}
+          open
+          onOpenChange={(next) => {
+            if (!next) setEditingAgent(null);
+          }}
+        />
       )}
     </div>
-
-    {editingAgent && (
-      <EditAgentDialog
-        agent={editingAgent}
-        open
-        onOpenChange={(next) => {
-          if (!next) setEditingAgent(null);
-        }}
-      />
-    )}
-  </div>
   );
 };

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
@@ -63,11 +63,7 @@ const AgentRailItem = ({
         </Tooltip>
       </Tooltip.Provider>
 
-      <EditAgentDialog
-        agent={agent}
-        open={editing}
-        onOpenChange={setEditing}
-      />
+      <EditAgentDialog agent={agent} open={editing} onOpenChange={setEditing} />
 
       <div className="flex items-start gap-2">
         <div className="relative shrink-0">

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
@@ -36,7 +36,12 @@ const AgentRailItem = ({
       } ${isWorking ? 'ea-working' : ''}`}
       onClick={() => onSelect(agent._id)}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+        // Only act on the row's own keys — ignore Enter/Space that bubbled up
+        // from the focused gear button (which has its own handler).
+        if (
+          (e.key === 'Enter' || e.key === ' ') &&
+          e.target === e.currentTarget
+        ) {
           e.preventDefault();
           onSelect(agent._id);
         }

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/AgentRail.tsx
@@ -1,11 +1,13 @@
-import { IconRobot } from '@tabler/icons-react';
-import { Skeleton } from 'erxes-ui';
+import { useState } from 'react';
+import { IconRobot, IconSettings } from '@tabler/icons-react';
+import { Button, Skeleton, Tooltip } from 'erxes-ui';
 import { IChatAgent } from '~/modules/chat/hooks/useChatAgents';
 import {
   useAgentActivity,
   useAgentUnread,
   useAgentWorking,
 } from '~/modules/chat/hooks/useChatView';
+import { EditAgentDialog } from '~/modules/chat/components/EditAgentDialog';
 
 // One agent row — subscribes to its own working/unread/activity slices so a
 // streaming reply only re-renders that row, not the whole rail.
@@ -22,14 +24,51 @@ const AgentRailItem = ({
   const hasUnread = useAgentUnread(agent._id) && !isActive;
   const activity = useAgentActivity(agent._id);
   const showActivity = isWorking ? activity : undefined;
+  const [editing, setEditing] = useState(false);
 
   return (
-    <button
-      className={`w-full text-left rounded-md px-2.5 py-2 transition-colors hover:bg-accent ${
+    <div
+      role="button"
+      tabIndex={0}
+      className={`group relative w-full cursor-pointer rounded-md px-2.5 py-2 text-left transition-colors hover:bg-accent ${
         isActive ? 'bg-accent' : ''
       } ${isWorking ? 'ea-working' : ''}`}
       onClick={() => onSelect(agent._id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(agent._id);
+        }
+      }}
     >
+      {/* Quick-edit affordance — appears on hover/focus, opens the in-chat
+          settings modal without leaving the conversation. */}
+      <Tooltip.Provider>
+        <Tooltip>
+          <Tooltip.Trigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              aria-label={`Edit ${agent.name} settings`}
+              className="absolute right-1 top-1 z-10 size-6 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditing(true);
+              }}
+            >
+              <IconSettings className="size-3.5" />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Edit agent settings</Tooltip.Content>
+        </Tooltip>
+      </Tooltip.Provider>
+
+      <EditAgentDialog
+        agent={agent}
+        open={editing}
+        onOpenChange={setEditing}
+      />
+
       <div className="flex items-start gap-2">
         <div className="relative shrink-0">
           <div
@@ -73,7 +112,7 @@ const AgentRailItem = ({
           </div>
         </div>
       )}
-    </button>
+    </div>
   );
 };
 

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/Composer.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/Composer.tsx
@@ -6,8 +6,9 @@ import {
   IconSend,
 } from '@tabler/icons-react';
 import { Button, Textarea, Tooltip } from 'erxes-ui';
-import { PendingAttachment } from '~/modules/chat/types';
+import { PendingAttachment, ReasoningEffort } from '~/modules/chat/types';
 import { ComposerAttachmentChip } from '~/modules/chat/components/ComposerAttachmentChip';
+import { ReasoningEffortControl } from '~/modules/chat/components/ReasoningEffortControl';
 
 export const Composer = ({
   input,
@@ -23,6 +24,8 @@ export const Composer = ({
   onRemoveAttachment,
   uploadsInFlight,
   agentName,
+  reasoningEffort,
+  onReasoningEffortChange,
   textareaRef,
   fileInputRef,
 }: {
@@ -39,6 +42,8 @@ export const Composer = ({
   onRemoveAttachment: (id: string) => void;
   uploadsInFlight: boolean;
   agentName: string;
+  reasoningEffort?: ReasoningEffort;
+  onReasoningEffortChange: (effort?: ReasoningEffort) => void;
   textareaRef: RefObject<HTMLTextAreaElement>;
   fileInputRef: RefObject<HTMLInputElement>;
 }) => (
@@ -93,6 +98,11 @@ export const Composer = ({
               </Tooltip.Provider>
             </>
           )}
+          <ReasoningEffortControl
+            value={reasoningEffort}
+            onChange={onReasoningEffortChange}
+            disabled={chatLoading}
+          />
           <Textarea
             ref={textareaRef}
             value={input}

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
@@ -172,7 +172,10 @@ export const EditAgentDialog = ({
                     <Form.Item>
                       <Form.Label>Name</Form.Label>
                       <Form.Control>
-                        <Input {...field} placeholder="Customer Support Agent" />
+                        <Input
+                          {...field}
+                          placeholder="Customer Support Agent"
+                        />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -400,7 +403,9 @@ export const EditAgentDialog = ({
                 <Tooltip>
                   <Tooltip.Trigger asChild>
                     <Button variant="ghost" size="sm" asChild>
-                      <Link to={`/settings/erxes-agent/agents/edit/${agent._id}`}>
+                      <Link
+                        to={`/settings/erxes-agent/agents/edit/${agent._id}`}
+                      >
                         Open full editor
                       </Link>
                     </Button>

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
@@ -1,29 +1,9 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { IconInfoCircle } from '@tabler/icons-react';
-import {
-  Alert,
-  Button,
-  Dialog,
-  Form,
-  Input,
-  Label,
-  Separator,
-  Slider,
-  Switch,
-  Textarea,
-  Tooltip,
-} from 'erxes-ui';
+import { Button, Dialog, Form, Tooltip } from 'erxes-ui';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Field, FormSection } from '~/components/FormLayout';
-import {
-  SelectModel,
-  SelectProvider,
-  useProviderOptions,
-} from '~/components/SelectProviderModel';
-import { AgentToolPicker } from '~/pages/agents/components/AgentToolPicker';
-import { useAvailableErxesTools } from '~/pages/agents/hooks/useAvailableErxesTools';
+import { AgentFormFields } from '~/pages/agents/components/AgentFormFields';
 import {
   AGENT_FORM_DEFAULTS,
   AgentFormValues,
@@ -33,11 +13,11 @@ import { IChatAgent } from '~/modules/chat/hooks/useChatAgents';
 import { useUpdateAgent } from '~/modules/chat/hooks/useUpdateAgent';
 
 /**
- * In-chat agent editor. Lets you retune the agent powering the current
- * conversation — model, provider, instructions, tools, behaviour — without
- * leaving for the Agents settings page. agentId is intentionally read-only:
- * it keys the bot endpoint and every persisted thread, so changing it here
- * would orphan the conversation you're in.
+ * In-chat agent editor. Renders the canonical agent form (AgentFormFields) in a
+ * modal so the agent powering the current conversation can be retuned — model,
+ * provider, instructions, tools, behaviour — without leaving for the Agents
+ * settings page. Unlike that page it stays put on save (useUpdateAgent) and
+ * keeps agentId read-only, since changing it would orphan this conversation.
  */
 export const EditAgentDialog = ({
   agent,
@@ -53,23 +33,14 @@ export const EditAgentDialog = ({
     defaultValues: AGENT_FORM_DEFAULTS,
   });
 
-  const toolPolicy = form.watch('toolPolicy');
-  const provider = form.watch('provider');
   const model = form.watch('model');
-  const temperature = form.watch('temperature');
-
-  const { providers: enabledProviders } = useProviderOptions();
-  const { operations, loading: availableLoading } = useAvailableErxesTools(
-    toolPolicy === 'custom',
-  );
   const { saveAgent, saving } = useUpdateAgent(agent._id, () =>
     onOpenChange(false),
   );
 
-  // Repopulate every time the dialog opens (or the target agent changes) so a
-  // reopened modal never shows a stale draft from a previous edit.
+  // Populate from the target agent when the dialog mounts. The dialog is only
+  // mounted while open (lifted in AgentRail), so this runs once per open.
   useEffect(() => {
-    if (!open) return;
     form.reset({
       name: agent.name || '',
       agentId: agent.agentId || '',
@@ -84,7 +55,7 @@ export const EditAgentDialog = ({
       temperature: agent.temperature ?? null,
       isEnabled: agent.isEnabled ?? true,
     });
-  }, [open, agent, form]);
+  }, [agent, form]);
 
   const onSubmit = (doc: AgentFormValues) => saveAgent(doc);
 
@@ -102,300 +73,7 @@ export const EditAgentDialog = ({
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <div className="max-h-[65vh] space-y-4 overflow-y-auto px-5 py-4">
-              <FormSection
-                title="AI Model"
-                description="Select the provider and model that powers this agent."
-              >
-                {enabledProviders.length === 0 ? (
-                  <Alert>
-                    <IconInfoCircle className="size-4" />
-                    <Alert.Title>No providers configured</Alert.Title>
-                    <Alert.Description>
-                      <Link
-                        to="/settings/erxes-agent/providers"
-                        className="underline underline-offset-4"
-                      >
-                        Add a provider
-                      </Link>{' '}
-                      to switch models.
-                    </Alert.Description>
-                  </Alert>
-                ) : (
-                  <>
-                    <Form.Field
-                      control={form.control}
-                      name="provider"
-                      render={({ field }) => (
-                        <Form.Item>
-                          <Form.Label>Provider</Form.Label>
-                          <SelectProvider
-                            value={field.value}
-                            onValueChange={(v) => {
-                              field.onChange(v);
-                              form.setValue('model', '');
-                            }}
-                          />
-                          <Form.Message />
-                        </Form.Item>
-                      )}
-                    />
-
-                    <Form.Field
-                      control={form.control}
-                      name="model"
-                      render={({ field }) => (
-                        <Form.Item>
-                          <Form.Label>Model</Form.Label>
-                          <SelectModel
-                            provider={provider}
-                            value={field.value}
-                            onValueChange={field.onChange}
-                          />
-                          <Form.Description>
-                            Listed live from the provider's model API.
-                          </Form.Description>
-                          <Form.Message />
-                        </Form.Item>
-                      )}
-                    />
-                  </>
-                )}
-              </FormSection>
-
-              <Separator />
-
-              <FormSection title="Basic Info">
-                <Form.Field
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Name</Form.Label>
-                      <Form.Control>
-                        <Input
-                          {...field}
-                          placeholder="Customer Support Agent"
-                        />
-                      </Form.Control>
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-
-                <Form.Field
-                  control={form.control}
-                  name="agentId"
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Agent ID</Form.Label>
-                      <Form.Control>
-                        <Input
-                          {...field}
-                          disabled
-                          className="font-mono text-sm"
-                        />
-                      </Form.Control>
-                      <Form.Description>
-                        Identifies the bot endpoint and this agent's threads —
-                        not editable here.
-                      </Form.Description>
-                    </Form.Item>
-                  )}
-                />
-
-                <Form.Field
-                  control={form.control}
-                  name="description"
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Description</Form.Label>
-                      <Form.Control>
-                        <Input {...field} placeholder="What this agent does" />
-                      </Form.Control>
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-
-                <Form.Field
-                  control={form.control}
-                  name="instructions"
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>System Instructions</Form.Label>
-                      <Form.Control>
-                        <Textarea
-                          {...field}
-                          placeholder="You are a helpful customer support agent for…"
-                          rows={5}
-                        />
-                      </Form.Control>
-                      <Form.Description>
-                        The system prompt sent to the LLM on every conversation.
-                      </Form.Description>
-                      <Form.Message />
-                    </Form.Item>
-                  )}
-                />
-              </FormSection>
-
-              <Separator />
-
-              <FormSection
-                title="Tool Access"
-                description="Control which erxes operations this agent can search and run."
-              >
-                <Form.Field
-                  control={form.control}
-                  name="toolPolicy"
-                  render={({ field }) => (
-                    <div className="flex items-center justify-between gap-4">
-                      <div>
-                        <Label className="font-medium">
-                          Restrict tool access
-                        </Label>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          {field.value === 'custom'
-                            ? 'This agent can only use the operations selected below.'
-                            : 'Off: the agent can search and run any erxes operation.'}
-                        </p>
-                      </div>
-                      <Switch
-                        checked={field.value === 'custom'}
-                        onCheckedChange={(v) =>
-                          field.onChange(v ? 'custom' : 'all')
-                        }
-                      />
-                    </div>
-                  )}
-                />
-
-                {toolPolicy === 'custom' && (
-                  <Form.Field
-                    control={form.control}
-                    name="allowedTools"
-                    render={({ field }) => (
-                      <AgentToolPicker
-                        value={field.value}
-                        onChange={field.onChange}
-                        operations={operations}
-                        loading={availableLoading}
-                      />
-                    )}
-                  />
-                )}
-              </FormSection>
-
-              <Separator />
-
-              <FormSection title="Behavior">
-                <Form.Field
-                  control={form.control}
-                  name="memoryEnabled"
-                  render={({ field }) => (
-                    <div className="flex items-center justify-between gap-4">
-                      <div>
-                        <Label className="font-medium">
-                          Conversation Memory
-                        </Label>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Remembers previous messages per conversation thread
-                        </p>
-                      </div>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </div>
-                  )}
-                />
-
-                <Separator />
-
-                <Form.Field
-                  control={form.control}
-                  name="maxSteps"
-                  render={({ field }) => (
-                    <Field
-                      label="Max Tool Steps"
-                      hint="Max consecutive tool calls the agent can make (default: 10)"
-                    >
-                      <Input
-                        type="number"
-                        min={1}
-                        max={50}
-                        value={field.value}
-                        onChange={(e) =>
-                          field.onChange(parseInt(e.target.value, 10) || 10)
-                        }
-                        className="w-24"
-                      />
-                    </Field>
-                  )}
-                />
-
-                <Separator />
-
-                <Form.Field
-                  control={form.control}
-                  name="temperature"
-                  render={({ field }) => (
-                    <Field
-                      label="Temperature"
-                      hint="Sampling randomness (0–2). Some models only accept a fixed value."
-                    >
-                      <div className="flex items-center gap-3">
-                        <Slider
-                          min={0}
-                          max={2}
-                          step={0.1}
-                          value={[field.value ?? 1]}
-                          onValueChange={([v]: number[]) => field.onChange(v)}
-                          className="max-w-xs flex-1"
-                        />
-                        <span className="w-16 text-sm tabular-nums text-muted-foreground">
-                          {temperature != null
-                            ? temperature.toFixed(1)
-                            : 'Default'}
-                        </span>
-                        {temperature != null && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 text-xs"
-                            onClick={() => field.onChange(null)}
-                          >
-                            Use default
-                          </Button>
-                        )}
-                      </div>
-                    </Field>
-                  )}
-                />
-
-                <Separator />
-
-                <Form.Field
-                  control={form.control}
-                  name="isEnabled"
-                  render={({ field }) => (
-                    <div className="flex items-center justify-between gap-4">
-                      <div>
-                        <Label className="font-medium">Enabled</Label>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Disabling removes the agent from the chat rail and bot
-                          webhook
-                        </p>
-                      </div>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </div>
-                  )}
-                />
-              </FormSection>
+              <AgentFormFields form={form} />
             </div>
 
             <Dialog.Footer className="flex items-center gap-2 border-t px-5 py-3.5">

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/EditAgentDialog.tsx
@@ -1,0 +1,428 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { IconInfoCircle } from '@tabler/icons-react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  Form,
+  Input,
+  Label,
+  Separator,
+  Slider,
+  Switch,
+  Textarea,
+  Tooltip,
+} from 'erxes-ui';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Field, FormSection } from '~/components/FormLayout';
+import {
+  SelectModel,
+  SelectProvider,
+  useProviderOptions,
+} from '~/components/SelectProviderModel';
+import { AgentToolPicker } from '~/pages/agents/components/AgentToolPicker';
+import { useAvailableErxesTools } from '~/pages/agents/hooks/useAvailableErxesTools';
+import {
+  AGENT_FORM_DEFAULTS,
+  AgentFormValues,
+  agentFormSchema,
+} from '~/pages/agents/validations';
+import { IChatAgent } from '~/modules/chat/hooks/useChatAgents';
+import { useUpdateAgent } from '~/modules/chat/hooks/useUpdateAgent';
+
+/**
+ * In-chat agent editor. Lets you retune the agent powering the current
+ * conversation — model, provider, instructions, tools, behaviour — without
+ * leaving for the Agents settings page. agentId is intentionally read-only:
+ * it keys the bot endpoint and every persisted thread, so changing it here
+ * would orphan the conversation you're in.
+ */
+export const EditAgentDialog = ({
+  agent,
+  open,
+  onOpenChange,
+}: {
+  agent: IChatAgent;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const form = useForm<AgentFormValues>({
+    resolver: zodResolver(agentFormSchema),
+    defaultValues: AGENT_FORM_DEFAULTS,
+  });
+
+  const toolPolicy = form.watch('toolPolicy');
+  const provider = form.watch('provider');
+  const model = form.watch('model');
+  const temperature = form.watch('temperature');
+
+  const { providers: enabledProviders } = useProviderOptions();
+  const { operations, loading: availableLoading } = useAvailableErxesTools(
+    toolPolicy === 'custom',
+  );
+  const { saveAgent, saving } = useUpdateAgent(agent._id, () =>
+    onOpenChange(false),
+  );
+
+  // Repopulate every time the dialog opens (or the target agent changes) so a
+  // reopened modal never shows a stale draft from a previous edit.
+  useEffect(() => {
+    if (!open) return;
+    form.reset({
+      name: agent.name || '',
+      agentId: agent.agentId || '',
+      description: agent.description || '',
+      instructions: agent.instructions || '',
+      provider: agent.provider || '',
+      model: agent.model || '',
+      toolPolicy: agent.toolPolicy === 'custom' ? 'custom' : 'all',
+      allowedTools: agent.allowedTools || [],
+      memoryEnabled: agent.memoryEnabled ?? true,
+      maxSteps: agent.maxSteps ?? 10,
+      temperature: agent.temperature ?? null,
+      isEnabled: agent.isEnabled ?? true,
+    });
+  }, [open, agent, form]);
+
+  const onSubmit = (doc: AgentFormValues) => saveAgent(doc);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content className="max-w-2xl gap-0 p-0">
+        <Dialog.Header className="border-b px-5 py-3.5">
+          <Dialog.Title>Edit {agent.name}</Dialog.Title>
+          <Dialog.Description>
+            Change this agent's model, provider and behaviour. Changes apply to
+            new messages right away.
+          </Dialog.Description>
+        </Dialog.Header>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="max-h-[65vh] space-y-4 overflow-y-auto px-5 py-4">
+              <FormSection
+                title="AI Model"
+                description="Select the provider and model that powers this agent."
+              >
+                {enabledProviders.length === 0 ? (
+                  <Alert>
+                    <IconInfoCircle className="size-4" />
+                    <Alert.Title>No providers configured</Alert.Title>
+                    <Alert.Description>
+                      <Link
+                        to="/settings/erxes-agent/providers"
+                        className="underline underline-offset-4"
+                      >
+                        Add a provider
+                      </Link>{' '}
+                      to switch models.
+                    </Alert.Description>
+                  </Alert>
+                ) : (
+                  <>
+                    <Form.Field
+                      control={form.control}
+                      name="provider"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label>Provider</Form.Label>
+                          <SelectProvider
+                            value={field.value}
+                            onValueChange={(v) => {
+                              field.onChange(v);
+                              form.setValue('model', '');
+                            }}
+                          />
+                          <Form.Message />
+                        </Form.Item>
+                      )}
+                    />
+
+                    <Form.Field
+                      control={form.control}
+                      name="model"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label>Model</Form.Label>
+                          <SelectModel
+                            provider={provider}
+                            value={field.value}
+                            onValueChange={field.onChange}
+                          />
+                          <Form.Description>
+                            Listed live from the provider's model API.
+                          </Form.Description>
+                          <Form.Message />
+                        </Form.Item>
+                      )}
+                    />
+                  </>
+                )}
+              </FormSection>
+
+              <Separator />
+
+              <FormSection title="Basic Info">
+                <Form.Field
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Name</Form.Label>
+                      <Form.Control>
+                        <Input {...field} placeholder="Customer Support Agent" />
+                      </Form.Control>
+                      <Form.Message />
+                    </Form.Item>
+                  )}
+                />
+
+                <Form.Field
+                  control={form.control}
+                  name="agentId"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Agent ID</Form.Label>
+                      <Form.Control>
+                        <Input
+                          {...field}
+                          disabled
+                          className="font-mono text-sm"
+                        />
+                      </Form.Control>
+                      <Form.Description>
+                        Identifies the bot endpoint and this agent's threads —
+                        not editable here.
+                      </Form.Description>
+                    </Form.Item>
+                  )}
+                />
+
+                <Form.Field
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Description</Form.Label>
+                      <Form.Control>
+                        <Input {...field} placeholder="What this agent does" />
+                      </Form.Control>
+                      <Form.Message />
+                    </Form.Item>
+                  )}
+                />
+
+                <Form.Field
+                  control={form.control}
+                  name="instructions"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>System Instructions</Form.Label>
+                      <Form.Control>
+                        <Textarea
+                          {...field}
+                          placeholder="You are a helpful customer support agent for…"
+                          rows={5}
+                        />
+                      </Form.Control>
+                      <Form.Description>
+                        The system prompt sent to the LLM on every conversation.
+                      </Form.Description>
+                      <Form.Message />
+                    </Form.Item>
+                  )}
+                />
+              </FormSection>
+
+              <Separator />
+
+              <FormSection
+                title="Tool Access"
+                description="Control which erxes operations this agent can search and run."
+              >
+                <Form.Field
+                  control={form.control}
+                  name="toolPolicy"
+                  render={({ field }) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <Label className="font-medium">
+                          Restrict tool access
+                        </Label>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          {field.value === 'custom'
+                            ? 'This agent can only use the operations selected below.'
+                            : 'Off: the agent can search and run any erxes operation.'}
+                        </p>
+                      </div>
+                      <Switch
+                        checked={field.value === 'custom'}
+                        onCheckedChange={(v) =>
+                          field.onChange(v ? 'custom' : 'all')
+                        }
+                      />
+                    </div>
+                  )}
+                />
+
+                {toolPolicy === 'custom' && (
+                  <Form.Field
+                    control={form.control}
+                    name="allowedTools"
+                    render={({ field }) => (
+                      <AgentToolPicker
+                        value={field.value}
+                        onChange={field.onChange}
+                        operations={operations}
+                        loading={availableLoading}
+                      />
+                    )}
+                  />
+                )}
+              </FormSection>
+
+              <Separator />
+
+              <FormSection title="Behavior">
+                <Form.Field
+                  control={form.control}
+                  name="memoryEnabled"
+                  render={({ field }) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <Label className="font-medium">
+                          Conversation Memory
+                        </Label>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Remembers previous messages per conversation thread
+                        </p>
+                      </div>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </div>
+                  )}
+                />
+
+                <Separator />
+
+                <Form.Field
+                  control={form.control}
+                  name="maxSteps"
+                  render={({ field }) => (
+                    <Field
+                      label="Max Tool Steps"
+                      hint="Max consecutive tool calls the agent can make (default: 10)"
+                    >
+                      <Input
+                        type="number"
+                        min={1}
+                        max={50}
+                        value={field.value}
+                        onChange={(e) =>
+                          field.onChange(parseInt(e.target.value, 10) || 10)
+                        }
+                        className="w-24"
+                      />
+                    </Field>
+                  )}
+                />
+
+                <Separator />
+
+                <Form.Field
+                  control={form.control}
+                  name="temperature"
+                  render={({ field }) => (
+                    <Field
+                      label="Temperature"
+                      hint="Sampling randomness (0–2). Some models only accept a fixed value."
+                    >
+                      <div className="flex items-center gap-3">
+                        <Slider
+                          min={0}
+                          max={2}
+                          step={0.1}
+                          value={[field.value ?? 1]}
+                          onValueChange={([v]: number[]) => field.onChange(v)}
+                          className="max-w-xs flex-1"
+                        />
+                        <span className="w-16 text-sm tabular-nums text-muted-foreground">
+                          {temperature != null
+                            ? temperature.toFixed(1)
+                            : 'Default'}
+                        </span>
+                        {temperature != null && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 text-xs"
+                            onClick={() => field.onChange(null)}
+                          >
+                            Use default
+                          </Button>
+                        )}
+                      </div>
+                    </Field>
+                  )}
+                />
+
+                <Separator />
+
+                <Form.Field
+                  control={form.control}
+                  name="isEnabled"
+                  render={({ field }) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <Label className="font-medium">Enabled</Label>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Disabling removes the agent from the chat rail and bot
+                          webhook
+                        </p>
+                      </div>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </div>
+                  )}
+                />
+              </FormSection>
+            </div>
+
+            <Dialog.Footer className="flex items-center gap-2 border-t px-5 py-3.5">
+              <Tooltip.Provider>
+                <Tooltip>
+                  <Tooltip.Trigger asChild>
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link to={`/settings/erxes-agent/agents/edit/${agent._id}`}>
+                        Open full editor
+                      </Link>
+                    </Button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>
+                    Edit every setting on the Agents page
+                  </Tooltip.Content>
+                </Tooltip>
+              </Tooltip.Provider>
+              <div className="flex-1" />
+              <Dialog.Close asChild>
+                <Button type="button" variant="outline" size="sm">
+                  Cancel
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" size="sm" disabled={saving || !model}>
+                {saving ? 'Saving…' : 'Save changes'}
+              </Button>
+            </Dialog.Footer>
+          </form>
+        </Form>
+      </Dialog.Content>
+    </Dialog>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/ReasoningEffortControl.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/ReasoningEffortControl.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { IconBrain, IconCheck } from '@tabler/icons-react';
+import { Button, Command, Popover, Tooltip } from 'erxes-ui';
+import {
+  ReasoningEffort,
+  REASONING_EFFORT_OPTIONS,
+} from '~/modules/chat/types';
+
+const REASONING_PICKER_ITEMS: {
+  value?: ReasoningEffort;
+  label: string;
+  hint: string;
+}[] = [
+  { value: undefined, label: 'Auto', hint: "Use the agent's default" },
+  ...REASONING_EFFORT_OPTIONS,
+];
+
+// One selectable row in the reasoning-level picker (kept separate so the menu
+// JSX tree stays shallow).
+const ReasoningOption = ({
+  label,
+  hint,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  hint: string;
+  selected: boolean;
+  onSelect: () => void;
+}) => (
+  <Command.Item
+    value={label}
+    onSelect={onSelect}
+    className="h-auto cursor-pointer items-start gap-2 rounded-lg px-2.5 py-2"
+  >
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <span
+        className={`text-sm leading-none ${
+          selected ? 'font-medium text-foreground' : 'text-foreground/90'
+        }`}
+      >
+        {label}
+      </span>
+      <span className="text-[11px] leading-snug text-muted-foreground">
+        {hint}
+      </span>
+    </div>
+    <IconCheck
+      className={`mt-0.5 shrink-0 text-muted-foreground transition-opacity ${
+        selected ? 'opacity-100' : 'opacity-0'
+      }`}
+    />
+  </Command.Item>
+);
+
+/**
+ * A deliberately low-key composer control: a ghost "brain" icon that opens a
+ * small level picker. Hidden in plain sight — most users never touch it, power
+ * users can dial reasoning up or down per conversation. The choice persists per
+ * agent (localStorage) and is unset by default, leaving the agent's configured
+ * behaviour untouched.
+ */
+export const ReasoningEffortControl = ({
+  value,
+  onChange,
+  disabled,
+}: {
+  value?: ReasoningEffort;
+  onChange: (effort?: ReasoningEffort) => void;
+  disabled?: boolean;
+}) => {
+  const [open, setOpen] = useState(false);
+  const active = Boolean(value);
+  const activeLabel = REASONING_EFFORT_OPTIONS.find(
+    (o) => o.value === value,
+  )?.label;
+
+  // Apply a level and close the popover.
+  const select = (effort?: ReasoningEffort) => {
+    onChange(effort);
+    setOpen(false);
+  };
+
+  // Extracted so the trigger's own element chain doesn't deepen the tree below.
+  const trigger = (
+    <Popover.Trigger asChild>
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="Thinking level"
+        disabled={disabled}
+        className={`size-9 shrink-0 transition-colors hover:text-foreground ${
+          active ? 'text-foreground' : 'text-muted-foreground'
+        }`}
+      >
+        <IconBrain className="size-4" />
+      </Button>
+    </Popover.Trigger>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip.Provider>
+        <Tooltip>
+          <Tooltip.Trigger asChild>{trigger}</Tooltip.Trigger>
+          <Tooltip.Content>
+            {active ? `Thinking: ${activeLabel}` : 'Thinking level'}
+          </Tooltip.Content>
+        </Tooltip>
+      </Tooltip.Provider>
+      <Popover.Content
+        align="start"
+        sideOffset={8}
+        className="w-60 overflow-hidden p-0"
+      >
+        <div className="px-3 pb-1.5 pt-2.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+          Thinking level
+        </div>
+        <Command shouldFilter={false}>
+          <Command.List className="px-1 pb-1">
+            {REASONING_PICKER_ITEMS.map((opt) => (
+              <ReasoningOption
+                key={opt.value ?? 'auto'}
+                label={opt.label}
+                hint={opt.hint}
+                selected={(opt.value ?? undefined) === (value ?? undefined)}
+                onSelect={() => select(opt.value)}
+              />
+            ))}
+          </Command.List>
+        </Command>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useChatAgents.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useChatAgents.ts
@@ -12,6 +12,14 @@ export interface IChatAgent {
   provider?: string;
   description?: string;
   isEnabled?: boolean;
+  // Full settings — present on the MASTRA_AGENTS payload, used by the in-chat
+  // "Edit agent" modal so it can populate without a second fetch.
+  instructions?: string;
+  toolPolicy?: string;
+  allowedTools?: string[];
+  memoryEnabled?: boolean;
+  maxSteps?: number;
+  temperature?: number | null;
 }
 
 interface MastraAgentsResponse {

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useUpdateAgent.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useUpdateAgent.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { MASTRA_AGENTS } from '~/graphql/queries';
+import { MASTRA_AGENT_UPDATE } from '~/graphql/mutations';
+import { AgentFormValues } from '~/pages/agents/validations';
+
+/**
+ * Inline agent update for the in-chat "Edit agent" modal. Unlike useSaveAgent
+ * (which navigates back to the settings list on success), this stays put and
+ * refetches the chat rail's agent list so the change shows immediately.
+ */
+export const useUpdateAgent = (id: string, onCompleted?: () => void) => {
+  const [updateAgent, { loading }] = useMutation(MASTRA_AGENT_UPDATE, {
+    refetchQueries: [{ query: MASTRA_AGENTS }],
+    awaitRefetchQueries: true,
+    onCompleted: () => {
+      toast({ title: 'Agent updated' });
+      onCompleted?.();
+    },
+    onError: (error) =>
+      toast({
+        title: 'Could not update agent',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+
+  const saveAgent = (doc: AgentFormValues) =>
+    updateAgent({ variables: { _id: id, doc } });
+
+  return { saveAgent, saving: loading };
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -20,6 +20,8 @@ import {
   EMPTY_THREAD,
   Message,
   MessageMeta,
+  ReasoningEffort,
+  REASONING_EFFORT_OPTIONS,
   SessionMeta,
   ThreadChatState,
 } from '~/modules/chat/types';
@@ -64,6 +66,25 @@ interface MastraAgentChatResponse {
 const threadKey = (agentKey: string, threadId: string) =>
   `${agentKey}:${threadId}`;
 
+const REASONING_EFFORT_VALUES = REASONING_EFFORT_OPTIONS.map((o) => o.value);
+
+/** localStorage key holding the persisted reasoning choice for one agent. */
+const reasoningEffortStorageKey = (agentKey: string) =>
+  `erxes-agent:reasoningEffort:${agentKey}`;
+
+// Best-effort read of the persisted choice — localStorage may be unavailable
+// (private mode / SSR) and may hold stale values from an older enum.
+const loadReasoningEffort = (agentKey: string): ReasoningEffort | undefined => {
+  try {
+    const raw = localStorage.getItem(reasoningEffortStorageKey(agentKey));
+    return raw && REASONING_EFFORT_VALUES.includes(raw as ReasoningEffort)
+      ? (raw as ReasoningEffort)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 // DB-backed chat store. Sessions (threads) and their messages live in MongoDB
 // via the erxes-agent_api plugin; this store mirrors them in memory for the UI.
 // Replies stream over SSE through the gateway plugin proxy, falling back to the
@@ -76,6 +97,10 @@ interface ChatStoreState {
 
   setCurrentAgent: (agentId: string | undefined) => void;
   markRead: (agentKey: string) => void;
+  setReasoningEffort: (
+    agentKey: string,
+    effort: ReasoningEffort | undefined,
+  ) => void;
   newDraft: (agentKey: string) => void;
   loadSessions: (
     client: Client,
@@ -274,6 +299,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
     message: string,
     abort: AbortController,
     attachments?: ChatAttachment[],
+    reasoningEffort?: ReasoningEffort,
   ): Promise<boolean> => {
     let response: Response;
     try {
@@ -288,6 +314,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
             message,
             threadId,
             attachments: attachments?.length ? attachments : undefined,
+            reasoningEffort: reasoningEffort || undefined,
           }),
           signal: abort.signal,
         },
@@ -381,6 +408,18 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
           ? { unreadAgents: s.unreadAgents.filter((a) => a !== agentKey) }
           : s,
       ),
+
+    // Persist the power-user reasoning choice for this agent's chat view.
+    setReasoningEffort: (agentKey, effort) => {
+      try {
+        const key = reasoningEffortStorageKey(agentKey);
+        if (effort) localStorage.setItem(key, effort);
+        else localStorage.removeItem(key);
+      } catch {
+        // localStorage unavailable — the in-memory patch below still applies.
+      }
+      patchAgent(agentKey, { reasoningEffort: effort });
+    },
 
     newDraft: (agentKey) => {
       const threadId = generateThreadId();
@@ -538,6 +577,8 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         agent = ensureAgent(agentKey);
       }
       const threadId = agent.activeThreadId!;
+      const reasoningEffort =
+        agent.reasoningEffort ?? loadReasoningEffort(agentKey);
 
       // Surface the session in the sidebar the instant the first message is
       // sent — don't wait for the turn to finish. The backend registers + tags
@@ -572,6 +613,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
           message,
           abort,
           attachments,
+          reasoningEffort,
         );
         if (!streamed) {
           await sendViaQuery(
@@ -614,6 +656,8 @@ export const selectAgentView = (
     : EMPTY_THREAD;
   return {
     ...agent,
+    // Surface the persisted choice even before the agent state is created.
+    reasoningEffort: agent.reasoningEffort ?? loadReasoningEffort(agentKey),
     messages: thread.messages,
     loading: thread.loading,
     messagesLoading: thread.messagesLoading,
@@ -681,6 +725,8 @@ export const chatStore = {
   setCurrentAgent: (agentId: string | undefined) =>
     useChatStore.getState().setCurrentAgent(agentId),
   markRead: (agentKey: string) => useChatStore.getState().markRead(agentKey),
+  setReasoningEffort: (agentKey: string, effort: ReasoningEffort | undefined) =>
+    useChatStore.getState().setReasoningEffort(agentKey, effort),
   newDraft: (agentKey: string) => useChatStore.getState().newDraft(agentKey),
   loadSessions: (client: Client, agentKey: string, mastraAgentId: string) =>
     useChatStore.getState().loadSessions(client, agentKey, mastraAgentId),

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -66,20 +66,24 @@ interface MastraAgentChatResponse {
 const threadKey = (agentKey: string, threadId: string) =>
   `${agentKey}:${threadId}`;
 
-const REASONING_EFFORT_VALUES = REASONING_EFFORT_OPTIONS.map((o) => o.value);
+const REASONING_EFFORT_VALUES: readonly string[] = REASONING_EFFORT_OPTIONS.map(
+  (o) => o.value,
+);
+
+const isReasoningEffort = (v: unknown): v is ReasoningEffort =>
+  typeof v === 'string' && REASONING_EFFORT_VALUES.includes(v);
 
 /** localStorage key holding the persisted reasoning choice for one agent. */
 const reasoningEffortStorageKey = (agentKey: string) =>
   `erxes-agent:reasoningEffort:${agentKey}`;
 
 // Best-effort read of the persisted choice — localStorage may be unavailable
-// (private mode / SSR) and may hold stale values from an older enum.
+// (private mode / SSR) and may hold stale values from an older enum. Read once
+// at agent-slice creation (setCurrentAgent), never inside a reactive selector.
 const loadReasoningEffort = (agentKey: string): ReasoningEffort | undefined => {
   try {
     const raw = localStorage.getItem(reasoningEffortStorageKey(agentKey));
-    return raw && REASONING_EFFORT_VALUES.includes(raw as ReasoningEffort)
-      ? (raw as ReasoningEffort)
-      : undefined;
+    return isReasoningEffort(raw) ? raw : undefined;
   } catch {
     return undefined;
   }
@@ -399,7 +403,17 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
 
     setCurrentAgent: (agentId) => {
       set({ currentViewedAgentId: agentId });
-      if (agentId) get().markRead(agentId);
+      if (agentId) {
+        get().markRead(agentId);
+        // Hydrate the persisted reasoning choice exactly once, when this
+        // agent's slice first comes into view. Reads localStorage a single
+        // time so the reactive selector never has to.
+        if (!get().agents[agentId]) {
+          patchAgent(agentId, {
+            reasoningEffort: loadReasoningEffort(agentId),
+          });
+        }
+      }
     },
 
     markRead: (agentKey) =>
@@ -577,8 +591,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         agent = ensureAgent(agentKey);
       }
       const threadId = agent.activeThreadId!;
-      const reasoningEffort =
-        agent.reasoningEffort ?? loadReasoningEffort(agentKey);
+      const reasoningEffort = agent.reasoningEffort;
 
       // Surface the session in the sidebar the instant the first message is
       // sent — don't wait for the turn to finish. The backend registers + tags
@@ -656,8 +669,6 @@ export const selectAgentView = (
     : EMPTY_THREAD;
   return {
     ...agent,
-    // Surface the persisted choice even before the agent state is created.
-    reasoningEffort: agent.reasoningEffort ?? loadReasoningEffort(agentKey),
     messages: thread.messages,
     loading: thread.loading,
     messagesLoading: thread.messagesLoading,

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
@@ -68,11 +68,30 @@ export interface ThreadChatState {
   activity?: string; // server-summarized "what is the agent doing right now"
 }
 
+// How hard the model should think before answering. Unset = let the agent's
+// configured default stand (current behaviour). The chat composer exposes this
+// behind a low-key brain control for power users; the backend maps it to the
+// right per-provider reasoning option at stream time.
+export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
+export const REASONING_EFFORT_OPTIONS: {
+  value: ReasoningEffort;
+  label: string;
+  hint: string;
+}[] = [
+  { value: 'off', label: 'Off', hint: 'Answer directly, no reasoning' },
+  { value: 'low', label: 'Low', hint: 'Brief reasoning, fastest' },
+  { value: 'medium', label: 'Medium', hint: 'Balanced reasoning' },
+  { value: 'high', label: 'High', hint: 'Deep reasoning, slowest' },
+];
+
 export interface AgentChatState {
   sessions: SessionMeta[];
   sessionsLoaded: boolean;
   activeThreadId?: string;
   isDraft: boolean; // active session is new and not yet persisted
+  // Power-user reasoning override for this agent's chat view. Unset = default.
+  reasoningEffort?: ReasoningEffort;
 }
 
 // What the conversation view renders: agent-level session state + the active
@@ -134,4 +153,5 @@ export const EMPTY_AGENT: AgentChatState = {
   sessionsLoaded: false,
   activeThreadId: undefined,
   isDraft: false,
+  reasoningEffort: undefined,
 };

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/AgentFormPage.tsx
@@ -1,31 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { IconRobot, IconArrowLeft, IconInfoCircle } from '@tabler/icons-react';
-import {
-  Alert,
-  Breadcrumb,
-  Button,
-  Form,
-  Input,
-  Label,
-  Separator,
-  Slider,
-  Switch,
-  Textarea,
-  Tooltip,
-} from 'erxes-ui';
+import { IconRobot, IconArrowLeft } from '@tabler/icons-react';
+import { Breadcrumb, Button, Form, Separator } from 'erxes-ui';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PageHeader } from 'ui-modules';
-import { Field, FormSection } from '~/components/FormLayout';
-import {
-  SelectModel,
-  SelectProvider,
-  useProviderOptions,
-} from '~/components/SelectProviderModel';
-import { AgentToolPicker } from './components/AgentToolPicker';
+import { AgentFormFields } from './components/AgentFormFields';
 import { useAgent } from './hooks/useAgent';
-import { useAvailableErxesTools } from './hooks/useAvailableErxesTools';
 import { useSaveAgent } from './hooks/useSaveAgent';
 import {
   AGENT_FORM_DEFAULTS,
@@ -46,11 +27,6 @@ export const AgentFormPage = () => {
   const [autoSlug, setAutoSlug] = useState(true);
 
   const { agent } = useAgent(id);
-  const toolPolicy = form.watch('toolPolicy');
-  const { operations, loading: availableLoading } = useAvailableErxesTools(
-    toolPolicy === 'custom',
-  );
-  const { providers: enabledProviders } = useProviderOptions();
   const { saveAgent, saving } = useSaveAgent(id);
 
   // Populate form from saved data — runs once when agent data arrives
@@ -82,8 +58,6 @@ export const AgentFormPage = () => {
   const onSubmit = (doc: AgentFormValues) => saveAgent(doc);
 
   const model = form.watch('model');
-  const provider = form.watch('provider');
-  const temperature = form.watch('temperature');
 
   const saveLabel = isEdit ? 'Save Changes' : 'Create Agent';
 
@@ -130,336 +104,12 @@ export const AgentFormPage = () => {
             onSubmit={form.handleSubmit(onSubmit)}
             className="max-w-2xl mx-auto space-y-4"
           >
-            <FormSection title="Basic Info">
-              <Form.Field
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <Form.Item>
-                    <Form.Label>Name</Form.Label>
-                    <Form.Control>
-                      <Input
-                        {...field}
-                        onChange={(e) => handleNameChange(e.target.value)}
-                        placeholder="Customer Support Agent"
-                      />
-                    </Form.Control>
-                    <Form.Message />
-                  </Form.Item>
-                )}
-              />
-
-              <Form.Field
-                control={form.control}
-                name="agentId"
-                render={({ field }) => (
-                  <Form.Item>
-                    <Form.Label>Agent ID</Form.Label>
-                    <Form.Control>
-                      <Input
-                        {...field}
-                        onChange={(e) => {
-                          setAutoSlug(false);
-                          field.onChange(e.target.value);
-                        }}
-                        placeholder="customer-support"
-                        className="font-mono text-sm"
-                      />
-                    </Form.Control>
-                    <Form.Description>
-                      Unique identifier used by the bot endpoint. Auto-generated
-                      from name.
-                    </Form.Description>
-                    <Form.Message />
-                  </Form.Item>
-                )}
-              />
-
-              <Form.Field
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <Form.Item>
-                    <Form.Label>Description</Form.Label>
-                    <Form.Control>
-                      <Input {...field} placeholder="What this agent does" />
-                    </Form.Control>
-                    <Form.Message />
-                  </Form.Item>
-                )}
-              />
-
-              <Form.Field
-                control={form.control}
-                name="instructions"
-                render={({ field }) => (
-                  <Form.Item>
-                    <Form.Label>System Instructions</Form.Label>
-                    <Form.Control>
-                      <Textarea
-                        {...field}
-                        placeholder="You are a helpful customer support agent for…"
-                        rows={6}
-                      />
-                    </Form.Control>
-                    <Form.Description>
-                      This is the system prompt sent to the LLM on every
-                      conversation.
-                    </Form.Description>
-                    <Form.Message />
-                  </Form.Item>
-                )}
-              />
-            </FormSection>
-
-            <FormSection
-              title="AI Model"
-              description="Select the provider and model that powers this agent."
-            >
-              {enabledProviders.length === 0 ? (
-                <Alert>
-                  <IconInfoCircle className="size-4" />
-                  <Alert.Title>No providers configured</Alert.Title>
-                  <Alert.Description>
-                    <Link
-                      to="/settings/erxes-agent/providers"
-                      className="underline underline-offset-4"
-                    >
-                      Add a provider
-                    </Link>{' '}
-                    before creating an agent.
-                  </Alert.Description>
-                </Alert>
-              ) : (
-                <>
-                  <Form.Field
-                    control={form.control}
-                    name="provider"
-                    render={({ field }) => (
-                      <Form.Item>
-                        <Form.Label>Provider</Form.Label>
-                        <SelectProvider
-                          value={field.value}
-                          onValueChange={(v) => {
-                            field.onChange(v);
-                            form.setValue('model', '');
-                          }}
-                        />
-                        <Form.Message />
-                      </Form.Item>
-                    )}
-                  />
-
-                  <Form.Field
-                    control={form.control}
-                    name="model"
-                    render={({ field }) => (
-                      <Form.Item>
-                        <Form.Label>Model</Form.Label>
-                        <SelectModel
-                          provider={provider}
-                          value={field.value}
-                          onValueChange={field.onChange}
-                        />
-                        <Form.Description>
-                          Listed live from the provider's model API.
-                        </Form.Description>
-                        <Form.Message />
-                      </Form.Item>
-                    )}
-                  />
-                </>
-              )}
-            </FormSection>
-
-            <FormSection
-              title="Tool Access"
-              description="Control which erxes operations this agent can search and run."
-            >
-              <Form.Field
-                control={form.control}
-                name="toolPolicy"
-                render={({ field }) => (
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <Label className="font-medium">
-                        Restrict tool access
-                      </Label>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {field.value === 'custom'
-                          ? 'This agent can only use the operations selected below.'
-                          : 'Off: the agent can search and run any erxes operation (reads and writes).'}
-                      </p>
-                    </div>
-                    <Switch
-                      checked={field.value === 'custom'}
-                      onCheckedChange={(v) =>
-                        field.onChange(v ? 'custom' : 'all')
-                      }
-                    />
-                  </div>
-                )}
-              />
-
-              {toolPolicy === 'all' ? (
-                <Alert>
-                  <IconInfoCircle className="size-4" />
-                  <Alert.Title>Full access</Alert.Title>
-                  <Alert.Description>
-                    The agent discovers operations on demand and can run any
-                    query or mutation across every installed erxes service. Turn
-                    on “Restrict tool access” to limit it to specific
-                    operations.
-                  </Alert.Description>
-                </Alert>
-              ) : (
-                <Form.Field
-                  control={form.control}
-                  name="allowedTools"
-                  render={({ field }) => (
-                    <AgentToolPicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      operations={operations}
-                      loading={availableLoading}
-                    />
-                  )}
-                />
-              )}
-            </FormSection>
-
-            <FormSection title="Behavior">
-              <Form.Field
-                control={form.control}
-                name="memoryEnabled"
-                render={({ field }) => (
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <Label className="font-medium">Conversation Memory</Label>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        Remembers previous messages per conversation thread
-                      </p>
-                    </div>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </div>
-                )}
-              />
-
-              <Separator />
-
-              <Form.Field
-                control={form.control}
-                name="maxSteps"
-                render={({ field }) => (
-                  <Field
-                    label="Max Tool Steps"
-                    hint="Max consecutive tool calls the agent can make (default: 10)"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Input
-                        type="number"
-                        min={1}
-                        max={50}
-                        value={field.value}
-                        onChange={(e) =>
-                          field.onChange(parseInt(e.target.value, 10) || 10)
-                        }
-                        className="w-24"
-                      />
-                      <Tooltip.Provider>
-                        <Tooltip>
-                          <Tooltip.Trigger asChild>
-                            <IconInfoCircle className="size-4 text-muted-foreground" />
-                          </Tooltip.Trigger>
-                          <Tooltip.Content className="max-w-xs">
-                            Prevents infinite loops. Raise this if the agent
-                            frequently stops mid-task.
-                          </Tooltip.Content>
-                        </Tooltip>
-                      </Tooltip.Provider>
-                    </div>
-                  </Field>
-                )}
-              />
-
-              <Separator />
-
-              <Form.Field
-                control={form.control}
-                name="temperature"
-                render={({ field }) => (
-                  <Field
-                    label="Temperature"
-                    hint="Sampling randomness (0–2). Some models only accept a fixed value — e.g. Kimi thinking models require 1."
-                  >
-                    <div className="flex items-center gap-3">
-                      <Slider
-                        min={0}
-                        max={2}
-                        step={0.1}
-                        value={[field.value ?? 1]}
-                        onValueChange={([v]: number[]) => field.onChange(v)}
-                        className="flex-1 max-w-xs"
-                      />
-                      <span className="w-16 text-sm tabular-nums text-muted-foreground">
-                        {temperature != null
-                          ? temperature.toFixed(1)
-                          : 'Default'}
-                      </span>
-                      {temperature != null && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => field.onChange(null)}
-                        >
-                          Use default
-                        </Button>
-                      )}
-                      <Tooltip.Provider>
-                        <Tooltip>
-                          <Tooltip.Trigger asChild>
-                            <IconInfoCircle className="size-4 text-muted-foreground" />
-                          </Tooltip.Trigger>
-                          <Tooltip.Content className="max-w-xs">
-                            Lower values give more deterministic answers, higher
-                            values more creative ones. If the provider rejects
-                            the configured value (e.g. &quot;only 1 is
-                            allowed&quot;), set it to the value the model
-                            requires.
-                          </Tooltip.Content>
-                        </Tooltip>
-                      </Tooltip.Provider>
-                    </div>
-                  </Field>
-                )}
-              />
-
-              <Separator />
-
-              <Form.Field
-                control={form.control}
-                name="isEnabled"
-                render={({ field }) => (
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <Label className="font-medium">Enabled</Label>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        Disabled agents won't respond to bot webhook requests
-                      </p>
-                    </div>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </div>
-                )}
-              />
-            </FormSection>
+            <AgentFormFields
+              form={form}
+              agentIdEditable
+              onNameChange={handleNameChange}
+              onAgentIdChange={() => setAutoSlug(false)}
+            />
 
             <div className="flex gap-3 pb-4 sm:hidden">
               <Button type="submit" disabled={saving}>

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
@@ -1,0 +1,380 @@
+import { Link } from 'react-router-dom';
+import { IconInfoCircle } from '@tabler/icons-react';
+import {
+  Alert,
+  Button,
+  Form,
+  Input,
+  Label,
+  Separator,
+  Slider,
+  Switch,
+  Textarea,
+  Tooltip,
+} from 'erxes-ui';
+import { UseFormReturn } from 'react-hook-form';
+import { Field, FormSection } from '~/components/FormLayout';
+import {
+  SelectModel,
+  SelectProvider,
+  useProviderOptions,
+} from '~/components/SelectProviderModel';
+import { AgentToolPicker } from './AgentToolPicker';
+import { useAvailableErxesTools } from '../hooks/useAvailableErxesTools';
+import { AgentFormValues } from '../validations';
+
+// Canonical agent form body — every field group, shared by the Agents settings
+// page (AgentFormPage) and the in-chat quick editor (EditAgentDialog). The two
+// only differ in chrome (page header vs modal footer) and save behaviour
+// (navigate-away vs stay-put), plus whether agentId is editable: on the create
+// page it's a writable slug, in edit contexts it keys the bot endpoint and
+// every persisted thread, so it stays read-only.
+export const AgentFormFields = ({
+  form,
+  agentIdEditable = false,
+  onNameChange,
+  onAgentIdChange,
+}: {
+  form: UseFormReturn<AgentFormValues>;
+  /** Create flow only — agentId is the bot-endpoint key, frozen once it exists. */
+  agentIdEditable?: boolean;
+  /** Lets the create page drive its auto-slug behaviour off the name field. */
+  onNameChange?: (value: string) => void;
+  /** Lets the create page stop auto-slugging once agentId is hand-edited. */
+  onAgentIdChange?: (value: string) => void;
+}) => {
+  const toolPolicy = form.watch('toolPolicy');
+  const provider = form.watch('provider');
+  const temperature = form.watch('temperature');
+
+  const { providers: enabledProviders } = useProviderOptions();
+  const { operations, loading: availableLoading } = useAvailableErxesTools(
+    toolPolicy === 'custom',
+  );
+
+  return (
+    <>
+      <FormSection title="Basic Info">
+        <Form.Field
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Name</Form.Label>
+              <Form.Control>
+                <Input
+                  {...field}
+                  onChange={(e) =>
+                    onNameChange
+                      ? onNameChange(e.target.value)
+                      : field.onChange(e.target.value)
+                  }
+                  placeholder="Customer Support Agent"
+                />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="agentId"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Agent ID</Form.Label>
+              <Form.Control>
+                <Input
+                  {...field}
+                  disabled={!agentIdEditable}
+                  onChange={(e) => {
+                    onAgentIdChange?.(e.target.value);
+                    field.onChange(e.target.value);
+                  }}
+                  placeholder="customer-support"
+                  className="font-mono text-sm"
+                />
+              </Form.Control>
+              <Form.Description>
+                {agentIdEditable
+                  ? 'Unique identifier used by the bot endpoint. Auto-generated from name.'
+                  : 'Identifies the bot endpoint and this agent’s threads — not editable here.'}
+              </Form.Description>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Description</Form.Label>
+              <Form.Control>
+                <Input {...field} placeholder="What this agent does" />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="instructions"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>System Instructions</Form.Label>
+              <Form.Control>
+                <Textarea
+                  {...field}
+                  placeholder="You are a helpful customer support agent for…"
+                  rows={6}
+                />
+              </Form.Control>
+              <Form.Description>
+                This is the system prompt sent to the LLM on every conversation.
+              </Form.Description>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      </FormSection>
+
+      <FormSection
+        title="AI Model"
+        description="Select the provider and model that powers this agent."
+      >
+        {enabledProviders.length === 0 ? (
+          <Alert>
+            <IconInfoCircle className="size-4" />
+            <Alert.Title>No providers configured</Alert.Title>
+            <Alert.Description>
+              <Link
+                to="/settings/erxes-agent/providers"
+                className="underline underline-offset-4"
+              >
+                Add a provider
+              </Link>{' '}
+              before creating an agent.
+            </Alert.Description>
+          </Alert>
+        ) : (
+          <>
+            <Form.Field
+              control={form.control}
+              name="provider"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Provider</Form.Label>
+                  <SelectProvider
+                    value={field.value}
+                    onValueChange={(v) => {
+                      field.onChange(v);
+                      form.setValue('model', '');
+                    }}
+                  />
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="model"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Model</Form.Label>
+                  <SelectModel
+                    provider={provider}
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  />
+                  <Form.Description>
+                    Listed live from the provider's model API.
+                  </Form.Description>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
+          </>
+        )}
+      </FormSection>
+
+      <FormSection
+        title="Tool Access"
+        description="Control which erxes operations this agent can search and run."
+      >
+        <Form.Field
+          control={form.control}
+          name="toolPolicy"
+          render={({ field }) => (
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label className="font-medium">Restrict tool access</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {field.value === 'custom'
+                    ? 'This agent can only use the operations selected below.'
+                    : 'Off: the agent can search and run any erxes operation (reads and writes).'}
+                </p>
+              </div>
+              <Switch
+                checked={field.value === 'custom'}
+                onCheckedChange={(v) => field.onChange(v ? 'custom' : 'all')}
+              />
+            </div>
+          )}
+        />
+
+        {toolPolicy === 'all' ? (
+          <Alert>
+            <IconInfoCircle className="size-4" />
+            <Alert.Title>Full access</Alert.Title>
+            <Alert.Description>
+              The agent discovers operations on demand and can run any query or
+              mutation across every installed erxes service. Turn on “Restrict
+              tool access” to limit it to specific operations.
+            </Alert.Description>
+          </Alert>
+        ) : (
+          <Form.Field
+            control={form.control}
+            name="allowedTools"
+            render={({ field }) => (
+              <AgentToolPicker
+                value={field.value}
+                onChange={field.onChange}
+                operations={operations}
+                loading={availableLoading}
+              />
+            )}
+          />
+        )}
+      </FormSection>
+
+      <FormSection title="Behavior">
+        <Form.Field
+          control={form.control}
+          name="memoryEnabled"
+          render={({ field }) => (
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label className="font-medium">Conversation Memory</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Remembers previous messages per conversation thread
+                </p>
+              </div>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </div>
+          )}
+        />
+
+        <Separator />
+
+        <Form.Field
+          control={form.control}
+          name="maxSteps"
+          render={({ field }) => (
+            <Field
+              label="Max Tool Steps"
+              hint="Max consecutive tool calls the agent can make (default: 10)"
+            >
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  max={50}
+                  value={field.value}
+                  onChange={(e) =>
+                    field.onChange(parseInt(e.target.value, 10) || 10)
+                  }
+                  className="w-24"
+                />
+                <Tooltip.Provider>
+                  <Tooltip>
+                    <Tooltip.Trigger asChild>
+                      <IconInfoCircle className="size-4 text-muted-foreground" />
+                    </Tooltip.Trigger>
+                    <Tooltip.Content className="max-w-xs">
+                      Prevents infinite loops. Raise this if the agent frequently
+                      stops mid-task.
+                    </Tooltip.Content>
+                  </Tooltip>
+                </Tooltip.Provider>
+              </div>
+            </Field>
+          )}
+        />
+
+        <Separator />
+
+        <Form.Field
+          control={form.control}
+          name="temperature"
+          render={({ field }) => (
+            <Field
+              label="Temperature"
+              hint="Sampling randomness (0–2). Some models only accept a fixed value — e.g. Kimi thinking models require 1."
+            >
+              <div className="flex items-center gap-3">
+                <Slider
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={[field.value ?? 1]}
+                  onValueChange={([v]: number[]) => field.onChange(v)}
+                  className="flex-1 max-w-xs"
+                />
+                <span className="w-16 text-sm tabular-nums text-muted-foreground">
+                  {temperature != null ? temperature.toFixed(1) : 'Default'}
+                </span>
+                {temperature != null && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() => field.onChange(null)}
+                  >
+                    Use default
+                  </Button>
+                )}
+                <Tooltip.Provider>
+                  <Tooltip>
+                    <Tooltip.Trigger asChild>
+                      <IconInfoCircle className="size-4 text-muted-foreground" />
+                    </Tooltip.Trigger>
+                    <Tooltip.Content className="max-w-xs">
+                      Lower values give more deterministic answers, higher values
+                      more creative ones. If the provider rejects the configured
+                      value (e.g. &quot;only 1 is allowed&quot;), set it to the
+                      value the model requires.
+                    </Tooltip.Content>
+                  </Tooltip>
+                </Tooltip.Provider>
+              </div>
+            </Field>
+          )}
+        />
+
+        <Separator />
+
+        <Form.Field
+          control={form.control}
+          name="isEnabled"
+          render={({ field }) => (
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label className="font-medium">Enabled</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Disabled agents won't respond to bot webhook requests
+                </p>
+              </div>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </div>
+          )}
+        />
+      </FormSection>
+    </>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
@@ -296,8 +296,8 @@ export const AgentFormFields = ({
                       <IconInfoCircle className="size-4 text-muted-foreground" />
                     </Tooltip.Trigger>
                     <Tooltip.Content className="max-w-xs">
-                      Prevents infinite loops. Raise this if the agent frequently
-                      stops mid-task.
+                      Prevents infinite loops. Raise this if the agent
+                      frequently stops mid-task.
                     </Tooltip.Content>
                   </Tooltip>
                 </Tooltip.Provider>
@@ -345,10 +345,10 @@ export const AgentFormFields = ({
                       <IconInfoCircle className="size-4 text-muted-foreground" />
                     </Tooltip.Trigger>
                     <Tooltip.Content className="max-w-xs">
-                      Lower values give more deterministic answers, higher values
-                      more creative ones. If the provider rejects the configured
-                      value (e.g. &quot;only 1 is allowed&quot;), set it to the
-                      value the model requires.
+                      Lower values give more deterministic answers, higher
+                      values more creative ones. If the provider rejects the
+                      configured value (e.g. &quot;only 1 is allowed&quot;), set
+                      it to the value the model requires.
                     </Tooltip.Content>
                   </Tooltip>
                 </Tooltip.Provider>


### PR DESCRIPTION
## What

Two related additions to the agent chat console (`frontend/plugins/erxes-agent_ui/src/modules/chat`):

### 1. In-chat agent editor (new)
Each agent in the chat rail now has a **hover gear button** (top-right, appears on hover/focus) that opens an **Edit agent** modal. From there you can retune the agent powering the current conversation — provider, model, name, description, system instructions, tool access, memory, max steps, temperature, enabled — without navigating away to the Agents settings page. Switching **model/provider** is front-and-center.

- `agentId` is shown read-only in the modal: it keys the bot endpoint and every persisted thread, so changing it mid-chat would orphan the conversation. An "Open full editor" link drops to the Agents page for that.
- Saving updates via `mastraAgentUpdate` and refetches the rail's agent list, so the change shows immediately (no navigation, no page reload).

### 2. Per-conversation thinking level (re-applies #8068)
PR #8068 added a per-conversation reasoning control but predates the chat frontend refactor (`pages/chat` → `modules/chat`). This re-applies the same feature on the refactored code:

- A low-key **brain icon** in the composer opens a level picker: **Auto** (default, no override) / **Off** / **Low** / **Medium** / **High**.
- The choice persists **per agent** in `localStorage` and threads through the `/chat/stream` request.
- The backend (`providers.ts`) maps the single enum to each provider's reasoning knob — OpenAI `reasoningEffort`, Anthropic/Google thinking-token budget — and validates the request input (`routes.ts`). Providers without a portable reasoning knob ignore it, leaving the model's configured default untouched.

The backend changes (`providers.ts`, `routes.ts`, `reasoning.test.ts`) are unchanged from #8068 since the refactor was frontend-only; #8068 can be closed in favour of this PR.

## Testing
- `reasoning.test.ts` — 7/7 passing (enum guard + per-provider option mapping).
- New frontend files typecheck clean.

## Notes
- Reasoning defaults to **Auto** (unset) — existing behaviour is unchanged unless a user opts in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-agent “Thinking level” control (Auto/off/low/medium/high) to chat, persisted in your browser and applied to supported AI providers.
  * Added in-chat agent editing, including model selection, instructions, tool access, and behavior settings.

* **UX Improvements**
  * Improved agent rail accessibility with keyboard-friendly selection and a dedicated edit action.

* **Tests**
  * Added automated tests for reasoning-effort parsing/validation and provider-specific option mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->