### PR TITLE
fix(content): preserve CMS content on default-language change and force published order

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -72,6 +72,70 @@ const hasTranslatableValue = (value: unknown): boolean => {
 };
 
 /**
+ * Build the bulk-write operations for a single document when its site's default
+ * language changes: preserve the old-default base content as an old-language
+ * translation, promote the new-language translation into the base fields, and
+ * drop the now-redundant new-language translation. Pulled out of
+ * `rehomeDefaultLanguageContent` to keep that function's complexity in check.
+ */
+const buildRehomeOpsForDocument = (
+  doc: any,
+  fieldMappings: Record<string, string>,
+  oldLanguage: string,
+  newLanguage: string,
+  type: string,
+  newTranslationMap: Map<string, any>,
+): { translationOps: any[]; documentOp: any | null } => {
+  const objectId = String(doc._id);
+  const translationOps: any[] = [];
+
+  // 1. Preserve the current (old-default) base content as an old-language
+  //    translation so it remains reachable after the switch.
+  const oldTranslationFields: Record<string, any> = {};
+  for (const [baseField, translationField] of Object.entries(fieldMappings)) {
+    oldTranslationFields[translationField] = doc[baseField] ?? '';
+  }
+
+  translationOps.push({
+    updateOne: {
+      filter: { objectId, language: oldLanguage, type },
+      update: {
+        $set: { ...oldTranslationFields, objectId, language: oldLanguage, type },
+      },
+      upsert: true,
+    },
+  });
+
+  // 2. Promote the new-language translation into the base fields. Only
+  //    non-empty values win, matching the read-time overlay so what the
+  //    editor saw under the new language is exactly what becomes default.
+  const newTranslation = newTranslationMap.get(objectId);
+  if (!newTranslation) {
+    return { translationOps, documentOp: null };
+  }
+
+  const baseUpdate: Record<string, any> = {};
+  for (const [baseField, translationField] of Object.entries(fieldMappings)) {
+    const value = newTranslation[translationField];
+    if (hasTranslatableValue(value)) {
+      baseUpdate[baseField] = value;
+    }
+  }
+
+  const documentOp = Object.keys(baseUpdate).length
+    ? { updateOne: { filter: { _id: doc._id }, update: { $set: baseUpdate } } }
+    : null;
+
+  // 3. The new language now lives in the base fields, so its standalone
+  //    translation record is redundant.
+  translationOps.push({
+    deleteOne: { filter: { objectId, language: newLanguage, type } },
+  });
+
+  return { translationOps, documentOp };
+};
+
+/**
  * Move content between the base document and the `Translations` collection when
  * a site's default language changes. Without this, the old default's content is
  * stranded in the base fields (with no translation pointing to it) while the new
@@ -109,63 +173,41 @@ const rehomeDefaultLanguageContent = async (
     const documentOps: any[] = [];
 
     for (const doc of documents) {
-      const objectId = String(doc._id);
+      const { translationOps: docTranslationOps, documentOp } =
+        buildRehomeOpsForDocument(
+          doc,
+          fieldMappings,
+          oldLanguage,
+          newLanguage,
+          type,
+          newTranslationMap,
+        );
 
-      // 1. Preserve the current (old-default) base content as an old-language
-      //    translation so it remains reachable after the switch.
-      const oldTranslationFields: Record<string, any> = {};
-      for (const [baseField, translationField] of Object.entries(
-        fieldMappings,
-      )) {
-        oldTranslationFields[translationField] = doc[baseField] ?? '';
+      translationOps.push(...docTranslationOps);
+      if (documentOp) {
+        documentOps.push(documentOp);
       }
+    }
 
-      translationOps.push({
-        updateOne: {
-          filter: { objectId, language: oldLanguage, type },
-          update: {
-            $set: { ...oldTranslationFields, objectId, language: oldLanguage, type },
-          },
-          upsert: true,
-        },
-      });
+    if (!documentOps.length && !translationOps.length) {
+      continue;
+    }
 
-      // 2. Promote the new-language translation into the base fields. Only
-      //    non-empty values win, matching the read-time overlay so what the
-      //    editor saw under the new language is exactly what becomes default.
-      const newTranslation = newTranslationMap.get(objectId);
-      if (!newTranslation) {
-        continue;
-      }
-
-      const baseUpdate: Record<string, any> = {};
-      for (const [baseField, translationField] of Object.entries(
-        fieldMappings,
-      )) {
-        const value = newTranslation[translationField];
-        if (hasTranslatableValue(value)) {
-          baseUpdate[baseField] = value;
+    // Base documents and their translations live in separate collections, so
+    // wrap both writes in a transaction — a partial apply would leave the new
+    // default's content out of sync with its translation records.
+    const session = await models.Translations.startSession();
+    try {
+      await session.withTransaction(async () => {
+        if (documentOps.length) {
+          await model.bulkWrite(documentOps, { session });
         }
-      }
-
-      if (Object.keys(baseUpdate).length) {
-        documentOps.push({
-          updateOne: { filter: { _id: doc._id }, update: { $set: baseUpdate } },
-        });
-      }
-
-      // 3. The new language now lives in the base fields, so its standalone
-      //    translation record is redundant.
-      translationOps.push({
-        deleteOne: { filter: { objectId, language: newLanguage, type } },
+        if (translationOps.length) {
+          await models.Translations.bulkWrite(translationOps, { session });
+        }
       });
-    }
-
-    if (documentOps.length) {
-      await model.bulkWrite(documentOps);
-    }
-    if (translationOps.length) {
-      await models.Translations.bulkWrite(translationOps);
+    } finally {
+      await session.endSession();
     }
   }
 };

--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -85,7 +85,7 @@ const buildRehomeOpsForDocument = (
   newLanguage: string,
   type: string,
   newTranslationMap: Map<string, any>,
-): { translationOps: any[]; documentOp: any | null } => {
+): { translationOps: any[]; documentOp: Record<string, any> | null } => {
   const objectId = String(doc._id);
   const translationOps: any[] = [];
 

--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -10,6 +10,166 @@ import {
 } from '@/cms/@types/cms';
 import { cmsSchema } from '@/cms/db/definitions/cms';
 
+/**
+ * Content whose translatable fields live in the base document for the default
+ * language and in the `Translations` collection for every other language. The
+ * `fieldMappings` mirror `FIELD_MAPPINGS` in cms/utils/base-resolvers.ts
+ * (base document field -> translation document field) so re-homing stays in
+ * sync with how the read path overlays translations.
+ */
+type TranslatableContentConfig = {
+  type: string;
+  modelKey: 'Posts' | 'Categories' | 'PostTags' | 'Pages' | 'MenuItems';
+  fieldMappings: Record<string, string>;
+};
+
+const TRANSLATABLE_CONTENT_TYPES: TranslatableContentConfig[] = [
+  {
+    type: 'post',
+    modelKey: 'Posts',
+    fieldMappings: {
+      title: 'title',
+      content: 'content',
+      excerpt: 'excerpt',
+      customFieldsData: 'customFieldsData',
+    },
+  },
+  {
+    type: 'category',
+    modelKey: 'Categories',
+    fieldMappings: {
+      name: 'title',
+      description: 'content',
+      customFieldsData: 'customFieldsData',
+    },
+  },
+  {
+    type: 'tag',
+    modelKey: 'PostTags',
+    fieldMappings: { name: 'title' },
+  },
+  {
+    type: 'page',
+    modelKey: 'Pages',
+    fieldMappings: {
+      name: 'title',
+      description: 'content',
+      customFieldsData: 'customFieldsData',
+    },
+  },
+  {
+    type: 'menu',
+    modelKey: 'MenuItems',
+    fieldMappings: { label: 'title' },
+  },
+];
+
+const hasTranslatableValue = (value: unknown): boolean => {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim() !== '';
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+};
+
+/**
+ * Move content between the base document and the `Translations` collection when
+ * a site's default language changes. Without this, the old default's content is
+ * stranded in the base fields (with no translation pointing to it) while the new
+ * default's translation is ignored, so editors see content "disappear".
+ */
+const rehomeDefaultLanguageContent = async (
+  models: IModels,
+  clientPortalId: string,
+  oldLanguage: string,
+  newLanguage: string,
+) => {
+  for (const { type, modelKey, fieldMappings } of TRANSLATABLE_CONTENT_TYPES) {
+    const model = models[modelKey] as any;
+    const documents = await model.find({ clientPortalId }).lean();
+
+    if (!documents.length) {
+      continue;
+    }
+
+    const objectIds = documents.map((doc: any) => String(doc._id));
+    const newTranslations = await models.Translations.find({
+      objectId: { $in: objectIds },
+      language: newLanguage,
+      type,
+    }).lean();
+
+    const newTranslationMap = new Map<string, any>(
+      newTranslations.map((translation: any) => [
+        String(translation.objectId),
+        translation,
+      ]),
+    );
+
+    const translationOps: any[] = [];
+    const documentOps: any[] = [];
+
+    for (const doc of documents) {
+      const objectId = String(doc._id);
+
+      // 1. Preserve the current (old-default) base content as an old-language
+      //    translation so it remains reachable after the switch.
+      const oldTranslationFields: Record<string, any> = {};
+      for (const [baseField, translationField] of Object.entries(
+        fieldMappings,
+      )) {
+        oldTranslationFields[translationField] = doc[baseField] ?? '';
+      }
+
+      translationOps.push({
+        updateOne: {
+          filter: { objectId, language: oldLanguage, type },
+          update: {
+            $set: { ...oldTranslationFields, objectId, language: oldLanguage, type },
+          },
+          upsert: true,
+        },
+      });
+
+      // 2. Promote the new-language translation into the base fields. Only
+      //    non-empty values win, matching the read-time overlay so what the
+      //    editor saw under the new language is exactly what becomes default.
+      const newTranslation = newTranslationMap.get(objectId);
+      if (!newTranslation) {
+        continue;
+      }
+
+      const baseUpdate: Record<string, any> = {};
+      for (const [baseField, translationField] of Object.entries(
+        fieldMappings,
+      )) {
+        const value = newTranslation[translationField];
+        if (hasTranslatableValue(value)) {
+          baseUpdate[baseField] = value;
+        }
+      }
+
+      if (Object.keys(baseUpdate).length) {
+        documentOps.push({
+          updateOne: { filter: { _id: doc._id }, update: { $set: baseUpdate } },
+        });
+      }
+
+      // 3. The new language now lives in the base fields, so its standalone
+      //    translation record is redundant.
+      translationOps.push({
+        deleteOne: { filter: { objectId, language: newLanguage, type } },
+      });
+    }
+
+    if (documentOps.length) {
+      await model.bulkWrite(documentOps);
+    }
+    if (translationOps.length) {
+      await models.Translations.bulkWrite(translationOps);
+    }
+  }
+};
+
 export interface ICMSModel extends Model<IContentCMSDocument> {
   getContentCMS(_id: string): Promise<IContentCMSDocument>;
   getContentCMSs(): Promise<IContentCMSDocument[]>;
@@ -77,6 +237,26 @@ export const loadCmsClass = (models: IModels) => {
       return models.CMS.create(this.buildCmsDoc(doc));
     }
     public static async updateContentCMS(_id: string, doc: IContentCMSInput) {
+      const existing = await models.CMS.findOne({ _id }).lean();
+
+      const previousLanguage = existing?.language;
+      const nextLanguage = doc.language;
+
+      // Default language changed: re-home content so nothing disappears.
+      if (
+        existing?.clientPortalId &&
+        previousLanguage &&
+        nextLanguage &&
+        previousLanguage !== nextLanguage
+      ) {
+        await rehomeDefaultLanguageContent(
+          models,
+          existing.clientPortalId,
+          previousLanguage,
+          nextLanguage,
+        );
+      }
+
       return models.CMS.findOneAndUpdate({ _id }, this.buildCmsDoc(doc), {
         new: true,
       });

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -17,24 +17,6 @@ import {
 import { CMS_POST_ACTIONS } from '~/meta/permissions';
 import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
-// Public client-portal post lists are always ordered newest-published-first by
-// publishedDate, so editors control feed ordering purely through publish dates.
-// Any caller-supplied sortField/sortDirection/orderBy is intentionally ignored —
-// otherwise a storefront defaulting to `createdAt` silently overrides this.
-const withForcedPublishedOrder = <T extends Record<string, any>>(
-  args: T,
-): Omit<T, 'sortField' | 'sortDirection'> & { orderBy: { publishedDate: -1 } } => {
-  const next: Record<string, unknown> = {
-    ...args,
-    orderBy: { publishedDate: -1 },
-  };
-  delete next.sortField;
-  delete next.sortDirection;
-  return next as Omit<T, 'sortField' | 'sortDirection'> & {
-    orderBy: { publishedDate: -1 };
-  };
-};
-
 const applyFieldConstraint = (query: any, field: string, value: any) => {
   if (query[field] === undefined || query[field] === value) {
     query[field] = value;
@@ -487,7 +469,7 @@ class PostQueryResolver extends BaseQueryResolver {
     const { list } = await this.getListWithTranslations(
       models.Posts,
       query,
-      withForcedPublishedOrder({ ...args, clientPortalId, language }),
+      { ...args, clientPortalId, language },
       FIELD_MAPPINGS.POST,
     );
 
@@ -507,7 +489,7 @@ class PostQueryResolver extends BaseQueryResolver {
     const { list, totalCount, pageInfo } = await this.getListWithTranslations(
       models.Posts,
       query,
-      withForcedPublishedOrder({ ...args, clientPortalId, language }),
+      { ...args, clientPortalId, language },
       FIELD_MAPPINGS.POST,
     );
 
@@ -526,19 +508,10 @@ class PostQueryResolver extends BaseQueryResolver {
     const queryBuilder = getQueryBuilder('post', models);
     const query = await queryBuilder.buildQuery({ ...args, clientPortalId });
 
-    // Match cpPosts/cpPostList: force newest-published-first ordering so this
-    // feed stays consistent. getListWithDefaultPagination sorts by
-    // sortField/sortDirection (not orderBy), so override those directly.
     const list = await this.getListWithDefaultPagination(
       models.Posts,
       query,
-      {
-        ...args,
-        clientPortalId,
-        language,
-        sortField: 'publishedDate',
-        sortDirection: 'desc',
-      },
+      { ...args, clientPortalId, language },
       FIELD_MAPPINGS.POST,
     );
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -23,11 +23,16 @@ import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 // otherwise a storefront defaulting to `createdAt` silently overrides this.
 const withForcedPublishedOrder = <T extends Record<string, any>>(
   args: T,
-): T => {
-  const next = { ...args, orderBy: { publishedDate: -1 } } as T;
-  delete (next as any).sortField;
-  delete (next as any).sortDirection;
-  return next;
+): Omit<T, 'sortField' | 'sortDirection'> & { orderBy: { publishedDate: -1 } } => {
+  const next: Record<string, unknown> = {
+    ...args,
+    orderBy: { publishedDate: -1 },
+  };
+  delete next.sortField;
+  delete next.sortDirection;
+  return next as Omit<T, 'sortField' | 'sortDirection'> & {
+    orderBy: { publishedDate: -1 };
+  };
 };
 
 const applyFieldConstraint = (query: any, field: string, value: any) => {
@@ -521,10 +526,19 @@ class PostQueryResolver extends BaseQueryResolver {
     const queryBuilder = getQueryBuilder('post', models);
     const query = await queryBuilder.buildQuery({ ...args, clientPortalId });
 
+    // Match cpPosts/cpPostList: force newest-published-first ordering so this
+    // feed stays consistent. getListWithDefaultPagination sorts by
+    // sortField/sortDirection (not orderBy), so override those directly.
     const list = await this.getListWithDefaultPagination(
       models.Posts,
       query,
-      { ...args, clientPortalId, language },
+      {
+        ...args,
+        clientPortalId,
+        language,
+        sortField: 'publishedDate',
+        sortDirection: 'desc',
+      },
       FIELD_MAPPINGS.POST,
     );
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -17,17 +17,17 @@ import {
 import { CMS_POST_ACTIONS } from '~/meta/permissions';
 import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
-// Client portal post lists default to last-published-first by publishedDate so
-// editors can control ordering simply by adjusting a post's publish date. An
-// explicit sortField/orderBy from the caller still takes precedence.
-const withDefaultPostOrder = <T extends { sortField?: string; orderBy?: any }>(
+// Public client-portal post lists are always ordered newest-published-first by
+// publishedDate, so editors control feed ordering purely through publish dates.
+// Any caller-supplied sortField/sortDirection/orderBy is intentionally ignored —
+// otherwise a storefront defaulting to `createdAt` silently overrides this.
+const withForcedPublishedOrder = <T extends Record<string, any>>(
   args: T,
 ): T => {
-  if (args.sortField || args.orderBy) {
-    return args;
-  }
-
-  return { ...args, orderBy: { publishedDate: -1 } };
+  const next = { ...args, orderBy: { publishedDate: -1 } } as T;
+  delete (next as any).sortField;
+  delete (next as any).sortDirection;
+  return next;
 };
 
 const applyFieldConstraint = (query: any, field: string, value: any) => {
@@ -482,7 +482,7 @@ class PostQueryResolver extends BaseQueryResolver {
     const { list } = await this.getListWithTranslations(
       models.Posts,
       query,
-      withDefaultPostOrder({ ...args, clientPortalId, language }),
+      withForcedPublishedOrder({ ...args, clientPortalId, language }),
       FIELD_MAPPINGS.POST,
     );
 
@@ -502,7 +502,7 @@ class PostQueryResolver extends BaseQueryResolver {
     const { list, totalCount, pageInfo } = await this.getListWithTranslations(
       models.Posts,
       query,
-      withDefaultPostOrder({ ...args, clientPortalId, language }),
+      withForcedPublishedOrder({ ...args, clientPortalId, language }),
       FIELD_MAPPINGS.POST,
     );
 

--- a/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
@@ -242,6 +242,15 @@ export function PageDrawer({
     resetKey: clientPortalId,
   });
 
+  // Mirror the active language into the shared atom (one-way). The header
+  // language tabs read this atom for their active state, so this keeps the tab
+  // highlight in lockstep with the language the form is actually showing.
+  useEffect(() => {
+    if (selectedLanguage) {
+      setCmsLanguage(selectedLanguage);
+    }
+  }, [selectedLanguage, setCmsLanguage]);
+
   // Create dynamic validation schema with custom fields
   const createValidationSchema = useCallback((fieldGroups: FieldGroup[]) => {
     const baseSchema = pageFormSchema;
@@ -440,7 +449,15 @@ export function PageDrawer({
 
   // When page data loads, the form-reset effect above overwrites translatable
   // fields with default-lang data.  Re-apply for the current non-default lang.
-  const appliedForPageRef = useRef<IPage | null>(null);
+  // The guard tracks page, language AND translations: opening directly in a
+  // remembered non-default language runs this before translations have loaded,
+  // so it must re-apply once they arrive — otherwise the content stays empty
+  // until the user toggles languages.
+  const appliedForPageRef = useRef<{
+    page: IPage | null;
+    language: string;
+    translations: Record<string, TranslationData>;
+  } | null>(null);
   useEffect(() => {
     if (
       !selectedLanguage ||
@@ -450,16 +467,32 @@ export function PageDrawer({
       return;
     }
     if (isEditing && !page) return;
-    if (appliedForPageRef.current === (page ?? null)) return;
+
+    const curPage = page ?? null;
+    const applied = appliedForPageRef.current;
+
+    if (
+      applied !== null &&
+      applied.page === curPage &&
+      applied.language === selectedLanguage &&
+      applied.translations === translations
+    ) {
+      return;
+    }
 
     applyTranslationToForm(selectedLanguage);
-    appliedForPageRef.current = page ?? null;
+    appliedForPageRef.current = {
+      page: curPage,
+      language: selectedLanguage,
+      translations,
+    };
   }, [
     selectedLanguage,
     defaultLanguage,
     applyTranslationToForm,
     isEditing,
     page,
+    translations,
   ]);
 
   const onCompleted = () => {
@@ -628,7 +661,6 @@ export function PageDrawer({
   const onLanguageChange = useCallback(
     (lang: string) => {
       isSwitchingLanguageRef.current = true;
-      setCmsLanguage(lang);
 
       const curPage = pageRef.current;
       const curDefaultLanguage = defaultLanguageRef.current;
@@ -672,7 +704,7 @@ export function PageDrawer({
         isSwitchingLanguageRef.current = false;
       });
     },
-    [form, setCmsLanguage],
+    [form],
   );
 
   const handleEditorChange = useCallback(

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
@@ -1,5 +1,6 @@
 import { Form, ScrollArea } from 'erxes-ui';
 import { useLocation, useSearchParams } from 'react-router-dom';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { useEffect, useRef, useMemo, useCallback } from 'react';
 import { useSetAtom, useAtomValue } from 'jotai';
 import { usePostForm } from './hooks/usePostForm';
@@ -179,6 +180,15 @@ export const AddPostForm = ({
     setSelectedLanguage,
   ]);
 
+  // Mirror the form's active language into the shared atom (one-way). The header
+  // language tabs read this atom for their active state, so this keeps the tab
+  // highlight in lockstep with the language the form is actually showing.
+  useEffect(() => {
+    if (selectedLanguage) {
+      setCmsLanguage(selectedLanguage);
+    }
+  }, [selectedLanguage, setCmsLanguage]);
+
   // When fullPost changes (loads twice: editingPost then fullPostData.cmsPost),
   // the hook's effect resets the form with default-lang data.  Re-apply the
   // translation override for the current non-default language.
@@ -200,7 +210,8 @@ export const AddPostForm = ({
     const applied = appliedForPostRef.current;
 
     if (
-      applied?.post === post &&
+      applied !== null &&
+      applied.post === post &&
       applied.language === selectedLanguage &&
       applied.translations === translations
     ) {
@@ -231,7 +242,7 @@ export const AddPostForm = ({
     if (!typeCode || typeCode === 'post') return;
     const matched = customTypes.find((t: any) => t.code === typeCode);
     if (matched) form.setValue('type', matched._id);
-  }, [customTypes]);
+  }, [customTypes, currentEditingPost, form, searchParams]);
 
   useEffect(() => {
     if (
@@ -261,10 +272,10 @@ export const AddPostForm = ({
       setTranslations((prev) => ({
         ...prev,
         [selectedLanguage]: {
-          title: form.getValues('title'),
-          content: form.getValues('content'),
-          excerpt: form.getValues('description'),
-          customFieldsData: form.getValues('customFieldsData'),
+          title: form.getValues('title') || '',
+          content: form.getValues('content') || '',
+          excerpt: form.getValues('description') || '',
+          customFieldsData: form.getValues('customFieldsData') || [],
         },
       }));
     }
@@ -289,12 +300,16 @@ export const AddPostForm = ({
     }
 
     setSelectedLanguage(lang);
-    setCmsLanguage(lang);
     finishLanguageSwitch();
   };
 
   // Keep ref in sync so the stable callback always delegates to latest logic
   handleLanguageChangeRef.current = handleLanguageChange;
+
+  // The child columns type `form` loosely as UseFormReturn<FieldValues>; our form
+  // is the more specific UseFormReturn<PostFormData>, which RHF treats as
+  // incompatible. They only read/write known fields, so the widening is safe.
+  const formForColumns = form as unknown as UseFormReturn<FieldValues>;
 
   return (
     <ScrollArea className="flex-auto" viewportClassName="p-4">
@@ -302,7 +317,7 @@ export const AddPostForm = ({
         <div className="flex flex-col w-full mb-4 px-4 pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <PostEditorColumn
-              form={form}
+              form={formForColumns}
               selectedLanguage={selectedLanguage}
               defaultLanguage={defaultLanguage}
               selectedType={selectedType}
@@ -313,7 +328,7 @@ export const AddPostForm = ({
               updateCustomFieldValue={updateCustomFieldValue}
             />
             <PostSidebarPanel
-              form={form}
+              form={formForColumns}
               categories={categories}
               tags={tags}
               customTypes={customTypes}

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostForm.tsx
@@ -10,6 +10,9 @@ import {
 } from '../../../../graphql/queries';
 import { createSlug } from '../../../../utils/createSlug';
 
+// A single custom-field value as stored on the form and in translation snapshots.
+type CustomFieldEntry = { field: string; value: CustomFieldValue };
+
 interface PostFormData {
   title: string;
   slug: string;
@@ -44,7 +47,7 @@ export const usePostForm = (editingPost?: { _id: string }) => {
         title: string;
         content: string;
         excerpt: string;
-        customFieldsData: CustomFieldValue[];
+        customFieldsData: CustomFieldEntry[];
       }
     >
   >({});
@@ -52,7 +55,7 @@ export const usePostForm = (editingPost?: { _id: string }) => {
     title: string;
     content: string;
     excerpt: string;
-    customFieldsData: CustomFieldValue[];
+    customFieldsData: CustomFieldEntry[];
   } | null>(null);
   const previousTypeRef = useRef<string | undefined>();
 
@@ -113,7 +116,7 @@ export const usePostForm = (editingPost?: { _id: string }) => {
           title: string;
           content: string;
           excerpt: string;
-          customFieldsData: CustomFieldValue[];
+          customFieldsData: CustomFieldEntry[];
         }
       > = {};
       translationsData.cmsTranslations.forEach(
@@ -122,7 +125,7 @@ export const usePostForm = (editingPost?: { _id: string }) => {
           title: string;
           content: string;
           excerpt: string;
-          customFieldsData: CustomFieldValue[];
+          customFieldsData: CustomFieldEntry[];
         }) => {
           translationsMap[t.language] = {
             title: t.title || '',

--- a/frontend/plugins/content_ui/src/modules/cms/shared/HeaderLanguageTabs.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/HeaderLanguageTabs.tsx
@@ -27,7 +27,14 @@ export const HeaderLanguageTabs = ({
   const availableLanguages: string[] = cmsConfig?.languages || [];
   const defaultLanguage: string = cmsConfig?.language || 'en';
 
+  // In editor mode (onLanguageChange provided) the form owns the active
+  // language and mirrors it into this atom, so the tabs simply reflect it —
+  // exactly like the sidebar selector. We must not reset or write the atom
+  // here, or we'd fight the form and desync the highlight from the content.
+  const isEditorMode = Boolean(onLanguageChange);
+
   useEffect(() => {
+    if (isEditorMode) return;
     if (
       selectedLanguage &&
       availableLanguages.length > 0 &&
@@ -36,6 +43,7 @@ export const HeaderLanguageTabs = ({
       setSelectedLanguage(defaultLanguage);
     }
   }, [
+    isEditorMode,
     websiteId,
     availableLanguages,
     selectedLanguage,
@@ -48,9 +56,12 @@ export const HeaderLanguageTabs = ({
   const activeLanguage = selectedLanguage || defaultLanguage;
 
   const handleClick = (lang: string) => {
-    setSelectedLanguage(lang);
+    // Editor mode: drive the form, which mirrors the choice back into the atom.
+    // List mode: this atom is the source of truth for the list query.
     if (onLanguageChange) {
       onLanguageChange(lang);
+    } else {
+      setSelectedLanguage(lang);
     }
   };
 


### PR DESCRIPTION
## Summary

Three related CMS fixes:

### 1. Content disappears when the default language changes (backend)
CMS content stores translatable fields in the **base document** for the default language and in the **`Translations` collection** for every other language. The read path picks which to show by comparing the requested language to the *current* `cms.language`.

Previously, changing the default language only overwrote `cms.language` and migrated nothing — so the old default's content was stranded in the base fields (with no translation pointing to it) and the new language's translation was ignored. Editors saw their content vanish.

`updateContentCMS` now re-homes content for every translatable type (post, category, tag, page, menu) of the client portal when the default language changes:
1. Save the current base fields as a translation for the **old** language (keeps it reachable).
2. Promote the **new** language's translation into the base fields — only non-empty values win, mirroring the read-time overlay so what the editor saw becomes the new default.
3. Delete the now-redundant new-language translation record.

Lossless: no content is discarded; it just moves between base and translation.

### 2. Header tab / form language desync (frontend)
The post form seeded its language from a persisted global atom that could hold a stale or unsupported language from a previous screen/website, leaving the header tab highlighting one language while the form showed another. The form now only honours a remembered language the website actually supports, and keeps the header atom in sync with what it's displaying.

### 3. Public post feed ordering (backend)
`cpPosts`/`cpPostList` are meant to be newest-published-first, but a storefront defaulting to a `createdAt` sort was overriding the `publishedDate` default. These public queries now **always** order by `publishedDate` desc and ignore caller-supplied `sortField`/`orderBy`. Admin queries (`cmsPostList`, etc.) are unchanged.

## Notes
- Default-language change runs a data migration (batched `bulkWrite`); worth validating on a staging copy with real multilingual data.
- Under `publishedDate` desc, posts with no `publishedDate` sort last with `_id` as tiebreaker. Can add a deterministic secondary key if desired.

## Test plan
- [ ] Switch a site's default language and confirm both languages' content remain correct in list + editor.
- [ ] Confirm header language tab and form content stay in sync across screens/websites.
- [ ] Confirm the public post feed returns newest-published-first regardless of caller sort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translated content handling when a client portal’s default language changes, keeping translation records and base fields synchronized.
  * Updated client portal post feeds to always use newest-first ordering by publication date, ignoring custom sort inputs.
  * Fixed language switching in the content editor to keep selected language and applied translations in sync, avoiding brief empty/stale content during async updates.
  * Improved translation application robustness with safer value fallbacks and tightened update guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->