### PR TITLE
fix(agent): reliable chat session persistence — memory on by default, persist on empty subdomain, Apollo-cache sidebar

### DIFF
--- a/backend/plugins/erxes-agent_api/src/main.ts
+++ b/backend/plugins/erxes-agent_api/src/main.ts
@@ -38,10 +38,10 @@ startPlugin({
     },
   },
   onServerInit: async () => {
-    // Advanced memory (opt-in via ERXES_AGENT_MEMORY=enable): ping Qdrant and ensure
-    // the collection exists. Loaded lazily and only when enabled, so default
-    // deployments never even import the memory module at boot.
-    if ((process.env.ERXES_AGENT_MEMORY ?? '').trim() === 'enable') {
+    // Advanced memory is on by default (chat persistence rides on it); ping
+    // Qdrant and ensure the collection exists. Loaded lazily, and skipped only
+    // when explicitly disabled via ERXES_AGENT_MEMORY=disable.
+    if ((process.env.ERXES_AGENT_MEMORY ?? '').trim() !== 'disable') {
       const { initAdvancedMemory } = await import('~/mastra/memory');
       await initAdvancedMemory();
     }

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -44,12 +44,13 @@ export async function getOrCreateAgent(
   models: IModels,
   subdomain?: string,
 ): Promise<AgentWithTools> {
-  // Mastra Memory (semantic recall + working memory) is opt-in and tenant-bound
-  // — only attached when advanced memory is enabled AND we know the tenant.
+  // Mastra Memory (persistence + semantic recall + working memory) is attached
+  // whenever advanced memory is on and the agent hasn't opted out. An unknown
+  // tenant must NOT detach memory — that would stop the turn from being
+  // persisted (and lose the session); scopedResource defaults an empty subdomain
+  // to the "os" scope.
   const useMemory =
-    isAdvancedMemoryEnabled() &&
-    agentConfig.memoryEnabled !== false &&
-    Boolean(subdomain);
+    isAdvancedMemoryEnabled() && agentConfig.memoryEnabled !== false;
   const [providers, settings] = await Promise.all([
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/__tests__/config.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/__tests__/config.test.ts
@@ -9,26 +9,26 @@ import {
 describe('advanced-memory config', () => {
   // ── Feature flag (AM-FLAG-1..4) ──────────────────────────────────────────
   describe('isAdvancedMemoryEnabled', () => {
-    it('AM-FLAG-1: defaults to false when unset', () => {
-      expect(isAdvancedMemoryEnabled({})).toBe(false);
+    it('AM-FLAG-1: defaults to enabled when unset', () => {
+      expect(isAdvancedMemoryEnabled({})).toBe(true);
     });
 
-    it('AM-FLAG-2: true only for exact "enable"', () => {
-      expect(isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: 'enable' })).toBe(
-        true,
+    it('AM-FLAG-2: false only for exact "disable"', () => {
+      expect(isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: 'disable' })).toBe(
+        false,
       );
     });
 
-    it('AM-FLAG-3: other truthy-looking values are off', () => {
-      for (const v of ['true', '1', 'on', 'ENABLE', 'enabled', 'yes']) {
-        expect(isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: v })).toBe(false);
+    it('AM-FLAG-3: other values leave it enabled', () => {
+      for (const v of ['enable', 'true', '1', 'on', 'DISABLE', 'disabled', 'no']) {
+        expect(isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: v })).toBe(true);
       }
     });
 
     it('AM-FLAG-4: trims surrounding whitespace', () => {
       expect(
-        isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: '  enable  ' }),
-      ).toBe(true);
+        isAdvancedMemoryEnabled({ ERXES_AGENT_MEMORY: '  disable  ' }),
+      ).toBe(false);
     });
   });
 
@@ -129,7 +129,9 @@ describe('advanced-memory config', () => {
   // ── Status (AM-SET-1/2) ──────────────────────────────────────────────────
   describe('computeAdvancedMemoryStatus', () => {
     it('AM-SET-1: disabled → all details null', () => {
-      expect(computeAdvancedMemoryStatus({})).toEqual({
+      expect(
+        computeAdvancedMemoryStatus({ ERXES_AGENT_MEMORY: 'disable' }),
+      ).toEqual({
         enabled: false,
         embedder: null,
         embedderModel: null,

--- a/backend/plugins/erxes-agent_api/src/mastra/memory/config.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/memory/config.ts
@@ -61,12 +61,13 @@ function val(env: Env, key: string): string {
 }
 
 /**
- * The master switch. Advanced memory is enabled ONLY when ERXES_AGENT_MEMORY is
- * exactly "enable" (whitespace-trimmed). Every other value — true/1/on/ENABLE —
- * is treated as off, so the flag is unambiguous and hard to enable by accident.
+ * The master switch. Advanced memory is ON by default — chat persistence and the
+ * session sidebar ride on it, so it must not depend on an env opt-in. Set
+ * ERXES_AGENT_MEMORY to exactly "disable" (whitespace-trimmed) to turn it off;
+ * every other value (including absent) leaves it enabled.
  */
 export function isAdvancedMemoryEnabled(env: Env = process.env): boolean {
-  return val(env, 'ERXES_AGENT_MEMORY') === 'enable';
+  return val(env, 'ERXES_AGENT_MEMORY') !== 'disable';
 }
 
 /** Resolve the embedder kind, model, dimension, and (for openai) endpoint/key. */

--- a/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/schedules/runner.ts
@@ -86,9 +86,7 @@ export async function runSchedule(args: {
     // the thread's own history so successive runs can build on earlier output
     // (e.g. "compare with yesterday") and persists this turn itself.
     const useMemory =
-      isAdvancedMemoryEnabled() &&
-      agentConfig.memoryEnabled !== false &&
-      Boolean(subdomain);
+      isAdvancedMemoryEnabled() && agentConfig.memoryEnabled !== false;
     const memoryBinding = useMemory
       ? {
           thread: threadId,

--- a/backend/plugins/erxes-agent_api/src/modules/agent/prepare.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/agent/prepare.ts
@@ -67,10 +67,12 @@ export async function prepareChatTurn(params: {
 
   // Mastra Memory (attached to the agent in getOrCreateAgent) is the ONLY chat
   // store: it persists the turn, replays recent history, and runs semantic
-  // recall + working memory via the per-turn binding below. Active when advanced
-  // memory is on AND we know the tenant. (No tenant → the turn is answered
-  // statelessly; there is no custom fallback store.)
-  const useMemory = advanced && Boolean(subdomain);
+  // recall + working memory via the per-turn binding below. Active whenever
+  // advanced memory is on. An unknown tenant does NOT skip persistence — it
+  // would silently drop the turn and lose the session; scopedResource defaults
+  // an empty subdomain to the "os" scope so the thread is still persisted and
+  // listable.
+  const useMemory = advanced;
   const memoryBinding = useMemory
     ? {
         thread: sessionId,

--- a/backend/plugins/erxes-agent_api/src/routes.ts
+++ b/backend/plugins/erxes-agent_api/src/routes.ts
@@ -570,7 +570,6 @@ router.post('/bot/:conversationId', llmRouteLimiter, async (req, res) => {
     const useMemory =
       isAdvancedMemoryEnabled() &&
       agentConfig.memoryEnabled !== false &&
-      Boolean(subdomain) &&
       Boolean(userText.trim());
     const memoryBinding = useMemory
       ? {

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -16,6 +16,9 @@ import {
   useAttachmentsEnabled,
 } from '~/modules/chat/hooks/useChatAgents';
 import { useAgentChatView } from '~/modules/chat/hooks/useChatView';
+import { useMastraThreads } from '~/modules/chat/hooks/useMastraThreads';
+import { useRenameMastraThread } from '~/modules/chat/hooks/useRenameMastraThread';
+import { useRemoveMastraThread } from '~/modules/chat/hooks/useRemoveMastraThread';
 import { useAttachments } from '~/modules/chat/hooks/useAttachments';
 import { AgentRail } from '~/modules/chat/components/AgentRail';
 import { SessionList } from '~/modules/chat/components/SessionList';
@@ -45,8 +48,6 @@ export const ChatPage = () => {
 
   const view = useAgentChatView(agentId);
   const {
-    sessions,
-    sessionsLoaded,
     activeThreadId,
     isDraft,
     reasoningEffort,
@@ -55,6 +56,14 @@ export const ChatPage = () => {
     messagesLoading,
     streamTick,
   } = view;
+
+  // The persisted session list lives in the Apollo cache, not the chat store.
+  const { threads, loading: threadsLoading } = useMastraThreads(
+    selectedAgent?.agentId,
+  );
+  const sessionsLoaded = !!selectedAgent && !threadsLoading;
+  const { renameThread } = useRenameMastraThread();
+  const { removeThread } = useRemoveMastraThread(selectedAgent?.agentId);
 
   const [input, setInput] = useState('');
   const [isDragging, setIsDragging] = useState(false);
@@ -100,12 +109,18 @@ export const ChatPage = () => {
     return () => chatStore.setCurrentAgent(undefined);
   }, [agentId]);
 
-  // Load the agent's persisted sessions once its record is available.
+  // Bootstrap / re-home the active session: once the cached list has loaded and
+  // nothing is selected (first open of this agent, or after deleting the active
+  // session), open the most recent session or a fresh draft.
   useEffect(() => {
-    if (!agentId || !selectedAgent) return;
-    chatStore.loadSessions(apolloClient, agentId, selectedAgent.agentId);
+    if (!agentId || !selectedAgent || !sessionsLoaded || activeThreadId) return;
+    if (threads.length > 0) {
+      chatStore.selectSession(apolloClient, agentId, threads[0].threadId);
+    } else {
+      chatStore.newDraft(agentId);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentId, selectedAgent?.agentId]);
+  }, [agentId, selectedAgent?.agentId, sessionsLoaded, activeThreadId, threads]);
 
   // Keep the view pinned to the bottom — also while a reply streams (the last
   // message grows without the list length changing). The store bumps streamTick
@@ -148,14 +163,15 @@ export const ChatPage = () => {
   ) => {
     e.stopPropagation();
     if (!agentId || !selectedAgent) return;
-    if (window.confirm('Delete this session and all its messages?')) {
-      chatStore.deleteSession(
-        apolloClient,
-        agentId,
-        selectedAgent.agentId,
-        threadId,
-      );
-    }
+    if (!window.confirm('Delete this session and all its messages?')) return;
+    // The cached list filter (hook) + local state teardown (store); the
+    // bootstrap effect re-selects the next session if this one was active.
+    removeThread(threadId);
+    chatStore.discardThread(agentId, threadId);
+  };
+
+  const handleRenameSession = (id: string, threadId: string, title: string) => {
+    renameThread(id, threadId, title);
   };
 
   const handlePaste = (e: React.ClipboardEvent) => {
@@ -305,13 +321,14 @@ export const ChatPage = () => {
         {selectedAgent && agentId && (
           <SessionList
             agentId={agentId}
-            sessions={sessions}
+            sessions={threads}
             sessionsLoaded={sessionsLoaded}
             isDraft={isDraft}
             activeThreadId={activeThreadId}
             onSelect={handleSelectSession}
             onNew={handleNewThread}
             onDelete={handleDeleteSession}
+            onRename={handleRenameSession}
           />
         )}
 

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/SessionList.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/SessionList.tsx
@@ -1,6 +1,7 @@
-import type {
-  MouseEvent as ReactMouseEvent,
-  KeyboardEvent as ReactKeyboardEvent,
+import {
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import {
   IconLoader2,
@@ -9,7 +10,7 @@ import {
   IconTrash,
 } from '@tabler/icons-react';
 import { Button, Skeleton } from 'erxes-ui';
-import { SessionMeta } from '~/modules/chat/types';
+import { IMastraThread } from '~/modules/chat/types';
 import { useThreadWorking } from '~/modules/chat/hooks/useChatView';
 
 type DeleteHandler = (
@@ -17,12 +18,15 @@ type DeleteHandler = (
   threadId: string,
 ) => void;
 
+type RenameHandler = (id: string, threadId: string, title: string) => void;
+
 interface SessionItemProps {
-  session: SessionMeta;
+  session: IMastraThread;
   agentId: string;
   active: boolean;
   onSelect: (threadId: string) => void;
   onDelete: DeleteHandler;
+  onRename: RenameHandler;
 }
 
 const SessionItem = ({
@@ -31,8 +35,26 @@ const SessionItem = ({
   active,
   onSelect,
   onDelete,
+  onRename,
 }: SessionItemProps) => {
   const working = useThreadWorking(agentId, session.threadId);
+  const title = session.title || 'New chat';
+  const [editing, setEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(title);
+
+  const beginEdit = () => {
+    setDraftTitle(title);
+    setEditing(true);
+  };
+
+  const commit = () => {
+    setEditing(false);
+    const next = draftTitle.trim();
+    if (next && next !== title) {
+      onRename(session._id, session.threadId, next);
+    }
+  };
+
   return (
     <button
       onClick={() => onSelect(session.threadId)}
@@ -48,7 +70,37 @@ const SessionItem = ({
         ) : (
           <IconMessage2 className="size-3.5 text-muted-foreground shrink-0" />
         )}
-        <p className="text-sm truncate flex-1">{session.title}</p>
+        {editing ? (
+          <input
+            autoFocus
+            value={draftTitle}
+            onChange={(e) => setDraftTitle(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commit();
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setEditing(false);
+              }
+            }}
+            className="text-sm flex-1 min-w-0 bg-transparent outline-none border-b border-primary"
+          />
+        ) : (
+          <p
+            className="text-sm truncate flex-1"
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              beginEdit();
+            }}
+          >
+            {title}
+          </p>
+        )}
         <span
           role="button"
           tabIndex={0}
@@ -73,13 +125,14 @@ const SessionItem = ({
 
 interface SessionListProps {
   agentId: string;
-  sessions: SessionMeta[];
+  sessions: IMastraThread[];
   sessionsLoaded: boolean;
   isDraft: boolean;
   activeThreadId?: string;
   onSelect: (threadId: string) => void;
   onNew: () => void;
   onDelete: DeleteHandler;
+  onRename: RenameHandler;
 }
 
 export const SessionList = ({
@@ -91,6 +144,7 @@ export const SessionList = ({
   onSelect,
   onNew,
   onDelete,
+  onRename,
 }: SessionListProps) => {
   return (
     <div className="w-60 border-r flex flex-col shrink-0">
@@ -142,6 +196,7 @@ export const SessionList = ({
                   active={s.threadId === activeThreadId}
                   onSelect={onSelect}
                   onDelete={onDelete}
+                  onRename={onRename}
                 />
               ))
             )}

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useMastraThreads.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useMastraThreads.tsx
@@ -1,0 +1,21 @@
+import { useQuery } from '@apollo/client';
+import { MASTRA_THREADS } from '~/graphql/queries';
+import { IMastraThreadsResponse } from '~/modules/chat/types';
+
+// The agent's persisted session list, read from the Apollo cache. Optimistic
+// create (on send), rename, remove, and the turn-end refetch all write into the
+// same cached query, so this stays in sync without a hand-rolled store array.
+export const useMastraThreads = (mastraAgentId?: string) => {
+  const { data, loading } = useQuery<IMastraThreadsResponse>(MASTRA_THREADS, {
+    variables: { agentId: mastraAgentId },
+    skip: !mastraAgentId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  return {
+    threads: data?.mastraThreads ?? [],
+    // Only "still loading" before the first read resolves — background refetches
+    // (turn end) keep `data`, so the sidebar skeleton never flickers back.
+    loading: loading && !data,
+  };
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useRemoveMastraThread.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useRemoveMastraThread.tsx
@@ -1,0 +1,46 @@
+import { useMutation } from '@apollo/client';
+import { useToast } from 'erxes-ui';
+import { MASTRA_THREAD_REMOVE } from '~/graphql/mutations';
+import { MASTRA_THREADS } from '~/graphql/queries';
+import { IMastraThreadsResponse } from '~/modules/chat/types';
+
+interface MastraThreadRemoveResponse {
+  mastraThreadRemove: boolean;
+}
+
+// Remove a session, optimistically filtering it out of the cached list so it
+// disappears from the sidebar instantly (Apollo restores it on error).
+export const useRemoveMastraThread = (mastraAgentId?: string) => {
+  const { toast } = useToast();
+  const [removeThread, { loading }] = useMutation<MastraThreadRemoveResponse>(
+    MASTRA_THREAD_REMOVE,
+  );
+
+  const mutate = (threadId: string) =>
+    removeThread({
+      variables: { threadId },
+      optimisticResponse: { mastraThreadRemove: true },
+      update: (cache) => {
+        if (!mastraAgentId) return;
+        cache.updateQuery<IMastraThreadsResponse>(
+          { query: MASTRA_THREADS, variables: { agentId: mastraAgentId } },
+          (prev) =>
+            prev
+              ? {
+                  mastraThreads: prev.mastraThreads.filter(
+                    (t) => t.threadId !== threadId,
+                  ),
+                }
+              : prev ?? undefined,
+        );
+      },
+      onError: (error) => {
+        toast({
+          title: error?.message || 'Failed to delete session',
+          variant: 'destructive',
+        });
+      },
+    });
+
+  return { removeThread: mutate, loading };
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useRenameMastraThread.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/hooks/useRenameMastraThread.tsx
@@ -1,0 +1,56 @@
+import { useMutation } from '@apollo/client';
+import { useToast } from 'erxes-ui';
+import { MASTRA_THREAD_RENAME } from '~/graphql/mutations';
+
+interface MastraThreadRenameResponse {
+  mastraThreadRename: {
+    __typename?: 'MastraThread';
+    _id: string;
+    threadId: string;
+    title: string;
+  } | null;
+}
+
+// Rename a session, optimistically updating the cached thread by identity so the
+// new title shows instantly and Apollo rolls back on error.
+export const useRenameMastraThread = () => {
+  const { toast } = useToast();
+  const [renameThread, { loading }] = useMutation<MastraThreadRenameResponse>(
+    MASTRA_THREAD_RENAME,
+  );
+
+  const mutate = (id: string, threadId: string, title: string) =>
+    renameThread({
+      variables: { threadId, title },
+      optimisticResponse: {
+        mastraThreadRename: {
+          __typename: 'MastraThread',
+          _id: id,
+          threadId,
+          title,
+        },
+      },
+      update: (cache, { data }) => {
+        const thread = data?.mastraThreadRename;
+        if (!thread?._id) return;
+        const cacheId = cache.identify({
+          __typename: 'MastraThread',
+          _id: thread._id,
+        });
+        if (cacheId) {
+          cache.modify({
+            id: cacheId,
+            fields: { title: () => thread.title },
+          });
+        }
+      },
+      onError: (error) => {
+        toast({
+          title: error?.message || 'Failed to rename session',
+          variant: 'destructive',
+        });
+      },
+    });
+
+  return { renameThread: mutate, loading };
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -490,7 +490,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
           variables: { agentId: mastraAgentId },
           fetchPolicy: 'network-only',
         });
-        const sessions: SessionMeta[] = (data?.mastraThreads ?? []).map(
+        const serverSessions: SessionMeta[] = (data?.mastraThreads ?? []).map(
           (t) => ({
             threadId: t.threadId,
             title: t.title || 'New chat',
@@ -500,6 +500,21 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         );
 
         const before = ensureAgent(agentKey);
+        // A just-created chat the server list hasn't caught up to yet must not be
+        // dropped by this refetch — keep the active thread's local entry until the
+        // server returns it, or the new session vanishes from the sidebar.
+        const activeId = before.activeThreadId;
+        const sessions =
+          activeId && !serverSessions.some((s) => s.threadId === activeId)
+            ? [
+                before.sessions.find((s) => s.threadId === activeId) ?? {
+                  threadId: activeId,
+                  title: 'New chat',
+                  messageCount: 0,
+                },
+                ...serverSessions,
+              ]
+            : serverSessions;
         patchAgent(agentKey, { sessions, sessionsLoaded: true });
 
         if (!before.activeThreadId) {

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -4,14 +4,9 @@ import { REACT_APP_API_URL } from 'erxes-ui';
 import {
   MASTRA_AGENT_CHAT,
   MASTRA_MESSAGE_FEEDBACKS,
-  MASTRA_THREADS,
   MASTRA_THREAD_MESSAGES,
 } from '~/graphql/queries';
-import {
-  MASTRA_MESSAGE_FEEDBACK,
-  MASTRA_THREAD_REMOVE,
-  MASTRA_THREAD_RENAME,
-} from '~/graphql/mutations';
+import { MASTRA_MESSAGE_FEEDBACK } from '~/graphql/mutations';
 import {
   AgentChatState,
   AgentChatView,
@@ -22,7 +17,6 @@ import {
   MessageMeta,
   ReasoningEffort,
   REASONING_EFFORT_OPTIONS,
-  SessionMeta,
   ThreadChatState,
 } from '~/modules/chat/types';
 import {
@@ -30,6 +24,11 @@ import {
   partsFromMeta,
   randomIdSuffix,
 } from '~/modules/chat/utils';
+import {
+  prependThreadToCache,
+  refetchThreadsIntoCache,
+  setThreadTitleInCache,
+} from '~/modules/chat/threadsCache';
 import { readStreamEvents } from '~/modules/chat/lib/streamTransport';
 import {
   ApplyOps,
@@ -38,15 +37,6 @@ import {
 } from '~/modules/chat/lib/applyEvent';
 
 type Client = ApolloClient<object>;
-
-interface MastraThreadsResponse {
-  mastraThreads?: Array<{
-    threadId: string;
-    title?: string;
-    messageCount?: number;
-    lastMessageAt?: string;
-  }>;
-}
 
 interface MastraThreadMessagesResponse {
   mastraThreadMessages?: Array<{
@@ -110,11 +100,6 @@ interface ChatStoreState {
     effort: ReasoningEffort | undefined,
   ) => void;
   newDraft: (agentKey: string) => void;
-  loadSessions: (
-    client: Client,
-    agentKey: string,
-    mastraAgentId: string,
-  ) => Promise<void>;
   selectSession: (
     client: Client,
     agentKey: string,
@@ -127,18 +112,9 @@ interface ChatStoreState {
     messageId: string,
     rating: 1 | -1,
   ) => Promise<void>;
-  renameSession: (
-    client: Client,
-    agentKey: string,
-    threadId: string,
-    title: string,
-  ) => Promise<void>;
-  deleteSession: (
-    client: Client,
-    agentKey: string,
-    mastraAgentId: string,
-    threadId: string,
-  ) => Promise<void>;
+  // Drop a removed thread's local streaming/message state. The cached session
+  // list is filtered by useRemoveMastraThread; this only clears store-side state.
+  discardThread: (agentKey: string, threadId: string) => void;
   stop: (agentKey: string, threadId: string) => void;
   sendMessage: (
     client: Client,
@@ -224,22 +200,6 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
     patchThread(agentKey, threadId, { messages });
   };
 
-  // Local-only title update — used when the server pushes an auto-generated
-  // title over the stream (the server already persisted it).
-  const setSessionTitle = (
-    agentKey: string,
-    threadId: string,
-    title: string,
-  ) => {
-    const agent = ensureAgent(agentKey);
-    if (!agent.sessions.some((s) => s.threadId === threadId)) return;
-    patchAgent(agentKey, {
-      sessions: agent.sessions.map((s) =>
-        s.threadId === threadId ? { ...s, title } : s,
-      ),
-    });
-  };
-
   const hydrateFeedbacks = async (
     client: Client,
     agentKey: string,
@@ -266,8 +226,9 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
     }
   };
 
-  // Mark the turn persisted: refresh sessions (titles/ordering/counts) and flag
-  // unread when the user is looking at another agent.
+  // Mark the turn persisted: reconcile the cached session list
+  // (titles/ordering/counts + the real _id) and flag unread when the user is
+  // looking at another agent.
   const finishTurn = (
     client: Client,
     agentKey: string,
@@ -285,7 +246,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
     if (agent.activeThreadId === threadId && agent.isDraft) {
       patchAgent(agentKey, { isDraft: false });
     }
-    void get().loadSessions(client, agentKey, mastraAgentId);
+    void refetchThreadsIntoCache(client, mastraAgentId);
   };
 
   // Legacy blocking transport — single GraphQL query, no intermediate events.
@@ -330,6 +291,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
   // before any event arrived (caller falls back to GraphQL); throws on errors
   // the user should see.
   const sendViaStream = async (
+    client: Client,
     agentKey: string,
     threadId: string,
     mastraAgentId: string,
@@ -407,7 +369,8 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         }),
       setActivity: (text) =>
         patchThread(agentKey, threadId, { activity: text }),
-      setSessionTitle: (tid, title) => setSessionTitle(agentKey, tid, title),
+      setSessionTitle: (tid, title) =>
+        setThreadTitleInCache(client, mastraAgentId, tid, title),
       fallbackThreadId: threadId,
     };
 
@@ -483,52 +446,6 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       patchThread(agentKey, threadId, { messages: [], loading: false });
     },
 
-    loadSessions: async (client, agentKey, mastraAgentId) => {
-      try {
-        const { data } = await client.query<MastraThreadsResponse>({
-          query: MASTRA_THREADS,
-          variables: { agentId: mastraAgentId },
-          fetchPolicy: 'network-only',
-        });
-        const serverSessions: SessionMeta[] = (data?.mastraThreads ?? []).map(
-          (t) => ({
-            threadId: t.threadId,
-            title: t.title || 'New chat',
-            messageCount: t.messageCount ?? 0,
-            lastMessageAt: t.lastMessageAt,
-          }),
-        );
-
-        const before = ensureAgent(agentKey);
-        // A just-created chat the server list hasn't caught up to yet must not be
-        // dropped by this refetch — keep the active thread's local entry until the
-        // server returns it, or the new session vanishes from the sidebar.
-        const activeId = before.activeThreadId;
-        const sessions =
-          activeId && !serverSessions.some((s) => s.threadId === activeId)
-            ? [
-                before.sessions.find((s) => s.threadId === activeId) ?? {
-                  threadId: activeId,
-                  title: 'New chat',
-                  messageCount: 0,
-                },
-                ...serverSessions,
-              ]
-            : serverSessions;
-        patchAgent(agentKey, { sessions, sessionsLoaded: true });
-
-        if (!before.activeThreadId) {
-          if (sessions.length > 0) {
-            await get().selectSession(client, agentKey, sessions[0].threadId);
-          } else {
-            get().newDraft(agentKey);
-          }
-        }
-      } catch {
-        patchAgent(agentKey, { sessionsLoaded: true });
-      }
-    },
-
     selectSession: async (client, agentKey, threadId) => {
       patchAgent(agentKey, { activeThreadId: threadId, isDraft: false });
 
@@ -585,50 +502,17 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       }
     },
 
-    renameSession: async (client, agentKey, threadId, title) => {
-      const agent = ensureAgent(agentKey);
-      patchAgent(agentKey, {
-        sessions: agent.sessions.map((s) =>
-          s.threadId === threadId ? { ...s, title } : s,
-        ),
-      });
-      try {
-        await client.mutate({
-          mutation: MASTRA_THREAD_RENAME,
-          variables: { threadId, title },
-        });
-      } catch {
-        // best-effort; optimistic update already applied
-      }
-    },
-
-    deleteSession: async (client, agentKey, mastraAgentId, threadId) => {
-      try {
-        await client.mutate({
-          mutation: MASTRA_THREAD_REMOVE,
-          variables: { threadId },
-        });
-      } catch {
-        return;
-      }
-
+    discardThread: (agentKey, threadId) => {
       getThread(agentKey, threadId).abort?.abort();
       set((s) => {
         const next = { ...s.threads };
         delete next[threadKey(agentKey, threadId)];
         return { threads: next };
       });
-
-      const agent = ensureAgent(agentKey);
-      const remaining = agent.sessions.filter((s) => s.threadId !== threadId);
-      patchAgent(agentKey, { sessions: remaining });
-
-      if (agent.activeThreadId === threadId) {
-        if (remaining.length > 0) {
-          await get().selectSession(client, agentKey, remaining[0].threadId);
-        } else {
-          get().newDraft(agentKey);
-        }
+      // Drop the active selection so the view's bootstrap effect re-selects the
+      // next session (or opens a fresh draft) from the now-filtered cached list.
+      if (ensureAgent(agentKey).activeThreadId === threadId) {
+        patchAgent(agentKey, { activeThreadId: undefined, isDraft: false });
       }
     },
 
@@ -662,17 +546,11 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
       // Surface the session in the sidebar the instant the first message is
       // sent — don't wait for the turn to finish. The backend registers + tags
       // the thread at turn start (so a refresh keeps it); this mirrors it into
-      // the list optimistically. The streamed thread_title event fills the real
-      // title, and loadSessions in finishTurn reconciles title/count/order.
-      if (!agent.sessions.some((s) => s.threadId === threadId)) {
-        patchAgent(agentKey, {
-          sessions: [
-            { threadId, title: 'New chat', messageCount: 0 },
-            ...agent.sessions,
-          ],
-          isDraft: false,
-        });
-      }
+      // the cached list optimistically. The streamed thread_title event fills
+      // the real title, and the finishTurn refetch reconciles title/count/order
+      // and the real _id into the same cached query.
+      prependThreadToCache(client, mastraAgentId, threadId);
+      if (agent.isDraft) patchAgent(agentKey, { isDraft: false });
 
       appendMessage(agentKey, threadId, {
         role: 'user',
@@ -686,6 +564,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
 
       try {
         const streamed = await sendViaStream(
+          client,
           agentKey,
           threadId,
           mastraAgentId,
@@ -806,8 +685,6 @@ export const chatStore = {
   setReasoningEffort: (agentKey: string, effort: ReasoningEffort | undefined) =>
     useChatStore.getState().setReasoningEffort(agentKey, effort),
   newDraft: (agentKey: string) => useChatStore.getState().newDraft(agentKey),
-  loadSessions: (client: Client, agentKey: string, mastraAgentId: string) =>
-    useChatStore.getState().loadSessions(client, agentKey, mastraAgentId),
   selectSession: (client: Client, agentKey: string, threadId: string) =>
     useChatStore.getState().selectSession(client, agentKey, threadId),
   rateMessage: (
@@ -820,21 +697,8 @@ export const chatStore = {
     useChatStore
       .getState()
       .rateMessage(client, agentKey, threadId, messageId, rating),
-  renameSession: (
-    client: Client,
-    agentKey: string,
-    threadId: string,
-    title: string,
-  ) => useChatStore.getState().renameSession(client, agentKey, threadId, title),
-  deleteSession: (
-    client: Client,
-    agentKey: string,
-    mastraAgentId: string,
-    threadId: string,
-  ) =>
-    useChatStore
-      .getState()
-      .deleteSession(client, agentKey, mastraAgentId, threadId),
+  discardThread: (agentKey: string, threadId: string) =>
+    useChatStore.getState().discardThread(agentKey, threadId),
   stop: (agentKey: string, threadId: string) =>
     useChatStore.getState().stop(agentKey, threadId),
   sendMessage: (

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/threadsCache.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/threadsCache.ts
@@ -1,0 +1,81 @@
+import { ApolloClient } from '@apollo/client';
+import { MASTRA_THREADS } from '~/graphql/queries';
+import { IMastraThread, IMastraThreadsResponse } from '~/modules/chat/types';
+
+type Client = ApolloClient<object>;
+
+// Write helpers for the cached `mastraThreads` list. The session list lives in
+// the Apollo cache (house convention); the chat store reconciles it through
+// these instead of owning a copied array. Mutations triggered from the UI use
+// the dedicated hooks — these cover the store-driven moments (send / stream
+// title / turn end) where there is no GraphQL mutation to hang an update on.
+
+const variablesFor = (mastraAgentId: string) => ({ agentId: mastraAgentId });
+
+// Surface a brand-new session in the sidebar the instant the first message is
+// sent. Idempotent: skips when the thread is already in the list, so a resend
+// can't duplicate it. The streamed `thread_title` event and the turn-end
+// refetch reconcile the real title / count / order into the same cached list.
+export const prependThreadToCache = (
+  client: Client,
+  mastraAgentId: string,
+  threadId: string,
+) => {
+  client.cache.updateQuery<IMastraThreadsResponse>(
+    { query: MASTRA_THREADS, variables: variablesFor(mastraAgentId) },
+    (prev) => {
+      const list = prev?.mastraThreads ?? [];
+      if (list.some((t) => t.threadId === threadId)) return prev ?? undefined;
+      const optimistic: IMastraThread = {
+        __typename: 'MastraThread',
+        _id: threadId,
+        threadId,
+        title: 'New chat',
+        messageCount: 0,
+        lastMessageAt: null,
+        createdAt: null,
+      };
+      return { mastraThreads: [optimistic, ...list] };
+    },
+  );
+};
+
+// Local title update for the server-pushed `thread_title` stream event (the
+// server already persisted it — this only mirrors it into the cached list).
+export const setThreadTitleInCache = (
+  client: Client,
+  mastraAgentId: string,
+  threadId: string,
+  title: string,
+) => {
+  client.cache.updateQuery<IMastraThreadsResponse>(
+    { query: MASTRA_THREADS, variables: variablesFor(mastraAgentId) },
+    (prev) => {
+      if (!prev) return prev ?? undefined;
+      return {
+        mastraThreads: prev.mastraThreads.map((t) =>
+          t.threadId === threadId ? { ...t, title } : t,
+        ),
+      };
+    },
+  );
+};
+
+// Reconcile the cached list against the server after a turn finishes: title,
+// message count, ordering, and the real `_id` for the just-created thread.
+// Apollo MERGES the network result into the cached query — it never clobbers a
+// separate array — so an optimistic entry already present cannot vanish.
+export const refetchThreadsIntoCache = async (
+  client: Client,
+  mastraAgentId: string,
+) => {
+  try {
+    await client.query<IMastraThreadsResponse>({
+      query: MASTRA_THREADS,
+      variables: variablesFor(mastraAgentId),
+      fetchPolicy: 'network-only',
+    });
+  } catch {
+    // best-effort — the optimistic list stays until the next successful read
+  }
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/types.ts
@@ -57,11 +57,21 @@ export interface MessageMeta {
   interrupted?: boolean;
 }
 
-export interface SessionMeta {
+// One persisted chat session (thread) as returned by `mastraThreads` and held in
+// the Apollo cache. The session LIST lives in the cache (house convention), not
+// in the chat store — only per-thread streaming/message state stays in the store.
+export interface IMastraThread {
+  __typename?: 'MastraThread';
+  _id: string;
   threadId: string;
   title: string;
   messageCount: number;
-  lastMessageAt?: string;
+  lastMessageAt?: string | null;
+  createdAt?: string | null;
+}
+
+export interface IMastraThreadsResponse {
+  mastraThreads: IMastraThread[];
 }
 
 // Per-thread chat state. Keyed by `${agentKey}:${threadId}` so an in-flight
@@ -96,8 +106,6 @@ export const REASONING_EFFORT_OPTIONS: {
 ];
 
 export interface AgentChatState {
-  sessions: SessionMeta[];
-  sessionsLoaded: boolean;
   activeThreadId?: string;
   isDraft: boolean; // active session is new and not yet persisted
   // Power-user reasoning override for this agent's chat view. Unset = default.
@@ -160,8 +168,6 @@ export const EMPTY_THREAD: ThreadChatState = {
 };
 
 export const EMPTY_AGENT: AgentChatState = {
-  sessions: [],
-  sessionsLoaded: false,
   activeThreadId: undefined,
   isDraft: false,
   reasoningEffort: undefined,


### PR DESCRIPTION
## Why

Chat sessions were intermittently "lost" — creating a new chat sometimes didn't appear in the sidebar, and the thread was never persisted. Two root causes:

1. **Persistence was gated behind an env opt-in + a tenant check.** The native chat store (which backs the sidebar) only ran when `ERXES_AGENT_MEMORY=enable` *and* `subdomain` was non-empty. With either off, the turn was answered statelessly and never saved.
2. **The sidebar was a hand-rolled store array.** The session list was copied into the chat store and a `network-only` refetch *overwrote* it, wiping the optimistic new-chat entry.

## What

### Backend — persistence always on
- `isAdvancedMemoryEnabled()` now defaults **on**; only `ERXES_AGENT_MEMORY=disable` turns it off (config + boot init aligned).
- Dropped the `Boolean(subdomain)` gate everywhere it silently skipped persistence: `agentRuntime.ts` (the critical one — it *attaches* Memory), `prepare.ts` (chat), `routes.ts` (bot/widget), `schedules/runner.ts`. `scopedResource` already defaults an empty subdomain to the `os:` scope, so threads persist consistently instead of being dropped.
- Updated `mastra/memory/config` unit tests to the inverted default (all green).

### Frontend — session list from Apollo cache (house convention)
- Removed the hand-rolled `sessions` array, `loadSessions`, the optimistic-insert block, and the temporary "keep active thread" patch from the chat store.
- New typed hooks: `useMastraThreads` (cache-backed list), `useRenameMastraThread`, `useRemoveMastraThread` — using `cache.updateQuery` / `cache.modify` with optimistic updates + automatic rollback, matching the rest of the repo.
- Optimistic create writes the new thread directly into the `MASTRA_THREADS` cache; the post-turn refetch merges instead of clobbering, so a new chat never vanishes. Streaming / abort / draft / unread / rating logic untouched.

## Verification
- `mastra/memory` config tests pass.
- erxes-agent_ui: eslint clean on touched/new files; `tsc --noEmit` clean for the plugin's `src`.

## Mergeability note
- Conflict-free against #8105 / #8107 (no shared files).
- Backend touches files also changed by #8035 (`agentRuntime.ts`, `runner.ts`, `routes.ts`) — if #8035 lands first, rebase this and re-apply the gate change in the new runner structure. #8036 shares only `routes.ts` (different region, likely auto-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Session renaming: Double-click session titles to rename conversations inline
  - Persistent thread caching integration: Session lists now leverage cached threads for improved conversation continuity and recovery

* **Improvements**
  - Advanced memory now enabled by default: Conversation sessions persist automatically with opt-out available via configuration
  - Enhanced session management: Better cache synchronization ensures immediate UI updates and reliable session state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->