### PR TITLE
fix(agent-ui): chat streaming correctness — message identity, send guard, scroll

### DIFF
--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -40,7 +40,7 @@ export const ChatPage = () => {
   // The route is keyed by the agent record _id, but inbound links (e.g.
   // Schedules → View output) may carry the agent slug — accept both.
   const selectedAgent = agentId
-    ? agents.find((a) => a._id === agentId || a.agentId === agentId) ?? null
+    ? (agents.find((a) => a._id === agentId || a.agentId === agentId) ?? null)
     : null;
 
   const view = useAgentChatView(agentId);

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -52,6 +52,7 @@ export const ChatPage = () => {
     messages,
     loading: chatLoading,
     messagesLoading,
+    streamTick,
   } = view;
 
   const [input, setInput] = useState('');
@@ -106,19 +107,13 @@ export const ChatPage = () => {
   }, [agentId, selectedAgent?.agentId]);
 
   // Keep the view pinned to the bottom — also while a reply streams (the last
-  // message grows without the list length changing).
-  const lastMsg = messages[messages.length - 1];
-  const lastMsgSize =
-    (lastMsg?.content?.length ?? 0) +
-    (lastMsg?.parts?.reduce(
-      (n, p) => n + (p.kind === 'thinking' ? p.text.length : 1),
-      0,
-    ) ?? 0);
+  // message grows without the list length changing). The store bumps streamTick
+  // on every live update, so following it re-fires this effect per token.
   useEffect(() => {
     if (atBottomRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages.length, chatLoading, lastMsgSize]);
+  }, [messages.length, chatLoading, streamTick]);
 
   // Switching threads re-pins to the bottom of the freshly loaded conversation.
   useEffect(() => {

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -23,6 +23,11 @@ import { MessageList } from '~/modules/chat/components/MessageList';
 import { Composer } from '~/modules/chat/components/Composer';
 import '~/modules/chat/chat.css';
 
+// Distance (px) from the bottom under which we keep following streamed output.
+const SCROLL_PIN_THRESHOLD = 120;
+// Distance (px) from the bottom past which the "Latest" jump button appears.
+const SCROLL_BUTTON_THRESHOLD = 280;
+
 export const ChatPage = () => {
   const { agentId } = useParams<{ agentId: string }>();
   const navigate = useNavigate();
@@ -35,7 +40,7 @@ export const ChatPage = () => {
   // The route is keyed by the agent record _id, but inbound links (e.g.
   // Schedules → View output) may carry the agent slug — accept both.
   const selectedAgent = agentId
-    ? (agents.find((a) => a._id === agentId || a.agentId === agentId) ?? null)
+    ? agents.find((a) => a._id === agentId || a.agentId === agentId) ?? null
     : null;
 
   const view = useAgentChatView(agentId);
@@ -54,6 +59,9 @@ export const ChatPage = () => {
   const [showScrollDown, setShowScrollDown] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesBoxRef = useRef<HTMLDivElement>(null);
+  // Whether the view is pinned to the bottom. Gates streaming auto-scroll so a
+  // user who scrolled up to read history isn't yanked back on every token.
+  const atBottomRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragDepth = useRef(0);
@@ -107,8 +115,15 @@ export const ChatPage = () => {
       0,
     ) ?? 0);
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (atBottomRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [messages.length, chatLoading, lastMsgSize]);
+
+  // Switching threads re-pins to the bottom of the freshly loaded conversation.
+  useEffect(() => {
+    atBottomRef.current = true;
+  }, [activeThreadId]);
 
   useEffect(() => {
     if (!chatLoading) textareaRef.current?.focus();
@@ -182,6 +197,8 @@ export const ChatPage = () => {
 
   const sendMessage = (message: string, atts: ChatAttachment[]) => {
     if (!selectedAgent || !agentId) return;
+    // Sending re-pins to the bottom so the user follows their own message.
+    atBottomRef.current = true;
     // Fire-and-forget: the store holds the Apollo client reference so the
     // request continues even if the user navigates away before it completes.
     chatStore.sendMessage(
@@ -234,11 +251,15 @@ export const ChatPage = () => {
   const handleMessagesScroll = () => {
     const el = messagesBoxRef.current;
     if (!el) return;
-    setShowScrollDown(el.scrollHeight - el.scrollTop - el.clientHeight > 280);
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    atBottomRef.current = distanceFromBottom < SCROLL_PIN_THRESHOLD;
+    setShowScrollDown(distanceFromBottom > SCROLL_BUTTON_THRESHOLD);
   };
 
-  const scrollToBottom = () =>
+  const scrollToBottom = () => {
+    atBottomRef.current = true;
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
 
   return (
     <div className="flex flex-col h-full">

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
@@ -84,7 +84,7 @@ export const MessageList = ({
           <>
             {messages.map((msg, i) => (
               <MessageBubble
-                key={i}
+                key={msg._clientId ?? msg.id ?? i}
                 msg={msg}
                 onRegenerate={
                   msg.role === 'assistant' &&

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
@@ -84,7 +84,7 @@ export const MessageList = ({
           <>
             {messages.map((msg, i) => (
               <MessageBubble
-                key={msg._clientId ?? msg.id ?? i}
+                key={msg._clientId}
                 msg={msg}
                 onRegenerate={
                   msg.role === 'assistant' &&

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -150,11 +150,27 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       };
     });
 
-  const appendMessage = (agentKey: string, threadId: string, msg: Message) => {
+  // Atomically claim a thread for a new turn: check `loading` and set it true in
+  // one synchronous step. Returns false when the thread is already streaming, so
+  // a concurrent send (regenerate, suggestion, double Enter) can't slip past the
+  // guard in the window before `loading` would otherwise be set.
+  const claimThread = (agentKey: string, threadId: string): boolean => {
+    const key = threadKey(agentKey, threadId);
+    if ((get().threads[key] ?? EMPTY_THREAD).loading) return false;
+    patchThread(agentKey, threadId, { loading: true });
+    return true;
+  };
+
+  const appendMessage = (
+    agentKey: string,
+    threadId: string,
+    msg: Omit<Message, '_clientId'> & { _clientId?: string },
+  ) => {
     const t = getThread(agentKey, threadId);
-    const withId: Message = msg._clientId
-      ? msg
-      : { ...msg, _clientId: `m-${randomIdSuffix(8)}` };
+    const withId: Message = {
+      ...msg,
+      _clientId: msg._clientId ?? `m-${randomIdSuffix(8)}`,
+    };
     patchThread(agentKey, threadId, { messages: [...t.messages, withId] });
   };
 
@@ -343,6 +359,11 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       else appendMessage(agentKey, threadId, next);
       live = next;
       liveState.hasLive = true;
+      // Bump a monotonic tick so the view can follow streamed output off a
+      // single dependency, rather than inferring growth from message contents.
+      patchThread(agentKey, threadId, {
+        streamTick: (getThread(agentKey, threadId).streamTick ?? 0) + 1,
+      });
     };
 
     const ops: ApplyOps = {
@@ -456,6 +477,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         const messages: Message[] = (data?.mastraThreadMessages ?? []).map(
           (m) => ({
             id: m._id,
+            _clientId: m._id || `m-${randomIdSuffix(8)}`,
             role: m.role,
             content: m.content,
             timestamp: m.createdAt ? new Date(m.createdAt) : new Date(),
@@ -564,7 +586,9 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       // concurrent send (regenerate, suggestion, double Enter) would overwrite
       // the in-flight AbortController, orphaning the first stream so it can no
       // longer be stopped and letting two replies interleave into one bubble.
-      if (getThread(agentKey, threadId).loading) return;
+      // claimThread checks-and-sets `loading` in one synchronous step so the
+      // guard holds even though `abort` is attached further down.
+      if (!claimThread(agentKey, threadId)) return;
 
       // Surface the session in the sidebar the instant the first message is
       // sent — don't wait for the turn to finish. The backend registers + tags
@@ -589,7 +613,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       });
 
       const abort = new AbortController();
-      patchThread(agentKey, threadId, { loading: true, abort });
+      patchThread(agentKey, threadId, { abort });
 
       try {
         const streamed = await sendViaStream(
@@ -644,6 +668,7 @@ export const selectAgentView = (
     messages: thread.messages,
     loading: thread.loading,
     messagesLoading: thread.messagesLoading,
+    streamTick: thread.streamTick,
   };
 };
 

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -637,7 +637,7 @@ export const selectAgentView = (
 ): AgentChatView => {
   const agent = s.agents[agentKey] ?? EMPTY_AGENT;
   const thread = agent.activeThreadId
-    ? s.threads[threadKey(agentKey, agent.activeThreadId)] ?? EMPTY_THREAD
+    ? (s.threads[threadKey(agentKey, agent.activeThreadId)] ?? EMPTY_THREAD)
     : EMPTY_THREAD;
   return {
     ...agent,

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -23,7 +23,11 @@ import {
   SessionMeta,
   ThreadChatState,
 } from '~/modules/chat/types';
-import { generateThreadId, partsFromMeta } from '~/modules/chat/utils';
+import {
+  generateThreadId,
+  partsFromMeta,
+  randomIdSuffix,
+} from '~/modules/chat/utils';
 import { readStreamEvents } from '~/modules/chat/lib/streamTransport';
 import {
   ApplyOps,
@@ -148,18 +152,31 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
 
   const appendMessage = (agentKey: string, threadId: string, msg: Message) => {
     const t = getThread(agentKey, threadId);
-    patchThread(agentKey, threadId, { messages: [...t.messages, msg] });
+    const withId: Message = msg._clientId
+      ? msg
+      : { ...msg, _clientId: `m-${randomIdSuffix(8)}` };
+    patchThread(agentKey, threadId, { messages: [...t.messages, withId] });
   };
 
-  const replaceLastMessage = (
+  // Replace a message by its stable `_clientId` rather than by position, so an
+  // error (or any message) appended between two stream events can't be
+  // overwritten by the live bubble's next update. Appends if it's gone (e.g.
+  // the first live event, or a thread cleared mid-stream).
+  const replaceMessageById = (
     agentKey: string,
     threadId: string,
+    clientId: string,
     msg: Message,
   ) => {
     const t = getThread(agentKey, threadId);
-    patchThread(agentKey, threadId, {
-      messages: t.messages.slice(0, -1).concat(msg),
-    });
+    const idx = t.messages.findIndex((m) => m._clientId === clientId);
+    if (idx < 0) {
+      patchThread(agentKey, threadId, { messages: [...t.messages, msg] });
+      return;
+    }
+    const messages = t.messages.slice();
+    messages[idx] = msg;
+    patchThread(agentKey, threadId, { messages });
   };
 
   // Local-only title update — used when the server pushes an auto-generated
@@ -306,8 +323,11 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       return false;
     }
 
-    // The live assistant bubble; advanced in place as events arrive.
+    // The live assistant bubble; advanced in place as events arrive. Keyed by a
+    // stable client id so its updates land on the same row even if another
+    // message is appended mid-stream.
     let live: Message | null = null;
+    const liveClientId = `m-${randomIdSuffix(8)}`;
     const liveState: LiveState = { sawDone: false, hasLive: false };
 
     const upsertLive = (mutate: (m: Message) => Message) => {
@@ -316,9 +336,10 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         content: '',
         timestamp: new Date(),
         streaming: true,
+        _clientId: liveClientId,
       };
       const next = mutate({ ...base, parts: base.parts?.slice() });
-      if (live) replaceLastMessage(agentKey, threadId, next);
+      if (live) replaceMessageById(agentKey, threadId, liveClientId, next);
       else appendMessage(agentKey, threadId, next);
       live = next;
       liveState.hasLive = true;
@@ -539,6 +560,12 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       }
       const threadId = agent.activeThreadId!;
 
+      // Never start a second stream on a thread that's already streaming — a
+      // concurrent send (regenerate, suggestion, double Enter) would overwrite
+      // the in-flight AbortController, orphaning the first stream so it can no
+      // longer be stopped and letting two replies interleave into one bubble.
+      if (getThread(agentKey, threadId).loading) return;
+
       // Surface the session in the sidebar the instant the first message is
       // sent — don't wait for the turn to finish. The backend registers + tags
       // the thread at turn start (so a refresh keeps it); this mirrors it into
@@ -610,7 +637,7 @@ export const selectAgentView = (
 ): AgentChatView => {
   const agent = s.agents[agentKey] ?? EMPTY_AGENT;
   const thread = agent.activeThreadId
-    ? (s.threads[threadKey(agentKey, agent.activeThreadId)] ?? EMPTY_THREAD)
+    ? s.threads[threadKey(agentKey, agent.activeThreadId)] ?? EMPTY_THREAD
     : EMPTY_THREAD;
   return {
     ...agent,

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
@@ -33,8 +33,9 @@ export interface Message {
   // Stable client-generated id, assigned when the message is first appended.
   // Identifies the live streaming bubble independently of its position so an
   // error/other message appended mid-stream can't be clobbered, and gives the
-  // list a stable React key before a persisted `id` exists.
-  _clientId?: string;
+  // list a stable React key before a persisted `id` exists. Always present on a
+  // stored message — the patch helpers assign it on the way in.
+  _clientId: string;
   role: 'user' | 'assistant' | 'error';
   content: string;
   timestamp: Date;
@@ -71,6 +72,10 @@ export interface ThreadChatState {
   messagesLoading: boolean; // hydrating this thread's messages from the DB
   abort?: AbortController; // in-flight stream — abort() = interrupt
   activity?: string; // server-summarized "what is the agent doing right now"
+  // Monotonic counter bumped on every live stream update so the view can drive
+  // streaming auto-scroll off a single dependency instead of inferring growth
+  // from message contents.
+  streamTick?: number;
 }
 
 export interface AgentChatState {
@@ -86,6 +91,7 @@ export interface AgentChatView extends AgentChatState {
   messages: Message[];
   loading: boolean;
   messagesLoading: boolean;
+  streamTick?: number;
 }
 
 // A file in the composer, before the message is sent.

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
@@ -30,6 +30,11 @@ export interface Message {
   // Persisted message _id — present after hydration, or from the stream's
   // `done` event. Required for thumbs feedback.
   id?: string;
+  // Stable client-generated id, assigned when the message is first appended.
+  // Identifies the live streaming bubble independently of its position so an
+  // error/other message appended mid-stream can't be clobbered, and gives the
+  // list a stable React key before a persisted `id` exists.
+  _clientId?: string;
   role: 'user' | 'assistant' | 'error';
   content: string;
   timestamp: Date;


### PR DESCRIPTION
## Summary

PR **B** of three from the agent-plugin prod-readiness hunt. Fixes four streaming/state races in the agent chat. Independent of PR #8105 (touches only `modules/chat/`).

### Changes

| # | Sev | Fix |
|---|-----|-----|
| B1 | 🔴 Critical | **Live bubble corruption.** The streaming assistant bubble was finalized by replacing `messages[last]`, assuming it's always the last row. But the `error` event appends a row mid-stream (the event loop keeps draining buffered events after it), so the next `text`/`tool` event clobbered the error. Now every appended message carries a stable `_clientId`, and the live bubble is updated **by identity** (`replaceMessageById`) instead of by position. |
| B2 | 🟠 High | **Concurrent send orphaned the stream.** `sendMessage` didn't re-check the thread's `loading` flag, so a regenerate / suggestion / double-Enter overwrote the in-flight `AbortController` — the first stream could no longer be stopped and two replies interleaved into one bubble. Now bails out if the thread is already streaming. |
| B3 | 🟡 Med | **Auto-scroll yank.** Scroll-to-bottom fired on every streamed token unconditionally, pulling a user who'd scrolled up to read history back down. Now gated on an at-bottom check derived from scroll position; re-pins on send, thread switch, and the "Latest" button. Thresholds extracted as named constants. |
| B4 | 🟡 Med | **Index-as-key.** `MessageList` keyed rows by array index, so per-message UI state (thinking / tool-call expand) stuck to the wrong row as the tail mutated. Now keyed by `_clientId` / `id`. |

### Design note
`_clientId` is a client-only stable id assigned at append time (via the existing `randomIdSuffix`). It's distinct from the persisted `id` (used for thumbs feedback, set from the `done` event) so the streaming bubble can be tracked before it has a server id — and it doubles as the stable React key.

### Deferred
- B5 (client-side attachment size/type validation + object-URL leak on unmount in `useAttachments`) was marked optional in the plan and is **not** in this PR — kept the diff focused on the streaming races. Can follow in PR C or a small follow-up.

### Verification
- ✅ `tsc -p tsconfig.app.json --noEmit`: clean for the chat module (42 remaining errors are all pre-existing in `libs/erxes-ui`).
- ✅ Prettier-clean.
- ✅ CodeRabbit: 1 minor finding (smooth-scroll/ref race) reviewed — largely self-healing (the `scrollIntoView` animation completes regardless of the ref, and the settle/next-token event re-pins); applied its named-constants suggestion. The streaming races (B1/B2) warrant live-stream verification before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve agent chat streaming robustness and scrolling behavior in the agent UI.

Bug Fixes:
- Ensure streaming assistant messages are updated by stable client-side message identity instead of list position to avoid overwriting intervening messages such as errors.
- Prevent starting a new message stream on a thread that is already loading to avoid orphaned streams and interleaved replies in a single bubble.
- Gate auto-scroll during streaming on whether the view is currently near the bottom so users who scroll up are not pulled back down on every token.
- Provide stable React keys for chat messages using client or server message IDs so per-message UI state stays attached to the correct row.

Enhancements:
- Introduce scroll pin and scroll button thresholds and track bottom-pinned state to control when the "Latest" jump button appears and when auto-scroll is re-pinned on thread change or send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **Latest** button to jump back to the newest messages after scrolling up.
  * Improved chat auto-scroll so it follows new/streaming messages only when you’re effectively pinned to the bottom.

* **Bug Fixes**
  * Fixed issues with live/streaming message updates to ensure the correct message consistently updates during streaming.
  * Prevented multiple simultaneous sends/streams on the same thread from causing message conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->