### PR TITLE
feat(content): placeholder in record tables when default language is empty

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
@@ -19,6 +19,7 @@ import {
 import { ICategory } from '@/cms/categories/types/CategoriesType';
 import { useEditCategory } from '@/cms/categories/hooks/useEditCategory';
 import { useIsTranslationMissing } from '@/cms/shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '@/cms/shared/components/CmsTranslatableBadge';
 import { useAtomValue } from 'jotai';
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 import { getTranslation } from '@/cms/shared/utils';
@@ -110,16 +111,14 @@ export const useCategoriesColumns = (
             }}
           >
             <RecordTableInlineCell.Trigger>
-              <Badge
-                variant={missing ? 'destructive' : 'secondary'}
-                className={missing ? 'border-red-300' : ''}
-              >
-                {prefix}
-                <TextOverflowTooltip
-                  value={cell.getValue() as string}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={cell.getValue() as string}
+                missing={missing}
+                placeholder="Untitled category"
+                prefix={prefix}
+                missingVariant="destructive"
+                missingClassName="border-red-300"
+              />
             </RecordTableInlineCell.Trigger>
             <RecordTableInlineCell.Content>
               <Input
@@ -150,6 +149,16 @@ export const useCategoriesColumns = (
         );
         const missing = isNonDefaultLanguage && !translation?.content?.trim();
         const value = cell.getValue() as string;
+
+        if (!value?.trim()) {
+          return (
+            <RecordTableInlineCell>
+              <span className="italic text-muted-foreground">
+                No description
+              </span>
+            </RecordTableInlineCell>
+          );
+        }
 
         if (missing) {
           return (

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesColumn.tsx
@@ -3,7 +3,6 @@ import {
   RecordTableInlineCell,
   TextOverflowTooltip,
   RelativeDateDisplay,
-  Badge,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
 import { pageMoreColumn } from './PagesMoreColumn';
@@ -16,6 +15,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { IPage } from '../types/pageTypes';
 import { useIsTranslationMissing } from '../../shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '../../shared/components/CmsTranslatableBadge';
 
 export const usePagesColumns = (
   onEditPage?: (page: IPage) => void,
@@ -48,12 +48,11 @@ export const usePagesColumns = (
               }}
               className="cursor-pointer"
             >
-              <Badge
-                variant={missing ? 'outline' : 'secondary'}
-                className={missing ? 'text-red-500 border-red-300' : ''}
-              >
-                <TextOverflowTooltip value={page.name} className="leading-normal" />
-              </Badge>
+              <CmsTranslatableBadge
+                value={page.name}
+                missing={missing}
+                placeholder="Untitled page"
+              />
             </div>
           </RecordTableInlineCell>
         );

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsColumn.tsx
@@ -3,7 +3,6 @@ import {
   TextOverflowTooltip,
   RecordTableInlineCell,
   RelativeDateDisplay,
-  Badge,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
 import {
@@ -23,6 +22,7 @@ import { postMoreColumn } from './PostMoreColumn';
 import { PostsRecordTableStatusInlineCell } from './PostsRecordTableStatusInlineCell';
 import { PostPublicUrlButton } from './PostPublicUrlButton';
 import { useIsTranslationMissing } from '../../shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '../../shared/components/CmsTranslatableBadge';
 import type { Posts } from '../types/postsType';
 import type { IWebsite } from '../../types';
 import { buildCurrentPostsReturnPath } from '../utils/postsNavigation';
@@ -118,15 +118,11 @@ export const usePostsColumns = (
               }}
               className="cursor-pointer "
             >
-              <Badge
-                variant={missing ? 'outline' : 'secondary'}
-                className={missing ? 'text-red-500 border-red-300' : ''}
-              >
-                <TextOverflowTooltip
-                  value={post.title}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={post.title}
+                missing={missing}
+                placeholder="Untitled post"
+              />
             </div>
           </RecordTableInlineCell>
         );

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
@@ -1,0 +1,51 @@
+import { Badge, TextOverflowTooltip, cn } from 'erxes-ui';
+import { ReactNode } from 'react';
+
+interface CmsTranslatableBadgeProps {
+  value?: string;
+  // True when the selected (non-default) language has no translation, so the
+  // cell is falling back to the default-language content.
+  missing?: boolean;
+  // Generic per-field text shown when there is nothing to display — i.e. the
+  // selected language and the default language are both empty.
+  placeholder: string;
+  prefix?: ReactNode;
+  missingVariant?: 'outline' | 'destructive';
+  missingClassName?: string;
+}
+
+/**
+ * Record-table cell for a translatable field. Shows the value as a secondary
+ * badge, the default-language fallback in a "missing" (red) style, and a muted
+ * placeholder when there is no content in either the selected or default
+ * language.
+ */
+export const CmsTranslatableBadge = ({
+  value,
+  missing,
+  placeholder,
+  prefix,
+  missingVariant = 'outline',
+  missingClassName = 'text-red-500 border-red-300',
+}: CmsTranslatableBadgeProps) => {
+  const hasValue = !!value?.trim();
+
+  if (!hasValue) {
+    return (
+      <Badge variant="outline" className="italic text-muted-foreground">
+        {prefix}
+        {placeholder}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      variant={missing ? missingVariant : 'secondary'}
+      className={cn(missing && missingClassName)}
+    >
+      {prefix}
+      <TextOverflowTooltip value={value} className="leading-normal" />
+    </Badge>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsColumn.tsx
@@ -4,7 +4,6 @@ import {
   Input,
   Popover,
   RelativeDateDisplay,
-  Badge,
   TextOverflowTooltip,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
@@ -14,6 +13,7 @@ import { IconTag, IconCalendar } from '@tabler/icons-react';
 import { CmsTag } from '@/cms/tags/types/tagTypes';
 import { useEditTag } from '@/cms/tags/hooks/useEditTag';
 import { useIsTranslationMissing } from '@/cms/shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '@/cms/shared/components/CmsTranslatableBadge';
 import { useAtomValue } from 'jotai';
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 import { getTranslation } from '@/cms/shared/utils';
@@ -96,15 +96,13 @@ export const useTagsColumns = (
             }}
           >
             <RecordTableInlineCell.Trigger>
-              <Badge
-                variant={missing ? 'destructive' : 'secondary'}
-                className={missing ? 'border-red-300' : ''}
-              >
-                <TextOverflowTooltip
-                  value={cell.getValue() as string}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={cell.getValue() as string}
+                missing={missing}
+                placeholder="Untitled tag"
+                missingVariant="destructive"
+                missingClassName="border-red-300"
+              />
             </RecordTableInlineCell.Trigger>
             <RecordTableInlineCell.Content>
               <Input


### PR DESCRIPTION
## What

In the CMS record tables (posts, pages, categories, tags), when a row's translatable field has no content in **either** the selected language or the default language, the cell now shows a muted generic placeholder (e.g. *Untitled post*) instead of rendering blank.

## Why

When viewing a non-default language:
- an untranslated field falls back to the **default-language** content, shown in red to flag it as untranslated;
- but when the default language is *also* empty, there's nothing to fall back to and the cell rendered blank — looking like a broken/empty row.

This adds a clear placeholder for that empty case while leaving the existing red-fallback behavior untouched.

## How

- New shared `CmsTranslatableBadge` component encapsulates the three states: normal value, red default-language fallback (`missing`), and muted placeholder (empty).
- Wired into `PostsColumn`, `PagesColumn`, `TagsColumn`, and `CategoriesColumn` (name + description). Each keeps its own "missing" styling via props.

## Test

- `tsc --noEmit` and `eslint` pass.
- Manual: switch to a language with no translation for a row whose default language is empty → cell shows the placeholder; rows with default content still show the red fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty descriptions in categories now display a "No description" placeholder for improved clarity.

* **Style**
  * Updated display styling for translatable content (categories, pages, posts, tags) with consistent rendering of translation status across content management tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->