### PR TITLE
fix(frontline): handle already-replied Facebook comment errors

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/index.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/index.ts
@@ -305,7 +305,7 @@ export const actionCreateMessage = async ({
           conversationId: conversation._id,
           botId,
           botData,
-          mid: sendReplyResult.mid,
+          mid: sendReplyResult.message_id || sendReplyResult.mid,
           conversationErxesApiId: conversation.erxesApiId,
           source: messageSource,
         });

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/meta/automation/messages/utils.ts
@@ -377,6 +377,27 @@ export const sendMessage = async (
       integration.erxesApiId,
     );
   } catch (error) {
+    const isAlreadyRepliedComment =
+      !!commentId &&
+      (error.message.includes('Activity already replied to') ||
+        error.message.includes('#10900'));
+
+    if (isAlreadyRepliedComment) {
+      return await sendMessage(
+        models,
+        bot,
+        {
+          senderId,
+          recipientId,
+          integration,
+          message,
+          tag,
+          commentId: undefined,
+        },
+        isLoop,
+      );
+    }
+
     const shouldRetryWithTag =
       error.message.includes(
         'This message is sent outside of allowed window',

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
@@ -464,12 +464,15 @@ export const sendReply = async (
       } data: ${JSON.stringify(data)}`,
     );
 
+
+    const messageLevelErrorCodes = [10, 10900];
+
     if (e.message.includes('access token')) {
       await models.FacebookIntegrations.updateOne(
         { _id: integration._id },
         { $set: { healthStatus: 'page-token', error: `${e.message}` } },
       );
-    } else if (e.code !== 10) {
+    } else if (!messageLevelErrorCodes.includes(e.code)) {
       await models.FacebookIntegrations.updateOne(
         { _id: integration._id },
         { $set: { healthStatus: 'account-token', error: `${e.message}` } },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Facebook message ID tracking in conversations for better message persistence.
  * Enhanced error handling for Facebook API responses when messages are already replied to, with automatic recovery.
  * Refined integration health status monitoring for Facebook account and message-level errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->