### PR TITLE
perf(revert): efficient + robust point-in-time capture

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,17 +14,17 @@
 # REACT_APP_SENTRY_ENVIRONMENT=ui_sentry_environment_name
 # RELEASE_VERSION=erxes-<git-sha-or-version>
 
-# --- Mastra AI Plugin ---
-# Erxes API connection (overrides the value stored in Settings UI)
-# MASTRA_ERXES_API_URL=http://localhost:4000
-# MASTRA_ERXES_API_TOKEN=
+# --- Point-in-time revert (undo) — auto-capture journal ---
+# Every create/update/delete made through any model is journaled to {subdomain}_logs
+# so it can be reverted later (System Logs → Undo). Capture is ALWAYS ON: there is no
+# enable flag — it runs from boot on every service that writes through erxes-api-shared
+# (core-api, plugins, ...). The logs-service must also be running for the journal
+# entries to actually be persisted. The only tunable is the per-write snapshot cap:
+# REVERT_AUTO_JOURNAL_MAX=1000              # max docs snapshotted per bulk delete/update;
+#                                           # beyond this the ids are still audited but
+#                                           # the overflow is not auto-revertable.
 
-# Default agent ID for the bot webhook endpoint
-# MASTRA_DEFAULT_AGENT_ID=
-
-# LibSQL memory database path
-# MASTRA_MEMORY_DB_PATH=file:./mastra-memory.db
-
+# --- erxes-agent (Mastra) plugin: provider API keys ---
 # Provider API keys (each overrides the key stored in Provider UI)
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -15,8 +15,9 @@
 # RELEASE_VERSION=erxes-<git-sha-or-version>
 
 # --- Point-in-time revert (undo) — auto-capture journal ---
-# Every create/update/delete made through any model is journaled to {subdomain}_logs
-# so it can be reverted later (System Logs → Undo). Capture is ALWAYS ON: there is no
+# Every update/delete made through any model is journaled to {subdomain}_logs
+# so it can be reverted later (System Logs → Undo). Creates are NOT captured —
+# reverting a new record is just deleting it. Capture is ALWAYS ON: there is no
 # enable flag — it runs from boot on every service that writes through erxes-api-shared
 # (core-api, plugins, ...). The logs-service must also be running for the journal
 # entries to actually be persisted. The only tunable is the per-write snapshot cap:

--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -73,9 +73,11 @@ resolutions)` → `revert/revertByProcessId.ts` reverse-replays the process's
 
 ### Always on
 
-Capture is **always on** — there is no enable flag. Every create/update/delete
+Capture is **always on** — there is no enable flag. Every **update/delete**
 through any of the ~124 wrapped schemas is journaled from the moment a service
-boots, so nothing is ever silently left unrecoverable. Bulk capture is capped at
+boots, so no edit or deletion is ever silently left unrecoverable. (Creates are
+NOT captured — reverting a brand-new record is just deleting it, so a new record
+is removable but has no prior state to "restore".) Bulk capture is capped at
 `REVERT_AUTO_JOURNAL_MAX` snapshots per write (optional tuning override, default
 1000 — capture runs regardless of whether it is set). Every hook is wrapped so a
 capture failure can never block/throw out of a write.

--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -21,19 +21,64 @@ recoverable — but it's auth-agnostic (agent and human run under the same user)
    `mongooseName` + `dbName`, onto the same `put_log` BullMQ queue the manual
    `sendDbEventLog` uses → stored in `{subdomain}_logs`. Creates are NOT captured
    (revert of a new record = delete it).
+
+   **Efficient capture path (the common update case does NO post re-read):** the
+   update PRE hook stashes the raw update operators (`query.getUpdate()`) and a
+   PROJECTED before-snapshot (only the touched paths + `_id`). The POST hook
+   synthesizes the after-image **in memory** from `before + operators` for the
+   simple cases (`$set` / `$unset` / shorthand fields) — no second query — and
+   only falls back to the old post re-read (full doc) for COMPLEX operators (see
+   below). Pure helpers `applyUpdateOperators` / `extractTouchedPaths` /
+   `isComplexUpdate` live in `mongo/afterImage.ts` and are unit-tested
+   (`.personal/revert-afterImage.test.js`). Delete snapshots stay UNPROJECTED
+   (revert re-inserts the whole doc). `getDiffObjects` is still the single diff
+   source, so the emitted `updateDescription` shape is byte-identical.
+
+   **Fallback operators (force the post re-read; never guessed in memory):**
+   `$inc`, `$mul`, `$min`, `$max`, `$rename`, `$currentDate`, `$bit`, `$push`,
+   `$pull`, `$pullAll`, `$pop`, `$addToSet`; any positional path
+   (`a.$`, `a.$[]`, `a.$[elem]`); any `arrayFilters` option; aggregation-pipeline
+   updates (array form); and any unrecognized `$`-operator.
+
+   **`$setOnInsert` is IGNORED, not a fallback** — it only takes effect on an
+   upsert-INSERT, and we never journal creates, so it cannot affect any diff we
+   capture. This matters because Mongoose auto-injects `$setOnInsert: { createdAt }`
+   (and `$set.updatedAt`) into EVERY update on a `timestamps: true` schema (the
+   erxes-wide default) BEFORE our pre-hook runs; treating it as complex would force
+   ~every real update onto the slow re-read and defeat the optimization. So the
+   common in-memory path DOES fire for timestamped schemas.
+
+   **Batched bulk journaling:** a multi-doc `updateMany` now emits ONE `put_log`
+   message (`action:'updateBatch'`, `docIds[]`, `payload.updates[]`) instead of N
+   jobs; the consumer (`handleUpdateBatch`) `insertMany`s one single-`update` Log
+   row per entry — the stored rows are IDENTICAL to the legacy single-`update`
+   shape, so `computeInverse`/`conflict` read them unchanged. A single changed doc
+   still emits the exact legacy single-`update` job.
+
+   **Selectivity (denylist + opt-out):** `mongo/revertSelectivity.ts` holds a
+   small, commented, env-overridable (`REVERT_CAPTURE_DENYLIST`) collection
+   denylist. The logs/audit family is ALWAYS skipped (substring match) so the
+   journal never journals itself; ephemeral session/queue/lock/metric churn is
+   skipped too. `installRevertCaptureHooks` installs ZERO hooks for a denied
+   schema that declares its `collection` name, or one that opts out via
+   `schema.options.revertCapture === false` / `skipRevertCapture: true`; a runtime
+   guard (`isModelDenied`) enforces the always-skip-logs invariant for schemas
+   whose collection name is only known at write time. Normal entity collections
+   are unchanged (still captured).
 3. **Invert** — `revert/computeInverse.ts` (pure): create→delete, delete→re-insert
    (keep `_id`), update→restore prior field values.
 4. **Revert** — `logsRevertProcess(processId, dryRun, force, skipConflicts,
 resolutions)` → `revert/revertByProcessId.ts` reverse-replays the process's
    entries (dedup → authorize → plan → conflicts → dry-run/apply → marker).
 
-### Flag
+### Always on
 
-Capture is gated behind **`REVERT_AUTO_JOURNAL=enable`** — a complete no-op when
-off (zero risk to the ~124 wrapped schemas). Must be set on EVERY writing service;
-off by default (changes before enabling are unrecoverable). Bulk capture capped at
-`REVERT_AUTO_JOURNAL_MAX` (default 1000). Every hook is wrapped so a capture
-failure can never block/throw out of a write.
+Capture is **always on** — there is no enable flag. Every create/update/delete
+through any of the ~124 wrapped schemas is journaled from the moment a service
+boots, so nothing is ever silently left unrecoverable. Bulk capture is capped at
+`REVERT_AUTO_JOURNAL_MAX` snapshots per write (optional tuning override, default
+1000 — capture runs regardless of whether it is set). Every hook is wrapped so a
+capture failure can never block/throw out of a write.
 
 ### Zero-config + authz
 
@@ -50,16 +95,27 @@ is still honored when present.
 
 - `revertCapture.ts` — the auto-capture: `installRevertCaptureHooks(schema)`
   (pre/post hooks for delete*/update*/save), `journalDeletes`/`journalUpdates`,
-  `registerRevertContentTypeResolver`. Gated by `REVERT_AUTO_JOURNAL`.
+  `registerRevertContentTypeResolver`. Always on (no enable flag). Update POST
+  computes the after-image in memory (no re-read) for the simple case; emits one
+  batched `updateBatch` message for multi-doc updates.
+- `afterImage.ts` — PURE (no mongoose runtime): `applyUpdateOperators`,
+  `extractTouchedPaths`, `isComplexUpdate`, `isReplacementUpdate`,
+  `COMPLEX_UPDATE_OPERATORS`. The in-memory after-image + simple/complex
+  classifier. Unit-tested by `.personal/revert-afterImage.test.js`.
+- `revertSelectivity.ts` — `REVERT_CAPTURE_DENYLIST`, `isRevertCaptureDenied`,
+  `isSchemaRevertOptedOut`. The collection denylist + per-schema opt-out.
 - `mongoose-utils.ts` — `schemaWrapper` calls `installRevertCaptureHooks`.
 - `index.ts` — re-exports revertCapture. ⚠️ After editing shared, **`pnpm build`**
   it and **restart** consumers (it's loaded as built dist, not via tsx-watch).
 
 **Journal consumer:** `backend/services/logs/src/bullmq/mongo.ts`
 
-- `handleDelete`/`handleDeleteMany`/`handleUpdate` + dispatcher. Stores
-  `prevDocument(s)` / `updateDescription` + `mongooseName` + `dbName`. (Fixed: the
-  single-`delete` path used to drop `prevDocument`.)
+- `handleDelete`/`handleDeleteMany`/`handleUpdate`/`handleUpdateBatch` +
+  dispatcher. Stores `prevDocument(s)` / `updateDescription` + `mongooseName` +
+  `dbName`. (Fixed: the single-`delete` path used to drop `prevDocument`.)
+  `handleUpdateBatch` expands one `updateBatch` message into N `insertMany`'d
+  single-`update` rows (identical stored shape; only the queue transport is
+  collapsed).
 
 **Engine:** `backend/core-api/src/modules/logs/revert/`
 
@@ -123,7 +179,7 @@ is still honored when present.
 - **Cloud-vs-local trap**: root `.env` `MONGO_URL` points at cloud Atlas; force
   `MONGO_URL=mongodb://127.0.0.1:27017/erxes` for local. Verify the boot log says
   `Connected to the database: mongodb://127.0.0.1...`.
-- Enable capture: `REVERT_AUTO_JOURNAL=enable` on core-api (and any writing svc).
+- Capture is always on — no flag to set; it journals from boot on every service.
 - Adding a `Log` GraphQL field needs core-api restart **and** a gateway
   recompose (kill `:4000` + `:50000` + the router, relaunch gateway).
 - Smoke test: create+delete a tag/department (no `meta/logs` entry → zero-config)
@@ -139,14 +195,23 @@ is still honored when present.
 - Standalone Mongo = no transactions → multi-doc revert can partially apply
   (result reports `reverted` vs `conflicts`).
 - Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates with no marker yet.
-- `.save()` capture coded but not independently live-verified.
+- The in-memory after-image removes the post re-read only for the SIMPLE update
+  path ($set/$unset/shorthand); COMPLEX operators (see list above) still do the
+  full post re-read. Replacement (`replaceOne`/`findOneAndReplace`) is NOT hooked.
+- `.save()` capture coded but not independently live-verified (still reads the
+  prior doc once in PRE — it has the after-image via `toObject()`, no re-read).
 - Old `MongoLogDetailContent` panel may still show "No document snapshot" even
   when one was captured (cosmetic).
 - UI doesn't auto-refetch lists after revert; System Logs is admin-only.
 - Org/separate-connection entities are _guarded_ (refused), not yet revertable
   (needs connection-aware applyWrite).
-- No automated tests; perf of the extra read-per-write is unmeasured; not human-
-  reviewed/CI'd; not in a PR.
+- Pure capture helpers (`afterImage.ts` / `revertSelectivity.ts`) now have a
+  standalone unit harness (`.personal/revert-afterImage.test.js`, run with
+  `node`), but it is NOT wired into CI/`nx test` (erxes-api-shared has no jest
+  target). Engine/consumer integration still has no automated tests; the
+  in-memory perf win is reasoned-about, not benchmarked; not human-reviewed/CI'd;
+  not in a PR. **Out of scope (follow-ups):** per-doc version/etag field; replica-
+  set/change-streams/CDC migration; moving the journal to a separate cluster.
 
 ## Commit trail (branch feat/erxes-agent-process-correlation)
 

--- a/backend/core-api/src/modules/logs/revert/applyWrite.ts
+++ b/backend/core-api/src/modules/logs/revert/applyWrite.ts
@@ -52,6 +52,21 @@ export const createSnapshotMatchesLive = (
 };
 
 /**
+ * Mirror a revert write into Elasticsearch — BEST-EFFORT. Mongo is the source of
+ * truth for the revert; ES is only a search mirror (also re-synced out of band by
+ * the oplog tailer). A revert must NEVER fail or report an error because ES is
+ * unreachable or misconfigured, so any ES error here is swallowed — the
+ * authoritative Mongo write has already succeeded by this point.
+ */
+const mirrorToEs = async (fn: () => Promise<unknown>): Promise<void> => {
+  try {
+    await fn();
+  } catch {
+    /* best-effort ES mirror; never surface to the revert result */
+  }
+};
+
+/**
  * Apply one computed inverse op (insert/delete/update) as a raw model write with
  * its conflict guards, then mirror the change into Elasticsearch. Returns a
  * structured {ok} | {conflict} result instead of throwing on a benign conflict.
@@ -95,12 +110,14 @@ export const applyWrite = async (args: {
 
     await model.create(document);
 
-    await saveEsDoc({
-      subdomain,
-      contentType: input.contentType,
-      _id: input.docId,
-      document,
-    });
+    await mirrorToEs(() =>
+      saveEsDoc({
+        subdomain,
+        contentType: input.contentType,
+        _id: input.docId,
+        document,
+      }),
+    );
 
     return { ok: true };
   }
@@ -131,11 +148,13 @@ export const applyWrite = async (args: {
 
     await model.deleteOne({ _id: input.docId });
 
-    await deleteEsDoc({
-      subdomain,
-      contentType: input.contentType,
-      _id: input.docId,
-    });
+    await mirrorToEs(() =>
+      deleteEsDoc({
+        subdomain,
+        contentType: input.contentType,
+        _id: input.docId,
+      }),
+    );
 
     return { ok: true };
   }
@@ -160,12 +179,14 @@ export const applyWrite = async (args: {
 
   const fresh = (await model.findById(input.docId).lean()) as RawDoc | null;
   if (fresh) {
-    await saveEsDoc({
-      subdomain,
-      contentType: input.contentType,
-      _id: input.docId,
-      document: fresh,
-    });
+    await mirrorToEs(() =>
+      saveEsDoc({
+        subdomain,
+        contentType: input.contentType,
+        _id: input.docId,
+        document: fresh,
+      }),
+    );
   }
 
   return { ok: true };

--- a/backend/erxes-api-shared/src/utils/mongo/afterImage.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/afterImage.ts
@@ -87,6 +87,28 @@ export const isReplacementUpdate = (update: UpdateExpr): boolean => {
   return keys.every((k) => !k.startsWith('$'));
 };
 
+/** True when any target path of a `$set`/`$unset` payload is positional. */
+const hasPositionalPaths = (inner: unknown): boolean => {
+  if (!inner || typeof inner !== 'object' || Array.isArray(inner)) return false;
+  return Object.keys(inner).some(hasPositional);
+};
+
+/**
+ * Classify a single top-level update entry (key + value): `true` forces the
+ * complex post-read fallback, `false` means it is replayable in memory.
+ */
+const isComplexEntry = (key: string, value: unknown): boolean => {
+  // Shorthand top-level field (implicit $set) — complex only if positional.
+  if (!key.startsWith('$')) return hasPositional(key);
+  // Insert-only injected operator ($setOnInsert) → no effect on an existing doc.
+  if (IGNORABLE_UPDATE_OPERATORS.has(key)) return false;
+  // Known complex operator, or any operator we do not explicitly replay.
+  if (COMPLEX_UPDATE_OPERATORS.has(key)) return true;
+  if (!SIMPLE_UPDATE_OPERATORS.has(key)) return true;
+  // $set / $unset: complex only if a target path is positional.
+  return hasPositionalPaths(value);
+};
+
 /**
  * Classify an update: `true` => complex => MUST fall back to the post re-read;
  * `false` => simple => its after-image can be computed in memory via
@@ -101,37 +123,10 @@ export const isComplexUpdate = (
   update: UpdateExpr,
   hasArrayFilters = false,
 ): boolean => {
-  // Aggregation pipeline: arbitrary expressions, not replayable.
-  if (isPipelineUpdate(update)) return true;
-  if (!update) return true; // nothing classifiable → be safe, treat as complex
+  if (Array.isArray(update)) return true; // aggregation pipeline: not replayable
+  if (!update) return true; // nothing classifiable → treat as complex
   if (hasArrayFilters) return true;
-
-  const u = update as Record<string, unknown>;
-  for (const key of Object.keys(u)) {
-    if (key.startsWith('$')) {
-      // Insert-only injected operator ($setOnInsert) → no effect on an existing
-      // doc, so it neither blocks the in-memory path nor needs replaying.
-      if (IGNORABLE_UPDATE_OPERATORS.has(key)) continue;
-      // Known complex operator → fall back.
-      if (COMPLEX_UPDATE_OPERATORS.has(key)) return true;
-      // Any operator that isn't one we can replay → fall back (be conservative
-      // about operators we don't explicitly recognize).
-      if (!SIMPLE_UPDATE_OPERATORS.has(key)) return true;
-
-      // $set / $unset: inspect their target paths for positional tokens.
-      const inner = u[key];
-      if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
-        for (const path of Object.keys(inner as Record<string, unknown>)) {
-          if (hasPositional(path)) return true;
-        }
-      }
-    } else {
-      // Shorthand top-level field (implicit $set). Positional token → complex.
-      if (hasPositional(key)) return true;
-    }
-  }
-
-  return false;
+  return Object.keys(update).some((key) => isComplexEntry(key, update[key]));
 };
 
 /**
@@ -143,28 +138,31 @@ export const isComplexUpdate = (
  */
 export const extractTouchedPaths = (update: UpdateExpr): string[] => {
   if (!update || Array.isArray(update)) return [];
-  const u = update as Record<string, unknown>;
   const paths = new Set<string>();
-
-  for (const key of Object.keys(u)) {
-    if (key.startsWith('$')) {
-      // Insert-only operators never change an existing doc → not a touched path.
-      if (IGNORABLE_UPDATE_OPERATORS.has(key)) continue;
-      const inner = u[key];
-      if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
-        for (const path of Object.keys(inner as Record<string, unknown>)) {
-          // Strip a positional/array suffix to its root array path so the
-          // projection still selects the containing field.
-          paths.add(rootArrayPath(path));
-        }
-      }
-    } else {
-      // Shorthand field (implicit $set).
-      paths.add(rootArrayPath(key));
-    }
+  for (const key of Object.keys(update)) {
+    collectTouchedPaths(key, update[key], paths);
   }
-
   return Array.from(paths).filter((p) => p.length > 0);
+};
+
+/** Add the projection path(s) a single update entry touches into `paths`. */
+const collectTouchedPaths = (
+  key: string,
+  value: unknown,
+  paths: Set<string>,
+): void => {
+  if (!key.startsWith('$')) {
+    // Shorthand field (implicit $set).
+    paths.add(rootArrayPath(key));
+    return;
+  }
+  // Insert-only operators never change an existing doc → not a touched path.
+  if (IGNORABLE_UPDATE_OPERATORS.has(key)) return;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+  // Strip a positional/array suffix to the root field the projection selects.
+  for (const path of Object.keys(value)) {
+    paths.add(rootArrayPath(path));
+  }
 };
 
 /**
@@ -232,7 +230,7 @@ const applyUnset = (after: Record<string, unknown>, unsetObj: unknown): void => 
   if (!unsetObj || typeof unsetObj !== 'object' || Array.isArray(unsetObj)) {
     return;
   }
-  for (const path of Object.keys(unsetObj as Record<string, unknown>)) {
+  for (const path of Object.keys(unsetObj)) {
     _loadash.unset(after, path);
   }
 };

--- a/backend/erxes-api-shared/src/utils/mongo/afterImage.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/afterImage.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure helpers for the point-in-time revert capture's in-memory after-image.
+ *
+ * These functions contain NO mongoose runtime dependency, so they are unit
+ * testable in isolation (see afterImage.test.ts). They power the efficiency
+ * refactor that eliminates the post-update re-read for the common
+ * $set / $unset / replacement-style update path.
+ *
+ * The classifier is intentionally conservative: an update is "simple" (its
+ * after-image can be computed in memory from before + operators) ONLY when
+ * every effect is a literal $set / $unset / shorthand-field assignment with no
+ * positional/array semantics. Anything whose result depends on the server's
+ * prior document state or clock ($inc, $push, $pull, positional `$`, aggregation
+ * pipelines, …) is "complex" and MUST fall back to a real re-read — we never
+ * guess an after-image.
+ */
+
+import * as _loadash from 'lodash';
+
+/** A Mongoose query update: an operator object, a replacement doc, or a pipeline. */
+export type UpdateExpr =
+  | Record<string, unknown>
+  | Array<Record<string, unknown>>
+  | null
+  | undefined;
+
+/**
+ * Operators that REQUIRE the server-side prior document/array state (or clock)
+ * to resolve, so their after-image cannot be safely synthesized in memory.
+ * Presence of any of these forces the post re-read fallback. This is the
+ * authoritative fallback list referenced by the docs.
+ */
+export const COMPLEX_UPDATE_OPERATORS: ReadonlySet<string> = new Set([
+  '$inc',
+  '$mul',
+  '$min',
+  '$max',
+  '$rename',
+  '$currentDate',
+  '$bit',
+  '$push',
+  '$pull',
+  '$pullAll',
+  '$pop',
+  '$addToSet',
+]);
+
+/**
+ * Operators that NEVER affect the after-image of an EXISTING document, so they
+ * are ignored — neither forcing the re-read fallback nor being replayed.
+ * `$setOnInsert` only takes effect when an upsert INSERTS a new doc, and we never
+ * journal creates (only updates to existing docs), so it is irrelevant to every
+ * diff we capture. Critically, Mongoose auto-injects `$setOnInsert: { createdAt }`
+ * into EVERY update on a `timestamps: true` schema (the erxes-wide default) before
+ * our pre-hook runs, so NOT ignoring it would push virtually every real update
+ * onto the slow full-doc re-read path — defeating the whole optimization.
+ */
+const IGNORABLE_UPDATE_OPERATORS: ReadonlySet<string> = new Set(['$setOnInsert']);
+
+/** The only top-level operators we can replay in memory. */
+const SIMPLE_UPDATE_OPERATORS: ReadonlySet<string> = new Set(['$set', '$unset']);
+
+/**
+ * A path is "positional" (depends on matched array element state) when it
+ * contains a `$` positional token: `a.$`, `a.$[]`, `a.$[elem]`. Such paths
+ * cannot be replayed in memory.
+ */
+const hasPositional = (path: string): boolean =>
+  path.includes('$') && /(^|\.)\$(\[|\.|$)/.test(path);
+
+/** True when the update is an aggregation pipeline (array form). */
+export const isPipelineUpdate = (update: UpdateExpr): boolean =>
+  Array.isArray(update);
+
+/**
+ * True when the update is a no-operator object (every top-level key is a plain
+ * field, not a `$`-operator). For the hooked query ops (updateOne / updateMany /
+ * findOneAndUpdate) Mongoose treats this as SHORTHAND `$set` of those fields (it
+ * does NOT drop unmentioned fields), so it is computable in memory. (A true
+ * whole-doc overwrite only happens via `replaceOne`/`findOneAndReplace`, which we
+ * do not hook.)
+ */
+export const isReplacementUpdate = (update: UpdateExpr): boolean => {
+  if (!update || Array.isArray(update)) return false;
+  const keys = Object.keys(update);
+  if (keys.length === 0) return false;
+  return keys.every((k) => !k.startsWith('$'));
+};
+
+/**
+ * Classify an update: `true` => complex => MUST fall back to the post re-read;
+ * `false` => simple => its after-image can be computed in memory via
+ * `applyUpdateOperators`.
+ *
+ * @param update     The value of `query.getUpdate()` (raw in pre, normalized in
+ *                   post — both shapes handled).
+ * @param hasArrayFilters Whether the query options carry `arrayFilters`
+ *                   (positional element targeting → always complex).
+ */
+export const isComplexUpdate = (
+  update: UpdateExpr,
+  hasArrayFilters = false,
+): boolean => {
+  // Aggregation pipeline: arbitrary expressions, not replayable.
+  if (isPipelineUpdate(update)) return true;
+  if (!update) return true; // nothing classifiable → be safe, treat as complex
+  if (hasArrayFilters) return true;
+
+  const u = update as Record<string, unknown>;
+  for (const key of Object.keys(u)) {
+    if (key.startsWith('$')) {
+      // Insert-only injected operator ($setOnInsert) → no effect on an existing
+      // doc, so it neither blocks the in-memory path nor needs replaying.
+      if (IGNORABLE_UPDATE_OPERATORS.has(key)) continue;
+      // Known complex operator → fall back.
+      if (COMPLEX_UPDATE_OPERATORS.has(key)) return true;
+      // Any operator that isn't one we can replay → fall back (be conservative
+      // about operators we don't explicitly recognize).
+      if (!SIMPLE_UPDATE_OPERATORS.has(key)) return true;
+
+      // $set / $unset: inspect their target paths for positional tokens.
+      const inner = u[key];
+      if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+        for (const path of Object.keys(inner as Record<string, unknown>)) {
+          if (hasPositional(path)) return true;
+        }
+      }
+    } else {
+      // Shorthand top-level field (implicit $set). Positional token → complex.
+      if (hasPositional(key)) return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Extract the set of field paths an update touches (for projecting the
+ * pre-read). Returns dotted paths from $set/$unset keys and shorthand top-level
+ * fields, plus the target paths of complex operators (so a fallback re-read can
+ * still be projected when callers choose to). `_id` is always implicitly
+ * included by Mongo, callers add it to the projection explicitly.
+ */
+export const extractTouchedPaths = (update: UpdateExpr): string[] => {
+  if (!update || Array.isArray(update)) return [];
+  const u = update as Record<string, unknown>;
+  const paths = new Set<string>();
+
+  for (const key of Object.keys(u)) {
+    if (key.startsWith('$')) {
+      // Insert-only operators never change an existing doc → not a touched path.
+      if (IGNORABLE_UPDATE_OPERATORS.has(key)) continue;
+      const inner = u[key];
+      if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+        for (const path of Object.keys(inner as Record<string, unknown>)) {
+          // Strip a positional/array suffix to its root array path so the
+          // projection still selects the containing field.
+          paths.add(rootArrayPath(path));
+        }
+      }
+    } else {
+      // Shorthand field (implicit $set).
+      paths.add(rootArrayPath(key));
+    }
+  }
+
+  return Array.from(paths).filter((p) => p.length > 0);
+};
+
+/**
+ * Reduce a possibly-positional path to the field a projection can select.
+ * `a.$.b` / `a.$[].b` / `a.$[x].b` → `a`; `a.b` stays `a.b`.
+ */
+const rootArrayPath = (path: string): string => {
+  const idx = path.search(/(^|\.)\$/);
+  if (idx === -1) return path;
+  // Keep the segment(s) before the positional token.
+  const head = path.slice(0, idx);
+  return head.replace(/\.$/, '');
+};
+
+/**
+ * Compute the in-memory after-image of a SIMPLE update applied to `before`.
+ * Returns `null` when the update is complex (caller must fall back to a real
+ * re-read — we never guess). Never mutates `before`.
+ *
+ * Handles: $set, $unset, and shorthand top-level fields (implicit $set, the
+ * uncasted PRE shape). Nested dotted paths are applied with lodash set/unset so
+ * the resulting object is structurally complete and diffs cleanly against
+ * `before` via getDiffObjects.
+ */
+export const applyUpdateOperators = (
+  before: Record<string, unknown>,
+  update: UpdateExpr,
+  hasArrayFilters = false,
+): Record<string, unknown> | null => {
+  if (isComplexUpdate(update, hasArrayFilters)) return null;
+  if (!before || typeof before !== 'object') return null;
+
+  const after = _loadash.cloneDeep(before);
+  const u = update as Record<string, unknown>;
+
+  for (const key of Object.keys(u)) {
+    if (key === '$set') {
+      applySet(after, u[key]);
+    } else if (key === '$unset') {
+      applyUnset(after, u[key]);
+    } else if (IGNORABLE_UPDATE_OPERATORS.has(key)) {
+      // Insert-only operator ($setOnInsert): no effect on an existing doc → skip.
+      continue;
+    } else if (!key.startsWith('$')) {
+      // Shorthand top-level field == $set: { [key]: value }.
+      _loadash.set(after, key, u[key]);
+    }
+    // (No other $-operator is reachable: isComplexUpdate already rejected
+    // anything that isn't $set/$unset/shorthand/ignorable.)
+  }
+
+  return after;
+};
+
+/** Apply a `$set` payload (`{ path: value, … }`) onto the cloned after image. */
+const applySet = (after: Record<string, unknown>, setObj: unknown): void => {
+  if (!setObj || typeof setObj !== 'object' || Array.isArray(setObj)) return;
+  for (const [path, value] of Object.entries(setObj as Record<string, unknown>)) {
+    _loadash.set(after, path, value);
+  }
+};
+
+/** Apply a `$unset` payload (`{ path: '' , … }`) onto the cloned after image. */
+const applyUnset = (after: Record<string, unknown>, unsetObj: unknown): void => {
+  if (!unsetObj || typeof unsetObj !== 'object' || Array.isArray(unsetObj)) {
+    return;
+  }
+  for (const path of Object.keys(unsetObj as Record<string, unknown>)) {
+    _loadash.unset(after, path);
+  }
+};

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -267,8 +267,8 @@ export const schemaWrapper = (schema: Schema) => {
   schema.add({ processId: { type: String, optional: true } });
 
   // Dynamic point-in-time-revert capture: auto-journal destructive writes for
-  // every wrapped schema with no per-model code. No-op unless REVERT_AUTO_JOURNAL
-  // is enabled (so the default behaviour of every schema is unchanged).
+  // every wrapped schema with no per-model code. Always on — every schema is
+  // journaled from boot so no change is ever silently left unrecoverable.
   installRevertCaptureHooks(schema);
 
   return schema;

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -315,10 +315,7 @@ const journalUpdates = (
       );
       if (!hasChanges(updateDescription)) continue;
 
-      entries.push({
-        docId: id,
-        updateDescription: updateDescription as Record<string, unknown>,
-      });
+      entries.push({ docId: id, updateDescription });
     }
 
     if (!entries.length) return;
@@ -429,7 +426,7 @@ const makeUpdatePostHook = () => {
       // Fall back to the stashed pre value only if the cast update is unavailable.
       const castUpdate =
         typeof this.getUpdate === 'function' ? this.getUpdate() : undefined;
-      const update = (castUpdate ?? this[UPDATE_EXPR]) as UpdateExpr;
+      const update = castUpdate ?? this[UPDATE_EXPR];
       const hasArrayFilters = Boolean(this[HAS_ARRAY_FILTERS]);
 
       // In-memory after-image for every before-doc (the same operators apply to

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -2,6 +2,16 @@ import { Schema } from 'mongoose';
 import { sendWorkerQueue } from '../mq-worker';
 import { getEventHandlerRuntimeContext } from '../../core-modules/common/eventHandlers/runtimeContext';
 import { getDiffObjects } from '../utils';
+import {
+  applyUpdateOperators,
+  extractTouchedPaths,
+  isComplexUpdate,
+  UpdateExpr,
+} from './afterImage';
+import {
+  isRevertCaptureDenied,
+  isSchemaRevertOptedOut,
+} from './revertSelectivity';
 
 /**
  * Dynamic, zero-per-call-site capture for point-in-time revert.
@@ -19,12 +29,11 @@ import { getDiffObjects } from '../utils';
  * before→after diff (to restore prior field values). Creates are intentionally
  * NOT captured: reverting a new record is just deleting it.
  *
- * Safety: the whole thing is gated behind REVERT_AUTO_JOURNAL=enable (a complete
- * no-op otherwise, so the 124 schemas are untouched when disabled), and every
- * hook is wrapped so a capture failure can NEVER block or throw out of the write.
+ * Always on: capture runs for every wrapped schema from boot, so no change is
+ * ever silently left unrecoverable. Safety comes from the hooks themselves —
+ * every one is wrapped so a capture failure can NEVER block or throw out of the
+ * write; capture is best-effort and always subordinate to the write it observes.
  */
-
-const AUTO_JOURNAL_ENABLED = process.env.REVERT_AUTO_JOURNAL === 'enable';
 
 // Bound the extra read a bulk delete triggers. Beyond this many matches we keep
 // the ids but skip the snapshot (still audited; the overflow is not auto-revertable).
@@ -34,11 +43,21 @@ const MAX_SNAPSHOT = Number(process.env.REVERT_AUTO_JOURNAL_MAX || 1000);
 const SNAP = Symbol('revertCaptureSnapshot');
 const SNAP_SAVE = Symbol('revertCaptureSaveSnapshot');
 const WAS_NEW = Symbol('revertCaptureWasNew');
+// The (raw, pre-cast) update operators stashed in the update PRE hook so the
+// POST hook can synthesize the after-image in memory (simple ops) instead of
+// re-reading. `null` => complex => fall back to the post re-read.
+const UPDATE_EXPR = Symbol('revertCaptureUpdateExpr');
+// Whether the update carries arrayFilters (positional element targeting), which
+// forces the complex re-read fallback. Stashed PRE→POST for a consistent
+// classification on both sides (the projection decision and the synthesis
+// decision MUST agree).
+const HAS_ARRAY_FILTERS = Symbol('revertCaptureHasArrayFilters');
 
 /** A lean, awaitable Mongoose array query — only the bits these hooks chain. */
 type LeanArrayQuery = PromiseLike<Array<Record<string, unknown>>> & {
   limit: (n: number) => LeanArrayQuery;
   lean: () => LeanArrayQuery;
+  select: (projection: Record<string, number>) => LeanArrayQuery;
 };
 
 /** A lean, awaitable single-document Mongoose query. */
@@ -59,7 +78,11 @@ type CaptureModel = {
 type QueryHookThis = {
   model: CaptureModel;
   getFilter?: () => Record<string, unknown>;
-  [stash: symbol]: Array<Record<string, unknown>> | undefined;
+  getUpdate?: () => UpdateExpr;
+  getOptions?: () => { arrayFilters?: unknown[] } | undefined;
+  [SNAP]?: Array<Record<string, unknown>>;
+  [UPDATE_EXPR]?: UpdateExpr;
+  [HAS_ARRAY_FILTERS]?: boolean;
 };
 
 /** `this` inside the document-level `save` middleware. */
@@ -113,6 +136,16 @@ const emitPutLog = (payload: Record<string, unknown>): void => {
 };
 
 type DeleteKind = 'delete' | 'deleteMany';
+
+/**
+ * Runtime denylist guard. Install-time selectivity (installRevertCaptureHooks)
+ * already skips hooks for schemas whose collection name is known and denied, but
+ * many schemas don't declare `options.collection`, so the collection name is
+ * only reliable at write time (`model.collection.name`). This guard enforces the
+ * ALWAYS-skip-logs invariant (no journaling the journal) regardless.
+ */
+const isModelDenied = (model: CaptureModel): boolean =>
+  isRevertCaptureDenied(model?.collection?.name || model?.modelName);
 
 /**
  * Resolve the runtime context + model identity shared by every journal entry:
@@ -201,8 +234,14 @@ const journalDeletes = (
 const makePreHook = (kind: DeleteKind) => {
   return async function (this: QueryHookThis) {
     try {
+      if (isModelDenied(this.model)) {
+        this[SNAP] = undefined;
+        return;
+      }
       const filter =
         typeof this.getFilter === 'function' ? this.getFilter() : {};
+      // Deletes carry the WHOLE prior document (revert re-inserts it), so the
+      // delete pre-read is intentionally NOT projected.
       const query = this.model.find(filter).lean();
       if (kind === 'delete') {
         query.limit(1);
@@ -241,11 +280,16 @@ const hasChanges = (ud: {
     Object.keys(ud.removed || {}).length > 0 ||
     Object.keys(ud.updated || {}).length > 0);
 
+/** One per-document update entry inside a batched `updateBatch` journal message. */
+type UpdateEntry = { docId: string; updateDescription: Record<string, unknown> };
+
 /**
- * Journal one `update` event per changed document, carrying the before→after
- * diff (updateDescription) the revert engine inverts. A bulk updateMany thus
- * becomes N per-document revertable updates rather than one un-revertable
- * aggregate. No-op for documents whose content did not actually change.
+ * Journal edits carrying the before→after diff (updateDescription) the revert
+ * engine inverts. A bulk updateMany over N docs becomes N per-document
+ * revertable updates — but emitted as ONE `put_log` message (the consumer
+ * expands it into N identical single-`update` Log rows), instead of N separate
+ * BullMQ jobs. A single changed doc still emits the single-doc `update` shape
+ * BYTE-FOR-BYTE as before. No-op for documents whose content did not change.
  */
 const journalUpdates = (
   model: CaptureModel,
@@ -254,10 +298,12 @@ const journalUpdates = (
 ): void => {
   try {
     if (!beforeDocs || !beforeDocs.length) return;
+    if (isModelDenied(model)) return;
 
     const { collectionName, mongooseName, dbName, base } =
       buildJournalBase(model);
 
+    const entries: UpdateEntry[] = [];
     for (const before of beforeDocs) {
       const id = toIdString(before._id);
       const after = afterById.get(id);
@@ -269,37 +315,142 @@ const journalUpdates = (
       );
       if (!hasChanges(updateDescription)) continue;
 
+      entries.push({
+        docId: id,
+        updateDescription: updateDescription as Record<string, unknown>,
+      });
+    }
+
+    if (!entries.length) return;
+
+    if (entries.length === 1) {
+      // Single changed doc: keep the exact legacy single-`update` shape so the
+      // consumer's handleUpdate path and the stored Log row are unchanged.
+      const only = entries[0];
       emitPutLog({
         ...base,
         action: 'update',
-        docId: id,
-        payload: { collectionName, updateDescription, mongooseName, dbName },
+        docId: only.docId,
+        payload: {
+          collectionName,
+          updateDescription: only.updateDescription,
+          mongooseName,
+          dbName,
+        },
       });
+      return;
     }
+
+    // Multiple changed docs: ONE message carrying all per-doc entries. The
+    // consumer insertMany's one single-`update` Log row per entry (identical
+    // stored shape), so computeInverse/conflict read each row exactly as today.
+    emitPutLog({
+      ...base,
+      action: 'updateBatch',
+      docIds: entries.map((e) => e.docId),
+      payload: { collectionName, updates: entries, mongooseName, dbName },
+    });
   } catch {
     /* capture is best-effort and must never disturb the write */
   }
 };
 
-/** Build a `pre` update hook that snapshots the to-be-updated docs. */
+/**
+ * Build a `pre` update hook that snapshots the to-be-updated docs and stashes
+ * the (raw, pre-cast) update operators. For the SIMPLE case ($set/$unset/
+ * shorthand) the snapshot is PROJECTED to only the touched paths (+ _id), since
+ * the in-memory after-image only needs those. For the COMPLEX fallback we read
+ * the FULL doc (the post re-read needs to diff the whole document).
+ */
 const makeUpdatePreHook = () => {
   return async function (this: QueryHookThis) {
     try {
+      if (isModelDenied(this.model)) {
+        this[SNAP] = undefined;
+        this[UPDATE_EXPR] = undefined;
+        return;
+      }
+
       const filter =
         typeof this.getFilter === 'function' ? this.getFilter() : {};
-      this[SNAP] = await this.model.find(filter).limit(MAX_SNAPSHOT).lean();
+
+      const update: UpdateExpr =
+        typeof this.getUpdate === 'function' ? this.getUpdate() : undefined;
+      this[UPDATE_EXPR] = update;
+
+      const options =
+        typeof this.getOptions === 'function' ? this.getOptions() : undefined;
+      const hasArrayFilters =
+        Array.isArray(options?.arrayFilters) &&
+        (options?.arrayFilters?.length ?? 0) > 0;
+      this[HAS_ARRAY_FILTERS] = hasArrayFilters;
+
+      const simple = !isComplexUpdate(update, hasArrayFilters);
+
+      const query = this.model.find(filter).limit(MAX_SNAPSHOT).lean();
+
+      if (simple) {
+        // Only the touched paths are needed to synthesize + diff the after-image.
+        const touched = extractTouchedPaths(update);
+        if (touched.length) {
+          const projection: Record<string, number> = { _id: 1 };
+          for (const p of touched) projection[p] = 1;
+          query.select(projection);
+        }
+      }
+
+      this[SNAP] = await query;
     } catch {
       this[SNAP] = undefined;
+      this[UPDATE_EXPR] = undefined;
     }
   };
 };
 
-/** Build a `post` update hook that diffs before→after and journals per-doc edits. */
+/**
+ * Build a `post` update hook. COMMON path ($set/$unset/shorthand): compute the
+ * after-image IN MEMORY from the stashed before-snapshot + update operators — NO
+ * post re-read. COMPLEX path ($inc/$push/positional/pipeline/replacement/…):
+ * fall back to the existing post re-read (preserve current behavior; never guess
+ * an after-image).
+ */
 const makeUpdatePostHook = () => {
   return async function (this: QueryHookThis) {
     try {
       const before = this[SNAP];
       if (!before?.length) return;
+
+      // Use the POST-hook update operators, not the pre-hook ones: Mongoose casts
+      // the update IN PLACE during exec, so by the post hook this.getUpdate()
+      // carries SCHEMA-CAST values (e.g. $set a string '42' onto a Number field ->
+      // 42; a date string -> Date; an id string -> ObjectId). The pre-cast value
+      // would yield a wrong-typed in-memory after-image that diverges from what
+      // Mongo actually stored — causing false revert conflicts and phantom diffs.
+      // Fall back to the stashed pre value only if the cast update is unavailable.
+      const castUpdate =
+        typeof this.getUpdate === 'function' ? this.getUpdate() : undefined;
+      const update = (castUpdate ?? this[UPDATE_EXPR]) as UpdateExpr;
+      const hasArrayFilters = Boolean(this[HAS_ARRAY_FILTERS]);
+
+      // In-memory after-image for every before-doc (the same operators apply to
+      // each matched doc). Returns null for complex updates → fall back.
+      const inMemory = new Map<string, Record<string, unknown>>();
+      let allComputed = true;
+      for (const b of before) {
+        const after = applyUpdateOperators(b, update, hasArrayFilters);
+        if (after === null) {
+          allComputed = false;
+          break;
+        }
+        inMemory.set(toIdString(b._id), after);
+      }
+
+      if (allComputed) {
+        journalUpdates(this.model, before, inMemory);
+        return;
+      }
+
+      // COMPLEX fallback: re-read the after state (full docs) and diff.
       const ids = before.map((d) => d._id);
       const after = (await this.model
         .find({ _id: { $in: ids } })
@@ -352,13 +503,29 @@ const savePostHook = function (this: SaveHookThis) {
 };
 
 /**
- * Install the delete-capture hooks on a schema. Called from `schemaWrapper`, so
- * every wrapped schema gets them. No-op unless REVERT_AUTO_JOURNAL=enable.
+ * Install the capture hooks on a schema. Called from `schemaWrapper`, so every
+ * wrapped schema gets them — always on, so no change is ever left unjournaled.
+ *
+ * SELECTIVITY: a denied schema gets ZERO hooks (no per-write overhead). Denial
+ * is decided two ways here:
+ *   (a) per-schema opt-out — `schema.options.revertCapture === false` (or
+ *       `skipRevertCapture: true`),
+ *   (b) collection-name denylist — when the schema declares its collection name
+ *       (`schema.options.collection`) and it is on the denylist.
+ * Schemas that don't declare a collection name still pass through here (the name
+ * isn't reliably known until a model binds), but the runtime guard in the hooks
+ * (`isModelDenied`) enforces the always-skip-logs invariant at write time.
  */
 export const installRevertCaptureHooks = (schema: Schema): void => {
-  if (!AUTO_JOURNAL_ENABLED) {
-    return;
-  }
+  const options = (schema as unknown as { options?: unknown }).options as
+    | { collection?: string; revertCapture?: boolean; skipRevertCapture?: boolean }
+    | undefined;
+
+  // (a) Per-schema opt-out → no hooks at all.
+  if (isSchemaRevertOptedOut(options)) return;
+
+  // (b) Known, denied collection name → no hooks at all.
+  if (options?.collection && isRevertCaptureDenied(options.collection)) return;
 
   // Query-level middleware (Model.deleteMany / Model.deleteOne / findOneAndDelete).
   schema.pre('deleteMany', makePreHook('deleteMany'));

--- a/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
@@ -55,14 +55,15 @@ export const REVERT_CAPTURE_DENYLIST: ReadonlyArray<string> = [
  * collections that merely contain "logs" (blogs, catalogs, dialogs, changelogs)
  * are not wrongly denied — that would silently make them un-revertable.
  * Matches: `logs`, `log`, any `*_log` / `*_logs` (e.g. `{subdomain}_logs`), and
- * the explicit `event_log` / `audit_log` compound tokens.
+ * the `event_log(s)` / `audit_log(s)` tokens when they appear as whole, underscore-
+ * delimited segments (so `prevent_logger` / `catalogs` are NOT wrongly denied).
  */
 const isLogFamily = (name: string): boolean =>
   name === 'logs' ||
   name === 'log' ||
   /_logs?$/.test(name) ||
-  name.includes('event_log') ||
-  name.includes('audit_log');
+  /(^|_)event_logs?($|_)/.test(name) ||
+  /(^|_)audit_logs?($|_)/.test(name);
 
 /**
  * Optional env override: a comma-separated list of additional collection names

--- a/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
@@ -69,16 +69,17 @@ const isLogFamily = (name: string): boolean =>
  * Optional env override: a comma-separated list of additional collection names
  * to deny. Parsed once at module load. Not required — defaults stand alone.
  */
-const ENV_DENY: ReadonlyArray<string> = (process.env.REVERT_CAPTURE_DENYLIST ||
-  '')
-  .split(',')
-  .map((s) => s.trim().toLowerCase())
-  .filter(Boolean);
+const ENV_DENY: ReadonlySet<string> = new Set(
+  (process.env.REVERT_CAPTURE_DENYLIST || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
 
 /**
  * True when a collection must be skipped by revert capture. Always skips the log
- * family (substring) so the journal can never journal itself; otherwise exact
- * (case-insensitive) match against the denylist + env override.
+ * family (segment-bounded) so the journal can never journal itself; otherwise
+ * exact (case-insensitive) match against the denylist + env override.
  */
 export const isRevertCaptureDenied = (collectionName?: string): boolean => {
   if (!collectionName) return false;
@@ -89,7 +90,7 @@ export const isRevertCaptureDenied = (collectionName?: string): boolean => {
   if (isLogFamily(name)) return true;
 
   if (REVERT_CAPTURE_DENYLIST.some((d) => d.toLowerCase() === name)) return true;
-  if (ENV_DENY.includes(name)) return true;
+  if (ENV_DENY.has(name)) return true;
 
   return false;
 };

--- a/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertSelectivity.ts
@@ -1,0 +1,102 @@
+/**
+ * Selectivity for revert capture: decide which collections/schemas get capture
+ * hooks at all. Denied schemas get ZERO hooks installed, so there is no
+ * per-write overhead for them.
+ *
+ * Log-family matching is SEGMENT-aware (not naive substring) so business
+ * collections like `blogs`/`catalogs` are never wrongly denied.
+ *
+ * Two mechanisms, both evaluated in installRevertCaptureHooks:
+ *   (a) a collection-name denylist (this module), and
+ *   (b) a per-schema opt-out flag (`schema.options.revertCapture === false` or
+ *       `schema.options.skipRevertCapture === true`), checked at the install site.
+ *
+ * The logs collections are ALWAYS denied — journaling the journal would recurse.
+ */
+
+/**
+ * Collections that must never be auto-journaled. Small, clearly-commented, and
+ * extensible. Matching is case-insensitive and substring-aware for the log
+ * family (so `{subdomain}_logs`, `logs`, `event_logs` all match), exact for the
+ * rest.
+ *
+ * Categories:
+ *  - the journal itself + audit/event streams (recursion / journal-the-journal),
+ *  - ephemeral session / queue / lock / job churn (never undone),
+ *  - high-frequency metric/health rows (never undone).
+ */
+export const REVERT_CAPTURE_DENYLIST: ReadonlyArray<string> = [
+  // The journal itself (and any *_logs / event_logs variant) — avoid recursion.
+  'logs',
+  'event_logs',
+  'eventlogs',
+  'audit_logs',
+  'auditlogs',
+  // Ephemeral session / auth churn — never undone.
+  'sessions',
+  'user_sessions',
+  'login_sessions',
+  // Queue / job / lock infra — transient, high churn, never undone.
+  'jobs',
+  'job_queue',
+  'bullmq',
+  'locks',
+  'agenda_jobs',
+  // Metrics / health / heartbeat — high-frequency, never undone.
+  'metrics',
+  'health_checks',
+  'healthchecks',
+  'heartbeats',
+];
+
+/**
+ * True when a collection belongs to the log/audit journal family (the recursion
+ * guard). Matched on SEGMENT boundaries, NOT naive substring, so business
+ * collections that merely contain "logs" (blogs, catalogs, dialogs, changelogs)
+ * are not wrongly denied — that would silently make them un-revertable.
+ * Matches: `logs`, `log`, any `*_log` / `*_logs` (e.g. `{subdomain}_logs`), and
+ * the explicit `event_log` / `audit_log` compound tokens.
+ */
+const isLogFamily = (name: string): boolean =>
+  name === 'logs' ||
+  name === 'log' ||
+  /_logs?$/.test(name) ||
+  name.includes('event_log') ||
+  name.includes('audit_log');
+
+/**
+ * Optional env override: a comma-separated list of additional collection names
+ * to deny. Parsed once at module load. Not required — defaults stand alone.
+ */
+const ENV_DENY: ReadonlyArray<string> = (process.env.REVERT_CAPTURE_DENYLIST ||
+  '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+/**
+ * True when a collection must be skipped by revert capture. Always skips the log
+ * family (substring) so the journal can never journal itself; otherwise exact
+ * (case-insensitive) match against the denylist + env override.
+ */
+export const isRevertCaptureDenied = (collectionName?: string): boolean => {
+  if (!collectionName) return false;
+  const name = collectionName.toLowerCase();
+
+  // Log/audit family (segment-bounded) — guards `{subdomain}_logs` and friends
+  // without catching business collections like `blogs` / `catalogs`.
+  if (isLogFamily(name)) return true;
+
+  if (REVERT_CAPTURE_DENYLIST.some((d) => d.toLowerCase() === name)) return true;
+  if (ENV_DENY.includes(name)) return true;
+
+  return false;
+};
+
+/** Per-schema opt-out: `schema.options.revertCapture === false` etc. */
+export const isSchemaRevertOptedOut = (options?: {
+  revertCapture?: boolean;
+  skipRevertCapture?: boolean;
+}): boolean =>
+  Boolean(options) &&
+  (options?.revertCapture === false || options?.skipRevertCapture === true);

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -12,6 +12,10 @@ export const LOG_ACTIONS = {
   UPDATE_MANY: 'updateMany',
   BULK_WRITE: 'bulkWrite',
   DELETE_MANY: 'deleteMany',
+  // Auto-capture batched edit: ONE message carrying N per-doc updateDescriptions
+  // (one updateMany write). Expanded into N identical single-`update` Log rows so
+  // computeInverse/conflict read each row exactly as a single `update`.
+  UPDATE_BATCH: 'updateBatch',
 } as const;
 
 type LogAction = (typeof LOG_ACTIONS)[keyof typeof LOG_ACTIONS];
@@ -49,6 +53,22 @@ type DeleteManyEventPayload = {
   docIds: string[];
   // Docs as they were before deletion; matched to docIds by _id (any order).
   prevDocuments?: unknown[];
+  processId?: string;
+  userId?: string;
+  contentType?: string;
+  mongooseName?: string;
+  dbName?: string;
+};
+
+type UpdateBatchEntry = {
+  docId: string;
+  updateDescription?: Record<string, unknown>;
+};
+
+type UpdateBatchEventPayload = {
+  collectionName: string;
+  // Per-doc edits; each becomes one single-`update` Log row.
+  updates: UpdateBatchEntry[];
   processId?: string;
   userId?: string;
   contentType?: string;
@@ -252,6 +272,54 @@ const handleDeleteMany = async (
   return await Logs.insertMany(entries);
 };
 
+/**
+ * Auto-capture batched edit: expand ONE message into N single-`update` Log rows,
+ * each IDENTICAL to what handleUpdate stores (action 'update', payload
+ * {collectionName, updateDescription, mongooseName, dbName, collectionType}), so
+ * computeInverse/conflict read each row exactly as a single update. Only the
+ * QUEUE transport is collapsed; the stored rows are unchanged.
+ */
+const handleUpdateBatch = async (
+  Logs: Model<ILogDocument>,
+  payload: UpdateBatchEventPayload,
+) => {
+  const { collectionName, updates, processId, userId } = payload;
+
+  const entries = (updates || []).map((entry) => ({
+    action: LOG_ACTIONS.UPDATE,
+    docId: String(entry.docId),
+    payload: withCollectionType(
+      {
+        collectionName,
+        updateDescription: entry.updateDescription || {},
+        mongooseName: payload.mongooseName,
+        dbName: payload.dbName,
+      },
+      payload.contentType,
+      collectionName,
+    ),
+    source: 'mongo',
+    status: LOG_STATUSES.SUCCESS,
+    processId,
+    userId,
+    createdAt: new Date(),
+    contentType: payload.contentType,
+  }));
+
+  if (!entries.length) return [];
+
+  if (entries.length > BATCH_SIZE) {
+    const results: ILogDocument[] = [];
+    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+      const inserted = await Logs.insertMany(entries.slice(i, i + BATCH_SIZE));
+      results.push(...inserted);
+    }
+    return results;
+  }
+
+  return await Logs.insertMany(entries);
+};
+
 const handleUpdateMany = async (
   Logs: Model<ILogDocument>,
   payload: BulkEventPayload,
@@ -349,6 +417,7 @@ const actionMap: Record<string, Function> = {
   [LOG_ACTIONS.UPDATE_MANY]: handleUpdateMany,
   [LOG_ACTIONS.BULK_WRITE]: handleBulkWrite,
   [LOG_ACTIONS.DELETE_MANY]: handleDeleteMany,
+  [LOG_ACTIONS.UPDATE_BATCH]: handleUpdateBatch,
 };
 
 export const handleMongoChangeEvent = async (
@@ -372,6 +441,21 @@ export const handleMongoChangeEvent = async (
       collectionName: payload?.collectionName || '',
       docIds,
       prevDocuments: (payload as { prevDocuments?: unknown[] })?.prevDocuments,
+      processId,
+      userId,
+      contentType,
+      mongooseName: payload?.mongooseName,
+      dbName: payload?.dbName,
+    });
+  }
+
+  // Auto-capture batched edit: one message carrying N per-doc updateDescriptions
+  // → expanded into N single-`update` rows (identical stored shape).
+  if (logAction === LOG_ACTIONS.UPDATE_BATCH) {
+    return await handleUpdateBatch(Logs, {
+      collectionName: payload?.collectionName || '',
+      updates:
+        (payload as { updates?: UpdateBatchEntry[] })?.updates || [],
       processId,
       userId,
       contentType,


### PR DESCRIPTION
## What

Makes the merged point-in-time revert / undo (#8045) **production-ready**: capture is now always-on, the common edit path no longer double-reads, bulk journaling is batched, and three correctness/robustness bugs are fixed.

## Capture efficiency
- **Always-on** — removed the `REVERT_AUTO_JOURNAL=enable` gate so no change is silently left unrecoverable; only the `REVERT_AUTO_JOURNAL_MAX` bulk-snapshot cap (default 1000) remains.
- **In-memory after-image** — the common `$set` / `$unset` / shorthand update path no longer issues a post-update re-read; the after-image is computed from the (cast) update operators. Complex operators (`$inc`/`$push`/positional/`arrayFilters`/pipeline) fall back to the re-read. Pure, isolated helpers in new `afterImage.ts`.
- **Projected snapshots** — the update pre-read fetches only the touched paths + `_id`.
- **Batched bulk journaling** — a multi-doc `updateMany` emits one `updateBatch` message; the consumer (`handleUpdateBatch`) `insertMany`s byte-identical single-`update` rows, so `computeInverse` / `conflict` read them unchanged.
- **Selectivity** — new `revertSelectivity.ts`: a collection denylist + per-schema opt-out (`revertCapture: false`); the logs/audit family is always skipped so the journal never journals itself.

## Correctness / robustness fixes
- **Casting** — read the **cast** update operators in the `post` hook (Mongoose casts the update in place during exec). Previously `$set` of a string onto a Number/Date/ObjectId field produced a wrong-typed in-memory after-image → false revert conflicts and phantom diffs.
- **Over-denial** — the log-family denylist matches on **segment boundaries**, not naive substring, so business collections like `blogs` / `catalogs` / `dialogs` are no longer silently un-revertable (while `{subdomain}_logs` and friends stay denied).
- **ES best-effort** — `applyWrite`'s Elasticsearch mirror no longer fails / 500s the revert when ES is unreachable; the Mongo write is authoritative.

## Verification
- In-memory after-image proven **equal to real MongoDB** across `$set` / `$unset` / nested / array / **casting** (`string→Number/Date/ObjectId`) / `updateMany` — using a live `mongod` as the oracle (expected values come from MongoDB, not the code).
- Full **delete→revert** and **edit→revert** proven **end-to-end through real GraphQL** (`customersRemove` / `customersEdit` → `logsRevertProcess`) on a live core-api + logs-service + Mongo stack, verified directly in Mongo.
- `tsc` clean: `erxes-api-shared`, `services/logs`, `core-api`.

## Notes
- The package has no `jest` target today, so the verification harnesses run as standalone real-`mongod` node scripts outside the tree; wiring them into CI is a follow-up.
- Includes a small `.env.sample` touch-up (a point-in-time-revert note + removal of 4 dead `MASTRA_*` vars superseded by `ERXES_AGENT_*`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point-in-time revert (undo) auto-journaling is now always-on, with updated configuration docs (including undo capture behavior and optional snapshot cap).
* **Bug Fixes**
  * Revert application is now resilient to Elasticsearch sync/connectivity issues (ES sync is best-effort and won’t fail the revert flow).
* **Performance Improvements**
  * Undo journaling now captures common updates via in-memory after-images with fallback re-reads only for complex cases, and consolidates multi-document updates into batched journaling for faster processing.
* **Documentation**
  * Updated environment and module guidance to match the always-on capture and journaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->