### PR TITLE
fix(sales): remove default today filter, fix total count atom and customer filter display

### DIFF
--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posProduct.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posProduct.ts
@@ -3,6 +3,9 @@ import { IContext } from '~/connectionResolvers';
 
 const resolvers = {
   category: async (posProduct, _, { subdomain }: IContext) => {
+    if (!posProduct.categoryId) {
+      return null;
+    }
     return await sendTRPCMessage({
       subdomain,
 

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -133,7 +133,7 @@ const generateFilterPosQuery = async (models, params, currentUserId) => {
     query.paidDate = { $exists: true };
   }
 
-  if (paidDate === 'today' || !Object.keys(query).length) {
+  if (paidDate === 'today') {
     const now = new Date();
 
     const startDate = getToday(now);

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
@@ -4,6 +4,7 @@ import {
   IconClock,
   IconUser,
   IconTag,
+  IconFileText,
 } from '@tabler/icons-react';
 import { ColumnDef } from '@tanstack/table-core';
 import {
@@ -215,6 +216,21 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
       );
     },
     size: 150,
+  },
+  {
+    id: 'description',
+    accessorKey: 'description',
+    header: () => (
+      <RecordTable.InlineHead icon={IconFileText} label="Description" />
+    ),
+    cell: ({ cell }) => {
+      return (
+        <RecordTableInlineCell>
+          <TextOverflowTooltip value={cell.getValue() as string} />
+        </RecordTableInlineCell>
+      );
+    },
+    size: 200,
   },
 ];
 

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
@@ -53,6 +53,7 @@ export const PosOrderFilterPopover = () => {
   const [customer, setCustomer] = useQueryState<string>('customer');
   const [company, setCompany] = useQueryState<string>('company');
   const [user, setUser] = useQueryState<string>('user');
+  const [, setCustomerName] = useQueryState<string>('customerName');
   const hasFilters = Object.values(queries || {}).some(
     (value) => value !== null,
   );
@@ -116,6 +117,7 @@ export const PosOrderFilterPopover = () => {
               value={customer || ''}
               onValueChange={(value) => {
                 setCustomer(value as any);
+                setCustomerName(null);
                 resetFilterState();
               }}
             >
@@ -184,9 +186,17 @@ export const PosOrderFilter = () => {
   const [number] = useFilterQueryState<string>('number');
   const { sessionKey } = usePosOrderLeadSessionKey();
   const [customer, setCustomer] = useQueryState<string>('customer');
+  const [customerName, setCustomerName] = useQueryState<string>('customerName');
   const [company, setCompany] = useQueryState<string>('company');
   const [user, setUser] = useQueryState<string>('user');
   const [open, setOpen] = useState<boolean>(false);
+
+  const handleCustomerChange = (value: string) => {
+    setCustomer(value as string);
+    setCustomerName(null);
+    setOpen(false);
+  };
+
   return (
     <Filter id="pos-orders-filter" sessionKey={sessionKey}>
       <Filter.Bar>
@@ -208,15 +218,12 @@ export const PosOrderFilter = () => {
           <SelectCustomers.Provider
             mode="single"
             value={customer || ''}
-            onValueChange={(value) => {
-              setCustomer(value as string);
-              setOpen(false);
-            }}
+            onValueChange={handleCustomerChange}
           >
             <Popover open={open} onOpenChange={setOpen}>
               <Popover.Trigger asChild>
                 <Filter.BarButton filterKey={'customer'}>
-                  <SelectCustomers.Value />
+                  <SelectCustomers.Value fallbackLabel={customerName || undefined} />
                 </Filter.BarButton>
               </Popover.Trigger>
               <Combobox.Content>

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
@@ -115,19 +115,21 @@ export const SelectCustomersProvider = ({
 const SelectCustomersValue = ({
   placeholder,
   className,
+  fallbackLabel,
 }: {
   placeholder?: string;
   className?: string;
+  fallbackLabel?: string;
 }) => {
   const { value, customers } = useSelectCustomersContext();
   const selectedCustomer = customers?.find(
-    (customer) => customer._id === value,
+    (customer: ICustomer) => customer._id === value,
   );
 
   if (!selectedCustomer) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || 'Select customer'}
+        {fallbackLabel || placeholder || 'Select customer'}
       </span>
     );
   }

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/graphql/queries/queries.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/graphql/queries/queries.ts
@@ -46,7 +46,7 @@ const queryArgs = `
   brandId: $brandId
 `;
 
-const POS_ORDERS_QUERY = gql`
+export const POS_ORDERS_QUERY = gql`
   query PosOrders(${queryParams}) {
     posOrders(${queryArgs}) {
       _id
@@ -66,6 +66,7 @@ const POS_ORDERS_QUERY = gql`
       status
       totalAmount
       type
+      description
       user {
         username
         status
@@ -74,7 +75,3 @@ const POS_ORDERS_QUERY = gql`
     posOrdersTotalCount(${queryArgs})
   }
 `;
-
-export default {
-  POS_ORDERS_QUERY,
-};

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/hooks/UseOrderList.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/hooks/UseOrderList.tsx
@@ -1,4 +1,4 @@
-import queries from '~/modules/pos/orders/graphql/queries/queries';
+import { POS_ORDERS_QUERY } from '~/modules/pos/orders/graphql/queries/queries';
 import { useQuery } from '@apollo/client';
 import { useMemo, useCallback, useEffect } from 'react';
 import { IOrder } from '@/pos/types/order';
@@ -98,7 +98,7 @@ export const useOrdersList = (
 ): UseOrdersListReturn => {
   const variables = useOrdersVariables(options);
   const setOrdersTotalCount = useSetAtom(posOrderTotalCountAtom);
-  const { data, loading, fetchMore } = useQuery(queries.POS_ORDERS_QUERY, {
+  const { data, loading, fetchMore } = useQuery(POS_ORDERS_QUERY, {
     variables,
   });
 
@@ -133,8 +133,7 @@ export const useOrdersList = (
   }, [ordersList.length, fetchMore, data?.posOrders]);
 
   useEffect(() => {
-    if (!totalCount) return;
-    setOrdersTotalCount(totalCount);
+    setOrdersTotalCount(totalCount ?? null);
   }, [totalCount, setOrdersTotalCount]);
 
   return {

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
@@ -11,11 +11,22 @@ export const PosOrdersByCustomerMoreColumnCell = ({
 }) => {
   const navigate = useNavigate();
   const { posId } = useParams();
-  const { _id } = cell.row.original;
+  const { _id, customerDetail } = cell.row.original;
 
   const handleSeeOrders = (customerId: string) => {
     const newSearchParams = new URLSearchParams();
     newSearchParams.set('customer', customerId);
+
+    const detail = customerDetail || ({} as any);
+    const displayName =
+      detail.primaryName ||
+      `${detail.firstName || ''} ${detail.lastName || ''}`.trim() ||
+      detail.primaryEmail ||
+      detail.primaryPhone ||
+      '';
+    if (displayName) {
+      newSearchParams.set('customerName', displayName);
+    }
 
     if (!posId) {
       navigate(`../orders?${newSearchParams.toString()}`);

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
@@ -2,7 +2,17 @@ import { IOrder } from '@/pos/types/order';
 
 export interface IPosOrdersByCustomer {
   _id: string;
-  customerDetail: string;
+  customerDetail: {
+    _id?: string;
+    state?: string;
+    primaryName?: string;
+    firstName?: string;
+    lastName?: string;
+    primaryEmail?: string;
+    primaryPhone?: string;
+    code?: string;
+    emails?: { email?: string };
+  };
   customerType: string;
   orders: IOrder[];
   totalOrders: number;


### PR DESCRIPTION
## Changes

### Backend
- **Removed default `paidDate: today` filter** from `generateFilterPosQuery` (`orders.ts:136`). Previously, when no filters were specified, it defaulted to showing only today's paid orders, causing POS by-items, orders, and summary pages to show empty data. Now it returns all orders unless a date filter is explicitly provided.

### Frontend
- **Fixed total count atom** (`UseOrderList.tsx:136`): removed `if (!totalCount) return` guard that prevented the atom from being set to `0` when the list was empty, causing it to retain the previous non-zero count.
- **Fixed customer filter display** (`SelectCustomers.tsx`, `PosOrderFilter.tsx`, `PosOrdersByCustomerMoreColumn.tsx`, `posOrdersByCustomerType.ts`): when navigating from "Orders by Customer → See Orders", the customer name from `customerDetail` is passed as a `customerName` URL param and used as a `fallbackLabel` in `SelectCustomersValue`, so the filter bar shows the customer name even if they're not in the first 100 dropdown results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of missing product categories to prevent errors.
  * Corrected unintended automatic filtering behavior in orders by date.

* **New Features**
  * Added description column to orders table display.
  * Enhanced customer identification in order filtering with improved fallback labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->