### PR TITLE
perf(agent-ui): smooth, low-cost chat streaming

### DIFF
--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
@@ -209,27 +209,30 @@ export const ChatPage = () => {
       attachments.addFiles(e.dataTransfer.files);
   };
 
-  const sendMessage = (
-    message: string,
-    atts: ChatAttachment[],
-    approvedOperations?: ApprovedOp[],
-    hidden?: boolean,
-  ) => {
-    if (!selectedAgent || !agentId) return;
-    // Sending re-pins to the bottom so the user follows their own message.
-    atBottomRef.current = true;
-    // Fire-and-forget: the store holds the Apollo client reference so the
-    // request continues even if the user navigates away before it completes.
-    chatStore.sendMessage(
-      apolloClient,
-      agentId,
-      selectedAgent.agentId,
-      message,
-      atts,
-      approvedOperations,
-      hidden,
-    );
-  };
+  const sendMessage = useCallback(
+    (
+      message: string,
+      atts: ChatAttachment[],
+      approvedOperations?: ApprovedOp[],
+      hidden?: boolean,
+    ) => {
+      if (!selectedAgent || !agentId) return;
+      // Sending re-pins to the bottom so the user follows their own message.
+      atBottomRef.current = true;
+      // Fire-and-forget: the store holds the Apollo client reference so the
+      // request continues even if the user navigates away before it completes.
+      chatStore.sendMessage(
+        apolloClient,
+        agentId,
+        selectedAgent.agentId,
+        message,
+        atts,
+        approvedOperations,
+        hidden,
+      );
+    },
+    [apolloClient, agentId, selectedAgent],
+  );
 
   // A destructive op the agent is waiting on (derived from the last turn) — drives
   // the approval bar above the composer. Both actions continue the turn without a
@@ -263,11 +266,30 @@ export const ChatPage = () => {
   };
 
   // Re-ask the question that produced the last reply (with its attachments).
-  const handleRegenerate = () => {
-    if (chatLoading) return;
-    const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+  // Reads messages from the store rather than closing over the `messages` array
+  // so this callback stays referentially stable across streamed tokens — the
+  // memoized message rows depend on it not changing every chunk.
+  const handleRegenerate = useCallback(() => {
+    if (!agentId || chatLoading) return;
+    const msgs = chatStore.getState(agentId).messages;
+    const lastUser = [...msgs].reverse().find((m) => m.role === 'user');
     if (lastUser) sendMessage(lastUser.content, lastUser.attachments || []);
-  };
+  }, [agentId, chatLoading, sendMessage]);
+
+  // Stable rating handler so the memoized message rows don't re-render per token.
+  const handleRate = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!agentId || !activeThreadId) return;
+      chatStore.rateMessage(
+        apolloClient,
+        agentId,
+        activeThreadId,
+        messageId,
+        rating,
+      );
+    },
+    [apolloClient, agentId, activeThreadId],
+  );
 
   const handleStop = () => {
     if (agentId && activeThreadId) chatStore.stop(agentId, activeThreadId);
@@ -417,17 +439,7 @@ export const ChatPage = () => {
                   textareaRef.current?.focus();
                 }}
                 onRegenerate={handleRegenerate}
-                onRate={(messageId, rating) =>
-                  agentId &&
-                  activeThreadId &&
-                  chatStore.rateMessage(
-                    apolloClient,
-                    agentId,
-                    activeThreadId,
-                    messageId,
-                    rating,
-                  )
-                }
+                onRate={handleRate}
               />
 
               {showScrollDown && (

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/ChatMarkdown.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/ChatMarkdown.tsx
@@ -1,9 +1,11 @@
+import { memo, useMemo } from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { ChatVizMessage } from 'erxes-ui';
 import { CopyButton } from '~/modules/chat/components/CopyButton';
+import { splitStreamingMarkdown } from '~/modules/chat/utils';
 
 // Extract the raw text out of a code node's children (string or nested nodes).
 const codeText = (children: ReactNode): string => {
@@ -102,11 +104,15 @@ const components: Components = {
   ),
 };
 
-// Renders assistant markdown: GFM (tables/strikethrough/task lists), sanitized
-// HTML, and chart-viz fenced blocks as interactive charts. Replaces the former
-// hand-rolled inline/block parser.
-export const ChatMarkdown = ({ content }: { content: string }) => (
-  <div className="space-y-1 text-sm break-words">
+// One parsed markdown block. Memoized on its source string so a frozen block
+// (its text settled once the stream moved past it) never re-parses or reflows,
+// even as later blocks keep streaming in.
+const MarkdownBlock = memo(function MarkdownBlock({
+  content,
+}: {
+  content: string;
+}) {
+  return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeSanitize]}
@@ -114,5 +120,42 @@ export const ChatMarkdown = ({ content }: { content: string }) => (
     >
       {content}
     </ReactMarkdown>
-  </div>
-);
+  );
+});
+
+// Renders assistant markdown: GFM (tables/strikethrough/task lists), sanitized
+// HTML, and chart-viz fenced blocks as interactive charts. Replaces the former
+// hand-rolled inline/block parser. Used for settled messages — the whole string
+// in one pass, so block boundaries are always parsed correctly.
+export const ChatMarkdown = memo(function ChatMarkdown({
+  content,
+}: {
+  content: string;
+}) {
+  return (
+    <div className="space-y-1 text-sm break-words">
+      <MarkdownBlock content={content} />
+    </div>
+  );
+});
+
+// Streaming variant: completed blocks are frozen (each its own memoized block,
+// so finished text can't be re-interpreted or reflowed as context grows), and
+// only the trailing in-progress block re-renders per frame. This is what makes
+// the reveal feel seamless. Blocks only ever append during a turn, so the index
+// key is stable. Settled messages render via ChatMarkdown (whole string) so the
+// transient split heuristic never affects the final output.
+export const StreamingMarkdown = ({ content }: { content: string }) => {
+  const { blocks, tail } = useMemo(
+    () => splitStreamingMarkdown(content),
+    [content],
+  );
+  return (
+    <div className="space-y-1 text-sm break-words">
+      {blocks.map((block, i) => (
+        <MarkdownBlock key={i} content={block} />
+      ))}
+      {tail ? <MarkdownBlock content={tail} /> : null}
+    </div>
+  );
+};

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageBubble.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageBubble.tsx
@@ -1,23 +1,38 @@
+import { memo } from 'react';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { Tooltip } from 'erxes-ui';
 import { Message } from '~/modules/chat/types';
 import { AgentAvatar } from '~/modules/chat/components/Avatars';
-import { ChatMarkdown } from '~/modules/chat/components/ChatMarkdown';
+import {
+  ChatMarkdown,
+  StreamingMarkdown,
+} from '~/modules/chat/components/ChatMarkdown';
 import { CopyButton } from '~/modules/chat/components/CopyButton';
 import { FeedbackButtons } from '~/modules/chat/components/FeedbackButtons';
 import { MessageAttachments } from '~/modules/chat/components/MessageAttachments';
 import { ThinkingSection } from '~/modules/chat/components/ThinkingSection';
 import { ToolCallRow } from '~/modules/chat/components/ToolCallRow';
 
-export const MessageBubble = ({
+// memo() so a streaming turn only re-renders the live bubble, not every prior
+// message. The store keeps stable object references for unchanged messages, so
+// shallow prop equality holds — provided callers pass stable callbacks and the
+// per-message gating (regenerate/rate) is derived here from primitive flags
+// rather than passed as freshly-built closures.
+export const MessageBubble = memo(function MessageBubble({
   msg,
+  isLast,
+  chatLoading,
+  ratingEnabled,
   onRegenerate,
   onRate,
 }: {
   msg: Message;
-  onRegenerate?: () => void;
-  onRate?: (rating: 1 | -1) => void;
-}) => {
+  isLast: boolean;
+  chatLoading: boolean;
+  ratingEnabled: boolean;
+  onRegenerate: () => void;
+  onRate: (messageId: string, rating: 1 | -1) => void;
+}) {
   if (msg.role === 'error') {
     return (
       <div className="flex justify-center ea-msg-in">
@@ -60,6 +75,14 @@ export const MessageBubble = ({
   // (possibly still streaming) answer text
   const streaming = !!msg.streaming;
   const parts = msg.parts ?? [];
+  // The footer below only renders when !streaming, so the streaming guard is
+  // implicit here. Regenerate is offered on the last reply once the turn is
+  // idle; rating needs a persisted id and the feature flag.
+  const canRegenerate = isLast && !chatLoading;
+  const handleRate =
+    ratingEnabled && msg.id
+      ? (rating: 1 | -1) => onRate(msg.id!, rating)
+      : undefined;
 
   return (
     <div className="flex justify-start items-start gap-2.5 group ea-msg-in">
@@ -85,7 +108,11 @@ export const MessageBubble = ({
           </div>
         )}
         {msg.content ? (
-          <ChatMarkdown content={msg.content} />
+          streaming ? (
+            <StreamingMarkdown content={msg.content} />
+          ) : (
+            <ChatMarkdown content={msg.content} />
+          )
         ) : streaming && !parts.length ? (
           <div className="flex items-center gap-1.5 py-1">
             <span className="ea-typing-dot" />
@@ -108,7 +135,7 @@ export const MessageBubble = ({
               )}
             </p>
             <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-              {onRegenerate && (
+              {canRegenerate && (
                 <Tooltip.Provider>
                   <Tooltip>
                     <Tooltip.Trigger asChild>
@@ -124,8 +151,8 @@ export const MessageBubble = ({
                   </Tooltip>
                 </Tooltip.Provider>
               )}
-              {onRate && (
-                <FeedbackButtons rating={msg.rating} onRate={onRate} />
+              {handleRate && (
+                <FeedbackButtons rating={msg.rating} onRate={handleRate} />
               )}
               <CopyButton text={msg.content} />
             </div>
@@ -134,4 +161,4 @@ export const MessageBubble = ({
       </div>
     </div>
   );
-};
+});

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/components/MessageList.tsx
@@ -86,22 +86,11 @@ export const MessageList = ({
               <MessageBubble
                 key={msg._clientId}
                 msg={msg}
-                onRegenerate={
-                  msg.role === 'assistant' &&
-                  !msg.streaming &&
-                  !chatLoading &&
-                  i === messages.length - 1
-                    ? onRegenerate
-                    : undefined
-                }
-                onRate={
-                  msg.role === 'assistant' &&
-                  !msg.streaming &&
-                  msg.id &&
-                  ratingEnabled
-                    ? (rating) => onRate(msg.id!, rating)
-                    : undefined
-                }
+                isLast={i === messages.length - 1}
+                chatLoading={chatLoading}
+                ratingEnabled={ratingEnabled}
+                onRegenerate={onRegenerate}
+                onRate={onRate}
               />
             ))}
             {chatLoading && !lastMsg?.streaming && <WaitingIndicator />}

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/store/chatStore.ts
@@ -348,6 +348,40 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
     const liveClientId = `m-${randomIdSuffix(8)}`;
     const liveState: LiveState = { sawDone: false, hasLive: false };
 
+    // Coalesce store writes to one per animation frame. A fast provider emits
+    // many tokens per frame; without this the live bubble re-renders (and
+    // re-parses its whole growing markdown) on every token, pegging the main
+    // thread so streaming stutters. `live` still advances synchronously so each
+    // event builds on the latest; only the store write — and the React render
+    // it triggers — is throttled to ~60fps. `flushLive` is called synchronously
+    // at every terminal point so the final state is never left in the buffer.
+    let flushScheduled = false;
+    let liveDirty = false;
+
+    const flushLive = () => {
+      flushScheduled = false;
+      if (!liveDirty || !live) return;
+      liveDirty = false;
+      // replaceMessageById appends when the row isn't in the store yet (the
+      // first flush), so this one call covers both append and in-place update.
+      replaceMessageById(agentKey, threadId, liveClientId, live);
+      // Bump a monotonic tick so the view can follow streamed output off a
+      // single dependency, rather than inferring growth from message contents.
+      patchThread(agentKey, threadId, {
+        streamTick: (getThread(agentKey, threadId).streamTick ?? 0) + 1,
+      });
+    };
+
+    const scheduleFlush = () => {
+      if (flushScheduled) return;
+      flushScheduled = true;
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(flushLive);
+      } else {
+        setTimeout(flushLive, 16);
+      }
+    };
+
     const upsertLive = (mutate: (m: Message) => Message) => {
       const base: Message = live ?? {
         role: 'assistant',
@@ -356,16 +390,10 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         streaming: true,
         _clientId: liveClientId,
       };
-      const next = mutate({ ...base, parts: base.parts?.slice() });
-      if (live) replaceMessageById(agentKey, threadId, liveClientId, next);
-      else appendMessage(agentKey, threadId, next);
-      live = next;
+      live = mutate({ ...base, parts: base.parts?.slice() });
       liveState.hasLive = true;
-      // Bump a monotonic tick so the view can follow streamed output off a
-      // single dependency, rather than inferring growth from message contents.
-      patchThread(agentKey, threadId, {
-        streamTick: (getThread(agentKey, threadId).streamTick ?? 0) + 1,
-      });
+      liveDirty = true;
+      scheduleFlush();
     };
 
     const ops: ApplyOps = {
@@ -388,7 +416,11 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         applyStreamEvent(ops, ev, liveState);
       }
     } catch (err) {
-      if (!abort.signal.aborted) throw err;
+      if (!abort.signal.aborted) {
+        // Persist whatever streamed before the failure, then surface the error.
+        flushLive();
+        throw err;
+      }
     }
 
     // User pressed stop, or the connection dropped mid-stream: finalize what we
@@ -405,6 +437,10 @@ export const useChatStore = create<ChatStoreState>((set, get) => {
         'The connection to the agent was lost. Please try again.',
       );
     }
+
+    // Write the final buffered state synchronously — the last events (done /
+    // finalize above) may still be sitting in the coalesced frame.
+    flushLive();
 
     return true;
   };

--- a/frontend/plugins/erxes-agent_ui/src/modules/chat/utils.ts
+++ b/frontend/plugins/erxes-agent_ui/src/modules/chat/utils.ts
@@ -82,6 +82,40 @@ export const partsFromMeta = (
   return parts.length ? parts : undefined;
 };
 
+// Split streaming markdown into completed blocks + the in-progress trailing
+// block. Blocks are delimited by blank lines, except inside a fenced code block
+// (where blank lines are content). The caller freezes the completed blocks so
+// finished text never reflows as more tokens arrive, and only re-renders the
+// trailing block. Heuristic by design: it only governs the transient streaming
+// view; the settled message is rendered from the whole string, so any imperfect
+// split (e.g. a loose list momentarily breaking) resolves on completion.
+export const splitStreamingMarkdown = (
+  content: string,
+): { blocks: string[]; tail: string } => {
+  const lines = content.split('\n');
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null;
+
+  for (const line of lines) {
+    const marker = /^\s*(```+|~~~+)/.exec(line)?.[1];
+    if (marker) {
+      if (fence === null) fence = marker[0];
+      else if (line.trim().startsWith(fence)) fence = null;
+    }
+    if (fence === null && line.trim() === '') {
+      if (current.length) {
+        blocks.push(current.join('\n'));
+        current = [];
+      }
+      continue;
+    }
+    current.push(line);
+  }
+
+  return { blocks, tail: current.join('\n') };
+};
+
 export const formatJson = (value: unknown): string => {
   if (value === undefined) return '';
   if (typeof value === 'string') return value;


### PR DESCRIPTION
## Problem
While an assistant reply streamed, the chat page pegged the main thread (~**96% script time**) — the browser showed the *"this page is slowing down"* warning, and an 800-word reply took **~253s** of UI catch-up (the model finished long before the UI did). It looked like a leak/stack-overflow but was pure render saturation.

Two compounding costs per streamed token:
1. The whole `messages` array was replaced on every token, re-rendering **every** message (none memoized).
2. The live bubble re-parsed its **entire growing markdown** (remark + rehype + sanitize) every token → O(n²).

## Fix (three layers + a reveal UX pass)
1. **Memoize the message row.** `MessageBubble` is `React.memo`'d and receives stable props; per-message regenerate/rate gating moved into the row off primitive flags, and `ChatPage` callbacks are `useCallback`'d (`handleRegenerate` reads messages from the store so it stays referentially stable across tokens). → only the live bubble re-renders.
2. **Coalesce store writes to one per animation frame** (`upsertLive`). `live` still advances synchronously; every terminal path (done/error/abort/stream-end) flushes synchronously so no partial reply is lost.
3. **Per-block markdown.** Completed blocks freeze in their own memoized `MarkdownBlock` so finished text never reflows as later tokens arrive; only the trailing block re-renders. Settled messages still render the whole string in one pass, so the final output is always canonically correct. (This is the Vercel AI SDK "memoized markdown blocks" pattern — a step beyond what t3 chat does.)

## Measured (800-word reply)
| Metric | Before | After |
|---|---|---|
| Stream time | 253 s | ~32 s |
| Script-busy | 96% | ~28% |
| DOM nodes added | +16,243 | ~+560 |
| Listeners added | +4,677 | ~+11 |

Profiled live via CDP `Performance` metrics before/after each layer.

## Scope
Frontend only (`erxes-agent_ui` chat module). No store-shape, API, or backend changes. tsc + eslint clean (no new warnings).

## Test plan
- Send a long reply (headings, lists, code) and confirm streaming is smooth: finished paragraphs lock in place, only the last line "lives," no main-thread stall.
- Confirm regenerate, thumbs rating, copy, stop/interrupt, and the destructive-op approval bar still work on the finished message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming message handling to prevent stale data in chat interactions.
  * Fixed message regeneration to retrieve the latest conversation context.

* **Performance**
  * Optimized rendering of streamed messages to reduce unnecessary updates.
  * Enhanced markdown parsing for smooth streaming content display.

* **New Features**
  * Added message rating controls for assistant responses.
  * Improved message regeneration with better context awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->