### PR TITLE
fix: resolve Sentry issue #8158

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/activity/hooks/useActivities.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/hooks/useActivities.tsx
@@ -39,6 +39,7 @@ export const useActivities = (contentId: string) => {
         if (!prev || !subscriptionData.data) return prev;
 
         const { type, activity } = subscriptionData.data.ticketActivityChanged;
+        if (!prev.getTicketActivities) return prev;
         const currentList = prev.getTicketActivities.list;
 
         let updatedList = currentList;

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -102,6 +102,7 @@ export const useConversations = (
         if (!subscriptionData.data || !prev) return prev;
         const newMessage =
           subscriptionData.data.conversationClientMessageInserted;
+        if (!prev.conversations) return prev;
         const index = prev.conversations.list.findIndex(
           (conversation) => conversation._id === newMessage?._id,
         );

--- a/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useGetTickets.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useGetTickets.tsx
@@ -102,6 +102,7 @@ export const useTickets = (
         if (!prev || !subscriptionData.data) return prev;
 
         const { type, ticket } = subscriptionData.data.ticketListChanged;
+        if (!prev.getTickets) return prev;
         const currentList = prev.getTickets.list;
 
         let updatedList = currentList;


### PR DESCRIPTION
## Related issue

- GitHub: https://github.com/erxes/erxes/issues/8158
- Sentry: https://sentry.erxes.io/organizations/sentry/issues/135/

Fixes #8158

## Root cause

Sentry reported `TypeError: Cannot read properties of undefined (reading 'list')` thrown from an `updateQuery` callback in the `frontline_ui` bundle (stack: `updateQuery` -> `t.updateQuery` -> `Object.next`).

In `frontline_ui`, several `subscribeToMore` `updateQuery` callbacks only guarded the previous cache result itself (`if (!prev) return prev`), but not the nested cache key. When a subscription event arrives before the initial query has populated the cache, `prev` is `{}` (truthy) while the nested key (`prev.conversations`, `prev.getTickets`, `prev.getTicketActivities`) is `undefined`. Accessing `.list` on it then throws the reported TypeError.

## Fix summary

Add an early `return prev` guard for each nested cache key, consistent with the existing no-op pattern, so the cache is left untouched until the query result is available.

- `frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx` — guard `prev.conversations` (`conversationClientMessageInserted` subscription)
- `frontend/plugins/frontline_ui/src/modules/ticket/hooks/useGetTickets.tsx` — guard `prev.getTickets` (`ticketListChanged` subscription)
- `frontend/plugins/frontline_ui/src/modules/activity/hooks/useActivities.tsx` — guard `prev.getTicketActivities` (`ticketActivityChanged` subscription)

These three callbacks share the identical vulnerable pattern and all produce the exact error in this issue. The `fetchMore` callbacks in the same files are not affected because they route through `mergeCursorData` (`erxes-ui`), which already null-guards via `prevResult?.list || []`.

## Tests run

- Inspected the affected hooks and `mergeCursorData` (`frontend/libs/erxes-ui`) to confirm the vulnerable vs. safe access patterns.
- Full local build/test (`pnpm nx build frontline_ui`) was not run in this environment (monorepo install required); the change is a minimal, type-safe guard consistent with the surrounding code. CI (`ci-ui-frontline`) will build `frontline_ui` on this PR.

## Risks / follow-up

- Low risk. The guard only short-circuits the subscription update when the cache has no data yet; subsequent subscription events and query refetches populate the cache normally.
- Follow-up (optional): the same guard pattern could be applied to other plugins' `subscribeToMore` callbacks that access `prev.<key>.list` without a null check.

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError by short-circuiting frontline_ui subscription handlers when nested cache entries are not yet populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved runtime errors in real-time activity feed updates when data was incomplete
  * Fixed potential crashes in conversation updates during subscription synchronization
  * Enhanced reliability of ticket list updates in live data scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->