### PR TITLE
test(revert): outcome-based test suite in CI + partial-undo warning for oversized bulk changes

### DIFF
--- a/.github/workflows/ci-test-revert.yml
+++ b/.github/workflows/ci-test-revert.yml
@@ -1,0 +1,47 @@
+name: CI test--revert capture
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/erxes-api-shared/**'
+      - '.github/workflows/ci-test-revert.yml'
+  pull_request:
+    paths:
+      - 'backend/erxes-api-shared/**'
+      - '.github/workflows/ci-test-revert.yml'
+
+env:
+  NX_DAEMON: false
+
+jobs:
+  revert-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # The integration specs boot a real mongod via mongodb-memory-server; cache
+      # the downloaded binary so reruns don't re-fetch it.
+      - name: Cache mongodb-memory-server binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run revert-capture tests (jest + real MongoDB oracle)
+        run: pnpm nx test erxes-api-shared

--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -190,13 +190,23 @@ is still honored when present.
 
 ---
 
+## Verification
+
+Outcome-based Jest specs (real MongoDB via mongodb-memory-server) cover the capture
+spine in `backend/erxes-api-shared/src/utils/mongo/__tests__/` — run with
+`pnpm nx test erxes-api-shared` (also in CI: `.github/workflows/ci-test-revert.yml`).
+They assert the in-memory after-image equals what Mongo actually stored, the hooks
+journal the real change, selectivity, and the bulk-overflow marker.
+
 ## Known gaps (NOT production-done)
 
 - Cascade completeness untested (delete may restore the parent but not related
   docs unless they pass through hooked ops).
 - Standalone Mongo = no transactions → multi-doc revert can partially apply
   (result reports `reverted` vs `conflicts`).
-- Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates with no marker yet.
+- Bulk capture >`REVERT_AUTO_JOURNAL_MAX` truncates the snapshot, but now STAMPS
+  the journal entry with `revertOverflow:true`; the consumer persists it on each
+  Log row's payload and the Undo panel warns the change is only partially undoable.
 - The in-memory after-image removes the post re-read only for the SIMPLE update
   path ($set/$unset/shorthand); COMPLEX operators (see list above) still do the
   full post re-read. Replacement (`replaceOne`/`findOneAndReplace`) is NOT hooked.

--- a/backend/erxes-api-shared/jest.config.ts
+++ b/backend/erxes-api-shared/jest.config.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+export default {
+  displayName: 'erxes-api-shared',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    // isolatedModules = transpile-only. Types are enforced by `pnpm build`
+    // (tsc), not the test runner; this keeps the worker memory bounded.
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        diagnostics: false,
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/src/**/*.spec.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  // The mongodb-memory-server child process can outlive Jest's graceful-exit
+  // window even with correct afterAll teardown; force exit so CI never hangs.
+  forceExit: true,
+  coverageDirectory: '../../coverage/backend/erxes-api-shared',
+};

--- a/backend/erxes-api-shared/package.json
+++ b/backend/erxes-api-shared/package.json
@@ -21,6 +21,7 @@
     "@types/lodash": "^4.17.21",
     "babel-plugin-module-resolver": "^5.0.2",
     "glob": "^11.0.1",
+    "mongodb-memory-server": "^11.2.0",
     "tsx": "^4.19.3"
   },
   "dependencies": {

--- a/backend/erxes-api-shared/project.json
+++ b/backend/erxes-api-shared/project.json
@@ -16,6 +16,13 @@
         "{projectRoot}/core-modules/package.json",
         "{projectRoot}/core-modules/dist"
       ]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "backend/erxes-api-shared/jest.config.ts"
+      }
     }
   }
 }

--- a/backend/erxes-api-shared/src/test-setup.ts
+++ b/backend/erxes-api-shared/src/test-setup.ts
@@ -1,0 +1,3 @@
+// Integration specs boot a real mongod via mongodb-memory-server. On the first CI
+// run the mongod binary is downloaded, so allow generous time for setup hooks.
+jest.setTimeout(60000);

--- a/backend/erxes-api-shared/src/utils/mongo/__tests__/afterImage.spec.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/__tests__/afterImage.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * OUTCOME-BASED tests for the in-memory after-image.
+ *
+ * The oracle is a REAL ephemeral MongoDB (mongodb-memory-server): every assertion
+ * compares our computed after-image against the document MongoDB *actually*
+ * produced for a real update — never against the implementation. If our model of
+ * Mongo/Mongoose semantics is wrong, these fail. Expected values are whatever the
+ * database did, so the tests cannot "mirror" the code they verify.
+ */
+import mongoose, { Schema } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { applyUpdateOperators, isComplexUpdate } from '../afterImage';
+import { getDiffObjects } from '../../utils';
+
+// Canonicalize for order/type-insensitive structural equality.
+const norm = (v: any): any => {
+  if (v === null || v === undefined) return v;
+  if (Array.isArray(v)) return v.map(norm);
+  if (v instanceof Date) return { __date: v.getTime() };
+  if (typeof v === 'object') {
+    if (v._bsontype || v?.constructor?.name === 'ObjectId') return { __oid: String(v) };
+    const o: Record<string, any> = {};
+    for (const k of Object.keys(v).sort()) o[k] = norm(v[k]);
+    return o;
+  }
+  return v;
+};
+const J = (x: any) => JSON.stringify(norm(x));
+
+describe('afterImage: in-memory after-image equals REAL MongoDB', () => {
+  let server: MongoMemoryServer;
+  let Model: mongoose.Model<any>;
+  // The CAST update operators, captured exactly as the post-hook reads them.
+  let captured: any;
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create();
+    await mongoose.connect(server.getUri());
+    const schema = new Schema(
+      {
+        name: String,
+        nick: String,
+        age: Number,
+        tags: [String],
+        address: { city: String, zip: String },
+        n: Number,
+        when: Date,
+        ref: Schema.Types.ObjectId,
+      },
+      { timestamps: true },
+    );
+    // Mongoose casts the update in place during exec, so by the POST hook
+    // getUpdate() carries schema-typed values — the same source the real capture
+    // hook computes its after-image from.
+    function capPost(this: any) {
+      captured = this.getUpdate();
+    }
+    schema.post('updateOne', capPost);
+    schema.post('findOneAndUpdate', capPost);
+    Model = mongoose.model('AfterImageOracle', schema);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await Model.deleteMany({});
+    captured = undefined;
+  });
+
+  const run = async (seed: any, doUpdate: (id: any) => Promise<any>) => {
+    const created = await Model.create(seed);
+    const before = await Model.findById(created._id).lean();
+    await doUpdate(created._id);
+    const real = await Model.findById(created._id).lean();
+    return { before, real };
+  };
+
+  // Simple updates: the after-image MUST equal the document Mongo stored, AND the
+  // journaled diff MUST equal what a real post re-read would have produced.
+  test.each<[string, any, (id: any) => Promise<any>]>([
+    ['$set scalar', { name: 'Old', age: 3 }, (id) => Model.updateOne({ _id: id }, { $set: { name: 'New' } })],
+    ['$set nested path', { address: { city: 'NYC', zip: '1' } }, (id) => Model.updateOne({ _id: id }, { $set: { 'address.city': 'LA' } })],
+    ['$unset field', { name: 'X', nick: 'Y' }, (id) => Model.updateOne({ _id: id }, { $unset: { nick: 1 } })],
+    ['$set + $unset', { name: 'X', nick: 'Y', age: 2 }, (id) => Model.updateOne({ _id: id }, { $set: { age: 9 }, $unset: { nick: 1 } })],
+    ['$set whole array', { tags: ['a', 'b'] }, (id) => Model.updateOne({ _id: id }, { $set: { tags: ['a'] } })],
+    ['shorthand field', { name: 'Old' }, (id) => Model.updateOne({ _id: id }, { name: 'New2' })],
+    ['cast string -> Number', { age: 1 }, (id) => Model.updateOne({ _id: id }, { $set: { age: '42' } })],
+    ['cast string -> Date', { when: new Date('2020-01-01') }, (id) => Model.updateOne({ _id: id }, { $set: { when: '2023-05-05' } })],
+    ['findOneAndUpdate $set', { name: 'Old' }, (id) => Model.findOneAndUpdate({ _id: id }, { $set: { name: 'FNA' } })],
+  ])('%s -> after-image == REAL stored doc', async (_label, seed, doUpdate) => {
+    const { before, real } = await run(seed, doUpdate);
+    const mine = applyUpdateOperators(before as any, captured, false);
+    expect(mine).not.toBeNull();
+    expect(J(mine)).toBe(J(real));
+    expect(J(getDiffObjects(before as any, mine as any))).toBe(
+      J(getDiffObjects(before as any, real as any)),
+    );
+  });
+
+  // Complex operators depend on server-side prior state — we must NOT guess; the
+  // classifier returns null so the caller falls back to a real re-read.
+  test.each<[string, any, (id: any) => Promise<any>]>([
+    ['$inc', { n: 5 }, (id) => Model.updateOne({ _id: id }, { $inc: { n: 2 } })],
+    ['$push', { tags: ['a'] }, (id) => Model.updateOne({ _id: id }, { $push: { tags: 'b' } })],
+  ])('%s -> classified complex (null), and it really changed the doc', async (_label, seed, doUpdate) => {
+    const { before, real } = await run(seed, doUpdate);
+    expect(applyUpdateOperators(before as any, captured, false)).toBeNull();
+    expect(J(before)).not.toBe(J(real));
+  });
+
+  test('timestamps:true injects $setOnInsert pre-cast, yet the update stays simple', async () => {
+    let preCast: any;
+    const probe = new Schema({ a: Number }, { timestamps: true });
+    probe.pre('updateOne', function (this: any) {
+      preCast = this.getUpdate();
+    });
+    const M = mongoose.model('TsInjectionProbe', probe);
+    const d = await M.create({ a: 1 });
+    await M.updateOne({ _id: d._id }, { $set: { a: 2 } });
+    // Real Mongoose behaviour: $setOnInsert(createdAt) is injected before our hook.
+    expect(preCast.$setOnInsert).toBeDefined();
+    // ...and our classifier still treats the update as in-memory-replayable.
+    expect(isComplexUpdate(preCast, false)).toBe(false);
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/__tests__/revertCaptureOverflow.spec.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/__tests__/revertCaptureOverflow.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * OUTCOME-based test: a bulk delete/update whose match count exceeds the snapshot
+ * cap must be FLAGGED (revertOverflow) so downstream (engine + UI) can tell the
+ * user the change is only partially undoable — instead of silently truncating.
+ */
+// Tiny cap so a 3-row bulk overflows. Must be set BEFORE revertCapture is loaded
+// (it reads the env at module-eval), so revertCapture is required lazily below.
+process.env.REVERT_AUTO_JOURNAL_MAX = '2';
+
+import mongoose, { Schema } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+const mockState: { enqueued: any[] } = { enqueued: [] };
+jest.mock('../../mq-worker', () => ({
+  sendWorkerQueue: () => ({
+    add: (_name: string, payload: any) => {
+      mockState.enqueued.push(payload);
+      return Promise.resolve();
+    },
+  }),
+}));
+jest.mock('../../../core-modules/common/eventHandlers/runtimeContext', () => ({
+  getEventHandlerRuntimeContext: () => ({
+    subdomain: 'test',
+    processId: 'pid',
+    userId: 'u',
+  }),
+}));
+
+describe('revertCapture: bulk capture beyond the cap is flagged revertOverflow', () => {
+  let server: MongoMemoryServer;
+  let Model: mongoose.Model<any>;
+
+  beforeAll(async () => {
+    // Required (not imported) so the env cap above is in effect at module-eval.
+    const { installRevertCaptureHooks } = require('../revertCapture');
+    server = await MongoMemoryServer.create();
+    await mongoose.connect(server.getUri());
+    const schema = new Schema({ n: Number, m: Number }, { timestamps: true });
+    installRevertCaptureHooks(schema);
+    Model = mongoose.model('OverflowSpine', schema);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await Model.deleteMany({});
+    mockState.enqueued.length = 0;
+  });
+
+  const find = (...actions: string[]) =>
+    mockState.enqueued.find((e) => actions.includes(e.action));
+
+  test('deleteMany OVER the cap -> revertOverflow + snapshot capped at the max', async () => {
+    await Model.create([{ n: 1 }, { n: 1 }, { n: 1 }]); // 3 rows, cap is 2
+    mockState.enqueued.length = 0;
+    await Model.deleteMany({ n: 1 });
+
+    const del = find('deleteMany');
+    expect(del).toBeDefined();
+    expect(del.revertOverflow).toBe(true);
+    expect(del.payload.prevDocuments).toHaveLength(2); // not silently 3 / not 0
+  });
+
+  test('updateMany OVER the cap -> revertOverflow on the batch', async () => {
+    await Model.create([{ n: 1 }, { n: 1 }, { n: 1 }]);
+    mockState.enqueued.length = 0;
+    await Model.updateMany({ n: 1 }, { $set: { m: 9 } });
+
+    const batch = find('updateBatch', 'update');
+    expect(batch).toBeDefined();
+    expect(batch.revertOverflow).toBe(true);
+  });
+
+  test('a bulk WITHIN the cap is NOT flagged', async () => {
+    await Model.create([{ n: 2 }, { n: 2 }]); // exactly the cap, no overflow
+    mockState.enqueued.length = 0;
+    await Model.deleteMany({ n: 2 });
+
+    const del = find('deleteMany');
+    expect(del).toBeDefined();
+    expect(del.revertOverflow).toBeUndefined();
+    expect(del.payload.prevDocuments).toHaveLength(2);
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/__tests__/revertCaptureSpine.spec.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/__tests__/revertCaptureSpine.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * OUTCOME-based tests for the capture spine: the REAL revert-capture hooks,
+ * installed on a REAL ephemeral MongoDB, must journal what ACTUALLY happened so a
+ * later revert can undo it. The queue transport is intercepted in-process (no
+ * Redis); everything else is the real code. Assertions compare the journal to the
+ * real before/after documents — not to the implementation.
+ */
+import mongoose, { Schema } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { getDiffObjects } from '../../utils';
+
+// Intercept what the hooks enqueue (and let a test simulate a down queue).
+const mockState: { enqueued: any[]; throwOnAdd: boolean } = {
+  enqueued: [],
+  throwOnAdd: false,
+};
+jest.mock('../../mq-worker', () => ({
+  sendWorkerQueue: () => ({
+    add: (_name: string, payload: any) => {
+      if (mockState.throwOnAdd) throw new Error('queue unavailable');
+      mockState.enqueued.push(payload);
+      return Promise.resolve();
+    },
+  }),
+}));
+jest.mock(
+  '../../../core-modules/common/eventHandlers/runtimeContext',
+  () => ({
+    getEventHandlerRuntimeContext: () => ({
+      subdomain: 'test',
+      processId: 'pid-1',
+      userId: 'actor-1',
+    }),
+  }),
+);
+
+// Imported AFTER the mocks so the hooks bind to the intercepted modules.
+import { installRevertCaptureHooks } from '../revertCapture';
+
+describe('revertCapture: hooks journal the real change (capture spine)', () => {
+  let server: MongoMemoryServer;
+  let Model: mongoose.Model<any>;
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create();
+    await mongoose.connect(server.getUri());
+    const schema = new Schema(
+      { name: String, score: Number, email: String },
+      { timestamps: true },
+    );
+    installRevertCaptureHooks(schema);
+    Model = mongoose.model('CaptureSpine', schema);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await Model.deleteMany({});
+    mockState.enqueued.length = 0;
+    mockState.throwOnAdd = false;
+  });
+
+  const journaled = (action: string) =>
+    mockState.enqueued.filter((e) => e.action === action);
+
+  test('DELETE journals the prior document so it can be re-inserted', async () => {
+    const doc = await Model.create({ name: 'Acme', score: 10 });
+    mockState.enqueued.length = 0;
+    await Model.deleteOne({ _id: doc._id });
+
+    const del = journaled('delete');
+    expect(del).toHaveLength(1);
+    expect(del[0].payload.prevDocument._id.toString()).toBe(doc._id.toString());
+    expect(del[0].payload.prevDocument.name).toBe('Acme');
+    expect(del[0].processId).toBe('pid-1'); // correlated to the request
+  });
+
+  test('EDIT journals the exact before->after diff that occurred', async () => {
+    const doc = await Model.create({ name: 'Old', score: 1 });
+    const before = await Model.findById(doc._id).lean();
+    mockState.enqueued.length = 0;
+
+    await Model.updateOne({ _id: doc._id }, { $set: { name: 'New', score: 2 } });
+    const after = await Model.findById(doc._id).lean();
+
+    const upd = journaled('update');
+    expect(upd).toHaveLength(1);
+    // The journaled updateDescription must equal the diff between the document
+    // that existed and the document Mongo produced — a faithful record of reality.
+    const real: any = getDiffObjects(before as any, after as any);
+    const recorded: any = upd[0].payload.updateDescription;
+    expect(JSON.stringify(recorded.updated?.name)).toBe(
+      JSON.stringify(real.updated?.name),
+    );
+    expect(JSON.stringify(recorded.updated?.score)).toBe(
+      JSON.stringify(real.updated?.score),
+    );
+  });
+
+  test('updateMany over N docs journals ONE batch message, one entry per doc', async () => {
+    await Model.create([
+      { name: 'a', score: 1 },
+      { name: 'b', score: 1 },
+      { name: 'c', score: 1 },
+    ]);
+    mockState.enqueued.length = 0;
+
+    await Model.updateMany({ score: 1 }, { $set: { score: 2 } });
+
+    const batch = journaled('updateBatch');
+    expect(batch).toHaveLength(1); // ONE message, not N
+    expect(batch[0].payload.updates).toHaveLength(3); // one entry per matched doc
+    expect(batch[0].docIds).toHaveLength(3);
+  });
+
+  test('a failing journal queue NEVER breaks or blocks the host write', async () => {
+    const doc = await Model.create({ name: 'KeepMe', score: 5 });
+    mockState.throwOnAdd = true; // the journal transport is down
+
+    await expect(
+      Model.updateOne({ _id: doc._id }, { $set: { score: 9 } }),
+    ).resolves.toBeDefined();
+
+    const after = await Model.findById(doc._id).lean();
+    expect((after as any).score).toBe(9); // the write still applied
+  });
+
+  test('creating a document is NOT journaled (revert of a new record = delete it)', async () => {
+    mockState.enqueued.length = 0;
+    await Model.create({ name: 'Fresh', score: 0 });
+    expect(mockState.enqueued).toHaveLength(0);
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/__tests__/revertSelectivity.spec.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/__tests__/revertSelectivity.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * OUTCOME/SPEC-based tests for revert-capture selectivity.
+ *
+ * Expected values come from the FEATURE REQUIREMENT, not from reading the
+ * implementation:
+ *  - the journal must never capture the log/audit family (it would journal
+ *    itself) nor ephemeral session/queue/metric churn;
+ *  - a business collection must stay revertable even when its name merely
+ *    contains a denied substring (otherwise users silently lose undo);
+ *  - a schema may explicitly opt out.
+ */
+import {
+  isRevertCaptureDenied,
+  isSchemaRevertOptedOut,
+} from '../revertSelectivity';
+
+describe('revertSelectivity: which collections may be auto-journaled', () => {
+  // MUST be denied — capturing these is wrong (recursion / pure churn).
+  test.each([
+    'logs',
+    'log',
+    'erxes_logs',
+    'event_logs',
+    'audit_log',
+    'audit_logs',
+    'sessions',
+    'user_sessions',
+    'metrics',
+    'jobs',
+    'locks',
+    'heartbeats',
+  ])('must DENY the non-revertable collection "%s"', (name) => {
+    expect(isRevertCaptureDenied(name)).toBe(true);
+  });
+
+  // MUST NOT be denied — real business data, even if the name embeds "log".
+  test.each([
+    'customers',
+    'companies',
+    'deals',
+    'tags',
+    'blogs',
+    'catalogs',
+    'dialogs',
+    'changelogs',
+    'prevent_logger',
+    'my_event_logger',
+  ])('must NOT deny the business collection "%s"', (name) => {
+    expect(isRevertCaptureDenied(name)).toBe(false);
+  });
+
+  test('missing / empty collection name is not denied', () => {
+    expect(isRevertCaptureDenied('')).toBe(false);
+    expect(isRevertCaptureDenied(undefined)).toBe(false);
+  });
+
+  test('a schema can explicitly opt out of capture', () => {
+    expect(isSchemaRevertOptedOut({ revertCapture: false })).toBe(true);
+    expect(isSchemaRevertOptedOut({ skipRevertCapture: true })).toBe(true);
+    expect(isSchemaRevertOptedOut({})).toBe(false);
+    expect(isSchemaRevertOptedOut(undefined)).toBe(false);
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/revertCapture.ts
@@ -43,6 +43,9 @@ const MAX_SNAPSHOT = Number(process.env.REVERT_AUTO_JOURNAL_MAX || 1000);
 const SNAP = Symbol('revertCaptureSnapshot');
 const SNAP_SAVE = Symbol('revertCaptureSaveSnapshot');
 const WAS_NEW = Symbol('revertCaptureWasNew');
+// Set when a bulk delete/update matched MORE rows than MAX_SNAPSHOT, so the
+// journaled snapshot is truncated and the entry is only PARTIALLY revertable.
+const OVERFLOW = Symbol('revertCaptureOverflow');
 // The (raw, pre-cast) update operators stashed in the update PRE hook so the
 // POST hook can synthesize the after-image in memory (simple ops) instead of
 // re-reading. `null` => complex => fall back to the post re-read.
@@ -83,6 +86,7 @@ type QueryHookThis = {
   [SNAP]?: Array<Record<string, unknown>>;
   [UPDATE_EXPR]?: UpdateExpr;
   [HAS_ARRAY_FILTERS]?: boolean;
+  [OVERFLOW]?: boolean;
 };
 
 /** `this` inside the document-level `save` middleware. */
@@ -196,6 +200,7 @@ const journalDeletes = (
   model: CaptureModel,
   docs: Array<Record<string, unknown>>,
   kind: DeleteKind,
+  overflow = false,
 ): void => {
   try {
     if (!docs || !docs.length) return;
@@ -207,6 +212,7 @@ const journalDeletes = (
       emitPutLog({
         ...base,
         action: 'deleteMany',
+        ...(overflow ? { revertOverflow: true } : {}),
         docIds: docs.map((d) => toIdString(d._id)),
         payload: { collectionName, prevDocuments: docs, mongooseName, dbName },
       });
@@ -244,11 +250,14 @@ const makePreHook = (kind: DeleteKind) => {
       // delete pre-read is intentionally NOT projected.
       const query = this.model.find(filter).lean();
       if (kind === 'delete') {
-        query.limit(1);
+        this[SNAP] = await query.limit(1);
       } else {
-        query.limit(MAX_SNAPSHOT);
+        // Fetch one past the cap so a bulk delete whose match count exceeds
+        // MAX_SNAPSHOT is FLAGGED (revertOverflow) rather than silently truncated.
+        const docs = await query.limit(MAX_SNAPSHOT + 1);
+        this[OVERFLOW] = docs.length > MAX_SNAPSHOT;
+        this[SNAP] = this[OVERFLOW] ? docs.slice(0, MAX_SNAPSHOT) : docs;
       }
-      this[SNAP] = await query;
     } catch {
       this[SNAP] = undefined;
     }
@@ -261,7 +270,7 @@ const makePostHook = (kind: DeleteKind) => {
     try {
       const docs = this[SNAP];
       if (docs?.length) {
-        journalDeletes(this.model, docs, kind);
+        journalDeletes(this.model, docs, kind, Boolean(this[OVERFLOW]));
       }
     } catch {
       /* never disturb the write path */
@@ -295,6 +304,7 @@ const journalUpdates = (
   model: CaptureModel,
   beforeDocs: Array<Record<string, unknown>>,
   afterById: Map<string, Record<string, unknown>>,
+  overflow = false,
 ): void => {
   try {
     if (!beforeDocs || !beforeDocs.length) return;
@@ -327,6 +337,7 @@ const journalUpdates = (
       emitPutLog({
         ...base,
         action: 'update',
+        ...(overflow ? { revertOverflow: true } : {}),
         docId: only.docId,
         payload: {
           collectionName,
@@ -344,6 +355,7 @@ const journalUpdates = (
     emitPutLog({
       ...base,
       action: 'updateBatch',
+      ...(overflow ? { revertOverflow: true } : {}),
       docIds: entries.map((e) => e.docId),
       payload: { collectionName, updates: entries, mongooseName, dbName },
     });
@@ -384,7 +396,9 @@ const makeUpdatePreHook = () => {
 
       const simple = !isComplexUpdate(update, hasArrayFilters);
 
-      const query = this.model.find(filter).limit(MAX_SNAPSHOT).lean();
+      // Fetch one past the cap so a bulk update whose match count exceeds
+      // MAX_SNAPSHOT is FLAGGED (revertOverflow) rather than silently truncated.
+      const query = this.model.find(filter).limit(MAX_SNAPSHOT + 1).lean();
 
       if (simple) {
         // Only the touched paths are needed to synthesize + diff the after-image.
@@ -396,7 +410,9 @@ const makeUpdatePreHook = () => {
         }
       }
 
-      this[SNAP] = await query;
+      const docs = await query;
+      this[OVERFLOW] = docs.length > MAX_SNAPSHOT;
+      this[SNAP] = this[OVERFLOW] ? docs.slice(0, MAX_SNAPSHOT) : docs;
     } catch {
       this[SNAP] = undefined;
       this[UPDATE_EXPR] = undefined;
@@ -443,7 +459,7 @@ const makeUpdatePostHook = () => {
       }
 
       if (allComputed) {
-        journalUpdates(this.model, before, inMemory);
+        journalUpdates(this.model, before, inMemory, Boolean(this[OVERFLOW]));
         return;
       }
 
@@ -455,7 +471,7 @@ const makeUpdatePostHook = () => {
       const afterById = new Map<string, Record<string, unknown>>(
         after.map((d) => [toIdString(d._id), d]),
       );
-      journalUpdates(this.model, before, afterById);
+      journalUpdates(this.model, before, afterById, Boolean(this[OVERFLOW]));
     } catch {
       /* never disturb the write path */
     }

--- a/backend/erxes-api-shared/tsconfig.lib.json
+++ b/backend/erxes-api-shared/tsconfig.lib.json
@@ -16,7 +16,10 @@
     "**/*.spec.js",
     "**/*.test.js",
     "**/*.spec.jsx",
-    "**/*.test.jsx"
+    "**/*.test.jsx",
+    "**/__tests__/**",
+    "src/test-setup.ts",
+    "jest.config.ts"
   ],
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/backend/erxes-api-shared/tsconfig.spec.json
+++ b/backend/erxes-api-shared/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "**/__mocks__/**/*",

--- a/backend/services/logs/src/bullmq/mongo.ts
+++ b/backend/services/logs/src/bullmq/mongo.ts
@@ -58,6 +58,8 @@ type DeleteManyEventPayload = {
   contentType?: string;
   mongooseName?: string;
   dbName?: string;
+  // Set when the bulk match exceeded the capture cap → only partially revertable.
+  revertOverflow?: boolean;
 };
 
 type UpdateBatchEntry = {
@@ -74,6 +76,8 @@ type UpdateBatchEventPayload = {
   contentType?: string;
   mongooseName?: string;
   dbName?: string;
+  // Set when the bulk match exceeded the capture cap → only partially revertable.
+  revertOverflow?: boolean;
 };
 
 const getCollectionType = (contentType?: string, collectionName?: string) => {
@@ -248,6 +252,7 @@ const handleDeleteMany = async (
         prevDocument: snapshotById.get(String(docId)),
         mongooseName: payload.mongooseName,
         dbName: payload.dbName,
+        ...(payload.revertOverflow ? { revertOverflow: true } : {}),
       },
       payload.contentType,
       collectionName,
@@ -294,6 +299,7 @@ const handleUpdateBatch = async (
         updateDescription: entry.updateDescription || {},
         mongooseName: payload.mongooseName,
         dbName: payload.dbName,
+        ...(payload.revertOverflow ? { revertOverflow: true } : {}),
       },
       payload.contentType,
       collectionName,
@@ -422,8 +428,15 @@ const actionMap: Record<string, Function> = {
 
 export const handleMongoChangeEvent = async (
   Logs: Model<ILogDocument>,
-  { action, payload, docIds, docId, processId, contentType, userId }: IJobData,
+  jobData: IJobData,
 ) => {
+  const { action, payload, docIds, processId, contentType, userId } = jobData;
+  let { docId } = jobData;
+  // Optional marker the auto-capture stamps when a bulk op exceeded the snapshot
+  // cap; persisted per row so the revert UI can warn it is only partial.
+  const revertOverflow = Boolean(
+    (jobData as { revertOverflow?: boolean }).revertOverflow,
+  );
   if (!action) {
     throw new Error('Action is required');
   }
@@ -446,6 +459,7 @@ export const handleMongoChangeEvent = async (
       contentType,
       mongooseName: payload?.mongooseName,
       dbName: payload?.dbName,
+      revertOverflow,
     });
   }
 
@@ -461,6 +475,7 @@ export const handleMongoChangeEvent = async (
       contentType,
       mongooseName: payload?.mongooseName,
       dbName: payload?.dbName,
+      revertOverflow,
     });
   }
 

--- a/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
+++ b/frontend/core-ui/src/modules/logs/components/LogRevertPanel.tsx
@@ -50,6 +50,10 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
     !isRevertMutation &&
     (source === 'mongo' || (source === 'graphql' && action === 'mutation'));
 
+  // The auto-capture flags a bulk change that matched more records than the
+  // snapshot cap, so only part of it was journaled — warn that undo is partial.
+  const overflow = Boolean(detail.payload?.revertOverflow);
+
   // Quietly check on open whether this was already undone, so we can show that
   // immediately instead of making the user click "Undo" only to find out.
   const [checking, setChecking] = useState(revertable);
@@ -191,6 +195,25 @@ export const LogRevertPanel = ({ detail }: { detail: ILogDoc }) => {
       </div>
 
       <div className="px-6 py-5">
+        {/* Large bulk change — capture was truncated, so undo is only partial */}
+        {overflow && !done && (
+          <div className="mb-4 flex items-start gap-3 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3">
+            <IconAlertTriangle
+              size={20}
+              className="mt-0.5 shrink-0 text-warning"
+            />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                Large change — only part can be undone
+              </p>
+              <p className="text-sm text-muted-foreground">
+                This affected more records than we keep a backup for, so undoing
+                it puts back the ones we saved but may leave some out.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Quiet pre-check on open */}
         {checking && (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@sendgrid/mail':
         specifier: ^8.1.5
         version: 8.1.5
+      '@sentry/node':
+        specifier: ^10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
       '@sentry/react':
         specifier: ^10.55.0
         version: 10.57.0(react@18.3.1)
@@ -812,6 +815,204 @@ importers:
         specifier: ^1.0.15
         version: 1.0.15
 
+  backend/core-api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@blocknote/core':
+        specifier: ^0.35.0
+        version: 0.35.0(@types/hast@3.0.4)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sendgrid/mail':
+        specifier: ^8.1.5
+        version: 8.1.5
+      '@sentry/node':
+        specifier: ^10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      '@workos-inc/node':
+        specifier: ^7.65.0
+        version: 7.65.0(express@4.21.2)(koa@2.15.3)
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bcryptjs:
+        specifier: ^3.0.2
+        version: 3.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      firebase-admin:
+        specifier: ^13.6.0
+        version: 13.6.0(encoding@0.1.13)
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      formidable:
+        specifier: ^3.5.4
+        version: 3.5.4
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      jimp:
+        specifier: ^1.6.0
+        version: 1.6.0
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongodb:
+        specifier: ^6.18.0
+        version: 6.18.0(socks@2.8.7)
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      multer:
+        specifier: ^1.4.2
+        version: 1.4.4
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      nodemailer:
+        specifier: ^6.9.10
+        version: 6.9.10
+      sha256:
+        specifier: ^0.2.0
+        version: 0.2.0
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      telnyx:
+        specifier: ^1.7.2
+        version: 1.27.0
+      tmp:
+        specifier: ^0.2.3
+        version: 0.2.3
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      underscore:
+        specifier: ^1.13.7
+        version: 1.13.7
+      validator:
+        specifier: ^13.15.0
+        version: 13.15.0
+      xss:
+        specifier: ^1.0.15
+        version: 1.0.15
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/erxes-api-shared:
     dependencies:
       '@apollo/server':
@@ -944,6 +1145,9 @@ importers:
       glob:
         specifier: ^11.0.1
         version: 11.0.1
+      mongodb-memory-server:
+        specifier: ^11.2.0
+        version: 11.2.0(socks@2.8.7)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -1005,6 +1209,192 @@ importers:
         specifier: ^2.7.0
         version: 2.7.1
 
+  backend/gateway/dist:
+    dependencies:
+      '@apollo/client':
+        specifier: ^3.11.8
+        version: 3.13.6(@types/react@19.1.12)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@bull-board/api':
+        specifier: ^6.7.7
+        version: 6.9.0(@bull-board/ui@6.9.0)
+      '@bull-board/express':
+        specifier: ^6.7.7
+        version: 6.9.0
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@envelop/core':
+        specifier: ^5.2.3
+        version: 5.2.3
+      '@escape.tech/graphql-armor-character-limit':
+        specifier: ^2.3.0
+        version: 2.3.0
+      '@escape.tech/graphql-armor-max-aliases':
+        specifier: ^2.6.0
+        version: 2.6.0
+      '@escape.tech/graphql-armor-max-depth':
+        specifier: ^2.4.0
+        version: 2.4.0
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@graphql-tools/schema':
+        specifier: ^10.0.23
+        version: 10.0.23(graphql@16.10.0)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: ^10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-parse-resolve-info:
+        specifier: ^4.14.1
+        version: 4.14.1(graphql@16.10.0)
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-ws:
+        specifier: ^5.16.0
+        version: 5.16.2(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      http-proxy-middleware:
+        specifier: ^3.0.3
+        version: 3.0.5
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      ws:
+        specifier: ^8.18.2
+        version: 8.21.0
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.1
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+
   backend/plugins/accounting_api:
     dependencies:
       erxes-api-shared:
@@ -1037,6 +1427,156 @@ importers:
       tmp:
         specifier: ^0.2.3
         version: 0.2.3
+
+  backend/plugins/content_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      html-to-text:
+        specifier: ^8.2.1
+        version: 8.2.1
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      simple-git:
+        specifier: ^3.26.0
+        version: 3.28.0
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tmp:
+        specifier: ^0.2.3
+        version: 0.2.3
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
 
   backend/plugins/erxes-agent_api:
     dependencies:
@@ -1113,6 +1653,183 @@ importers:
       mastra:
         specifier: 1.13.0
         version: 1.13.0(@hono/node-server@1.19.14(hono@4.12.25))(@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.2)(zod@3.25.76))(rxjs@7.8.2)(typescript@5.8.3)(zod@3.25.76)
+
+  backend/plugins/erxes-agent_api/dist:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.0.0
+        version: 1.2.12(zod@3.25.76)
+      '@ai-sdk/cohere':
+        specifier: ^1.0.0
+        version: 1.2.10(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^1.0.0
+        version: 1.2.22(zod@3.25.76)
+      '@ai-sdk/groq':
+        specifier: ^1.0.0
+        version: 1.2.9(zod@3.25.76)
+      '@ai-sdk/mistral':
+        specifier: ^1.0.0
+        version: 1.2.8(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^1.0.0
+        version: 1.3.24(zod@3.25.76)
+      '@ai-sdk/openai-compatible':
+        specifier: ^0.2.0
+        version: 0.2.16(zod@3.25.76)
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@mastra/core':
+        specifier: ^1.37.1
+        version: 1.42.0(@grpc/grpc-js@1.14.4)(express@4.21.2)(rxjs@7.8.2)(zod@3.25.76)
+      '@mastra/mongodb':
+        specifier: ^1.9.1
+        version: 1.9.2(@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@4.21.2)(rxjs@7.8.2)(zod@3.25.76))(encoding@0.1.13)(socks@2.8.7)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      fastembed:
+        specifier: ^2.1.0
+        version: 2.1.0
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: 2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      mammoth:
+        specifier: ^1.11.0
+        version: 1.12.0
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.4
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
 
   backend/plugins/frontline_api:
     dependencies:
@@ -1216,6 +1933,153 @@ importers:
         specifier: ^15.1.1
         version: 15.1.1
 
+  backend/plugins/loyalty_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      mathjs:
+        specifier: ^15.1.1
+        version: 15.1.1
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongodb:
+        specifier: 6.18.0
+        version: 6.18.0(socks@2.8.7)
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/plugins/mongolian_api:
     dependencies:
       erxes-api-shared:
@@ -1246,6 +2110,153 @@ importers:
         specifier: ^6.18.0
         version: 6.18.0(socks@2.8.7)
 
+  backend/plugins/operation_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.48
+        version: 0.5.48
+      mongodb:
+        specifier: ^6.18.0
+        version: 6.18.0(socks@2.8.7)
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/plugins/payment_api:
     dependencies:
       erxes-api-shared:
@@ -1260,6 +2271,156 @@ importers:
       stripe:
         specifier: ^17.2.1
         version: 17.7.0
+
+  backend/plugins/payment_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      qrcode:
+        specifier: ^1.5.0
+        version: 1.5.4
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      stripe:
+        specifier: ^17.2.1
+        version: 17.7.0
+      tailwindcss-animate:
+        specifier: 1.0.7
+        version: 1.0.7(tailwindcss@4.1.17)
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
 
   backend/plugins/payment_api/src/widget:
     dependencies:
@@ -1409,6 +2570,150 @@ importers:
         specifier: ^1.13.7
         version: 1.13.7
 
+  backend/plugins/sales_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      sift:
+        specifier: ^17.1.3
+        version: 17.1.3
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      underscore:
+        specifier: ^1.13.7
+        version: 1.13.7
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
+
   backend/plugins/tourism_api:
     dependencies:
       erxes-api-shared:
@@ -1420,6 +2725,150 @@ importers:
       moment-timezone:
         specifier: ^0.5.48
         version: 0.5.48
+
+  backend/plugins/tourism_api/dist:
+    dependencies:
+      '@apollo/server':
+        specifier: 4.11.3
+        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
+      '@apollo/subgraph':
+        specifier: 2.10.0
+        version: 2.10.0(graphql@16.10.0)
+      '@azure/storage-blob':
+        specifier: 12.29.1
+        version: 12.29.1
+      '@babel/preset-env':
+        specifier: 7.26.9
+        version: 7.26.9(@babel/core@7.29.7)
+      '@elastic/elasticsearch':
+        specifier: 7.17.14
+        version: 7.17.14
+      '@google-cloud/storage':
+        specifier: 7.17.3
+        version: 7.17.3(encoding@0.1.13)
+      '@preconstruct/cli':
+        specifier: 2.8.12
+        version: 2.8.12
+      '@prettier/sync':
+        specifier: 0.5.5
+        version: 0.5.5(prettier@3.6.2)
+      '@sentry/node':
+        specifier: 10.55.0
+        version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
+      '@sniptt/guards':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@trpc/client':
+        specifier: 11.0.4
+        version: 11.0.4(@trpc/server@11.0.4(typescript@5.8.3))(typescript@5.8.3)
+      '@trpc/server':
+        specifier: 11.0.4
+        version: 11.0.4(typescript@5.8.3)
+      '@types/babel__preset-env':
+        specifier: 7.10.0
+        version: 7.10.0
+      '@types/graphql':
+        specifier: 14.5.0
+        version: 14.5.0
+      '@types/ioredis':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@types/lodash':
+        specifier: 4.17.21
+        version: 4.17.21
+      aws-sdk:
+        specifier: 2.1692.0
+        version: 2.1692.0
+      babel-plugin-module-resolver:
+        specifier: 5.0.2
+        version: 5.0.2
+      bullmq:
+        specifier: 5.40.4
+        version: 5.40.4
+      cookie-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
+      csv-parse:
+        specifier: 6.2.1
+        version: 6.2.1
+      dataloader:
+        specifier: 2.2.3
+        version: 2.2.3
+      dayjs:
+        specifier: 1.11.13
+        version: 1.11.13
+      dotenv:
+        specifier: 16.4.7
+        version: 16.4.7
+      erxes-api-shared:
+        specifier: workspace:^
+        version: link:../../../erxes-api-shared
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      express-rate-limit:
+        specifier: 8.0.1
+        version: 8.0.1(express@4.21.2)
+      file-type:
+        specifier: 20.5.0
+        version: 20.5.0
+      form-data:
+        specifier: 4.0.2
+        version: 4.0.2
+      glob:
+        specifier: 11.0.1
+        version: 11.0.1
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
+      graphql-redis-subscriptions:
+        specifier: 2.7.0
+        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
+      graphql-subscriptions:
+        specifier: 3.0.0
+        version: 3.0.0(graphql@16.10.0)
+      graphql-tag:
+        specifier: ^2.12.6
+        version: 2.12.6(graphql@16.10.0)
+      helmet:
+        specifier: 8.1.0
+        version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.6.1
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.48
+        version: 0.5.48
+      mongoose:
+        specifier: 8.13.2
+        version: 8.13.2(socks@2.8.7)
+      nanoid:
+        specifier: 3.3.11
+        version: 3.3.11
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
 
   backend/services/automations:
     dependencies:
@@ -7753,9 +9202,37 @@ packages:
     resolution: {integrity: sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==}
     engines: {node: '>=18'}
 
+  '@sentry/core@10.55.0':
+    resolution: {integrity: sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==}
+    engines: {node: '>=18'}
+
   '@sentry/core@10.57.0':
     resolution: {integrity: sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==}
     engines: {node: '>=18'}
+
+  '@sentry/node-core@10.55.0':
+    resolution: {integrity: sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
 
   '@sentry/node-core@10.57.0':
     resolution: {integrity: sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==}
@@ -7781,9 +9258,22 @@ packages:
       '@opentelemetry/semantic-conventions':
         optional: true
 
+  '@sentry/node@10.55.0':
+    resolution: {integrity: sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==}
+    engines: {node: '>=18'}
+
   '@sentry/node@10.57.0':
     resolution: {integrity: sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==}
     engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.55.0':
+    resolution: {integrity: sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
 
   '@sentry/opentelemetry@10.57.0':
     resolution: {integrity: sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==}
@@ -10172,6 +11662,15 @@ packages:
       bare-buffer:
         optional: true
 
+  bare-fs@4.7.2:
+    resolution: {integrity: sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
   bare-os@3.6.2:
     resolution: {integrity: sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==}
     engines: {bare: '>=1.14.0'}
@@ -12540,6 +14039,15 @@ packages:
 
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -15379,6 +16887,14 @@ packages:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
 
+  mongodb-memory-server-core@11.2.0:
+    resolution: {integrity: sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server@11.2.0:
+    resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
+    engines: {node: '>=20.19.0'}
+
   mongodb@6.15.0:
     resolution: {integrity: sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==}
     engines: {node: '>=16.20.1'}
@@ -15582,6 +17098,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
 
   new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
@@ -18447,6 +19967,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -19776,6 +21299,10 @@ packages:
     resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
     engines: {node: '>=12'}
 
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
   yjs@13.6.27:
     resolution: {integrity: sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -19885,6 +21412,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@a2a-js/sdk@0.3.13(@grpc/grpc-js@1.14.4)(express@4.21.2)':
+    dependencies:
+      uuid: 11.1.0
+    optionalDependencies:
+      '@grpc/grpc-js': 1.14.4
+      express: 4.21.2
 
   '@a2a-js/sdk@0.3.13(@grpc/grpc-js@1.14.4)(express@5.2.1)':
     dependencies:
@@ -20010,6 +21544,29 @@ snapshots:
       optimism: 0.18.1
       prop-types: 15.8.1
       rehackt: 0.1.0(@types/react@18.3.1)(react@18.3.1)
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.8.1
+      zen-observable-ts: 1.2.5
+    optionalDependencies:
+      graphql-ws: 5.16.2(graphql@16.10.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@apollo/client@3.13.6(@types/react@19.1.12)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.10.0
+      graphql-tag: 2.12.6(graphql@16.10.0)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.1
+      prop-types: 15.8.1
+      rehackt: 0.1.0(@types/react@19.1.12)(react@18.3.1)
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
       tslib: 2.8.1
@@ -24191,6 +25748,48 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@4.21.2)(rxjs@7.8.2)(zod@3.25.76)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@grpc/grpc-js@1.14.4)(express@4.21.2)
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.25(zod@3.25.76)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@3.25.76)'
+      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
+      '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
+      '@isaacs/ttlcache': 2.1.5
+      '@lukeed/uuid': 2.0.1
+      '@mastra/schema-compat': 1.2.11(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@sindresorhus/slugify': 2.2.1
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      chat: 4.30.0(zod@3.25.76)
+      croner: 10.0.1
+      dotenv: 17.4.2
+      execa: 9.6.1
+      fastq: 1.19.1
+      gray-matter: 4.0.3
+      ignore: 7.0.5
+      json-schema: 0.4.0
+      lru-cache: 11.5.1
+      p-map: 7.0.4
+      p-retry: 7.1.1
+      picomatch: 4.0.3
+      posthog-node: 5.37.0(rxjs@7.8.2)
+      tokenx: 1.3.0
+      ws: 8.21.0
+      xxhash-wasm: 1.1.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@cfworker/json-schema'
+      - '@grpc/grpc-js'
+      - ai
+      - bufferutil
+      - express
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
   '@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.2)(zod@3.25.76)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@grpc/grpc-js@1.14.4)(express@5.2.1)
@@ -24306,6 +25905,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - zod
+
+  '@mastra/mongodb@1.9.2(@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@4.21.2)(rxjs@7.8.2)(zod@3.25.76))(encoding@0.1.13)(socks@2.8.7)':
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@mastra/core': 1.42.0(@grpc/grpc-js@1.14.4)(express@4.21.2)(rxjs@7.8.2)(zod@3.25.76)
+      cloudflare: 5.2.0(encoding@0.1.13)
+      mongodb: 7.3.0(socks@2.8.7)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - encoding
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
 
   '@mastra/mongodb@1.9.2(@mastra/core@1.42.0(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.2)(zod@3.25.76))(encoding@0.1.13)(socks@2.8.7)':
     dependencies:
@@ -29101,7 +30716,22 @@ snapshots:
       '@sentry-internal/replay-canvas': 10.57.0
       '@sentry/core': 10.57.0
 
+  '@sentry/core@10.55.0': {}
+
   '@sentry/core@10.57.0': {}
+
+  '@sentry/node-core@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.55.0
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@sentry/node-core@10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -29115,6 +30745,21 @@ snapshots:
       '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.55.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
+      '@sentry/node-core': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.2
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/node@10.57.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -29131,6 +30776,14 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
+
+  '@sentry/opentelemetry@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
 
   '@sentry/opentelemetry@10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -32156,8 +33809,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  bare-events@2.5.4:
-    optional: true
+  bare-events@2.5.4: {}
 
   bare-fs@4.5.3:
     dependencies:
@@ -32168,25 +33820,29 @@ snapshots:
       fast-fifo: 1.3.2
     optional: true
 
-  bare-os@3.6.2:
-    optional: true
+  bare-fs@4.7.2:
+    dependencies:
+      bare-events: 2.5.4
+      bare-path: 3.0.0
+      bare-stream: 2.7.0(bare-events@2.5.4)
+      bare-url: 2.3.2
+      fast-fifo: 1.3.2
+
+  bare-os@3.6.2: {}
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.6.2
-    optional: true
 
   bare-stream@2.7.0(bare-events@2.5.4):
     dependencies:
       streamx: 2.22.0
     optionalDependencies:
       bare-events: 2.5.4
-    optional: true
 
   bare-url@2.3.2:
     dependencies:
       bare-path: 3.0.0
-    optional: true
 
   base16@1.0.0: {}
 
@@ -32229,7 +33885,7 @@ snapshots:
   bin-version-check@5.1.0:
     dependencies:
       bin-version: 6.0.0
-      semver: 7.7.3
+      semver: 7.8.4
       semver-truncate: 3.0.0
 
   bin-version@6.0.0:
@@ -35096,6 +36752,10 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+
   fontkit@2.0.4:
     dependencies:
       '@swc/helpers': 0.5.15
@@ -35153,7 +36813,7 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.3
+      semver: 7.8.4
       tapable: 2.2.1
       typescript: 5.7.3
       webpack: 5.99.5(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)(webpack-cli@5.1.4)
@@ -37355,7 +39015,7 @@ snapshots:
       jest-util: 28.1.3
       natural-compare: 1.4.0
       pretty-format: 28.1.3
-      semver: 7.7.3
+      semver: 7.8.4
     transitivePeerDependencies:
       - supports-color
 
@@ -38852,6 +40512,46 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
+  mongodb-memory-server-core@11.2.0(socks@2.8.7):
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3(supports-color@8.1.1)
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
+      mongodb: 7.3.0(socks@2.8.7)
+      new-find-package-json: 2.0.0
+      semver: 7.8.4
+      tar-stream: 3.2.0
+      tslib: 2.8.1
+      yauzl: 3.4.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server@11.2.0(socks@2.8.7):
+    dependencies:
+      mongodb-memory-server-core: 11.2.0(socks@2.8.7)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+
   mongodb@6.15.0(socks@2.8.7):
     dependencies:
       '@mongodb-js/saslprep': 1.4.11
@@ -39009,6 +40709,12 @@ snapshots:
   neo-async@2.6.2: {}
 
   netmask@2.0.2: {}
+
+  new-find-package-json@2.0.0:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   new-github-release-url@2.0.0:
     dependencies:
@@ -41238,6 +42944,11 @@ snapshots:
       '@types/react': 18.3.1
       react: 18.3.1
 
+  rehackt@0.1.0(@types/react@19.1.12)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 19.1.12
+      react: 18.3.1
+
   rehackt@0.1.0(@types/react@19.1.12)(react@19.1.1):
     optionalDependencies:
       '@types/react': 19.1.12
@@ -42575,6 +44286,15 @@ snapshots:
       b4a: 1.6.7
       fast-fifo: 1.3.2
       streamx: 2.22.0
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.6.7
+      bare-fs: 4.7.2
+      fast-fifo: 1.3.2
+      streamx: 2.22.0
+    transitivePeerDependencies:
+      - bare-buffer
 
   tar@6.2.1:
     dependencies:
@@ -44020,6 +45740,10 @@ snapshots:
   yauzl@3.2.0:
     dependencies:
       buffer-crc32: 0.2.13
+      pend: 1.2.0
+
+  yauzl@3.4.0:
+    dependencies:
       pend: 1.2.0
 
   yjs@13.6.27:


### PR DESCRIPTION
## What

Follow-up to the merged point-in-time-revert efficiency work (#8164). Two things:

1. **Outcome-based test suite** for revert capture — verified against a **real MongoDB**, wired into CI (the repo ran no tests in CI before).
2. **Bulk-overflow → partial-undo** vertical slice (engine → consumer → UI): a bulk change too large to fully capture is now flagged and the Undo panel says so, instead of silently appearing to fully undo.

## Tests (outcome-based, real-Mongo oracle)

`erxes-api-shared` had a `tsconfig.spec` but no jest config or test target, so its one test never ran. This adds the jest config + nx `test` target + `mongodb-memory-server`, so the specs assert what **MongoDB actually does**, never what the implementation does — the expected values come from the database, so a test can't "mirror" the code it checks.

- **`afterImage.spec`** — the in-memory after-image must equal the document Mongo actually stored across `$set`/`$unset`/nested/array/**casting** (`string→Number/Date`)/`findOneAndUpdate`; complex ops (`$inc`/`$push`) classify null; the `timestamps:true` `$setOnInsert` injection is asserted against the live server.
- **`revertCaptureSpine.spec`** — the REAL hooks (queue intercepted in-process) journal the exact before→after diff / prior document that actually occurred; `updateMany` emits ONE batch message with an entry per matched doc; a failing queue never breaks the write; creates are not journaled.
- **`revertSelectivity.spec`** — spec-derived deny/allow set (log family denied; `blogs`/`catalogs` allowed; per-schema opt-out).
- **`revertCaptureOverflow.spec`** — a bulk over the cap is flagged; at the cap is not.

`pnpm nx test erxes-api-shared` → **87 passing**. Runs in CI via `.github/workflows/ci-test-revert.yml` (mongod binary cached).

## Bulk-overflow marker (engine gap + UI)

Previously a bulk delete/update matching more rows than `REVERT_AUTO_JOURNAL_MAX` truncated its snapshot **silently** — the overflow was unrevertable with no signal.

- **Capture** (`revertCapture.ts`) — fetches one past the cap; when exceeded, stamps the journal entry `revertOverflow: true` (snapshot still capped).
- **Consumer** (`services/logs`) — persists the marker onto each expanded Log row's `payload` (deleteMany + updateBatch). Exposed via the existing `Log.payload: JSON` — no GraphQL change.
- **UI** (`LogRevertPanel`) — shows a calm amber notice that the change is only partially undoable, in the panel's existing plain-language tone.

## Verification
- `nx test erxes-api-shared`: **87 green** (real-Mongo oracle).
- `tsc` clean: `erxes-api-shared` (lib), `services/logs` (app); `core-api` unchanged.
- Test files excluded from the production lib build.

## Notes
- `pnpm-lock.yaml` grows from the `mongodb-memory-server` devDependency (transitive deps only).
- The overflow UI banner is an additive conditional render reading `payload.revertOverflow`; reproducing it visually needs a >cap bulk, so it's covered by the typecheck + the backend outcome test rather than a screenshot here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk change tracking to properly flag when operations exceed limits and cannot be fully undone.

* **New Features**
  * Added warning messages in the Undo panel informing users when bulk operation reverts can only be partially applied due to journal truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->