### PR TITLE
fix(content): make post search match non-default-language content

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
@@ -42,6 +42,52 @@ export class BaseQueryBuilder {
   }
 
   /**
+   * Translation-aware search. The base document only holds the default
+   * language, so a regex over base fields misses content authored in any other
+   * language (e.g. Mongolian Cyrillic stored in the `Translations` collection).
+   * This matches the base fields AND any document whose translation for the
+   * active language matches, unioned by `_id`.
+   */
+  protected async addTranslatableSearchQuery(
+    query: any,
+    searchValue: string,
+    options: {
+      baseFields: string[];
+      language?: string;
+      translationType: string;
+      translationFields: string[];
+    },
+  ): Promise<void> {
+    if (!searchValue?.trim()) return;
+
+    const pattern = escapeRegExp(searchValue.trim());
+    const regex = new RegExp(pattern, 'i');
+
+    const orConditions: any[] = options.baseFields.map((field) => ({
+      [field]: regex,
+    }));
+
+    if (options.language) {
+      const matches = await this.models.Translations.find({
+        type: options.translationType,
+        language: options.language,
+        $or: options.translationFields.map((field) => ({ [field]: regex })),
+      })
+        .select('objectId')
+        .lean();
+
+      if (matches.length) {
+        const ids = Array.from(
+          new Set(matches.map((match: any) => String(match.objectId))),
+        );
+        orConditions.push({ _id: { $in: ids } });
+      }
+    }
+
+    query.$or = orConditions;
+  }
+
+  /**
    * Add array field filter to query
    */
   protected addArrayFilter(query: any, field: string, values: string[]): void {
@@ -66,14 +112,15 @@ export class PostQueryBuilder extends BaseQueryBuilder {
       clientPortalId: args.clientPortalId,
     };
 
-    // Add search functionality
+    // Add search functionality (also matches non-default-language content
+    // stored in the Translations collection).
     if (args.searchValue) {
-      this.addSearchQuery(query, args.searchValue, [
-        'title',
-        'slug',
-        'content',
-        'excerpt',
-      ]);
+      await this.addTranslatableSearchQuery(query, args.searchValue, {
+        baseFields: ['title', 'slug', 'content', 'excerpt'],
+        language: args.language,
+        translationType: 'post',
+        translationFields: ['title', 'content', 'excerpt'],
+      });
     }
 
     // Add filters


### PR DESCRIPTION
## Problem

Searching posts in a non-default language (e.g. **Mongolian Cyrillic**) returned nothing / wrong results.

The post search built a regex over the **base document** fields (`title`, `slug`, `content`, `excerpt`). The base document only stores the **default language**; content authored in any other language lives in the `Translations` collection, which the search never touched. So when viewing/searching in `mn` (a non-default language), the Cyrillic text simply wasn't in the fields being searched.

Note: this is **not** a case-folding issue — MongoDB's regex `i` flag handles Cyrillic case-insensitivity correctly (verified). The fields being searched were the problem.

## Fix

Added `addTranslatableSearchQuery` to the query builder. For posts it now:
- matches the base fields (unchanged), **and**
- queries the `Translations` collection for the active `language` (`title`/`content`/`excerpt`) and unions the matching post ids into the search `$or`.

All post list resolvers (`cmsPosts`, `cmsPostList`, `cpPosts`, `cpPostList`, `cpPostListWithPagination`) go through `PostQueryBuilder.buildQuery`, so they all benefit. Existing read-access/`_id` constraints AND with the search `$or`, so scoping is preserved.

## Scope

Posts only, per the report. Pages and categories share the same base-only search limitation; happy to extend the same helper to them in a follow-up if wanted.

## Test

- `tsc --noEmit` and `eslint` pass.
- Verified in a local MongoDB that case-insensitive Cyrillic regex matches across cases; the new path additionally surfaces posts whose Mongolian translation matches the query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now include translated content, providing more comprehensive search coverage across all document languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->