### PR TITLE
fix(agent-ui): form & attachment polish

### DIFF
--- a/frontend/plugins/erxes-agent_ui/src/components/ClampedNumberInput.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/components/ClampedNumberInput.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { Input } from 'erxes-ui';
+
+type NumberField = {
+  value: number;
+  onChange: (value: number) => void;
+  onBlur?: () => void;
+};
+
+/**
+ * Number input bound to a numeric form field. The text being edited lives in
+ * local state so the box can be cleared mid-type without ever writing
+ * `undefined`/`NaN` into the field: the field only takes valid parses while
+ * typing, and the value is clamped to `min`–`max` (or `fallback` when empty)
+ * on blur.
+ */
+export const ClampedNumberInput = ({
+  field,
+  min,
+  max,
+  fallback,
+  id,
+  className,
+}: {
+  field: NumberField;
+  min: number;
+  max: number;
+  fallback: number;
+  id?: string;
+  className?: string;
+}) => {
+  const [text, setText] = useState(String(field.value));
+
+  // Re-sync when the field changes from outside (form reset, blur clamp), but
+  // not while the user is typing a value that already parses to field.value.
+  useEffect(() => {
+    if (parseInt(text, 10) !== field.value) setText(String(field.value));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field.value]);
+
+  return (
+    <Input
+      id={id}
+      type="number"
+      min={min}
+      max={max}
+      value={text}
+      onChange={(e) => {
+        const raw = e.target.value;
+        setText(raw);
+        const n = parseInt(raw, 10);
+        if (!Number.isNaN(n)) field.onChange(n);
+      }}
+      onBlur={() => {
+        const n = parseInt(text, 10);
+        const clamped = Number.isNaN(n)
+          ? fallback
+          : Math.min(max, Math.max(min, n));
+        setText(String(clamped));
+        field.onChange(clamped);
+        field.onBlur?.();
+      }}
+      className={className}
+    />
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useAttachments.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useAttachments.ts
@@ -1,11 +1,30 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ChatAttachment, PendingAttachment } from '~/modules/chat/types';
 import { randomIdSuffix, uploadToStorage } from '~/modules/chat/utils';
+
+// Reject files larger than this before uploading — the round trip to storage
+// would only fail (or be slow) for oversize files.
+const MAX_ATTACHMENT_MB = 25;
+const MAX_ATTACHMENT_BYTES = MAX_ATTACHMENT_MB * 1024 * 1024;
 
 // Composer attachment state + upload lifecycle. Shared by the composer chips
 // and the chat-area drop overlay.
 export const useAttachments = (enabled: boolean) => {
   const [pendingAtts, setPendingAtts] = useState<PendingAttachment[]>([]);
+
+  // Revoke every outstanding preview object URL when the composer unmounts
+  // (navigate away mid-compose) — removeAttachment/clear only cover explicit
+  // removals.
+  const pendingRef = useRef<PendingAttachment[]>([]);
+  pendingRef.current = pendingAtts;
+  useEffect(
+    () => () => {
+      pendingRef.current.forEach(
+        (a) => a.previewUrl && URL.revokeObjectURL(a.previewUrl),
+      );
+    },
+    [],
+  );
 
   const addFiles = (files: FileList | File[]) => {
     if (!enabled) return;
@@ -26,6 +45,24 @@ export const useAttachments = (enabled: boolean) => {
       }
 
       const id = `att-${Date.now()}-${randomIdSuffix(6)}`;
+
+      // Reject oversize files up front — mark them errored without uploading
+      // (and without creating a preview URL that would need cleanup).
+      if (file.size > MAX_ATTACHMENT_BYTES) {
+        setPendingAtts((prev) => [
+          ...prev,
+          {
+            id,
+            name: file.name,
+            type: file.type || 'application/octet-stream',
+            size: file.size,
+            status: 'error',
+            error: `File exceeds the ${MAX_ATTACHMENT_MB} MB limit`,
+          },
+        ]);
+        continue;
+      }
+
       const entry: PendingAttachment = {
         id,
         name: file.name,

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useAttachments.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useAttachments.ts
@@ -16,7 +16,9 @@ export const useAttachments = (enabled: boolean) => {
   // (navigate away mid-compose) — removeAttachment/clear only cover explicit
   // removals.
   const pendingRef = useRef<PendingAttachment[]>([]);
-  pendingRef.current = pendingAtts;
+  useEffect(() => {
+    pendingRef.current = pendingAtts;
+  });
   useEffect(
     () => () => {
       pendingRef.current.forEach(

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/components/AgentFormFields.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from 'erxes-ui';
 import { UseFormReturn } from 'react-hook-form';
+import { ClampedNumberInput } from '~/components/ClampedNumberInput';
 import { Field, FormSection } from '~/components/FormLayout';
 import {
   SelectModel,
@@ -280,14 +281,11 @@ export const AgentFormFields = ({
               hint="Max consecutive tool calls the agent can make (default: 10)"
             >
               <div className="flex items-center gap-2">
-                <Input
-                  type="number"
+                <ClampedNumberInput
+                  field={field}
                   min={1}
                   max={50}
-                  value={field.value}
-                  onChange={(e) =>
-                    field.onChange(parseInt(e.target.value, 10) || 10)
-                  }
+                  fallback={10}
                   className="w-24"
                 />
                 <Tooltip.Provider>

--- a/frontend/plugins/erxes-agent_ui/src/pages/agents/utils.ts
+++ b/frontend/plugins/erxes-agent_ui/src/pages/agents/utils.ts
@@ -1,10 +1,13 @@
 import { IErxesTool, IToolItem, IToolPluginGroup } from './types';
 
-export const toSlug = (name: string): string =>
+// Slugify a name into an agentId. Names with no ASCII alphanumerics (e.g.
+// "日本語", "!!!") would otherwise slug to an empty string and fail the
+// required-field check with no visible hint — fall back to a non-empty default.
+export const toSlug = (name: string, fallback = 'agent'): string =>
   name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
+    .replace(/(^-|-$)/g, '') || fallback;
 
 // Built-in (non-erxes) tools, offered alongside operations in the picker.
 // Keep in sync with backend mastra/tools/builtins.ts (BUILTIN_TOOLS keys).

--- a/frontend/plugins/erxes-agent_ui/src/pages/settings/validations.ts
+++ b/frontend/plugins/erxes-agent_ui/src/pages/settings/validations.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 export const providerFormSchema = z.object({
-  provider: z.string(),
+  // Required: a custom provider with a blank key would otherwise silently
+  // no-op on save. Presets pre-fill this with their own key.
+  provider: z.string().min(1, 'Provider key is required'),
   apiKey: z.string(),
   baseUrl: z.string(),
   modelsEndpoint: z.string(),


### PR DESCRIPTION
## Summary

PR **C** of three from the agent-plugin prod-readiness hunt — lower-severity correctness/UX fixes. Independent of #8105 and #8106 (disjoint files).

### Changes

| # | Sev | Fix |
|---|-----|-----|
| C1 | 🟡 Med | **Max Tool Steps input** snapped to 10 mid-edit (`parseInt(...) || 10`) — the field couldn't be cleared, and `0` silently became `10`. Now allows an empty field while typing and clamps to 1–50 on blur. |
| C2 | 🟡 Med | **`toSlug` produced an empty `agentId`** for names with no ASCII alphanumerics (e.g. non-Latin names), which failed the required-field check with no visible hint. Falls back to a non-empty default. |
| C3 | 🟢 Low | **Custom provider key had no validation** — saving with a blank key silently no-opped. Now `provider` is required (`min(1)`); presets pre-fill it so they're unaffected. The custom field already renders a `Form.Message`. |
| B5 | 🟡 Med | **Chat attachments:** reject oversize files (>25 MB) up front instead of after a failed round trip, and revoke leftover preview object URLs when the composer unmounts (only explicit removals were cleaned up before — a leak on navigate-away mid-compose). |

### Notes / deferred
- **C3 (toggle in-flight disabled state)** from the plan's PR C is intentionally **not** here — it edits the same `AgentsIndexPage` toggle mutation as #8105 and would conflict. Best as a small follow-up on top of that PR.
- **`Widgets.tsx` placeholder** (dev text shipped via a module-federation expose) left untouched to avoid touching MF build config in a polish PR — flagged for a separate decision (implement vs. stop exposing).

### Verification
- ✅ `tsc -p tsconfig.app.json --noEmit`: clean for touched files (42 remaining errors are all pre-existing in `libs/erxes-ui`).
- ✅ Prettier-clean.
- ✅ CodeRabbit: **no findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file size limits for attachment uploads with clear error messages
  * Enhanced numeric input controls for agent configuration settings

* **Bug Fixes**
  * Fixed memory leak from unreleased image previews when navigating away during message composition
  * Provider keys now required in settings to prevent silent data loss

* **Improvements**
  * Better slug generation with fallback handling for agent identifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->