### PR TITLE
feat(content): CMS default-language, custom-field ordering, record-table placeholder & search fixes

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -116,11 +116,8 @@ const buildRehomeOpsForDocument = (
   const baseUpdate: Record<string, any> = {};
   for (const [baseField, translationField] of Object.entries(fieldMappings)) {
     const value = newTranslation?.[translationField];
-    baseUpdate[baseField] = hasTranslatableValue(value)
-      ? value
-      : Array.isArray(doc[baseField])
-        ? []
-        : '';
+    const emptyValue = Array.isArray(doc[baseField]) ? [] : '';
+    baseUpdate[baseField] = hasTranslatableValue(value) ? value : emptyValue;
   }
 
   const documentOp = {

--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -85,7 +85,7 @@ const buildRehomeOpsForDocument = (
   newLanguage: string,
   type: string,
   newTranslationMap: Map<string, any>,
-): { translationOps: any[]; documentOp: Record<string, any> | null } => {
+): { translationOps: any[]; documentOp: Record<string, any> } => {
   const objectId = String(doc._id);
   const translationOps: any[] = [];
 
@@ -106,25 +106,26 @@ const buildRehomeOpsForDocument = (
     },
   });
 
-  // 2. Promote the new-language translation into the base fields. Only
-  //    non-empty values win, matching the read-time overlay so what the
-  //    editor saw under the new language is exactly what becomes default.
+  // 2. Replace the base fields with the new language's content. Unlike the
+  //    read-time overlay (which falls back to the default for empty values),
+  //    promoting a language must NOT inherit the old default's content: a field
+  //    the new language left empty has to become empty, otherwise the previous
+  //    default's text leaks into the new default. Missing/empty values are reset
+  //    to an empty value matching the field's shape (array vs. string).
   const newTranslation = newTranslationMap.get(objectId);
-  if (!newTranslation) {
-    return { translationOps, documentOp: null };
-  }
-
   const baseUpdate: Record<string, any> = {};
   for (const [baseField, translationField] of Object.entries(fieldMappings)) {
-    const value = newTranslation[translationField];
-    if (hasTranslatableValue(value)) {
-      baseUpdate[baseField] = value;
-    }
+    const value = newTranslation?.[translationField];
+    baseUpdate[baseField] = hasTranslatableValue(value)
+      ? value
+      : Array.isArray(doc[baseField])
+        ? []
+        : '';
   }
 
-  const documentOp = Object.keys(baseUpdate).length
-    ? { updateOne: { filter: { _id: doc._id }, update: { $set: baseUpdate } } }
-    : null;
+  const documentOp = {
+    updateOne: { filter: { _id: doc._id }, update: { $set: baseUpdate } },
+  };
 
   // 3. The new language now lives in the base fields, so its standalone
   //    translation record is redundant.
@@ -184,9 +185,7 @@ const rehomeDefaultLanguageContent = async (
         );
 
       translationOps.push(...docTranslationOps);
-      if (documentOp) {
-        documentOps.push(documentOp);
-      }
+      documentOps.push(documentOp);
     }
 
     if (!documentOps.length && !translationOps.length) {

--- a/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/Cms.ts
@@ -193,21 +193,15 @@ const rehomeDefaultLanguageContent = async (
       continue;
     }
 
-    // Base documents and their translations live in separate collections, so
-    // wrap both writes in a transaction — a partial apply would leave the new
-    // default's content out of sync with its translation records.
-    const session = await models.Translations.startSession();
-    try {
-      await session.withTransaction(async () => {
-        if (documentOps.length) {
-          await model.bulkWrite(documentOps, { session });
-        }
-        if (translationOps.length) {
-          await models.Translations.bulkWrite(translationOps, { session });
-        }
-      });
-    } finally {
-      await session.endSession();
+    // NOTE: base documents and their translations live in separate
+    // collections. We intentionally do not wrap these in a transaction —
+    // the deployment's MongoDB may not be a replica set, and a session-bound
+    // write buffers and times out there ("buffering timed out after 10000ms").
+    if (documentOps.length) {
+      await model.bulkWrite(documentOps);
+    }
+    if (translationOps.length) {
+      await models.Translations.bulkWrite(translationOps);
     }
   }
 };

--- a/backend/plugins/content_api/src/modules/cms/db/models/FieldGroups.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/FieldGroups.ts
@@ -133,7 +133,7 @@ export const loadCustomFieldGroupClass = (models: IModels) => {
 
     public static getCustomFieldGroups = async (query: any) => {
       return await models.CustomFieldGroups.find(query)
-        .sort({ name: 1 })
+        .sort({ order: 1, name: 1 })
         .lean();
     };
   }

--- a/backend/plugins/content_api/src/modules/cms/db/models/FieldGroups.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/models/FieldGroups.ts
@@ -86,6 +86,16 @@ export const loadCustomFieldGroupClass = (models: IModels) => {
       if (count > 0) {
         data.label = `${data.label} (${count + 1})`;
       }
+      // Assign a default order so new groups land at the end of the sorted
+      // list (getCustomFieldGroups sorts by `order`); mirrors Menu.ts.
+      if (data.order == null) {
+        const lastGroup = await models.CustomFieldGroups.findOne({
+          clientPortalId: data.clientPortalId,
+        })
+          .sort({ order: -1 })
+          .lean();
+        data.order = (lastGroup?.order || 0) + 1;
+      }
       return await models.CustomFieldGroups.create(data);
     };
 

--- a/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
@@ -1,3 +1,4 @@
+import type { FilterQuery } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 
@@ -49,7 +50,7 @@ export class BaseQueryBuilder {
    * active language matches, unioned by `_id`.
    */
   protected async addTranslatableSearchQuery(
-    query: any,
+    query: FilterQuery<any>,
     searchValue: string,
     options: {
       baseFields: string[];
@@ -63,9 +64,11 @@ export class BaseQueryBuilder {
     const pattern = escapeRegExp(searchValue.trim());
     const regex = new RegExp(pattern, 'i');
 
-    const orConditions: any[] = options.baseFields.map((field) => ({
-      [field]: regex,
-    }));
+    const orConditions: Array<FilterQuery<any>> = options.baseFields.map(
+      (field) => ({
+        [field]: regex,
+      }),
+    );
 
     if (options.language) {
       const matches = await this.models.Translations.find({
@@ -74,11 +77,11 @@ export class BaseQueryBuilder {
         $or: options.translationFields.map((field) => ({ [field]: regex })),
       })
         .select('objectId')
-        .lean();
+        .lean<Array<{ objectId: string }>>();
 
       if (matches.length) {
         const ids = Array.from(
-          new Set(matches.map((match: any) => String(match.objectId))),
+          new Set(matches.map((match) => String(match.objectId))),
         );
         orConditions.push({ _id: { $in: ids } });
       }

--- a/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/query-builders.ts
@@ -42,6 +42,52 @@ export class BaseQueryBuilder {
   }
 
   /**
+   * Translation-aware search. The base document only holds the default
+   * language, so a regex over base fields misses content authored in any other
+   * language (e.g. Mongolian Cyrillic stored in the `Translations` collection).
+   * This matches the base fields AND any document whose translation for the
+   * active language matches, unioned by `_id`.
+   */
+  protected async addTranslatableSearchQuery(
+    query: any,
+    searchValue: string,
+    options: {
+      baseFields: string[];
+      language?: string;
+      translationType: string;
+      translationFields: string[];
+    },
+  ): Promise<void> {
+    if (!searchValue?.trim()) return;
+
+    const pattern = escapeRegExp(searchValue.trim());
+    const regex = new RegExp(pattern, 'i');
+
+    const orConditions: any[] = options.baseFields.map((field) => ({
+      [field]: regex,
+    }));
+
+    if (options.language) {
+      const matches = await this.models.Translations.find({
+        type: options.translationType,
+        language: options.language,
+        $or: options.translationFields.map((field) => ({ [field]: regex })),
+      })
+        .select('objectId')
+        .lean();
+
+      if (matches.length) {
+        const ids = Array.from(
+          new Set(matches.map((match: any) => String(match.objectId))),
+        );
+        orConditions.push({ _id: { $in: ids } });
+      }
+    }
+
+    query.$or = orConditions;
+  }
+
+  /**
    * Add array field filter to query
    */
   protected addArrayFilter(query: any, field: string, values: string[]): void {
@@ -66,14 +112,15 @@ export class PostQueryBuilder extends BaseQueryBuilder {
       clientPortalId: args.clientPortalId,
     };
 
-    // Add search functionality
+    // Add search functionality (also matches non-default-language content
+    // stored in the Translations collection).
     if (args.searchValue) {
-      this.addSearchQuery(query, args.searchValue, [
-        'title',
-        'slug',
-        'content',
-        'excerpt',
-      ]);
+      await this.addTranslatableSearchQuery(query, args.searchValue, {
+        baseFields: ['title', 'slug', 'content', 'excerpt'],
+        language: args.language,
+        translationType: 'post',
+        translationFields: ['title', 'content', 'excerpt'],
+      });
     }
 
     // Add filters

--- a/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/CmsCategoryDrawer.tsx
@@ -858,6 +858,7 @@ export function CmsCategoryDrawer({
               {fieldGroups.length > 0 && (
                 <CategoryCustomFieldsSection
                   fieldGroups={fieldGroups}
+                  websiteId={clientPortalId}
                   getCustomFieldValue={getCustomFieldValue}
                   updateCustomFieldValue={updateCustomFieldValue}
                   form={form}

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesColumn.tsx
@@ -19,6 +19,7 @@ import {
 import { ICategory } from '@/cms/categories/types/CategoriesType';
 import { useEditCategory } from '@/cms/categories/hooks/useEditCategory';
 import { useIsTranslationMissing } from '@/cms/shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '@/cms/shared/components/CmsTranslatableBadge';
 import { useAtomValue } from 'jotai';
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 import { getTranslation } from '@/cms/shared/utils';
@@ -110,16 +111,14 @@ export const useCategoriesColumns = (
             }}
           >
             <RecordTableInlineCell.Trigger>
-              <Badge
-                variant={missing ? 'destructive' : 'secondary'}
-                className={missing ? 'border-red-300' : ''}
-              >
-                {prefix}
-                <TextOverflowTooltip
-                  value={cell.getValue() as string}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={cell.getValue() as string}
+                missing={missing}
+                placeholder="Untitled category"
+                prefix={prefix}
+                missingVariant="destructive"
+                missingClassName="border-red-300"
+              />
             </RecordTableInlineCell.Trigger>
             <RecordTableInlineCell.Content>
               <Input
@@ -150,6 +149,16 @@ export const useCategoriesColumns = (
         );
         const missing = isNonDefaultLanguage && !translation?.content?.trim();
         const value = cell.getValue() as string;
+
+        if (!value?.trim()) {
+          return (
+            <RecordTableInlineCell>
+              <span className="italic text-muted-foreground">
+                No description
+              </span>
+            </RecordTableInlineCell>
+          );
+        }
 
         if (missing) {
           return (

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoryCustomFieldsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoryCustomFieldsSection.tsx
@@ -1,10 +1,11 @@
-import { Form, Button, Collapsible } from 'erxes-ui';
+import { Form } from 'erxes-ui';
 import {
   CustomFieldInput,
   CustomFieldValue,
   FieldDefinition,
 } from '../../posts/CustomFieldInput';
-import { UseFormReturn, FieldPath, FieldValues } from 'react-hook-form';
+import { ReorderableCustomFields } from '../../custom-fields/components/ReorderableCustomFields';
+import { UseFormReturn, FieldValues } from 'react-hook-form';
 
 export interface FieldGroup {
   _id: string;
@@ -16,6 +17,7 @@ interface CategoryCustomFieldsSectionProps<
   T extends FieldValues & { customFieldsData?: any },
 > {
   fieldGroups: FieldGroup[];
+  websiteId?: string;
   getCustomFieldValue: (fieldId: string) => CustomFieldValue;
   updateCustomFieldValue: (
     fieldId: string,
@@ -41,66 +43,52 @@ export const CategoryCustomFieldsSection = <
   T extends FieldValues & { customFieldsData?: any },
 >({
   fieldGroups,
+  websiteId,
   getCustomFieldValue,
   updateCustomFieldValue,
   form,
   customFieldErrors = {},
 }: CategoryCustomFieldsSectionProps<T>) => (
-  <div className="space-y-3 mt-6 pt-6 border-t">
-    <div className="text-sm font-semibold text-foreground">Custom Fields</div>
-    {fieldGroups.map((group) => (
-      <Collapsible key={group._id} defaultOpen className="group">
-        <Collapsible.Trigger asChild>
-          <Button variant="secondary" className="w-full justify-start">
-            <Collapsible.TriggerIcon />
-            {group.label}
-          </Button>
-        </Collapsible.Trigger>
-        <Collapsible.Content className="pt-4">
-          <div className="grid gap-4 grid-cols-1">
-            {(group.fields || []).map((field) => {
-              const error =
-                customFieldErrors[field._id] ||
-                getCustomFieldsDataError(
-                  form.formState.errors as Record<string, any>,
-                  field._id,
-                );
+  <ReorderableCustomFields
+    fieldGroups={fieldGroups}
+    websiteId={websiteId}
+    renderField={(field) => {
+      const error =
+        customFieldErrors[field._id] ||
+        getCustomFieldsDataError(
+          form.formState.errors as Record<string, any>,
+          field._id,
+        );
 
-              return (
-                <div key={field._id} className="flex flex-col gap-2">
-                  <Form.Label
-                    className={`text-sm font-medium ${
-                      error ? 'text-destructive' : ''
-                    }`}
-                    htmlFor={`custom-field-${field._id}`}
-                  >
-                    {field.label}
-                    {field.isRequired && (
-                      <span className="text-destructive ml-1">*</span>
-                    )}
-                  </Form.Label>
-                  <CustomFieldInput
-                    field={field}
-                    value={getCustomFieldValue(field._id)}
-                    onChange={(value) => {
-                      updateCustomFieldValue(field._id, value);
-                      // Clear error when user starts typing
-                      if (error) {
-                        form.clearErrors(`customFieldsData.${field._id}` as any);
-                      }
-                    }}
-                  />
-                  {error && (
-                    <Form.Message className="text-sm font-medium text-destructive">
-                      {error}
-                    </Form.Message>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </Collapsible.Content>
-      </Collapsible>
-    ))}
-  </div>
+      return (
+        <div className="flex flex-col gap-2">
+          <Form.Label
+            className={`text-sm font-medium ${error ? 'text-destructive' : ''}`}
+            htmlFor={`custom-field-${field._id}`}
+          >
+            {field.label}
+            {field.isRequired && (
+              <span className="text-destructive ml-1">*</span>
+            )}
+          </Form.Label>
+          <CustomFieldInput
+            field={field}
+            value={getCustomFieldValue(field._id)}
+            onChange={(value) => {
+              updateCustomFieldValue(field._id, value);
+              // Clear error when user starts typing
+              if (error) {
+                form.clearErrors(`customFieldsData.${field._id}` as any);
+              }
+            }}
+          />
+          {error && (
+            <Form.Message className="text-sm font-medium text-destructive">
+              {error}
+            </Form.Message>
+          )}
+        </div>
+      );
+    }}
+  />
 );

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -5,11 +5,29 @@ import {
   useConfirm,
   toast,
   PageContainer,
+  cn,
 } from 'erxes-ui';
 import { IconPlus } from '@tabler/icons-react';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 import { CustomFieldsHeader } from './components/CustomFieldsHeader';
 import { CmsSidebar } from '../shared/CmsSidebar';
@@ -20,6 +38,33 @@ import { FieldGroupDrawer } from './components/field-group-drawer/FieldGroupDraw
 import { FieldDrawer } from './components/field-drawer/FieldDrawer';
 import { CustomFieldGroupItem } from './components/CustomFieldGroupItem';
 import { CMS_CUSTOM_POST_TYPES } from '../graphql/queries';
+
+function SortableGroup({
+  group,
+  children,
+}: {
+  group: ICustomFieldGroup;
+  children: (dragHandleProps: React.HTMLAttributes<HTMLElement>) => ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: group._id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn(isDragging && 'opacity-50')}
+    >
+      {children({ ...attributes, ...listeners })}
+    </div>
+  );
+}
 
 export function CustomFields() {
   const { websiteId } = useParams();
@@ -34,8 +79,34 @@ export function CustomFields() {
   const [editingField, setEditingField] = useState<ICustomField | null>(null);
   const { confirm } = useConfirm();
 
-  const { groups, loading, refetch, addGroup, editGroup, removeGroup } =
-    useCustomFieldGroups(websiteId);
+  const {
+    groups,
+    loading,
+    refetch,
+    addGroup,
+    editGroup,
+    removeGroup,
+    reorderGroups,
+    reorderFields,
+  } = useCustomFieldGroups(websiteId);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleGroupDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = groups.findIndex((g) => g._id === active.id);
+    const newIndex = groups.findIndex((g) => g._id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    reorderGroups(arrayMove(groups, oldIndex, newIndex));
+  };
 
   const { data: customTypesData } = useQuery(CMS_CUSTOM_POST_TYPES, {
     variables: { clientPortalId: websiteId },
@@ -244,25 +315,41 @@ export function CustomFields() {
                     </Button>
                   </div>
                 ) : (
-                  <div className="flex flex-col gap-2 mt-2">
-                    {groups.map((group) => (
-                      <CustomFieldGroupItem
-                        key={group._id}
-                        group={group}
-                        selectedGroupId={selectedGroup?._id || null}
-                        onSelectGroup={setSelectedGroup}
-                        onEditGroup={handleEditGroup}
-                        onDeleteGroup={handleDeleteGroup}
-                        onEditField={handleEditField}
-                        onDeleteField={handleDeleteField}
-                        onAddField={() => {
-                          setSelectedGroup(group);
-                          setEditingField(null);
-                          setIsFieldDrawerOpen(true);
-                        }}
-                      />
-                    ))}
-                  </div>
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleGroupDragEnd}
+                  >
+                    <SortableContext
+                      items={groups.map((g) => g._id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <div className="flex flex-col gap-2 mt-2">
+                        {groups.map((group) => (
+                          <SortableGroup key={group._id} group={group}>
+                            {(dragHandleProps) => (
+                              <CustomFieldGroupItem
+                                group={group}
+                                selectedGroupId={selectedGroup?._id || null}
+                                onSelectGroup={setSelectedGroup}
+                                onEditGroup={handleEditGroup}
+                                onDeleteGroup={handleDeleteGroup}
+                                onEditField={handleEditField}
+                                onDeleteField={handleDeleteField}
+                                onReorderFields={reorderFields}
+                                dragHandleProps={dragHandleProps}
+                                onAddField={() => {
+                                  setSelectedGroup(group);
+                                  setEditingField(null);
+                                  setIsFieldDrawerOpen(true);
+                                }}
+                              />
+                            )}
+                          </SortableGroup>
+                        ))}
+                      </div>
+                    </SortableContext>
+                  </DndContext>
                 )}
               </div>
             </div>

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -42,10 +42,10 @@ import { CMS_CUSTOM_POST_TYPES } from '../graphql/queries';
 function SortableGroup({
   group,
   children,
-}: {
+}: Readonly<{
   group: ICustomFieldGroup;
   children: (dragHandleProps: React.HTMLAttributes<HTMLElement>) => ReactNode;
-}) {
+}>) {
   const {
     attributes,
     listeners,

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/CustomFields.tsx
@@ -8,7 +8,7 @@ import {
   cn,
 } from 'erxes-ui';
 import { IconPlus } from '@tabler/icons-react';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
@@ -90,6 +90,14 @@ export function CustomFields() {
     reorderFields,
   } = useCustomFieldGroups(websiteId);
 
+  // Local order so a drop reflects immediately (no snap-back while the
+  // persisted order round-trips); re-synced whenever the stored order changes.
+  const [orderedGroups, setOrderedGroups] = useState(groups);
+  const groupsKey = groups.map((g) => g._id).join('|');
+  useEffect(() => {
+    setOrderedGroups(groups);
+  }, [groupsKey]);
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, {
@@ -100,12 +108,14 @@ export function CustomFields() {
   const handleGroupDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return;
 
-    const oldIndex = groups.findIndex((g) => g._id === active.id);
-    const newIndex = groups.findIndex((g) => g._id === over.id);
+    const oldIndex = orderedGroups.findIndex((g) => g._id === active.id);
+    const newIndex = orderedGroups.findIndex((g) => g._id === over.id);
 
     if (oldIndex === -1 || newIndex === -1) return;
 
-    reorderGroups(arrayMove(groups, oldIndex, newIndex));
+    const next = arrayMove(orderedGroups, oldIndex, newIndex);
+    setOrderedGroups(next);
+    reorderGroups(next);
   };
 
   const { data: customTypesData } = useQuery(CMS_CUSTOM_POST_TYPES, {
@@ -321,11 +331,11 @@ export function CustomFields() {
                     onDragEnd={handleGroupDragEnd}
                   >
                     <SortableContext
-                      items={groups.map((g) => g._id)}
+                      items={orderedGroups.map((g) => g._id)}
                       strategy={verticalListSortingStrategy}
                     >
                       <div className="flex flex-col gap-2 mt-2">
-                        {groups.map((group) => (
+                        {orderedGroups.map((group) => (
                           <SortableGroup key={group._id} group={group}>
                             {(dragHandleProps) => (
                               <CustomFieldGroupItem

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
@@ -47,11 +47,11 @@ function SortableFieldRow({
   field,
   onEditField,
   onDeleteField,
-}: {
+}: Readonly<{
   field: ICustomField;
   onEditField: (field: ICustomField) => void;
   onDeleteField: (fieldId: string) => void;
-}) {
+}>) {
   const {
     attributes,
     listeners,

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
@@ -6,7 +6,7 @@ import {
   IconPlus,
   IconGripVertical,
 } from '@tabler/icons-react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -146,7 +146,15 @@ export function CustomFieldGroupItem({
   onReorderFields,
   dragHandleProps,
 }: CustomFieldGroupItemProps) {
-  const fields = group.fields || [];
+  const groupFields = group.fields || [];
+
+  // Local order so a drop reflects immediately (no snap-back while the
+  // persisted order round-trips); re-synced whenever the stored order changes.
+  const [fields, setFields] = useState(groupFields);
+  const fieldsKey = groupFields.map((f) => f._id).join('|');
+  useEffect(() => {
+    setFields(group.fields || []);
+  }, [fieldsKey]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -163,7 +171,9 @@ export function CustomFieldGroupItem({
 
     if (oldIndex === -1 || newIndex === -1) return;
 
-    onReorderFields(group._id, arrayMove(fields, oldIndex, newIndex));
+    const next = arrayMove(fields, oldIndex, newIndex);
+    setFields(next);
+    onReorderFields(group._id, next);
   };
 
   return (

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/CustomFieldGroupItem.tsx
@@ -1,5 +1,29 @@
-import { Button, Table, DropdownMenu, Collapsible } from 'erxes-ui';
-import { IconEdit, IconTrash, IconDots, IconPlus } from '@tabler/icons-react';
+import { Button, Table, DropdownMenu, Collapsible, cn } from 'erxes-ui';
+import {
+  IconEdit,
+  IconTrash,
+  IconDots,
+  IconPlus,
+  IconGripVertical,
+} from '@tabler/icons-react';
+import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   ICustomFieldGroup,
   ICustomField,
@@ -15,6 +39,99 @@ interface CustomFieldGroupItemProps {
   onEditField: (field: ICustomField) => void;
   onDeleteField: (fieldId: string) => void;
   onAddField: () => void;
+  onReorderFields: (groupId: string, fields: ICustomField[]) => void;
+  dragHandleProps?: React.HTMLAttributes<HTMLElement>;
+}
+
+function SortableFieldRow({
+  field,
+  onEditField,
+  onDeleteField,
+}: {
+  field: ICustomField;
+  onEditField: (field: ICustomField) => void;
+  onDeleteField: (fieldId: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: field._id });
+
+  const fieldTypeObject = FIELD_TYPES_OBJECT[field.type];
+
+  return (
+    <Table.Row
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn('hover:bg-sidebar', isDragging && 'opacity-50')}
+    >
+      <Table.Cell className="w-8 p-0.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-full w-full text-muted-foreground size-7 cursor-grab active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <IconGripVertical />
+        </Button>
+      </Table.Cell>
+      <Table.Cell>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-full w-full justify-start hover:bg-transparent"
+          asChild
+        >
+          <div>
+            {fieldTypeObject?.icon}
+            {field.label}
+            {field.isRequired && <span className="text-destructive">*</span>}
+          </div>
+        </Button>
+      </Table.Cell>
+      <Table.Cell>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-full w-full justify-start hover:bg-transparent text-muted-foreground"
+          asChild
+        >
+          <div>{fieldTypeObject?.label || field.type}</div>
+        </Button>
+      </Table.Cell>
+      <Table.Cell className="w-8 p-0.5">
+        <DropdownMenu>
+          <DropdownMenu.Trigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-full w-full text-muted-foreground size-7"
+            >
+              <IconDots />
+            </Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content className="min-w-48">
+            <DropdownMenu.Item onClick={() => onEditField(field)}>
+              <IconEdit />
+              Edit
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              className="text-destructive"
+              onClick={() => onDeleteField(field._id)}
+            >
+              <IconTrash />
+              Delete
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </Table.Cell>
+    </Table.Row>
+  );
 }
 
 export function CustomFieldGroupItem({
@@ -26,7 +143,29 @@ export function CustomFieldGroupItem({
   onEditField,
   onDeleteField,
   onAddField,
+  onReorderFields,
+  dragHandleProps,
 }: CustomFieldGroupItemProps) {
+  const fields = group.fields || [];
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleFieldDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = fields.findIndex((f) => f._id === active.id);
+    const newIndex = fields.findIndex((f) => f._id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    onReorderFields(group._id, arrayMove(fields, oldIndex, newIndex));
+  };
+
   return (
     <Collapsible
       key={group._id}
@@ -36,11 +175,19 @@ export function CustomFieldGroupItem({
     >
       <div className="relative">
         <Collapsible.Trigger asChild>
-          <Button variant="secondary" className="w-full justify-start">
+          <Button variant="secondary" className="w-full justify-start pl-8">
             <Collapsible.TriggerIcon />
             <span className="truncate leading-normal">{group.label}</span>
           </Button>
         </Collapsible.Trigger>
+        <Button
+          variant="secondary"
+          size="icon"
+          className="absolute left-0.5 top-0.5 size-6 px-0 cursor-grab active:cursor-grabbing text-muted-foreground"
+          {...dragHandleProps}
+        >
+          <IconGripVertical />
+        </Button>
         <DropdownMenu>
           <DropdownMenu.Trigger asChild>
             <Button
@@ -70,75 +217,35 @@ export function CustomFieldGroupItem({
       <Collapsible.Content className="pt-2">
         <Table className="[&_tr_td]:border-b-0 [&_tr_td:first-child]:border-l-0 [&_tr_td]:border-r-0">
           <Table.Body>
-            {(group.fields || []).length === 0 ? (
+            {fields.length === 0 ? (
               <Table.Row className="hover:bg-background">
                 <Table.Cell
-                  colSpan={3}
+                  colSpan={4}
                   className="h-auto py-12 text-center text-muted-foreground"
                 >
                   No fields found
                 </Table.Cell>
               </Table.Row>
             ) : (
-              (group.fields || []).map((field: ICustomField) => {
-                const fieldTypeObject = FIELD_TYPES_OBJECT[field.type];
-                return (
-                  <Table.Row key={field._id} className="hover:bg-sidebar">
-                    <Table.Cell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-full w-full justify-start hover:bg-transparent"
-                        asChild
-                      >
-                        <div>
-                          {fieldTypeObject?.icon}
-                          {field.label}
-                          {field.isRequired && (
-                            <span className="text-destructive">*</span>
-                          )}
-                        </div>
-                      </Button>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-full w-full justify-start hover:bg-transparent text-muted-foreground"
-                        asChild
-                      >
-                        <div>{fieldTypeObject?.label || field.type}</div>
-                      </Button>
-                    </Table.Cell>
-                    <Table.Cell className="w-8 p-0.5">
-                      <DropdownMenu>
-                        <DropdownMenu.Trigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-full w-full text-muted-foreground size-7"
-                          >
-                            <IconDots />
-                          </Button>
-                        </DropdownMenu.Trigger>
-                        <DropdownMenu.Content className="min-w-48">
-                          <DropdownMenu.Item onClick={() => onEditField(field)}>
-                            <IconEdit />
-                            Edit
-                          </DropdownMenu.Item>
-                          <DropdownMenu.Item
-                            className="text-destructive"
-                            onClick={() => onDeleteField(field._id)}
-                          >
-                            <IconTrash />
-                            Delete
-                          </DropdownMenu.Item>
-                        </DropdownMenu.Content>
-                      </DropdownMenu>
-                    </Table.Cell>
-                  </Table.Row>
-                );
-              })
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleFieldDragEnd}
+              >
+                <SortableContext
+                  items={fields.map((f) => f._id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {fields.map((field) => (
+                    <SortableFieldRow
+                      key={field._id}
+                      field={field}
+                      onEditField={onEditField}
+                      onDeleteField={onDeleteField}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
             )}
           </Table.Body>
         </Table>

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
@@ -1,6 +1,6 @@
 import { Button, Collapsible, cn } from 'erxes-ui';
 import { IconGripVertical } from '@tabler/icons-react';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -74,7 +74,15 @@ function FieldList({
   renderField: ReorderableCustomFieldsProps['renderField'];
   onReorderFields: (groupId: string, fields: FieldDefinition[]) => void;
 }) {
-  const fields = group.fields || [];
+  const groupFields = group.fields || [];
+
+  // Local order so a drop reflects immediately (no snap-back while the
+  // persisted order round-trips); re-synced whenever the stored order changes.
+  const [fields, setFields] = useState(groupFields);
+  const fieldsKey = groupFields.map((f) => f._id).join('|');
+  useEffect(() => {
+    setFields(group.fields || []);
+  }, [fieldsKey]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -91,7 +99,9 @@ function FieldList({
 
     if (oldIndex === -1 || newIndex === -1) return;
 
-    onReorderFields(group._id, arrayMove(fields, oldIndex, newIndex));
+    const next = arrayMove(fields, oldIndex, newIndex);
+    setFields(next);
+    onReorderFields(group._id, next);
   };
 
   return (
@@ -144,6 +154,14 @@ export const ReorderableCustomFields = ({
   const { reorderVisibleGroups, reorderFields } =
     useCustomFieldOrdering(websiteId);
 
+  // Local order so a drop reflects immediately (no snap-back while the
+  // persisted order round-trips); re-synced whenever the stored order changes.
+  const [groups, setGroups] = useState(fieldGroups);
+  const groupsKey = fieldGroups.map((g) => g._id).join('|');
+  useEffect(() => {
+    setGroups(fieldGroups);
+  }, [groupsKey]);
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, {
@@ -154,12 +172,14 @@ export const ReorderableCustomFields = ({
   const handleGroupDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return;
 
-    const oldIndex = fieldGroups.findIndex((g) => g._id === active.id);
-    const newIndex = fieldGroups.findIndex((g) => g._id === over.id);
+    const oldIndex = groups.findIndex((g) => g._id === active.id);
+    const newIndex = groups.findIndex((g) => g._id === over.id);
 
     if (oldIndex === -1 || newIndex === -1) return;
 
-    reorderVisibleGroups(arrayMove(fieldGroups, oldIndex, newIndex));
+    const next = arrayMove(groups, oldIndex, newIndex);
+    setGroups(next);
+    reorderVisibleGroups(next);
   };
 
   return (
@@ -171,10 +191,10 @@ export const ReorderableCustomFields = ({
         onDragEnd={handleGroupDragEnd}
       >
         <SortableContext
-          items={fieldGroups.map((g) => g._id)}
+          items={groups.map((g) => g._id)}
           strategy={verticalListSortingStrategy}
         >
-          {fieldGroups.map((group) => (
+          {groups.map((group) => (
             <Sortable key={group._id} id={group._id}>
               {(dragHandleProps) => (
                 <Collapsible defaultOpen className="group">

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
@@ -1,0 +1,215 @@
+import { Button, Collapsible, cn } from 'erxes-ui';
+import { IconGripVertical } from '@tabler/icons-react';
+import { ReactNode } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { FieldDefinition } from '../../posts/CustomFieldInput';
+import { useCustomFieldOrdering } from '../hooks/useCustomFieldOrdering';
+
+export interface ReorderableFieldGroup {
+  _id: string;
+  label: string;
+  fields?: FieldDefinition[];
+}
+
+interface ReorderableCustomFieldsProps {
+  fieldGroups: ReorderableFieldGroup[];
+  websiteId?: string;
+  renderField: (
+    field: FieldDefinition,
+    group: ReorderableFieldGroup,
+  ) => ReactNode;
+}
+
+type DragHandleProps = React.HTMLAttributes<HTMLElement>;
+
+function Sortable({
+  id,
+  children,
+}: {
+  id: string;
+  children: (dragHandleProps: DragHandleProps) => ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn(isDragging && 'opacity-50')}
+    >
+      {children({ ...attributes, ...listeners })}
+    </div>
+  );
+}
+
+function FieldList({
+  group,
+  renderField,
+  onReorderFields,
+}: {
+  group: ReorderableFieldGroup;
+  renderField: ReorderableCustomFieldsProps['renderField'];
+  onReorderFields: (groupId: string, fields: FieldDefinition[]) => void;
+}) {
+  const fields = group.fields || [];
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = fields.findIndex((f) => f._id === active.id);
+    const newIndex = fields.findIndex((f) => f._id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    onReorderFields(group._id, arrayMove(fields, oldIndex, newIndex));
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={fields.map((f) => f._id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="grid gap-4 grid-cols-1">
+          {fields.map((field) => (
+            <Sortable key={field._id} id={field._id}>
+              {(dragHandleProps) => (
+                <div className="flex items-start gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="mt-6 size-7 shrink-0 text-muted-foreground cursor-grab active:cursor-grabbing"
+                    {...dragHandleProps}
+                  >
+                    <IconGripVertical />
+                  </Button>
+                  <div className="min-w-0 flex-1">
+                    {renderField(field, group)}
+                  </div>
+                </div>
+              )}
+            </Sortable>
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+/**
+ * Renders custom field groups and their fields on a content detail editor with
+ * drag-to-reorder for both groups and the fields inside each group. The actual
+ * field input is provided by the caller via `renderField`, so each editor keeps
+ * its own value-binding/validation while sharing the reorder chrome.
+ */
+export const ReorderableCustomFields = ({
+  fieldGroups,
+  websiteId,
+  renderField,
+}: ReorderableCustomFieldsProps) => {
+  const { reorderVisibleGroups, reorderFields } =
+    useCustomFieldOrdering(websiteId);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleGroupDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = fieldGroups.findIndex((g) => g._id === active.id);
+    const newIndex = fieldGroups.findIndex((g) => g._id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    reorderVisibleGroups(arrayMove(fieldGroups, oldIndex, newIndex));
+  };
+
+  return (
+    <div className="space-y-3 mt-6 pt-6 border-t">
+      <div className="text-sm font-semibold text-foreground">Custom Fields</div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleGroupDragEnd}
+      >
+        <SortableContext
+          items={fieldGroups.map((g) => g._id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {fieldGroups.map((group) => (
+            <Sortable key={group._id} id={group._id}>
+              {(dragHandleProps) => (
+                <Collapsible defaultOpen className="group">
+                  <div className="relative">
+                    <Collapsible.Trigger asChild>
+                      <Button
+                        variant="secondary"
+                        className="w-full justify-start pl-8"
+                      >
+                        <Collapsible.TriggerIcon />
+                        {group.label}
+                      </Button>
+                    </Collapsible.Trigger>
+                    <Button
+                      variant="secondary"
+                      size="icon"
+                      className="absolute left-0.5 top-0.5 size-6 px-0 cursor-grab active:cursor-grabbing text-muted-foreground"
+                      {...dragHandleProps}
+                    >
+                      <IconGripVertical />
+                    </Button>
+                  </div>
+                  <Collapsible.Content className="pt-4">
+                    <FieldList
+                      group={group}
+                      renderField={renderField}
+                      onReorderFields={reorderFields}
+                    />
+                  </Collapsible.Content>
+                </Collapsible>
+              )}
+            </Sortable>
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/components/ReorderableCustomFields.tsx
@@ -41,10 +41,10 @@ type DragHandleProps = React.HTMLAttributes<HTMLElement>;
 function Sortable({
   id,
   children,
-}: {
+}: Readonly<{
   id: string;
   children: (dragHandleProps: DragHandleProps) => ReactNode;
-}) {
+}>) {
   const {
     attributes,
     listeners,
@@ -69,11 +69,11 @@ function FieldList({
   group,
   renderField,
   onReorderFields,
-}: {
+}: Readonly<{
   group: ReorderableFieldGroup;
   renderField: ReorderableCustomFieldsProps['renderField'];
   onReorderFields: (groupId: string, fields: FieldDefinition[]) => void;
-}) {
+}>) {
   const groupFields = group.fields || [];
 
   // Local order so a drop reflects immediately (no snap-back while the

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/mutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/mutations.ts
@@ -6,6 +6,7 @@ export const CMS_CUSTOM_FIELD_GROUP_ADD = gql`
       _id
       label
       code
+      order
       clientPortalId
       customPostTypeIds
       customPostTypes {
@@ -31,6 +32,7 @@ export const CMS_CUSTOM_FIELD_GROUP_EDIT = gql`
       _id
       label
       code
+      order
       clientPortalId
       customPostTypeIds
       customPostTypes {

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/graphql/queries.ts
@@ -7,6 +7,7 @@ export const CMS_CUSTOM_FIELD_GROUPS = gql`
         _id
         label
         code
+        order
         clientPortalId
         customPostTypeIds
         customPostTypes {

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -107,6 +107,7 @@ export const useCustomFieldGroups = (websiteId?: string) => {
 
   // Persist a new group order. `orderedGroups` is the full list in its desired
   // order; only groups whose 1-based position changed are written.
+  // `label` is required by CustomFieldGroupInput, so it is always sent.
   const reorderGroups = async (orderedGroups: ICustomFieldGroup[]) => {
     const changes = orderedGroups
       .map((group, index) => ({ group, order: index + 1 }))
@@ -116,7 +117,9 @@ export const useCustomFieldGroups = (websiteId?: string) => {
 
     await Promise.all(
       changes.map(({ group, order }) =>
-        editGroupSilent({ variables: { _id: group._id, input: { order } } }),
+        editGroupSilent({
+          variables: { _id: group._id, input: { label: group.label, order } },
+        }),
       ),
     );
     await refetch();
@@ -124,12 +127,19 @@ export const useCustomFieldGroups = (websiteId?: string) => {
 
   // Persist a new field order within a group. `reorderedFields` is the group's
   // `fields` array in its desired order (array position is the display order).
+  // `label` is required by CustomFieldGroupInput, so it is always sent.
   const reorderFields = async (
     groupId: string,
     reorderedFields: ICustomFieldGroup['fields'],
   ) => {
+    const group = groups.find((g) => g._id === groupId);
+    if (!group) return;
+
     await editGroupSilent({
-      variables: { _id: groupId, input: { fields: reorderedFields } },
+      variables: {
+        _id: groupId,
+        input: { label: group.label, fields: reorderedFields },
+      },
     });
     await refetch();
   };

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -26,20 +26,28 @@ const compareByLabel = (
   });
 };
 
+// Groups are manually ordered via the `order` column; fall back to label for
+// groups that don't have an order yet so they stay stable.
+const compareByOrder = (a: ICustomFieldGroup, b: ICustomFieldGroup) => {
+  const aOrder = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
+  const bOrder = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
+
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  return compareByLabel(a, b);
+};
+
 export const useCustomFieldGroups = (websiteId?: string) => {
   const { data, loading, refetch } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {
     variables: { clientPortalId: websiteId },
     skip: !websiteId,
   });
 
+  // Preserve the stored `fields` array order (that is the field display order);
+  // only the groups themselves are sorted, by their `order` column.
   const groups = useMemo(
     () =>
-      ((data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[])
-        .map((group) => ({
-          ...group,
-          fields: [...(group.fields || [])].sort(compareByLabel),
-        }))
-        .sort(compareByLabel),
+      [...((data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[])]
+        .sort(compareByOrder),
     [data?.cmsCustomFieldGroupList?.list],
   );
 
@@ -85,6 +93,47 @@ export const useCustomFieldGroups = (websiteId?: string) => {
     },
   });
 
+  // Silent edit used for drag-reordering so we don't toast on every persisted
+  // position change.
+  const [editGroupSilent] = useMutation(CMS_CUSTOM_FIELD_GROUP_EDIT, {
+    onError: (error) => {
+      toast({
+        title: 'Error',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  // Persist a new group order. `orderedGroups` is the full list in its desired
+  // order; only groups whose 1-based position changed are written.
+  const reorderGroups = async (orderedGroups: ICustomFieldGroup[]) => {
+    const changes = orderedGroups
+      .map((group, index) => ({ group, order: index + 1 }))
+      .filter(({ group, order }) => group.order !== order);
+
+    if (!changes.length) return;
+
+    await Promise.all(
+      changes.map(({ group, order }) =>
+        editGroupSilent({ variables: { _id: group._id, input: { order } } }),
+      ),
+    );
+    await refetch();
+  };
+
+  // Persist a new field order within a group. `reorderedFields` is the group's
+  // `fields` array in its desired order (array position is the display order).
+  const reorderFields = async (
+    groupId: string,
+    reorderedFields: ICustomFieldGroup['fields'],
+  ) => {
+    await editGroupSilent({
+      variables: { _id: groupId, input: { fields: reorderedFields } },
+    });
+    await refetch();
+  };
+
   return {
     groups,
     loading,
@@ -92,5 +141,7 @@ export const useCustomFieldGroups = (websiteId?: string) => {
     addGroup,
     editGroup,
     removeGroup,
+    reorderGroups,
+    reorderFields,
   };
 };

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldGroups.ts
@@ -8,33 +8,7 @@ import {
   CMS_CUSTOM_FIELD_GROUP_REMOVE,
 } from '../graphql/mutations';
 import { ICustomFieldGroup } from '../types/customFieldTypes';
-
-const compareByLabel = (
-  a: { _id?: string; label?: string; code?: string },
-  b: { _id?: string; label?: string; code?: string },
-) => {
-  const aValue = a.label || a.code || a._id || '';
-  const bValue = b.label || b.code || b._id || '';
-
-  if (!aValue && !bValue) return 0;
-  if (!aValue) return 1;
-  if (!bValue) return -1;
-
-  return aValue.localeCompare(bValue, 'en', {
-    numeric: true,
-    sensitivity: 'base',
-  });
-};
-
-// Groups are manually ordered via the `order` column; fall back to label for
-// groups that don't have an order yet so they stay stable.
-const compareByOrder = (a: ICustomFieldGroup, b: ICustomFieldGroup) => {
-  const aOrder = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
-  const bOrder = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
-
-  if (aOrder !== bOrder) return aOrder - bOrder;
-  return compareByLabel(a, b);
-};
+import { compareByOrder } from '../utils/comparators';
 
 export const useCustomFieldGroups = (websiteId?: string) => {
   const { data, loading, refetch } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldOrdering.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldOrdering.ts
@@ -4,12 +4,7 @@ import { useMemo } from 'react';
 import { CMS_CUSTOM_FIELD_GROUPS } from '../graphql/queries';
 import { CMS_CUSTOM_FIELD_GROUP_EDIT } from '../graphql/mutations';
 import { ICustomFieldGroup } from '../types/customFieldTypes';
-
-const byOrder = (a: ICustomFieldGroup, b: ICustomFieldGroup) => {
-  const aOrder = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
-  const bOrder = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
-  return aOrder - bOrder;
-};
+import { compareByOrder } from '../utils/comparators';
 
 /**
  * Drag-reorder helpers for custom field groups/fields usable from the content
@@ -30,7 +25,7 @@ export const useCustomFieldOrdering = (websiteId?: string) => {
     () =>
       [
         ...((data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[]),
-      ].sort(byOrder),
+      ].sort(compareByOrder),
     [data?.cmsCustomFieldGroupList?.list],
   );
 

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldOrdering.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/hooks/useCustomFieldOrdering.ts
@@ -1,0 +1,97 @@
+import { useMutation, useQuery } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { useMemo } from 'react';
+import { CMS_CUSTOM_FIELD_GROUPS } from '../graphql/queries';
+import { CMS_CUSTOM_FIELD_GROUP_EDIT } from '../graphql/mutations';
+import { ICustomFieldGroup } from '../types/customFieldTypes';
+
+const byOrder = (a: ICustomFieldGroup, b: ICustomFieldGroup) => {
+  const aOrder = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
+  const bOrder = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
+  return aOrder - bOrder;
+};
+
+/**
+ * Drag-reorder helpers for custom field groups/fields usable from the content
+ * detail editors (posts, pages, categories). Order is stored on the shared
+ * group definition (`order` column + `fields` array), so reordering here changes
+ * it globally — consistent with the Custom Fields settings page.
+ */
+export const useCustomFieldOrdering = (websiteId?: string) => {
+  const { data, refetch } = useQuery(CMS_CUSTOM_FIELD_GROUPS, {
+    variables: { clientPortalId: websiteId },
+    skip: !websiteId,
+    fetchPolicy: 'cache-first',
+  });
+
+  // Full group set in global order — needed to translate a reorder of the
+  // (possibly filtered) visible groups back into global `order` values.
+  const allGroups = useMemo(
+    () =>
+      [
+        ...((data?.cmsCustomFieldGroupList?.list || []) as ICustomFieldGroup[]),
+      ].sort(byOrder),
+    [data?.cmsCustomFieldGroupList?.list],
+  );
+
+  const [editGroup] = useMutation(CMS_CUSTOM_FIELD_GROUP_EDIT, {
+    onError: (error) =>
+      toast({
+        title: 'Error',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+
+  // Reorder only the visible (filtered) groups while keeping hidden groups in
+  // their existing slots, then persist any group whose 1-based order changed.
+  const reorderVisibleGroups = async (
+    visibleOrdered: { _id: string }[],
+  ) => {
+    const visibleIds = new Set(visibleOrdered.map((g) => g._id));
+    const byId = new Map(allGroups.map((g) => [g._id, g]));
+    const queue = visibleOrdered
+      .map((g) => byId.get(g._id))
+      .filter((g): g is ICustomFieldGroup => Boolean(g));
+
+    let cursor = 0;
+    const fullOrdered = allGroups.map((g) =>
+      visibleIds.has(g._id) ? queue[cursor++] : g,
+    );
+
+    const changes = fullOrdered
+      .map((group, index) => ({ group, order: index + 1 }))
+      .filter(({ group, order }) => group.order !== order);
+
+    if (!changes.length) return;
+
+    await Promise.all(
+      changes.map(({ group, order }) =>
+        editGroup({
+          variables: { _id: group._id, input: { label: group.label, order } },
+        }),
+      ),
+    );
+    await refetch();
+  };
+
+  // Persist a new field order within a group. `reorderedFields` is the group's
+  // `fields` array in its desired order (array position is the display order).
+  const reorderFields = async (
+    groupId: string,
+    reorderedFields: ICustomFieldGroup['fields'],
+  ) => {
+    const group = allGroups.find((g) => g._id === groupId);
+    if (!group) return;
+
+    await editGroup({
+      variables: {
+        _id: groupId,
+        input: { label: group.label, fields: reorderedFields },
+      },
+    });
+    await refetch();
+  };
+
+  return { reorderVisibleGroups, reorderFields };
+};

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.tsx
@@ -36,6 +36,7 @@ export interface ICustomFieldGroup {
   _id: string;
   label: string;
   code: string;
+  order?: number;
   clientPortalId: string;
   customPostTypeIds: string[];
   customPostTypes?: Array<{

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/utils/comparators.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/utils/comparators.ts
@@ -1,0 +1,28 @@
+import { ICustomFieldGroup } from '../types/customFieldTypes';
+
+export const compareByLabel = (
+  a: { _id?: string; label?: string; code?: string },
+  b: { _id?: string; label?: string; code?: string },
+) => {
+  const aValue = a.label || a.code || a._id || '';
+  const bValue = b.label || b.code || b._id || '';
+
+  if (!aValue && !bValue) return 0;
+  if (!aValue) return 1;
+  if (!bValue) return -1;
+
+  return aValue.localeCompare(bValue, 'en', {
+    numeric: true,
+    sensitivity: 'base',
+  });
+};
+
+// Groups are manually ordered via the `order` column; fall back to label for
+// groups that don't have an order yet so they stay stable.
+export const compareByOrder = (a: ICustomFieldGroup, b: ICustomFieldGroup) => {
+  const aOrder = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
+  const bOrder = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
+
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  return compareByLabel(a, b);
+};

--- a/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/PageDrawer.tsx
@@ -764,6 +764,7 @@ export function PageDrawer({
               {fieldGroups.length > 0 && (
                 <PageCustomFieldsSection
                   fieldGroups={fieldGroups}
+                  websiteId={clientPortalId}
                   form={form}
                 />
               )}

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PageCustomFieldsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PageCustomFieldsSection.tsx
@@ -1,10 +1,11 @@
-import { Form, Button, Collapsible } from 'erxes-ui';
+import { Form } from 'erxes-ui';
 import { UseFormReturn, Controller } from 'react-hook-form';
 import {
   CustomFieldInput,
   CustomFieldValue,
   FieldDefinition,
 } from '../../posts/CustomFieldInput';
+import { ReorderableCustomFields } from '../../custom-fields/components/ReorderableCustomFields';
 import { IPageFormData } from '../types/pageTypes';
 
 interface CustomFieldDataItem {
@@ -12,7 +13,7 @@ interface CustomFieldDataItem {
   value: CustomFieldValue;
 }
 
-interface CustomFieldsData extends Array<CustomFieldDataItem> {}
+type CustomFieldsData = CustomFieldDataItem[];
 
 export interface FieldGroup {
   _id: string;
@@ -31,6 +32,7 @@ export interface FieldGroup {
 
 interface PageCustomFieldsSectionProps {
   fieldGroups: FieldGroup[];
+  websiteId?: string;
   form: UseFormReturn<IPageFormData>;
 }
 
@@ -93,54 +95,41 @@ const CustomFieldController = ({
 
 export const PageCustomFieldsSection = ({
   fieldGroups,
+  websiteId,
   form,
 }: PageCustomFieldsSectionProps) => (
-  <div className="space-y-3 mt-6 pt-6 border-t">
-    <div className="text-sm font-semibold text-foreground">Custom Fields</div>
-    {fieldGroups.map((group) => (
-      <Collapsible key={group._id} defaultOpen className="group">
-        <Collapsible.Trigger asChild>
-          <Button variant="secondary" className="w-full justify-start">
-            <Collapsible.TriggerIcon />
-            {group.label}
-          </Button>
-        </Collapsible.Trigger>
-        <Collapsible.Content className="pt-4">
-          <div className="grid gap-4 grid-cols-1">
-            {(group.fields || []).map((field) => (
-              <Form.Field
-                key={field._id}
-                control={form.control}
-                name={`customFieldsData`}
-                render={({ field: formField }) => {
-                  const currentData: CustomFieldsData = formField.value || [];
-                  const fieldValue = getFieldValue(currentData, field._id);
+  <ReorderableCustomFields
+    fieldGroups={fieldGroups}
+    websiteId={websiteId}
+    renderField={(field) => (
+      <Form.Field
+        control={form.control}
+        name={`customFieldsData`}
+        render={({ field: formField }) => {
+          const currentData: CustomFieldsData = formField.value || [];
+          const fieldValue = getFieldValue(currentData, field._id);
 
-                  return (
-                    <div className="flex flex-col gap-2">
-                      <Form.Label
-                        className="text-sm font-medium"
-                        htmlFor={`custom-field-${field._id}`}
-                      >
-                        {field.label}
-                        {field.isRequired && (
-                          <span className="text-destructive ml-1">*</span>
-                        )}
-                      </Form.Label>
-                      <CustomFieldController
-                        field={field}
-                        fieldValue={fieldValue}
-                        form={form}
-                      />
-                      <Form.Message />
-                    </div>
-                  );
-                }}
+          return (
+            <div className="flex flex-col gap-2">
+              <Form.Label
+                className="text-sm font-medium"
+                htmlFor={`custom-field-${field._id}`}
+              >
+                {field.label}
+                {field.isRequired && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </Form.Label>
+              <CustomFieldController
+                field={field}
+                fieldValue={fieldValue}
+                form={form}
               />
-            ))}
-          </div>
-        </Collapsible.Content>
-      </Collapsible>
-    ))}
-  </div>
+              <Form.Message />
+            </div>
+          );
+        }}
+      />
+    )}
+  />
 );

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesColumn.tsx
@@ -3,7 +3,6 @@ import {
   RecordTableInlineCell,
   TextOverflowTooltip,
   RelativeDateDisplay,
-  Badge,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
 import { pageMoreColumn } from './PagesMoreColumn';
@@ -16,6 +15,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { IPage } from '../types/pageTypes';
 import { useIsTranslationMissing } from '../../shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '../../shared/components/CmsTranslatableBadge';
 
 export const usePagesColumns = (
   onEditPage?: (page: IPage) => void,
@@ -48,12 +48,11 @@ export const usePagesColumns = (
               }}
               className="cursor-pointer"
             >
-              <Badge
-                variant={missing ? 'outline' : 'secondary'}
-                className={missing ? 'text-red-500 border-red-300' : ''}
-              >
-                <TextOverflowTooltip value={page.name} className="leading-normal" />
-              </Badge>
+              <CmsTranslatableBadge
+                value={page.name}
+                missing={missing}
+                placeholder="Untitled page"
+              />
             </div>
           </RecordTableInlineCell>
         );

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsColumn.tsx
@@ -3,7 +3,6 @@ import {
   TextOverflowTooltip,
   RecordTableInlineCell,
   RelativeDateDisplay,
-  Badge,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
 import {
@@ -23,6 +22,7 @@ import { postMoreColumn } from './PostMoreColumn';
 import { PostsRecordTableStatusInlineCell } from './PostsRecordTableStatusInlineCell';
 import { PostPublicUrlButton } from './PostPublicUrlButton';
 import { useIsTranslationMissing } from '../../shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '../../shared/components/CmsTranslatableBadge';
 import type { Posts } from '../types/postsType';
 import type { IWebsite } from '../../types';
 import { buildCurrentPostsReturnPath } from '../utils/postsNavigation';
@@ -118,15 +118,11 @@ export const usePostsColumns = (
               }}
               className="cursor-pointer "
             >
-              <Badge
-                variant={missing ? 'outline' : 'secondary'}
-                className={missing ? 'text-red-500 border-red-300' : ''}
-              >
-                <TextOverflowTooltip
-                  value={post.title}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={post.title}
+                missing={missing}
+                placeholder="Untitled post"
+              />
             </div>
           </RecordTableInlineCell>
         );

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
@@ -322,6 +322,7 @@ export const AddPostForm = ({
               defaultLanguage={defaultLanguage}
               selectedType={selectedType}
               fieldGroups={fieldGroups}
+              websiteId={websiteId}
               fullPost={fullPost}
               handleEditorChange={handlePostEditorChange}
               getCustomFieldValue={getCustomFieldValue}

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CustomFieldsSection.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/CustomFieldsSection.tsx
@@ -1,9 +1,10 @@
-import { Form, Button, Collapsible } from 'erxes-ui';
+import { Form } from 'erxes-ui';
 import {
   CustomFieldInput,
   CustomFieldValue,
   FieldDefinition,
 } from '../../CustomFieldInput';
+import { ReorderableCustomFields } from '../../../custom-fields/components/ReorderableCustomFields';
 
 export interface FieldGroup {
   _id: string;
@@ -13,6 +14,7 @@ export interface FieldGroup {
 
 interface CustomFieldsSectionProps {
   fieldGroups: FieldGroup[];
+  websiteId?: string;
   getCustomFieldValue: (fieldId: string) => CustomFieldValue;
   updateCustomFieldValue: (
     fieldId: string,
@@ -22,42 +24,30 @@ interface CustomFieldsSectionProps {
 
 export const CustomFieldsSection = ({
   fieldGroups,
+  websiteId,
   getCustomFieldValue,
   updateCustomFieldValue,
 }: CustomFieldsSectionProps) => (
-  <div className="space-y-3 mt-6 pt-6 border-t">
-    <div className="text-sm font-semibold text-foreground">Custom Fields</div>
-    {fieldGroups.map((group) => (
-      <Collapsible key={group._id} defaultOpen className="group">
-        <Collapsible.Trigger asChild>
-          <Button variant="secondary" className="w-full justify-start">
-            <Collapsible.TriggerIcon />
-            {group.label}
-          </Button>
-        </Collapsible.Trigger>
-        <Collapsible.Content className="pt-4">
-          <div className="grid gap-4 grid-cols-1">
-            {(group.fields || []).map((field) => (
-              <div key={field._id} className="flex flex-col gap-2">
-                <Form.Label
-                  className="text-sm font-medium"
-                  htmlFor={`custom-field-${field._id}`}
-                >
-                  {field.label}
-                  {field.isRequired && (
-                    <span className="text-destructive ml-1">*</span>
-                  )}
-                </Form.Label>
-                <CustomFieldInput
-                  field={field}
-                  value={getCustomFieldValue(field._id)}
-                  onChange={(value) => updateCustomFieldValue(field._id, value)}
-                />
-              </div>
-            ))}
-          </div>
-        </Collapsible.Content>
-      </Collapsible>
-    ))}
-  </div>
+  <ReorderableCustomFields
+    fieldGroups={fieldGroups}
+    websiteId={websiteId}
+    renderField={(field) => (
+      <div className="flex flex-col gap-2">
+        <Form.Label
+          className="text-sm font-medium"
+          htmlFor={`custom-field-${field._id}`}
+        >
+          {field.label}
+          {field.isRequired && (
+            <span className="text-destructive ml-1">*</span>
+          )}
+        </Form.Label>
+        <CustomFieldInput
+          field={field}
+          value={getCustomFieldValue(field._id)}
+          onChange={(value) => updateCustomFieldValue(field._id, value)}
+        />
+      </div>
+    )}
+  />
 );

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/PostEditorColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/PostEditorColumn.tsx
@@ -10,6 +10,7 @@ interface PostEditorColumnProps {
   defaultLanguage: string;
   selectedType: string | undefined;
   fieldGroups: FieldGroup[];
+  websiteId?: string;
   fullPost: { _id?: string } | null | undefined;
   handleEditorChange: (content: string) => void;
   getCustomFieldValue: (fieldId: string) => CustomFieldValue;
@@ -25,6 +26,7 @@ export const PostEditorColumn = ({
   defaultLanguage,
   selectedType,
   fieldGroups,
+  websiteId,
   fullPost,
   handleEditorChange,
   getCustomFieldValue,
@@ -61,6 +63,7 @@ export const PostEditorColumn = ({
     {selectedType && fieldGroups.length > 0 && (
       <CustomFieldsSection
         fieldGroups={fieldGroups}
+        websiteId={websiteId}
         getCustomFieldValue={getCustomFieldValue}
         updateCustomFieldValue={updateCustomFieldValue}
       />

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
@@ -1,0 +1,51 @@
+import { Badge, TextOverflowTooltip, cn } from 'erxes-ui';
+import { ReactNode } from 'react';
+
+interface CmsTranslatableBadgeProps {
+  value?: string;
+  // True when the selected (non-default) language has no translation, so the
+  // cell is falling back to the default-language content.
+  missing?: boolean;
+  // Generic per-field text shown when there is nothing to display — i.e. the
+  // selected language and the default language are both empty.
+  placeholder: string;
+  prefix?: ReactNode;
+  missingVariant?: 'outline' | 'destructive';
+  missingClassName?: string;
+}
+
+/**
+ * Record-table cell for a translatable field. Shows the value as a secondary
+ * badge, the default-language fallback in a "missing" (red) style, and a muted
+ * placeholder when there is no content in either the selected or default
+ * language.
+ */
+export const CmsTranslatableBadge = ({
+  value,
+  missing,
+  placeholder,
+  prefix,
+  missingVariant = 'outline',
+  missingClassName = 'text-red-500 border-red-300',
+}: CmsTranslatableBadgeProps) => {
+  const hasValue = !!value?.trim();
+
+  if (!hasValue) {
+    return (
+      <Badge variant="outline" className="italic text-muted-foreground">
+        {prefix}
+        {placeholder}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      variant={missing ? missingVariant : 'secondary'}
+      className={cn(missing && missingClassName)}
+    >
+      {prefix}
+      <TextOverflowTooltip value={value} className="leading-normal" />
+    </Badge>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsTranslatableBadge.tsx
@@ -16,9 +16,9 @@ interface CmsTranslatableBadgeProps {
 
 /**
  * Record-table cell for a translatable field. Shows the value as a secondary
- * badge, the default-language fallback in a "missing" (red) style, and a muted
- * placeholder when there is no content in either the selected or default
- * language.
+ * badge, the default-language fallback in a "missing" (red) style, and the same
+ * "missing" style for the placeholder shown when there is no content in either
+ * the selected or default language.
  */
 export const CmsTranslatableBadge = ({
   value,
@@ -32,7 +32,7 @@ export const CmsTranslatableBadge = ({
 
   if (!hasValue) {
     return (
-      <Badge variant="outline" className="italic text-muted-foreground">
+      <Badge variant={missingVariant} className={cn(missingClassName)}>
         {prefix}
         {placeholder}
       </Badge>

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsColumn.tsx
@@ -4,7 +4,6 @@ import {
   Input,
   Popover,
   RelativeDateDisplay,
-  Badge,
   TextOverflowTooltip,
 } from 'erxes-ui';
 import { ColumnDef } from '@tanstack/react-table';
@@ -14,6 +13,7 @@ import { IconTag, IconCalendar } from '@tabler/icons-react';
 import { CmsTag } from '@/cms/tags/types/tagTypes';
 import { useEditTag } from '@/cms/tags/hooks/useEditTag';
 import { useIsTranslationMissing } from '@/cms/shared/hooks/useIsTranslationMissing';
+import { CmsTranslatableBadge } from '@/cms/shared/components/CmsTranslatableBadge';
 import { useAtomValue } from 'jotai';
 import { cmsLanguageAtom } from '@/cms/shared/states/cmsLanguageState';
 import { getTranslation } from '@/cms/shared/utils';
@@ -96,15 +96,13 @@ export const useTagsColumns = (
             }}
           >
             <RecordTableInlineCell.Trigger>
-              <Badge
-                variant={missing ? 'destructive' : 'secondary'}
-                className={missing ? 'border-red-300' : ''}
-              >
-                <TextOverflowTooltip
-                  value={cell.getValue() as string}
-                  className="leading-normal"
-                />
-              </Badge>
+              <CmsTranslatableBadge
+                value={cell.getValue() as string}
+                missing={missing}
+                placeholder="Untitled tag"
+                missingVariant="destructive"
+                missingClassName="border-red-300"
+              />
             </RecordTableInlineCell.Trigger>
             <RecordTableInlineCell.Content>
               <Input


### PR DESCRIPTION
Combined PR bundling four CMS/content changes.

## 1. Default-language change fixes 
- Drop the MongoDB transaction in `rehomeDefaultLanguageContent`: the session-bound `bulkWrite` requires a replica set and timed out on standalone MongoDB (`Connection operation buffering timed out after 10000ms`), breaking `contentUpdateCMS`. Reverted to plain sequential `bulkWrite`.
- Fix content leak: when promoting a language to default, fields the new language left empty now become empty instead of inheriting the previous default's content. Old content stays recoverable via the preserved old-language translation.

## 2. Custom field ordering 
- Drag-to-reorder custom field **groups** (persisted via the `order` column; backend sorts by `{ order, name }`) and **fields** (array position) in the Custom Fields settings page.
- Same reorder controls on the **post / page / category detail editors** via a shared `ReorderableCustomFields` component + `useCustomFieldOrdering` hook. Reordering a filtered detail view only moves visible groups, keeping hidden groups in place; changes apply globally.
- Optimistic ordering on drop to remove the dnd-kit snap-back glitch.

## 3. Record-table placeholder 
- When a translatable field has no content in either the selected or default language, record-table cells show a muted generic placeholder (e.g. *Untitled post*) instead of rendering blank. Shared `CmsTranslatableBadge` used by post/page/category/tag columns; the red default-language fallback styling is unchanged.

## 4. Translation-aware post search 
- Post search only matched base-document (default-language) fields, so content authored in another language (e.g. Mongolian Cyrillic) in the `Translations` collection was never found. Search now also matches translations for the active language and unions by `_id`.

## Test
- `tsc --noEmit` passes for both `content_api` (backend) and `content_ui` (frontend); eslint clean on changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering for CMS custom field groups and fields (applies across page and post editors).
  * Translation-aware post search that matches both base and translated content.
* **Improvements**
  * Consistent translatable badges with clearer missing/placeholder styling across categories, pages, posts, and tags.
  * Custom field groups now respect saved ordering; empty descriptions show a muted “No description” placeholder.
* **Bug Fixes**
  * Fixed content rehoming so missing translations no longer cause outdated default content to appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->