### PR TITLE
feat(erxes-agent): Agent Skills — teachable task playbooks

### DIFF
--- a/backend/plugins/erxes-agent_api/docs/AGENT-SKILLS.md
+++ b/backend/plugins/erxes-agent_api/docs/AGENT-SKILLS.md
@@ -1,0 +1,129 @@
+# Agent Skills — teach the agent a task once, reliably
+
+**Status:** Shipped (v1). **Module:** `src/modules/skill`. **Flag:** none — always on.
+
+## The problem this solves
+
+"I want to easily teach the agent anything, so it doesn't fail at specific
+tasks." Before this, the only ways to steer an agent were:
+
+| Mechanism            | What it is                                  | Why it isn't "teach a task" |
+| -------------------- | ------------------------------------------- | --------------------------- |
+| Agent `instructions` | one always-loaded system-prompt blob        | doesn't scale — every task you add bloats every prompt and the model loses focus |
+| Company knowledge    | RAG over company **data** (deals, KB, …)    | retrieves *facts*, not *how-to procedures* |
+| Learning             | auto-distilled lessons from past chats      | implicit & automatic — you can't deliberately author "do X this way" |
+| Workflows            | declarative durable automations             | powerful but heavyweight; not "just tell it how" |
+
+**Skills** add the missing piece: **procedural memory** — a named, authored
+playbook for one task, retrieved only when relevant.
+
+## What the research says (why it's built this way)
+
+This design follows the current expert consensus, drawn from primary sources:
+
+- **Anthropic — Agent Skills** ([engineering blog](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)):
+  skills load via **progressive disclosure** in levels — at startup only each
+  skill's **name + description** is in the prompt; the **full body** is read
+  only when a task matches; deeper files load on demand. This keeps many skills
+  available at a tiny context cost.
+- **"Skills are procedural memory"** ([SoK: Agentic Skills, arXiv 2602.20867](https://arxiv.org/abs/2602.20867)):
+  *"a curated skill that has been verified across multiple contexts is more
+  reliable than an ad-hoc plan generated on the fly."* Reliability is the point,
+  not convenience.
+- **ACE — Agentic Context Engineering** ([arXiv 2510.04618](https://arxiv.org/abs/2510.04618)):
+  contexts should be **detailed, structured playbooks**, not terse summaries
+  (reject "brevity bias"); rewriting context monolithically causes **context
+  collapse**. So a skill's body should be rich, and edits are independent rows —
+  never a global rewrite.
+- **LangChain — Context Engineering** ([blog](https://www.langchain.com/blog/context-engineering-for-agents)):
+  memory splits into **procedural** (how-to), **episodic** (examples), and
+  **semantic** (facts). A fixed always-loaded file (CLAUDE.md / Cursor rules) is
+  the simplest procedural store, but for many procedures you **select** the
+  relevant ones rather than loading all. Skills do exactly that.
+
+## How it works (two levels of progressive disclosure)
+
+```
+Level 1 — ALWAYS in the system prompt (lean index):
+  ## Skills — your verified playbooks (load before acting)
+  - refund-order — when a customer wants money back on a paid order
+  - close-deal   — when a deal is ready to be marked won
+  → "call load_skill with the exact name BEFORE doing a matching task"
+
+Level 2 — ON DEMAND (full body), via the load_skill tool:
+  load_skill("refund-order")
+  → { found: true, instructions: "<the full step-by-step playbook>" }
+```
+
+- The **index** (name + description only) is built per agent in
+  `agentRuntime.ts` and injected by `instructions/routing.ts` (`SKILLS_BLOCK`).
+- The **body** is fetched live from Mongo by the `load_skill` tool
+  (`mastra/tools/skillTools.ts`) — so editing a playbook takes effect on the
+  next use, and the lookup is **scoped to the asking agent** (an agent can never
+  load another agent's private or disabled skill).
+- The agent cache key includes a **skills fingerprint**
+  (`modules/skill/skillScope.ts#skillsFingerprint`), mirroring the existing
+  installed-services `inventory.fingerprint`: adding/editing/removing a skill
+  rebuilds the agent and refreshes the index on the very next turn.
+
+## Data model — `mastra_agent_skills`
+
+| Field           | Meaning |
+| --------------- | ------- |
+| `name`          | kebab-case identifier the agent passes to `load_skill` (unique per tenant; normalised on save) |
+| `title`         | human label for the UI |
+| `description`   | **the "when to use" trigger — always loaded.** The single most important field for reliable matching |
+| `body`          | the full playbook (markdown): steps, exact operations, gotchas, examples. Loaded on demand, so make it detailed |
+| `tags`          | optional grouping |
+| `agentIds`      | **empty = global** (every agent); otherwise scoped to the listed agents |
+| `isEnabled`     | disabled skills neither index nor load |
+| `usageCount` / `lastUsedAt` | best-effort telemetry (future curation) |
+
+## GraphQL API
+
+```graphql
+# queries
+mastraAgentSkills(agentId: String): [MastraAgentSkill]   # all, or those one agent can use
+mastraAgentSkill(_id: String!): MastraAgentSkill
+
+# mutations
+mastraAgentSkillAdd(doc: MastraAgentSkillInput!): MastraAgentSkill
+mastraAgentSkillEdit(_id: String!, doc: MastraAgentSkillEditInput!): MastraAgentSkill
+mastraAgentSkillRemove(_id: String!): JSON
+```
+
+Permissions (`meta/permissions.ts`, module `skill`): `agentSkillsView` (always —
+non-secret), `agentSkillsCreate`, `agentSkillsEdit`, `agentSkillsRemove`.
+
+## Authoring a good skill
+
+Following the research above:
+
+1. **`description` is a trigger, not a summary.** Write *when* to use it, in the
+   words a user would use: "when a customer wants a refund on an order they
+   already paid for." This is what the agent matches against.
+2. **`body` should be detailed and structured.** Numbered steps; name the exact
+   operations to run and the arguments that matter; call out gotchas; include a
+   worked example. Don't compress — the body only loads when needed.
+3. **One task per skill.** Split unrelated procedures into separate skills so the
+   agent loads only what applies (progressive disclosure).
+4. **Scope deliberately.** Leave `agentIds` empty for company-wide playbooks;
+   scope sensitive ones to specific agents.
+
+## Files
+
+```
+modules/skill/@types/skill.ts                         types
+modules/skill/db/definitions/skill.ts                 mongoose schema
+modules/skill/db/models/Skill.ts                      model (CRUD + runtime lookups)
+modules/skill/skillScope.ts                           pure scope + fingerprint rules (unit-tested)
+modules/skill/graphql/...                             CRUD resolvers + schema
+mastra/tools/skillTools.ts                            load_skill tool (Level 2)
+mastra/instructions/routing.ts                        SKILLS_BLOCK (Level 1 index)
+mastra/agentRuntime.ts                                fetch index, fingerprint cache, bind tool
+```
+
+Tests (real-oracle, no DB needed): `modules/skill/__tests__/skillScope.test.ts`
+(scope + fingerprint + slug rules), `mastra/tools/__tests__/skillTools.test.ts`
+(load_skill contract), `mastra/instructions/__tests__/routing.test.ts` (the
+always-loaded index never inlines the body).

--- a/backend/plugins/erxes-agent_api/src/apollo/resolvers/mutations.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/resolvers/mutations.ts
@@ -5,6 +5,7 @@ import { sessionMutations } from '@/session/graphql/resolvers/mutations/session'
 import { workflowMutations } from '@/workflow/graphql/resolvers/mutations/workflow';
 import { learningMutations } from '@/learning/graphql/resolvers/mutations/learning';
 import { scheduleMutations } from '@/schedule/graphql/resolvers/mutations/schedule';
+import { skillMutations } from '@/skill/graphql/resolvers/mutations/skill';
 
 export const mutations = {
   ...agentMutations,
@@ -14,4 +15,5 @@ export const mutations = {
   ...workflowMutations,
   ...learningMutations,
   ...scheduleMutations,
+  ...skillMutations,
 };

--- a/backend/plugins/erxes-agent_api/src/apollo/resolvers/queries.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/resolvers/queries.ts
@@ -6,6 +6,7 @@ import { sessionQueries } from '@/session/graphql/resolvers/queries/session';
 import { workflowQueries } from '@/workflow/graphql/resolvers/queries/workflow';
 import { learningQueries } from '@/learning/graphql/resolvers/queries/learning';
 import { scheduleQueries } from '@/schedule/graphql/resolvers/queries/schedule';
+import { skillQueries } from '@/skill/graphql/resolvers/queries/skill';
 
 export const queries = {
   ...agentQueries,
@@ -16,4 +17,5 @@ export const queries = {
   ...workflowQueries,
   ...learningQueries,
   ...scheduleQueries,
+  ...skillQueries,
 };

--- a/backend/plugins/erxes-agent_api/src/apollo/schema/schema.ts
+++ b/backend/plugins/erxes-agent_api/src/apollo/schema/schema.ts
@@ -38,6 +38,11 @@ import {
   queries as scheduleQueries,
   mutations as scheduleMutations,
 } from '@/schedule/graphql/schemas/schedule';
+import {
+  types as skillTypes,
+  queries as skillQueries,
+  mutations as skillMutations,
+} from '@/skill/graphql/schemas/skill';
 
 export const types = `
   ${agentTypes}
@@ -48,6 +53,7 @@ export const types = `
   ${workflowTypes}
   ${learningTypes}
   ${scheduleTypes}
+  ${skillTypes}
 `;
 
 export const queries = `
@@ -59,6 +65,7 @@ export const queries = `
   ${workflowQueries}
   ${learningQueries}
   ${scheduleQueries}
+  ${skillQueries}
 `;
 
 export const mutations = `
@@ -70,4 +77,5 @@ export const mutations = `
   ${workflowMutations}
   ${learningMutations}
   ${scheduleMutations}
+  ${skillMutations}
 `;

--- a/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
+++ b/backend/plugins/erxes-agent_api/src/connectionResolvers.ts
@@ -53,6 +53,11 @@ import {
   IMastraScheduleModel,
 } from '@/schedule/db/models/Schedule';
 import { IMastraScheduleDocument } from '@/schedule/@types/schedule';
+import {
+  loadAgentSkillClass,
+  IMastraAgentSkillModel,
+} from '@/skill/db/models/Skill';
+import { IMastraAgentSkillDocument } from '@/skill/@types/skill';
 
 export interface IModels {
   MastraAgent: IMastraAgentModel;
@@ -65,6 +70,7 @@ export interface IModels {
   MastraLearning: IMastraLearningModel;
   MastraFeedback: IMastraFeedbackModel;
   MastraSchedule: IMastraScheduleModel;
+  MastraAgentSkill: IMastraAgentSkillModel;
 }
 
 export interface IContext extends IMainContext {
@@ -126,6 +132,11 @@ export const loadClasses = (db: mongoose.Connection): IModels => {
     IMastraScheduleDocument,
     IMastraScheduleModel
   >('mastra_schedules', loadScheduleClass(models));
+
+  models.MastraAgentSkill = db.model<
+    IMastraAgentSkillDocument,
+    IMastraAgentSkillModel
+  >('mastra_agent_skills', loadAgentSkillClass(models));
 
   return models;
 };

--- a/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/agentRuntime.ts
@@ -7,6 +7,8 @@ import { buildModel } from './providers';
 import { buildSystemPrompt, ToolInfo } from './instructions/routing';
 import { getOperationRegistry } from './tools/operationRegistry';
 import { buildErxesMetaTools } from './tools/metaTools';
+import { buildSkillTools } from './tools/skillTools';
+import { skillsFingerprint } from '@/skill/skillScope';
 import {
   resolveToolPolicy,
   isBuiltinAllowed,
@@ -31,7 +33,7 @@ const agentCache = new Map<string, Agent>();
 const toolsCache = new Map<string, ToolsInput>();
 
 // Increment this whenever routing.ts, the meta-tools, or provider logic changes.
-const ROUTING_VERSION = 25;
+const ROUTING_VERSION = 26;
 
 export interface AgentWithTools {
   agent: Agent;
@@ -51,9 +53,13 @@ export async function getOrCreateAgent(
   // to the "os" scope.
   const useMemory =
     isAdvancedMemoryEnabled() && agentConfig.memoryEnabled !== false;
-  const [providers, settings] = await Promise.all([
+  const [providers, settings, skillIndex] = await Promise.all([
     models.MastraProvider.find({ isEnabled: true }),
     models.MastraSettings.getSettings(),
+    // The lean skill index (name + description, no body) for this agent. Powers
+    // the always-loaded "Skills" prompt block AND the cache fingerprint below,
+    // so teaching/editing a skill takes effect on the very next turn.
+    models.MastraAgentSkill.listIndexForAgent(agentConfig.agentId),
   ]);
 
   // The agent's reach: 'all' (every erxes operation + builtin) by default, or a
@@ -80,7 +86,11 @@ export async function getOrCreateAgent(
   const evaluationEnabled = isEvaluationEnabled();
   const evalTag = evaluationEnabled ? subdomain || 'os' : 'off';
 
-  const cacheKey = `${agentConfig._id}:${agentConfig.updatedAt?.getTime?.() ?? 0}:v${ROUTING_VERSION}:${inventory.fingerprint}:mem${useMemory ? subdomain : 'off'}:eval${evalTag}`;
+  // Skill index fingerprint — like inventory.fingerprint, it joins the cache key
+  // so adding/editing/removing a skill rebuilds the agent (and its prompt).
+  const skillsFp = skillsFingerprint(skillIndex);
+
+  const cacheKey = `${agentConfig._id}:${agentConfig.updatedAt?.getTime?.() ?? 0}:v${ROUTING_VERSION}:${inventory.fingerprint}:skills${skillsFp}:mem${useMemory ? subdomain : 'off'}:eval${evalTag}`;
 
   const cached = agentCache.get(cacheKey);
   if (cached) {
@@ -152,6 +162,22 @@ export async function getOrCreateAgent(
     });
   }
 
+  // Skill playbooks (procedural memory). Bound whenever this agent has at least
+  // one available skill; load_skill is scoped to this agent, so it can only
+  // read this agent's own enabled skills. Not policy-gated — skills are the
+  // agent's own taught behaviour, already scoped per agent.
+  const skillNames = skillIndex.map((skill) => skill.name);
+  if (skillNames.length) {
+    Object.assign(
+      tools,
+      buildSkillTools({
+        models,
+        agentId: agentConfig.agentId,
+        availableNames: skillNames,
+      }),
+    );
+  }
+
   // Conversation persistence + recent-history replay + recall are owned by the
   // attached Mastra Memory (the chat store IS the native memory store; see
   // memory below + session/nativeStore.ts). No custom message store.
@@ -161,6 +187,10 @@ export async function getOrCreateAgent(
     scopeLine: scopeSummary(policy),
     inventoryLines: inventory.lines,
     builtins: builtinInfos,
+    skills: skillIndex.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+    })),
   });
 
   // Workflow builds are 20+ steps (guide → searches → validate → simulate →

--- a/backend/plugins/erxes-agent_api/src/mastra/instructions/__tests__/routing.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/instructions/__tests__/routing.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Spec tests for the always-loaded skill index (Level 1 of progressive
+ * disclosure) in the system prompt. The contract:
+ *
+ *   - When the agent has skills, the prompt carries a "Skills" section listing
+ *     each skill's name + when-to-use, and tells the model to load_skill before
+ *     acting on a match.
+ *   - The index never inlines the full playbook body — that is the whole point
+ *     of progressive disclosure (the body arrives only via load_skill).
+ *   - With no skills, no Skills section appears at all.
+ *   - The Skills section precedes the agent's own custom instructions.
+ */
+import { buildSystemPrompt } from '../routing';
+
+const baseOpts = {
+  hasErxesTools: false,
+  scopeLine: '',
+  inventoryLines: [],
+  builtins: [],
+};
+
+describe('buildSystemPrompt — skill index (Level 1)', () => {
+  it('lists each skill by name and when-to-use, and instructs load_skill first', () => {
+    const prompt = buildSystemPrompt('', {
+      ...baseOpts,
+      skills: [
+        { name: 'refund-order', description: 'when a customer wants money back' },
+        { name: 'close-deal', description: 'when a deal is ready to win' },
+      ],
+    });
+
+    expect(prompt).toContain('Skills');
+    expect(prompt).toContain('refund-order');
+    expect(prompt).toContain('when a customer wants money back');
+    expect(prompt).toContain('close-deal');
+    expect(prompt).toContain('when a deal is ready to win');
+    // The agent is told to pull the full instructions before acting.
+    expect(prompt).toMatch(/load_skill/);
+  });
+
+  it('omits the Skills section entirely when there are no skills', () => {
+    expect(buildSystemPrompt('', baseOpts)).not.toMatch(/##\s*Skills/);
+    expect(
+      buildSystemPrompt('', { ...baseOpts, skills: [] }),
+    ).not.toMatch(/##\s*Skills/);
+  });
+
+  it('places the skill index before the agent custom instructions', () => {
+    const prompt = buildSystemPrompt('Always greet the user by name.', {
+      ...baseOpts,
+      skills: [{ name: 'refund-order', description: 'money back' }],
+    });
+    const skillsAt = prompt.indexOf('Skills');
+    const instructionsAt = prompt.indexOf('Always greet the user by name.');
+    expect(skillsAt).toBeGreaterThanOrEqual(0);
+    expect(instructionsAt).toBeGreaterThan(skillsAt);
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/instructions/routing.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/instructions/routing.ts
@@ -68,6 +68,14 @@ export interface ToolInfo {
   description?: string;
 }
 
+// The lean "always loaded" half of a skill: just enough for the agent to know
+// the playbook exists and when it applies. The full body is pulled in on
+// demand via load_skill (progressive disclosure).
+export interface SkillInfo {
+  name: string;
+  description: string;
+}
+
 // Matches the auto-generated placeholder descriptions (e.g. "mutation brandsAdd",
 // "query users") that carry no real meaning — fall back to a humanized name then.
 const GENERIC_DESC = /^(query|mutation)\s+\S+$/i;
@@ -163,6 +171,27 @@ ${hasRenderChart ? `\n${RENDER_CHART_HINT}` : ''}
 `.trim();
 };
 
+// Progressive disclosure (the Anthropic Agent Skills pattern): the index below
+// is ALWAYS in the prompt so the agent knows which verified playbooks exist and
+// when each applies; the detailed body is pulled in only when needed via
+// load_skill. This is how an admin "teaches" the agent a specific task once and
+// the agent stops failing at it — a loaded playbook overrides improvisation.
+const SKILLS_BLOCK = (skills: SkillInfo[]) =>
+  `
+## Skills — your verified playbooks (load before acting)
+
+You have step-by-step playbooks for specific tasks. Each one below is something you have been TAUGHT to do a precise way.
+
+Available skills (name — when to use):
+${skills.map((s) => `- ${s.name} — ${s.description}`).join('\n')}
+
+How to use them:
+1. When the user's request matches one of these skills, FIRST call load_skill with its exact name to read the full instructions.
+2. Then follow those instructions exactly — they are verified and take priority over your own guesses about how to do the task.
+3. If several could apply, load the closest match. If none clearly apply, proceed normally with your other tools.
+4. Never tell the user you are "loading a skill" or mention these names — just do the task.
+`.trim();
+
 const NO_TOOLS_BLOCK = `
 ## Capabilities
 
@@ -173,7 +202,8 @@ If the user asks you to read or change erxes data, explain that this agent is no
 /**
  * Builds the full system prompt for an agent.
  *
- *   [small-talk] + [erxes search→execute block?] + [builtin block?] + [agent instructions]
+ *   [small-talk] + [erxes search→execute block?] + [builtin block?]
+ *     + [skills index?] + [agent instructions]
  *
  * When the agent has neither erxes operations nor builtins, a short "no tools"
  * block keeps it honest about its (chat-only) capabilities.
@@ -185,6 +215,7 @@ export function buildSystemPrompt(
     scopeLine: string;
     inventoryLines?: string[];
     builtins: ToolInfo[];
+    skills?: SkillInfo[];
   },
 ): string {
   const parts: string[] = [SMALL_TALK_BLOCK.trim(), COMMUNICATION_BLOCK];
@@ -194,6 +225,10 @@ export function buildSystemPrompt(
   }
   if (opts.builtins.length) parts.push(BUILTIN_BLOCK(opts.builtins));
   if (!opts.hasErxesTools && !opts.builtins.length) parts.push(NO_TOOLS_BLOCK);
+
+  // The skill index sits between the agent's capabilities and its custom
+  // instructions: it is a capability, but custom instructions may reference it.
+  if (opts.skills?.length) parts.push(SKILLS_BLOCK(opts.skills));
 
   if (agentInstructions?.trim()) {
     parts.push(`## Agent Instructions\n\n${agentInstructions.trim()}`);

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/skillTools.test.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/__tests__/skillTools.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Contract tests for the load_skill tool (Level 2 of progressive disclosure).
+ * The Mastra tool wrapper is mocked so each tool's `execute` is directly
+ * callable; the model layer is a hand-built fake so we assert the tool's
+ * behaviour, not Mongo's:
+ *
+ *   - A known, in-scope skill returns its full body as `instructions`.
+ *   - An unknown/out-of-scope name returns found:false plus the available names
+ *     (so a mistyped name self-corrects instead of dead-ending).
+ *   - Loading a skill records a best-effort usage hit; a miss records nothing.
+ */
+jest.mock('@mastra/core/tools', () => ({
+  createTool: (cfg: unknown) => cfg,
+}));
+
+import { buildSkillTools } from '../skillTools';
+import type { IModels } from '~/connectionResolvers';
+
+const asTool = <TResult>(tool: unknown) =>
+  tool as { execute: (input: Record<string, unknown>) => Promise<TResult> };
+
+interface LoadResult {
+  found: boolean;
+  name?: string;
+  title?: string;
+  instructions?: string;
+  error?: string;
+  available?: string[];
+}
+
+const REFUND_SKILL = {
+  _id: 'skill-1',
+  name: 'refund-order',
+  title: 'Refund a paid order',
+  body: '1. Find the order. 2. Issue the refund. 3. Notify the customer.',
+};
+
+const buildFakeModels = () => {
+  const findForAgentByName = jest.fn((_agentId: string, name: string) =>
+    Promise.resolve(name === REFUND_SKILL.name ? REFUND_SKILL : null),
+  );
+  const recordSkillUse = jest.fn(() => Promise.resolve());
+  const models = {
+    MastraAgentSkill: { findForAgentByName, recordSkillUse },
+  } as unknown as IModels;
+  return { models, findForAgentByName, recordSkillUse };
+};
+
+const makeTool = (overrides?: { availableNames?: string[] }) => {
+  const fake = buildFakeModels();
+  const { load_skill } = buildSkillTools({
+    models: fake.models,
+    agentId: 'agent-1',
+    availableNames: overrides?.availableNames ?? ['refund-order', 'close-deal'],
+  });
+  return { tool: load_skill, ...fake };
+};
+
+describe('load_skill', () => {
+  it('returns the full playbook body for a known, in-scope skill', async () => {
+    const { tool, findForAgentByName, recordSkillUse } = makeTool();
+    const res = await asTool<LoadResult>(tool).execute({ name: 'refund-order' });
+
+    expect(res.found).toBe(true);
+    expect(res.name).toBe('refund-order');
+    expect(res.title).toBe('Refund a paid order');
+    expect(res.instructions).toBe(REFUND_SKILL.body);
+    // It looked the skill up scoped to THIS agent.
+    expect(findForAgentByName).toHaveBeenCalledWith('agent-1', 'refund-order');
+    // And recorded a usage hit against the resolved skill.
+    expect(recordSkillUse).toHaveBeenCalledWith('skill-1');
+  });
+
+  it('reports a miss with the available names and records no usage', async () => {
+    const { tool, recordSkillUse } = makeTool();
+    const res = await asTool<LoadResult>(tool).execute({ name: 'nope' });
+
+    expect(res.found).toBe(false);
+    expect(res.error).toMatch(/nope/);
+    expect(res.available).toEqual(['refund-order', 'close-deal']);
+    expect(recordSkillUse).not.toHaveBeenCalled();
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/mastra/tools/skillTools.ts
+++ b/backend/plugins/erxes-agent_api/src/mastra/tools/skillTools.ts
@@ -1,0 +1,58 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { IModels } from '~/connectionResolvers';
+
+// Level 2 of progressive disclosure (the Anthropic Agent Skills pattern): the
+// agent always sees the lean skill INDEX in its system prompt (name +
+// description); when a task matches one, it calls load_skill to pull the full
+// playbook into context and follow it. The body is fetched live from Mongo on
+// every call, so an edited playbook takes effect immediately — and the lookup
+// is scoped to THIS agent, so one agent can never read another's private skill.
+export function buildSkillTools(params: {
+  models: IModels;
+  agentId: string;
+  // The names visible to this agent — surfaced back to the model on a miss so a
+  // mistyped name self-corrects without a dead end.
+  availableNames: string[];
+}) {
+  const { models, agentId, availableNames } = params;
+
+  const loadSkill = createTool({
+    id: 'load_skill',
+    description:
+      'Load the full step-by-step instructions for one of your skills (named ' +
+      'playbooks listed under "Skills" in your instructions). BEFORE doing a ' +
+      'task that matches a skill, call this with its EXACT name, then follow the ' +
+      'returned instructions precisely — they are verified and take priority ' +
+      'over improvising.',
+    inputSchema: z.object({
+      name: z
+        .string()
+        .describe('Exact skill name from your Skills list, e.g. "refund-order".'),
+    }),
+    outputSchema: z.any(),
+    execute: async ({ name }) => {
+      const skill = await models.MastraAgentSkill.findForAgentByName(
+        agentId,
+        name,
+      );
+      if (!skill) {
+        return {
+          found: false,
+          error: `No skill named "${name}" is available to you.`,
+          available: availableNames,
+        };
+      }
+      // Best-effort usage telemetry; never blocks the load.
+      void models.MastraAgentSkill.recordSkillUse(skill._id);
+      return {
+        found: true,
+        name: skill.name,
+        title: skill.title,
+        instructions: skill.body,
+      };
+    },
+  });
+
+  return { load_skill: loadSkill };
+}

--- a/backend/plugins/erxes-agent_api/src/meta/permissions.ts
+++ b/backend/plugins/erxes-agent_api/src/meta/permissions.ts
@@ -161,6 +161,15 @@ const SPECS: Spec[] = [
     viewAlways: true,
     edit: 'Edit, re-status or pin a learning statement',
   },
+  {
+    name: 'skill',
+    description: 'Agent skills (teachable task playbooks)',
+    prefix: 'agentSkills',
+    noun: 'skill',
+    view: 'List and read agent skill playbooks',
+    viewAlways: true,
+    edit: 'Update a skill playbook or its agent scope',
+  },
 ];
 
 const modules: IPermissionModule[] = SPECS.map((s) =>
@@ -216,6 +225,7 @@ export const permissions: IPermissionConfig = {
         grant('workflow', ['workflowsView', 'workflowsRun']),
         grant('schedule', ['schedulesView']),
         grant('learning', ['learningView']),
+        grant('skill', ['agentSkillsView']),
       ],
     },
     {
@@ -229,6 +239,7 @@ export const permissions: IPermissionConfig = {
         grant('workflow', ['workflowsView']),
         grant('schedule', ['schedulesView']),
         grant('learning', ['learningView']),
+        grant('skill', ['agentSkillsView']),
       ],
     },
   ],

--- a/backend/plugins/erxes-agent_api/src/modules/skill/@types/skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/@types/skill.ts
@@ -1,0 +1,51 @@
+import { Document } from 'mongoose';
+
+// A "skill" is procedural memory: a named, authored playbook that teaches the
+// agent how to do ONE specific task reliably. It mirrors the Anthropic Agent
+// Skills design — a lightweight index (name + description) is always in the
+// prompt, and the full `body` is pulled in on demand via the load_skill tool
+// (progressive disclosure). This keeps the system prompt lean while letting an
+// admin teach the agent any number of tasks without it failing on them.
+export interface IMastraAgentSkill {
+  // Stable kebab-case identifier the agent passes to load_skill, e.g.
+  // "refund-a-paid-order". Unique per tenant.
+  name: string;
+  // Human-facing label shown in the management UI.
+  title: string;
+  // The "when to use" trigger — always loaded into the prompt index, so the
+  // agent can decide whether this skill is relevant. The single most important
+  // field for reliable matching.
+  description: string;
+  // The full playbook (markdown): step-by-step instructions, the exact
+  // operations to run, gotchas, and worked examples. Loaded only when the agent
+  // decides the skill applies — so it can be as detailed as needed.
+  body: string;
+  // Optional free-text tags for grouping/filtering in the UI.
+  tags?: string[];
+  // Agents this skill is available to. EMPTY = available to every agent
+  // (a global playbook); otherwise scoped to the listed agentIds.
+  agentIds?: string[];
+  // Disabled skills neither appear in the index nor load.
+  isEnabled?: boolean;
+  createdByUserId?: string;
+  // Light telemetry powering future curation ("verified across contexts").
+  usageCount?: number;
+  lastUsedAt?: Date;
+}
+
+export interface IMastraAgentSkillDocument extends IMastraAgentSkill, Document {
+  _id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// The lean projection used to build the always-loaded prompt index and the
+// cache fingerprint. Deliberately excludes `body` — that is the whole point of
+// progressive disclosure.
+export interface IMastraAgentSkillIndexEntry {
+  _id: string;
+  name: string;
+  title: string;
+  description: string;
+  updatedAt?: Date;
+}

--- a/backend/plugins/erxes-agent_api/src/modules/skill/__tests__/skillScope.test.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/__tests__/skillScope.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Spec tests for the agent-skill scope + fingerprint rules. The oracle is the
+ * specification itself, stated independently in each test — NOT values copied
+ * from the implementation:
+ *
+ *   - A skill is visible to an agent IFF it is enabled AND (global OR scoped to
+ *     that agent). "Global" means an empty/absent agent list.
+ *   - The index fingerprint changes iff the set of skills, their names, or their
+ *     edit times change — and never depends on ordering.
+ *   - A name normalises to a stable kebab-case slug.
+ */
+import {
+  isSkillAvailableToAgent,
+  normalizeSkillName,
+  skillsFingerprint,
+} from '@/skill/skillScope';
+
+describe('isSkillAvailableToAgent — enabled AND (global OR scoped)', () => {
+  it('makes a global skill (no agent list) visible to ANY agent', () => {
+    const global = { isEnabled: true, agentIds: [] as string[] };
+    expect(isSkillAvailableToAgent(global, 'agent-1')).toBe(true);
+    expect(isSkillAvailableToAgent(global, 'agent-2')).toBe(true);
+  });
+
+  it('treats an absent agent list the same as global', () => {
+    expect(isSkillAvailableToAgent({ isEnabled: true }, 'anyone')).toBe(true);
+  });
+
+  it('defaults a skill with no isEnabled flag to enabled', () => {
+    expect(isSkillAvailableToAgent({ agentIds: [] }, 'anyone')).toBe(true);
+  });
+
+  it('shows a scoped skill ONLY to the agents it names', () => {
+    const scoped = { isEnabled: true, agentIds: ['agent-1', 'agent-3'] };
+    expect(isSkillAvailableToAgent(scoped, 'agent-1')).toBe(true);
+    expect(isSkillAvailableToAgent(scoped, 'agent-3')).toBe(true);
+    expect(isSkillAvailableToAgent(scoped, 'agent-2')).toBe(false);
+  });
+
+  it('hides a disabled skill from everyone, even the agent it is scoped to', () => {
+    expect(
+      isSkillAvailableToAgent({ isEnabled: false, agentIds: ['agent-1'] }, 'agent-1'),
+    ).toBe(false);
+    expect(
+      isSkillAvailableToAgent({ isEnabled: false, agentIds: [] }, 'agent-1'),
+    ).toBe(false);
+  });
+});
+
+describe('normalizeSkillName — stable kebab-case slug', () => {
+  it('lowercases, trims, and collapses runs of non-alphanumerics to single dashes', () => {
+    expect(normalizeSkillName('  Refund a Paid Order!! ')).toBe(
+      'refund-a-paid-order',
+    );
+    expect(normalizeSkillName('Close   Deal')).toBe('close-deal');
+  });
+
+  it('leaves an already-normalised slug unchanged', () => {
+    expect(normalizeSkillName('refund-order')).toBe('refund-order');
+  });
+
+  it('strips leading and trailing separators', () => {
+    expect(normalizeSkillName('--hello--')).toBe('hello');
+    expect(normalizeSkillName('***')).toBe('');
+  });
+});
+
+describe('skillsFingerprint — index identity, order-independent', () => {
+  const a = { name: 'alpha', description: 'A', updatedAt: new Date(1000) };
+  const b = { name: 'beta', description: 'B', updatedAt: new Date(2000) };
+
+  it('marks an empty index distinctly', () => {
+    expect(skillsFingerprint([])).toBe('none');
+  });
+
+  it('is identical regardless of input ordering', () => {
+    expect(skillsFingerprint([a, b])).toBe(skillsFingerprint([b, a]));
+  });
+
+  it('changes when a skill is added or removed', () => {
+    expect(skillsFingerprint([a])).not.toBe(skillsFingerprint([a, b]));
+  });
+
+  it('changes when a skill is renamed', () => {
+    const renamed = { ...a, name: 'alpha-2' };
+    expect(skillsFingerprint([a])).not.toBe(skillsFingerprint([renamed]));
+  });
+
+  it('changes when a skill is edited (updatedAt advances)', () => {
+    const edited = { ...a, updatedAt: new Date(9999) };
+    expect(skillsFingerprint([a])).not.toBe(skillsFingerprint([edited]));
+  });
+
+  it('is stable for the same index across calls', () => {
+    expect(skillsFingerprint([a, b])).toBe(skillsFingerprint([a, b]));
+  });
+});

--- a/backend/plugins/erxes-agent_api/src/modules/skill/db/definitions/skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/db/definitions/skill.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'mongoose';
+import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+
+export const agentSkillSchema = new Schema(
+  {
+    _id: mongooseStringRandomId,
+    name: {
+      type: String,
+      required: true,
+      unique: true,
+      label: 'Name (identifier)',
+    },
+    title: { type: String, required: true, label: 'Title' },
+    description: { type: String, required: true, label: 'When to use' },
+    body: { type: String, required: true, label: 'Instructions' },
+    tags: { type: [String], default: [], label: 'Tags' },
+    // Empty = available to every agent; otherwise scoped to these agentIds.
+    agentIds: { type: [String], default: [], label: 'Agents' },
+    isEnabled: { type: Boolean, default: true, label: 'Enabled' },
+    createdByUserId: { type: String, label: 'Created by' },
+    usageCount: { type: Number, default: 0 },
+    lastUsedAt: { type: Date },
+  },
+  { timestamps: true },
+);
+
+// The index that powers the per-agent skill lookup (enabled + scope match).
+agentSkillSchema.index({ isEnabled: 1, agentIds: 1 });

--- a/backend/plugins/erxes-agent_api/src/modules/skill/db/models/Skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/db/models/Skill.ts
@@ -1,0 +1,137 @@
+import { Model } from 'mongoose';
+import { ExpectedError } from 'erxes-api-shared/utils';
+import { IModels } from '~/connectionResolvers';
+import { agentSkillSchema } from '@/skill/db/definitions/skill';
+import {
+  IMastraAgentSkill,
+  IMastraAgentSkillDocument,
+  IMastraAgentSkillIndexEntry,
+} from '@/skill/@types/skill';
+import {
+  isSkillAvailableToAgent,
+  normalizeSkillName,
+  skillAgentFilter,
+} from '@/skill/skillScope';
+
+const INDEX_PROJECTION = { name: 1, title: 1, description: 1, updatedAt: 1 };
+
+export interface IMastraAgentSkillModel
+  extends Model<IMastraAgentSkillDocument> {
+  getSkill(_id: string): Promise<IMastraAgentSkillDocument>;
+  listSkills(agentId?: string): Promise<IMastraAgentSkillDocument[]>;
+  // The lean always-loaded index (no body) for one agent's prompt.
+  listIndexForAgent(agentId: string): Promise<IMastraAgentSkillIndexEntry[]>;
+  // The full playbook for one agent, resolved on demand by load_skill.
+  findForAgentByName(
+    agentId: string,
+    name: string,
+  ): Promise<IMastraAgentSkillDocument | null>;
+  createSkill(
+    doc: IMastraAgentSkill,
+    userId?: string,
+  ): Promise<IMastraAgentSkillDocument>;
+  updateSkill(
+    _id: string,
+    doc: Partial<IMastraAgentSkill>,
+  ): Promise<IMastraAgentSkillDocument>;
+  removeSkill(_id: string): Promise<{ deletedCount?: number }>;
+  recordSkillUse(_id: string): Promise<void>;
+}
+
+export const loadAgentSkillClass = (models: IModels) => {
+  /** Validate + normalise a skill name, guarding against blanks/duplicates. */
+  const prepareName = async (
+    raw: string | undefined,
+    ignoreId?: string,
+  ): Promise<string> => {
+    const name = normalizeSkillName(raw ?? '');
+    if (!name) {
+      throw new ExpectedError(
+        'Skill name is required (letters, numbers and dashes).',
+      );
+    }
+    const clash = await models.MastraAgentSkill.findOne({ name });
+    if (clash && clash._id !== ignoreId) {
+      throw new ExpectedError(`A skill named "${name}" already exists.`);
+    }
+    return name;
+  };
+
+  class MastraAgentSkill {
+    public static async getSkill(_id: string) {
+      const skill = await models.MastraAgentSkill.findOne({ _id });
+      if (!skill) throw new ExpectedError('Skill not found');
+      return skill;
+    }
+
+    // Management listing: every skill (optionally those one agent can see).
+    public static async listSkills(agentId?: string) {
+      const filter = agentId ? skillAgentFilter(agentId) : {};
+      return models.MastraAgentSkill.find(filter).sort({ name: 1 });
+    }
+
+    public static async listIndexForAgent(agentId: string) {
+      return models.MastraAgentSkill.find(
+        skillAgentFilter(agentId),
+        INDEX_PROJECTION,
+      )
+        .sort({ name: 1 })
+        .lean();
+    }
+
+    // The security-sensitive path: one agent loading one playbook by name. The
+    // pure `isSkillAvailableToAgent` predicate is the authoritative enabled +
+    // scope check here (it must agree with `skillAgentFilter` used for bulk
+    // listing) so an agent can never load another agent's private or disabled
+    // skill — and that rule is unit-testable without a database.
+    public static async findForAgentByName(agentId: string, name: string) {
+      const skill = await models.MastraAgentSkill.findOne({
+        name: normalizeSkillName(name),
+      });
+      if (!skill || !isSkillAvailableToAgent(skill, agentId)) return null;
+      return skill;
+    }
+
+    public static async createSkill(doc: IMastraAgentSkill, userId?: string) {
+      const name = await prepareName(doc.name);
+      return models.MastraAgentSkill.create({
+        ...doc,
+        name,
+        ...(userId ? { createdByUserId: userId } : {}),
+      });
+    }
+
+    public static async updateSkill(
+      _id: string,
+      doc: Partial<IMastraAgentSkill>,
+    ) {
+      const existing = await models.MastraAgentSkill.getSkill(_id);
+      const update: Partial<IMastraAgentSkill> = { ...doc };
+      if (doc.name !== undefined) {
+        update.name = await prepareName(doc.name, _id);
+      }
+      await models.MastraAgentSkill.updateOne({ _id }, { $set: update });
+      return models.MastraAgentSkill.getSkill(existing._id);
+    }
+
+    public static async removeSkill(_id: string) {
+      await models.MastraAgentSkill.getSkill(_id);
+      return models.MastraAgentSkill.deleteOne({ _id });
+    }
+
+    // Best-effort usage telemetry — never blocks or fails a load_skill call.
+    public static async recordSkillUse(_id: string) {
+      try {
+        await models.MastraAgentSkill.updateOne(
+          { _id },
+          { $inc: { usageCount: 1 }, $set: { lastUsedAt: new Date() } },
+        );
+      } catch {
+        /* telemetry is non-critical */
+      }
+    }
+  }
+
+  agentSkillSchema.loadClass(MastraAgentSkill);
+  return agentSkillSchema;
+};

--- a/backend/plugins/erxes-agent_api/src/modules/skill/graphql/resolvers/mutations/skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/graphql/resolvers/mutations/skill.ts
@@ -1,0 +1,44 @@
+import { IUserDocument } from 'erxes-api-shared/core-types';
+import { ExpectedError } from 'erxes-api-shared/utils';
+import { IContext } from '~/connectionResolvers';
+import { IMastraAgentSkill } from '@/skill/@types/skill';
+
+/** Resolve the logged-in user's _id, rejecting unauthenticated calls. */
+const requireUserId = (user: IUserDocument | null | undefined): string => {
+  const userId = user?._id;
+  if (!userId) throw new ExpectedError('Login required');
+  return userId;
+};
+
+/** Mutations for authored agent skills (the "teach the agent" surface). */
+export const skillMutations = {
+  mastraAgentSkillAdd: async (
+    _parent: undefined,
+    { doc }: { doc: IMastraAgentSkill },
+    { models, user, checkPermission }: IContext,
+  ) => {
+    await checkPermission('agentSkillsCreate');
+    const userId = requireUserId(user);
+    return models.MastraAgentSkill.createSkill(doc, userId);
+  },
+
+  mastraAgentSkillEdit: async (
+    _parent: undefined,
+    { _id, doc }: { _id: string; doc: Partial<IMastraAgentSkill> },
+    { models, user, checkPermission }: IContext,
+  ) => {
+    await checkPermission('agentSkillsEdit');
+    requireUserId(user);
+    return models.MastraAgentSkill.updateSkill(_id, doc);
+  },
+
+  mastraAgentSkillRemove: async (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models, user, checkPermission }: IContext,
+  ) => {
+    await checkPermission('agentSkillsRemove');
+    requireUserId(user);
+    return models.MastraAgentSkill.removeSkill(_id);
+  },
+};

--- a/backend/plugins/erxes-agent_api/src/modules/skill/graphql/resolvers/queries/skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/graphql/resolvers/queries/skill.ts
@@ -1,0 +1,22 @@
+import { IContext } from '~/connectionResolvers';
+
+/** Queries over authored agent skills (procedural-memory playbooks). */
+export const skillQueries = {
+  mastraAgentSkills: async (
+    _parent: undefined,
+    { agentId }: { agentId?: string },
+    { models, checkPermission }: IContext,
+  ) => {
+    await checkPermission('agentSkillsView');
+    return models.MastraAgentSkill.listSkills(agentId);
+  },
+
+  mastraAgentSkill: async (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models, checkPermission }: IContext,
+  ) => {
+    await checkPermission('agentSkillsView');
+    return models.MastraAgentSkill.getSkill(_id);
+  },
+};

--- a/backend/plugins/erxes-agent_api/src/modules/skill/graphql/schemas/skill.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/graphql/schemas/skill.ts
@@ -1,0 +1,48 @@
+export const types = `
+  type MastraAgentSkill {
+    _id: String
+    name: String
+    title: String
+    description: String
+    body: String
+    tags: [String]
+    agentIds: [String]
+    isEnabled: Boolean
+    createdByUserId: String
+    usageCount: Float
+    lastUsedAt: Date
+    createdAt: Date
+    updatedAt: Date
+  }
+
+  input MastraAgentSkillInput {
+    name: String!
+    title: String!
+    description: String!
+    body: String!
+    tags: [String]
+    agentIds: [String]
+    isEnabled: Boolean
+  }
+
+  input MastraAgentSkillEditInput {
+    name: String
+    title: String
+    description: String
+    body: String
+    tags: [String]
+    agentIds: [String]
+    isEnabled: Boolean
+  }
+`;
+
+export const queries = `
+  mastraAgentSkills(agentId: String): [MastraAgentSkill]
+  mastraAgentSkill(_id: String!): MastraAgentSkill
+`;
+
+export const mutations = `
+  mastraAgentSkillAdd(doc: MastraAgentSkillInput!): MastraAgentSkill
+  mastraAgentSkillEdit(_id: String!, doc: MastraAgentSkillEditInput!): MastraAgentSkill
+  mastraAgentSkillRemove(_id: String!): JSON
+`;

--- a/backend/plugins/erxes-agent_api/src/modules/skill/skillScope.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/skillScope.ts
@@ -42,11 +42,15 @@ export function isSkillAvailableToAgent(
  * displayed name must be one and the same — normalising on save guarantees it.
  */
 export function normalizeSkillName(raw: string): string {
+  // Split on any run of non-alphanumerics and rejoin with single dashes. Doing
+  // it via split+filter (rather than a trailing-dash-trimming regex) keeps the
+  // patterns simple and linear — no backtracking risk.
   return (raw || '')
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .join('-');
 }
 
 /**
@@ -72,6 +76,6 @@ export function skillsFingerprint(
           skill.updatedAt ? new Date(skill.updatedAt).getTime() : 0
         }`,
     )
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .join('|');
 }

--- a/backend/plugins/erxes-agent_api/src/modules/skill/skillScope.ts
+++ b/backend/plugins/erxes-agent_api/src/modules/skill/skillScope.ts
@@ -1,0 +1,77 @@
+import type {
+  IMastraAgentSkill,
+  IMastraAgentSkillIndexEntry,
+} from '@/skill/@types/skill';
+
+// Scope + fingerprint logic for agent skills, kept pure (no DB, no Mongoose) so
+// it can be unit-tested against the spec directly and reused by both the model
+// layer (the Mongo filter) and the runtime (in-memory availability checks).
+
+/**
+ * The Mongo filter selecting the skills one agent may see: enabled, and either
+ * global (no `agentIds` / empty list) or explicitly scoped to this agent.
+ *
+ * A skill with an empty `agentIds` is a GLOBAL playbook — available to every
+ * agent. A non-empty list scopes it to exactly those agents.
+ */
+export function skillAgentFilter(agentId: string): Record<string, unknown> {
+  return {
+    isEnabled: { $ne: false },
+    $or: [
+      { agentIds: { $exists: false } },
+      { agentIds: { $size: 0 } },
+      { agentIds: agentId },
+    ],
+  };
+}
+
+/** In-memory mirror of {@link skillAgentFilter} — same rule, for a loaded doc. */
+export function isSkillAvailableToAgent(
+  skill: Pick<IMastraAgentSkill, 'isEnabled' | 'agentIds'>,
+  agentId: string,
+): boolean {
+  if (skill.isEnabled === false) return false;
+  const scope = skill.agentIds;
+  if (!scope || scope.length === 0) return true; // global playbook
+  return scope.includes(agentId);
+}
+
+/**
+ * Normalise a skill name to a stable kebab-case slug. The agent loads a skill
+ * by the exact name shown in its prompt index, so the stored name and the
+ * displayed name must be one and the same — normalising on save guarantees it.
+ */
+export function normalizeSkillName(raw: string): string {
+  return (raw || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A fingerprint of the skill INDEX for an agent — it changes whenever a skill
+ * is added, removed, renamed, re-described, or otherwise edited (`updatedAt`),
+ * and is independent of ordering. The agent cache keys on it so a freshly
+ * taught (or edited) skill takes effect on the very next turn, exactly like the
+ * installed-services inventory fingerprint already does for operations.
+ *
+ * It deliberately does NOT depend on the skill `body`: the body is fetched live
+ * by load_skill on every use, so a body-only edit needs no agent rebuild.
+ */
+export function skillsFingerprint(
+  skills: Array<
+    Pick<IMastraAgentSkillIndexEntry, 'name' | 'description' | 'updatedAt'>
+  >,
+): string {
+  if (!skills.length) return 'none';
+  return skills
+    .map(
+      (skill) =>
+        `${skill.name}@${
+          skill.updatedAt ? new Date(skill.updatedAt).getTime() : 0
+        }`,
+    )
+    .sort()
+    .join('|');
+}


### PR DESCRIPTION
## What & why

Adds **Agent Skills** to the erxes-agent plugin: a way to *teach the agent a specific task once* so it performs it reliably, instead of improvising (and sometimes failing) every time.

Before this, the only ways to steer an agent were the single `instructions` blob (doesn't scale — every taught task bloats every prompt), company-knowledge RAG (retrieves *facts*, not *procedures*), the auto-learning sweep (implicit, not authorable), and full workflows (powerful but heavyweight). A skill fills the gap: a named, authored **playbook** for one task — **procedural memory**.

## Design — progressive disclosure (the Anthropic Agent Skills pattern)

- **Level 1 (always loaded):** a lean index — each skill's `name` + a one-line "when to use" — is injected into the system prompt (`SKILLS_BLOCK` in `routing.ts`). Tiny context cost; the agent always knows which playbooks exist.
- **Level 2 (on demand):** when a task matches, the agent calls the **`load_skill`** tool, which fetches the full body live from Mongo. The lookup is **scoped to the asking agent**, so one agent can never read another's private or disabled skill.
- The agent cache key gains a **skills fingerprint** (mirroring the existing installed-services `inventory.fingerprint`), so adding/editing/removing a skill refreshes the index on the very next turn.

This follows the current expert consensus: progressive disclosure (Anthropic Agent Skills), "skills are procedural memory and more reliable than ad-hoc plans" (SoK: Agentic Skills), and "detailed structured playbooks beat terse summaries; never rewrite context monolithically" (ACE / Agentic Context Engineering). The body loads only when needed, so it can be as detailed as the task demands.

## Changes

- **New `skill` module** — `mastra_agent_skills` model + GraphQL CRUD: `mastraAgentSkills(agentId)`, `mastraAgentSkill(_id)`, `mastraAgentSkillAdd/Edit/Remove`.
- **`load_skill` tool** (`mastra/tools/skillTools.ts`) — Level 2 loader; a pure `isSkillAvailableToAgent` predicate is the authoritative enabled+scope check on the security-sensitive load path.
- **`routing.ts`** — `SKILLS_BLOCK` Level-1 index; `buildSystemPrompt` gains a `skills` option (placed between capabilities and the agent's custom instructions).
- **`agentRuntime.ts`** — fetches the lean index in parallel with providers/settings, binds `load_skill` when the agent has ≥1 skill, and adds the skills fingerprint to the cache key.
- **Permissions** — new `skill` module (`agentSkillsView` [always], `agentSkillsCreate/Edit/Remove`); `View` granted to the default user/viewer groups, full set to admin.
- **Docs** — `docs/AGENT-SKILLS.md` (design, research basis, authoring guide).

Scope model: a skill with an empty `agentIds` is a **global** playbook (every agent); a non-empty list scopes it to those agents. Disabled skills neither index nor load.

## Tests

Real-oracle unit tests (the spec is the oracle, no values copied from the impl):
- `skillScope.test.ts` — scope rule (global vs scoped vs disabled), name slug normalisation, index fingerprint (order-independent; changes on add/remove/rename/edit).
- `skillTools.test.ts` — `load_skill` returns the body for a known in-scope skill (and records usage), reports a miss with the available names (and records nothing).
- `routing.test.ts` — the always-loaded index lists name + when-to-use, instructs `load_skill` first, never inlines the body, and precedes custom instructions.

`pnpm nx test erxes-agent_api` → 19 new tests pass (253 total pass; the one unrelated failing suite is a pre-existing `@mastra/memory` module-load issue, untouched here). Production typecheck (`tsconfig.build.json`) is clean.

## Compatibility

Additive and always-on (no env flag). No migration: the collection is created lazily; agents with no skills are completely unaffected (no prompt block, no tool bound).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Agent Skills for authoring reusable playbooks that agents can load and follow on demand.
  * Added skill indexing with progressive disclosure in agent prompts, and automatic cache refresh when skills change.
  * Implemented agent-scoped skill availability with enable/disable controls and a `load_skill` tool flow.
  * Added GraphQL support for skill queries and mutations, plus skill permissions for viewing and editing.

* **Documentation**
  * Added Agent Skills documentation, including authoring guidance and API overview.

* **Tests**
  * Added coverage for routing behavior, skill tool contracts, and scope/fingerprint logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->