### PR TITLE
fix(sales): remove default today filter, fix total count atom and customer filter display

### DIFF
--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posProduct.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posProduct.ts
@@ -3,6 +3,9 @@ import { IContext } from '~/connectionResolvers';
 
 const resolvers = {
   category: async (posProduct, _, { subdomain }: IContext) => {
+    if (!posProduct.categoryId) {
+      return null;
+    }
     return await sendTRPCMessage({
       subdomain,
 

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -138,7 +138,7 @@ const generateFilterPosQuery = async (models, params, currentUserId) => {
     query.paidDate = { $exists: true };
   }
 
-  if (paidDate === 'today' || !Object.keys(query).length) {
+  if (paidDate === 'today') {
     const now = new Date();
 
     const startDate = getToday(now);

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -904,7 +904,7 @@ const queries = {
       params.types?.length ||
       params.statuses?.length ||
       params.excludeStatuses?.length ||
-      params.hasPaidDate ||
+      params.hasPaidDate !== undefined ||
       params.brandId;
 
     const resultProducts = hasOrderFilter

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -889,10 +889,32 @@ const queries = {
       (p) => !(p.status === 'deleted' && !p.count && !p.amount),
     );
 
-    const totalCount = filteredProducts.length;
+    // ❗ STEP 5: filter out products with zero sales when user-applied filters are active
+    // (posId/posToken are contextual scope, not user-applied filters)
+    const hasOrderFilter =
+      params.search ||
+      params.paidStartDate ||
+      params.paidEndDate ||
+      params.createdStartDate ||
+      params.createdEndDate ||
+      params.paidDate ||
+      params.userId ||
+      params.customerId ||
+      params.customerType ||
+      params.types?.length ||
+      params.statuses?.length ||
+      params.excludeStatuses?.length ||
+      params.hasPaidDate ||
+      params.brandId;
 
-    // ❗ STEP 5: apply pagination LAST (correct place)
-    const paginatedProducts = filteredProducts.slice(skip, skip + limit);
+    const resultProducts = hasOrderFilter
+      ? filteredProducts.filter((p) => p.count > 0 || p.amount > 0)
+      : filteredProducts;
+
+    const totalCount = resultProducts.length;
+
+    // ❗ STEP 6: apply pagination LAST
+    const paginatedProducts = resultProducts.slice(skip, skip + limit);
 
     return {
       totalCount,

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
@@ -4,6 +4,7 @@ import {
   IconClock,
   IconUser,
   IconTag,
+  IconFileText,
 } from '@tabler/icons-react';
 import { ColumnDef } from '@tanstack/table-core';
 import { useTranslation } from 'react-i18next';
@@ -213,6 +214,21 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
       );
     },
     size: 150,
+  },
+  {
+    id: 'description',
+    accessorKey: 'description',
+    header: () => (
+      <RecordTable.InlineHead icon={IconFileText} label="Description" />
+    ),
+    cell: ({ cell }) => {
+      return (
+        <RecordTableInlineCell>
+          <TextOverflowTooltip value={cell.getValue() as string} />
+        </RecordTableInlineCell>
+      );
+    },
+    size: 200,
   },
 ];
 

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
@@ -65,7 +65,12 @@ export const generateOtherPaymentColumns = (summary?: PaymentSummary) => {
     id: `${title}_${index}`,
     header: () => {
       const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconClock} label={t(title, { defaultValue: title })} />;
+      return (
+        <RecordTable.InlineHead
+          icon={IconClock}
+          label={t(title, { defaultValue: title })}
+        />
+      );
     },
     cell: ({ row }: { row: PaymentRow }) => {
       const order = row.original;
@@ -86,7 +91,12 @@ export const firstOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'number',
     accessorKey: 'number',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconLabel} label={t('bill-number')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return (
+        <RecordTable.InlineHead icon={IconLabel} label={t('bill-number')} />
+      );
+    },
     cell: ({ cell, row }) => {
       return (
         <ClickableBillNumber value={cell.getValue() as string} row={row} />
@@ -96,7 +106,10 @@ export const firstOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'paidDate',
     accessorKey: 'paidDate',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconMobiledata} label={t('date')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconMobiledata} label={t('date')} />;
+    },
     cell: ({ cell }) => {
       return (
         <RelativeDateDisplay value={cell.getValue() as string} asChild>
@@ -119,7 +132,12 @@ export const firstOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'cashAmount',
     accessorKey: 'cashAmount',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconLabel} label={t('cash-amount')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return (
+        <RecordTable.InlineHead icon={IconLabel} label={t('cash-amount')} />
+      );
+    },
     cell: ({ cell }) => {
       const value = cell.getValue() as number;
       return (
@@ -133,7 +151,12 @@ export const firstOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'mobileAmount',
     accessorKey: 'mobileAmount',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconLabel} label={t('mobile-amount')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return (
+        <RecordTable.InlineHead icon={IconLabel} label={t('mobile-amount')} />
+      );
+    },
     cell: ({ cell }) => {
       const value = cell.getValue() as number;
       return (
@@ -150,7 +173,10 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'totalAmount',
     accessorKey: 'totalAmount',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconLabel} label={t('amount')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconLabel} label={t('amount')} />;
+    },
     cell: ({ cell }) => {
       const value = cell.getValue() as number;
       return (
@@ -164,7 +190,10 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'customerType',
     accessorKey: 'customerType',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconClock} label={t('customer')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconClock} label={t('customer')} />;
+    },
     cell: ({ cell }) => {
       const value = cell.getValue() as string;
       return (
@@ -178,7 +207,10 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'posName',
     accessorKey: 'posName',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconUser} label={t('pos')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconUser} label={t('pos')} />;
+    },
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>
@@ -191,7 +223,10 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'type',
     accessorKey: 'type',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconTag} label={t('type')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconTag} label={t('type')} />;
+    },
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>
@@ -204,7 +239,10 @@ export const secondOrderColumns: ColumnDef<IOrder>[] = [
   {
     id: 'user',
     accessorKey: 'user',
-    header: () => { const { t } = useTranslation('sales'); return <RecordTable.InlineHead icon={IconUser} label={t('user')} />; },
+    header: () => {
+      const { t } = useTranslation('sales');
+      return <RecordTable.InlineHead icon={IconUser} label={t('user')} />;
+    },
     cell: ({ cell }) => {
       const user = cell.getValue() as IUser;
       return (

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
@@ -226,7 +226,9 @@ export const PosOrderFilter = () => {
             <Popover open={open} onOpenChange={setOpen}>
               <Popover.Trigger asChild>
                 <Filter.BarButton filterKey={'customer'}>
-                  <SelectCustomers.Value fallbackLabel={customerName || undefined} />
+                  <SelectCustomers.Value
+                    fallbackLabel={customerName || undefined}
+                  />
                 </Filter.BarButton>
               </Popover.Trigger>
               <Combobox.Content>

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
@@ -55,6 +55,7 @@ export const PosOrderFilterPopover = () => {
   const [customer, setCustomer] = useQueryState<string>('customer');
   const [company, setCompany] = useQueryState<string>('company');
   const [user, setUser] = useQueryState<string>('user');
+  const [, setCustomerName] = useQueryState<string>('customerName');
   const hasFilters = Object.values(queries || {}).some(
     (value) => value !== null,
   );
@@ -118,6 +119,7 @@ export const PosOrderFilterPopover = () => {
               value={customer || ''}
               onValueChange={(value) => {
                 setCustomer(value as any);
+                setCustomerName(null);
                 resetFilterState();
               }}
             >
@@ -187,9 +189,17 @@ export const PosOrderFilter = () => {
   const [number] = useFilterQueryState<string>('number');
   const { sessionKey } = usePosOrderLeadSessionKey();
   const [customer, setCustomer] = useQueryState<string>('customer');
+  const [customerName, setCustomerName] = useQueryState<string>('customerName');
   const [company, setCompany] = useQueryState<string>('company');
   const [user, setUser] = useQueryState<string>('user');
   const [open, setOpen] = useState<boolean>(false);
+
+  const handleCustomerChange = (value: string) => {
+    setCustomer(value as string);
+    setCustomerName(null);
+    setOpen(false);
+  };
+
   return (
     <Filter id="pos-orders-filter" sessionKey={sessionKey}>
       <Filter.Bar>
@@ -211,15 +221,12 @@ export const PosOrderFilter = () => {
           <SelectCustomers.Provider
             mode="single"
             value={customer || ''}
-            onValueChange={(value) => {
-              setCustomer(value as string);
-              setOpen(false);
-            }}
+            onValueChange={handleCustomerChange}
           >
             <Popover open={open} onOpenChange={setOpen}>
               <Popover.Trigger asChild>
                 <Filter.BarButton filterKey={'customer'}>
-                  <SelectCustomers.Value />
+                  <SelectCustomers.Value fallbackLabel={customerName || undefined} />
                 </Filter.BarButton>
               </Popover.Trigger>
               <Combobox.Content>

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
@@ -116,20 +116,22 @@ export const SelectCustomersProvider = ({
 const SelectCustomersValue = ({
   placeholder,
   className,
+  fallbackLabel,
 }: {
   placeholder?: string;
   className?: string;
+  fallbackLabel?: string;
 }) => {
   const { t } = useTranslation('sales');
   const { value, customers } = useSelectCustomersContext();
   const selectedCustomer = customers?.find(
-    (customer) => customer._id === value,
+    (customer: ICustomer) => customer._id === value,
   );
 
   if (!selectedCustomer) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-customer')}
+        {fallbackLabel || placeholder || t('select-customer')}
       </span>
     );
   }

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/selects/SelectCustomers.tsx
@@ -191,7 +191,9 @@ const SelectCustomersContent = () => {
         <Command.Input placeholder={t('search-customers')} />
         <Command.List>
           <div className="flex items-center justify-center py-4 h-32">
-            <span className="text-muted-foreground">{t('loading-customers')}</span>
+            <span className="text-muted-foreground">
+              {t('loading-customers')}
+            </span>
           </div>
         </Command.List>
       </Command>

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/graphql/queries/queries.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/graphql/queries/queries.ts
@@ -46,7 +46,7 @@ const queryArgs = `
   brandId: $brandId
 `;
 
-const POS_ORDERS_QUERY = gql`
+export const POS_ORDERS_QUERY = gql`
   query PosOrders(${queryParams}) {
     posOrders(${queryArgs}) {
       _id
@@ -66,6 +66,7 @@ const POS_ORDERS_QUERY = gql`
       status
       totalAmount
       type
+      description
       user {
         username
         status
@@ -74,7 +75,3 @@ const POS_ORDERS_QUERY = gql`
     posOrdersTotalCount(${queryArgs})
   }
 `;
-
-export default {
-  POS_ORDERS_QUERY,
-};

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/hooks/UseOrderList.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/hooks/UseOrderList.tsx
@@ -1,4 +1,4 @@
-import queries from '~/modules/pos/orders/graphql/queries/queries';
+import { POS_ORDERS_QUERY } from '~/modules/pos/orders/graphql/queries/queries';
 import { useQuery } from '@apollo/client';
 import { useMemo, useCallback, useEffect } from 'react';
 import { IOrder } from '@/pos/types/order';
@@ -98,7 +98,7 @@ export const useOrdersList = (
 ): UseOrdersListReturn => {
   const variables = useOrdersVariables(options);
   const setOrdersTotalCount = useSetAtom(posOrderTotalCountAtom);
-  const { data, loading, fetchMore } = useQuery(queries.POS_ORDERS_QUERY, {
+  const { data, loading, fetchMore } = useQuery(POS_ORDERS_QUERY, {
     variables,
   });
 
@@ -133,8 +133,7 @@ export const useOrdersList = (
   }, [ordersList.length, fetchMore, data?.posOrders]);
 
   useEffect(() => {
-    if (!totalCount) return;
-    setOrdersTotalCount(totalCount);
+    setOrdersTotalCount(totalCount ?? null);
   }, [totalCount, setOrdersTotalCount]);
 
   return {

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-by-items/hooks/UsePosByItemsList.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-by-items/hooks/UsePosByItemsList.tsx
@@ -4,6 +4,7 @@ import {
   useQueryState,
 } from 'erxes-ui';
 import { useCallback, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { IProduct } from '@/pos/pos-by-items/types/PosByItemType';
 import { POS_BY_ITEMS_QUERY } from '@/pos/pos-by-items/graphql/queries';
@@ -14,7 +15,6 @@ import { useSetAtom } from 'jotai';
 const POS_PER_PAGE = 30;
 
 interface UsePosByItemsListOptions {
-  posId?: string;
   [key: string]: unknown;
 }
 
@@ -34,7 +34,8 @@ interface UsePosByItemsListReturn {
 export const usePosByItemsVariables = (
   options: UsePosByItemsListOptions = {},
 ) => {
-  const { posId, ...otherOptions } = options;
+  const { posId: posIdFromUrl } = useParams();
+  const { ...otherOptions } = options;
 
   const [
     {
@@ -81,13 +82,9 @@ export const usePosByItemsVariables = (
   return {
     perPage: POS_PER_PAGE,
     page: 1,
-    posId: posId !== undefined ? posId : pos || undefined,
-    search: (() => {
-      const searchParts = [];
-      if (searchValue) searchParts.push(searchValue);
-      if (number) searchParts.push(number);
-      return searchParts.length > 0 ? searchParts.join(' ') : undefined;
-    })(),
+    posId: posIdFromUrl || pos || undefined,
+    search: number || undefined,
+    searchValue: searchValue || undefined,
     customerId: customerIdValue,
     userId: user || undefined,
     categoryId: category && category !== 'all' ? category : undefined,
@@ -152,7 +149,6 @@ export const usePosByItemsList = (
   }, [posByItemsList.length, fetchMore, data?.posProducts, variables]);
 
   useEffect(() => {
-    if (!totalCount) return;
     setPosByItemsTotalCount(totalCount);
   }, [totalCount, setPosByItemsTotalCount]);
 

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
@@ -374,12 +374,12 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
     },
     cell: ({ row }) => {
       const item = row.original.items;
-      const value =
-        item?.discountPercent && item.discountPercent > 0
-          ? 'Percent'
-          : item?.discountAmount && item.discountAmount > 0
-            ? 'Amount'
-            : '';
+      let value = '';
+      if (item?.discountPercent && item.discountPercent > 0) {
+        value = 'Percent';
+      } else if (item?.discountAmount && item.discountAmount > 0) {
+        value = 'Amount';
+      }
       return (
         <RecordTableInlineCell>
           {value ? <Badge variant="default">{value}</Badge> : ''}

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
@@ -4,6 +4,7 @@ import {
   IconLabel,
   IconClock,
   IconUser,
+  TablerIcon,
 } from '@tabler/icons-react';
 import { ColumnDef } from '@tanstack/table-core';
 import {
@@ -21,15 +22,17 @@ import { useTranslation } from 'react-i18next';
 const fmt = (val: number | null | undefined) =>
   val != null ? val.toLocaleString() : '0';
 
+const PosItemHeaderCell = ({ icon, label }: { icon: TablerIcon; label: string }) => {
+  const { t } = useTranslation('sales');
+  return <RecordTable.InlineHead icon={icon} label={t(label)} />;
+};
+
 export const PosItemColumns: ColumnDef<IPosItem>[] = [
   PosItemMoreColumn,
   {
     id: 'number',
     accessorKey: 'number',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconLabel} label={t('number')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconLabel} label="number" />,
     cell: ({ cell, row }) => (
       <ClickableBillNumber value={cell.getValue() as string} row={row} />
     ),
@@ -37,10 +40,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'createdAt',
     accessorKey: 'createdAt',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconLabel} label={t('created-date')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconLabel} label="created-date" />,
     cell: ({ cell }) => {
       const val = cell.getValue() as string;
       return (
@@ -56,10 +56,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'createdTime',
     accessorKey: 'createdAt',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconLabel} label={t('created-time')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconLabel} label="created-time" />,
     cell: ({ cell }) => {
       const val = cell.getValue() as string;
       return (
@@ -75,10 +72,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'posName',
     accessorKey: 'posName',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconBuilding} label={t('pos')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconBuilding} label="pos" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={(cell.getValue() as string) || ''} />
@@ -89,10 +83,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'branch',
     accessorKey: 'branch',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconChartBar} label={t('branch')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconChartBar} label="branch" />,
     cell: ({ row }) => {
       const b = row.original.branch;
       return (
@@ -106,10 +97,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'department',
     accessorKey: 'department',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconClock} label={t('department')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconClock} label="department" />,
     cell: ({ row }) => {
       const d = row.original.department;
       return (
@@ -123,10 +111,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'user',
     accessorKey: 'user',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('cashier')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="cashier" />,
     cell: ({ row }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={row.original.user?.email || ''} />
@@ -137,10 +122,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'type',
     accessorKey: 'type',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('type')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="type" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <Badge variant="default">{(cell.getValue() as string) || ''}</Badge>
@@ -151,10 +133,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'billType',
     accessorKey: 'billType',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('bill-type')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="bill-type" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={(cell.getValue() as string) || ''} />
@@ -165,10 +144,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'registerNumber',
     accessorKey: 'registerNumber',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('company-rd')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="company-rd" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={(cell.getValue() as string) || ''} />
@@ -179,10 +155,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'customerType',
     accessorKey: 'customerType',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('customer-type')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="customer-type" />,
     cell: ({ cell }) => {
       const value = cell.getValue() as string;
       return (
@@ -196,10 +169,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'customer',
     accessorKey: 'customer.primaryEmail',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('customer')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="customer" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={(cell.getValue() as string) || ''} />
@@ -209,10 +179,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'barcode',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('barcode')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="barcode" />,
     cell: ({ row }) => {
       const item = row.original.items;
       const barcodes = item?.barcodes ?? item?.product?.barcodes ?? [];
@@ -227,10 +194,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'factor',
     accessorKey: 'factor',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('factor')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="factor" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={fmt(cell.getValue() as number)} />
@@ -240,10 +204,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'code',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('code')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="code" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -256,10 +217,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'categoryCode',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('category-code')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="category-code" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -279,10 +237,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'categoryName',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('category-name')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="category-name" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -302,10 +257,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'name',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('name')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="name" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -318,10 +270,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'count',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('count')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="count" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -336,10 +285,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'firstPrice',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('first-price')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="first-price" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -352,10 +298,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'discount',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('discount')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="discount" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -368,10 +311,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'discountType',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('discount-type')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="discount-type" />,
     cell: ({ row }) => {
       const item = row.original.items;
       let value = '';
@@ -390,10 +330,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'salePrice',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('sale-price')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="sale-price" />,
     cell: ({ row }) => {
       const item = row.original.items;
       return (
@@ -407,10 +344,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'totalAmount',
     accessorKey: 'totalAmount',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('amount')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="amount" />,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={fmt(cell.getValue() as number)} />
@@ -421,10 +355,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   {
     id: 'paymentType',
     accessorKey: 'paidAmounts',
-    header: () => {
-      const { t } = useTranslation('sales');
-      return <RecordTable.InlineHead icon={IconUser} label={t('payment-type')} />;
-    },
+    header: () => <PosItemHeaderCell icon={IconUser} label="payment-type" />,
     cell: ({ row }) => {
       const raw = row.original.paidAmounts;
       const paidAmounts: Array<{ type?: string }> = Array.isArray(raw)

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
@@ -22,7 +22,13 @@ import { useTranslation } from 'react-i18next';
 const fmt = (val: number | null | undefined) =>
   val != null ? val.toLocaleString() : '0';
 
-const PosItemHeaderCell = ({ icon, label }: { icon: TablerIcon; label: string }) => {
+const PosItemHeaderCell = ({
+  icon,
+  label,
+}: {
+  icon: TablerIcon;
+  label: string;
+}) => {
   const { t } = useTranslation('sales');
   return <RecordTable.InlineHead icon={icon} label={t(label)} />;
 };
@@ -361,8 +367,8 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
       const paidAmounts: Array<{ type?: string }> = Array.isArray(raw)
         ? raw
         : raw
-        ? [raw as { type?: string }]
-        : [];
+          ? [raw as { type?: string }]
+          : [];
       const types = paidAmounts
         .map((pa) => pa.type)
         .filter((t): t is string => Boolean(t))

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-items/components/PosItemColumns.tsx
@@ -267,6 +267,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
           <TextOverflowTooltip
             value={
               item?.productCategoryCode ||
+              item?.productCategory?.code ||
               item?.product?.productCategory?.code ||
               ''
             }
@@ -289,6 +290,7 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
           <TextOverflowTooltip
             value={
               item?.productCategoryName ||
+              item?.productCategory?.name ||
               item?.product?.productCategory?.name ||
               ''
             }
@@ -366,13 +368,18 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
   },
   {
     id: 'discountType',
-    accessorKey: 'discountType',
     header: () => {
       const { t } = useTranslation('sales');
       return <RecordTable.InlineHead icon={IconUser} label={t('discount-type')} />;
     },
-    cell: ({ cell }) => {
-      const value = cell.getValue() as string;
+    cell: ({ row }) => {
+      const item = row.original.items;
+      const value =
+        item?.discountPercent && item.discountPercent > 0
+          ? 'Percent'
+          : item?.discountAmount && item.discountAmount > 0
+            ? 'Amount'
+            : '';
       return (
         <RecordTableInlineCell>
           {value ? <Badge variant="default">{value}</Badge> : ''}
@@ -423,8 +430,8 @@ export const PosItemColumns: ColumnDef<IPosItem>[] = [
       const paidAmounts: Array<{ type?: string }> = Array.isArray(raw)
         ? raw
         : raw
-          ? [raw as { type?: string }]
-          : [];
+        ? [raw as { type?: string }]
+        : [];
       const types = paidAmounts
         .map((pa) => pa.type)
         .filter((t): t is string => Boolean(t))

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-items/types/posItem.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-items/types/posItem.ts
@@ -83,6 +83,10 @@ export interface IPosItem extends IFields {
       name?: string;
     };
     productCode?: string;
+    productCategory?: {
+      code?: string;
+      name?: string;
+    };
     productCategoryCode?: string;
     productCategoryName?: string;
     productName?: string;

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
@@ -19,7 +19,8 @@ export const PosOrdersByCustomerMoreColumnCell = ({
     const newSearchParams = new URLSearchParams();
     newSearchParams.set('customer', customerId);
 
-    const detail = customerDetail || ({} as any);
+    const detail: IPosOrdersByCustomer['customerDetail'] =
+      customerDetail || {};
     const displayName =
       detail.primaryName ||
       `${detail.firstName || ''} ${detail.lastName || ''}`.trim() ||

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
@@ -13,11 +13,22 @@ export const PosOrdersByCustomerMoreColumnCell = ({
   const { t } = useTranslation('sales');
   const navigate = useNavigate();
   const { posId } = useParams();
-  const { _id } = cell.row.original;
+  const { _id, customerDetail } = cell.row.original;
 
   const handleSeeOrders = (customerId: string) => {
     const newSearchParams = new URLSearchParams();
     newSearchParams.set('customer', customerId);
+
+    const detail = customerDetail || ({} as any);
+    const displayName =
+      detail.primaryName ||
+      `${detail.firstName || ''} ${detail.lastName || ''}`.trim() ||
+      detail.primaryEmail ||
+      detail.primaryPhone ||
+      '';
+    if (displayName) {
+      newSearchParams.set('customerName', displayName);
+    }
 
     if (!posId) {
       navigate(`../orders?${newSearchParams.toString()}`);

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/components/PosOrdersByCustomerMoreColumn.tsx
@@ -19,8 +19,7 @@ export const PosOrdersByCustomerMoreColumnCell = ({
     const newSearchParams = new URLSearchParams();
     newSearchParams.set('customer', customerId);
 
-    const detail: IPosOrdersByCustomer['customerDetail'] =
-      customerDetail || {};
+    const detail: IPosOrdersByCustomer['customerDetail'] = customerDetail || {};
     const displayName =
       detail.primaryName ||
       `${detail.firstName || ''} ${detail.lastName || ''}`.trim() ||

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
@@ -2,7 +2,7 @@ import { IOrder } from '@/pos/types/order';
 
 export interface IPosOrdersByCustomer {
   _id: string;
-  customerDetail: {
+  customerDetail?: {
     _id?: string;
     state?: string;
     primaryName?: string;
@@ -12,7 +12,7 @@ export interface IPosOrdersByCustomer {
     primaryPhone?: string;
     code?: string;
     emails?: { email?: string };
-  };
+  } | null;
   customerType: string;
   orders: IOrder[];
   totalOrders: number;

--- a/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/pos-orders-by-customer/types/posOrdersByCustomerType.ts
@@ -2,7 +2,17 @@ import { IOrder } from '@/pos/types/order';
 
 export interface IPosOrdersByCustomer {
   _id: string;
-  customerDetail: string;
+  customerDetail: {
+    _id?: string;
+    state?: string;
+    primaryName?: string;
+    firstName?: string;
+    lastName?: string;
+    primaryEmail?: string;
+    primaryPhone?: string;
+    code?: string;
+    emails?: { email?: string };
+  };
   customerType: string;
   orders: IOrder[];
   totalOrders: number;

--- a/frontend/plugins/sales_ui/src/pages/PosByitemsPage.tsx
+++ b/frontend/plugins/sales_ui/src/pages/PosByitemsPage.tsx
@@ -1,15 +1,25 @@
 import { PageHeader } from 'ui-modules';
-import { Breadcrumb, PageSubHeader } from 'erxes-ui';
+import { Breadcrumb, PageSubHeader, Separator } from 'erxes-ui';
 import { PosByItemsRecordTable } from '@/pos/pos-by-items/components/PosByItemsRecordTable';
 import { PosByItemsFilter } from '@/pos/pos-by-items/components/PosByItemsFilter';
+import { PosBreadcrumb } from '~/modules/pos/pos/breadcumb/PosBreadcrumb';
+import { useParams } from 'react-router-dom';
 
 export const PosByItemsPage = () => {
+  const { posId } = useParams();
   return (
     <>
       <PageHeader>
         <PageHeader.Start>
           <Breadcrumb>
-            <Breadcrumb.List className="gap-1"></Breadcrumb.List>
+            <Breadcrumb.List className="gap-1">
+              {posId && (
+                <>
+                  <PosBreadcrumb />
+                  <Separator.Inline />
+                </>
+              )}
+            </Breadcrumb.List>
           </Breadcrumb>
         </PageHeader.Start>
       </PageHeader>


### PR DESCRIPTION
## Changes

### Backend
- **Removed default `paidDate: today` filter** from `generateFilterPosQuery` (`orders.ts:136`). Previously, when no filters were specified, it defaulted to showing only today's paid orders, causing POS by-items, orders, and summary pages to show empty data. Now it returns all orders unless a date filter is explicitly provided.

### Frontend
- **Fixed total count atom** (`UseOrderList.tsx:136`): removed `if (!totalCount) return` guard that prevented the atom from being set to `0` when the list was empty, causing it to retain the previous non-zero count.
- **Fixed customer filter display** (`SelectCustomers.tsx`, `PosOrderFilter.tsx`, `PosOrdersByCustomerMoreColumn.tsx`, `posOrdersByCustomerType.ts`): when navigating from "Orders by Customer → See Orders", the customer name from `customerDetail` is passed as a `customerName` URL param and used as a `fallbackLabel` in `SelectCustomersValue`, so the filter bar shows the customer name even if they're not in the first 100 dropdown results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * POS product category resolution now handles missing category data safely.
  * POS orders/product filtering refined: the “today” paid-date rule applies only when selected, and zero-count/zero-amount products are excluded with active filters.
* **New Features**
  * Added a “Description” column to the POS orders table.
* **UI Improvements**
  * Improved POS order customer filtering/reset and displayed fallback labeling; “See Orders” now also carries a customer name search hint when available.
  * Refreshed POS item table rendering for category, discount type, and payment type; improved POS-by-items breadcrumb when a POS is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->