### PR TITLE
feat(mongolian): cursor pagination for exchange rates, command bars for erkhet sync

### DIFF
--- a/backend/plugins/mongolian_api/src/modules/exchangeRates/graphql/resolvers/queries.ts
+++ b/backend/plugins/mongolian_api/src/modules/exchangeRates/graphql/resolvers/queries.ts
@@ -1,5 +1,5 @@
 import { IContext } from '~/connectionResolvers';
-import { defaultPaginate } from 'erxes-api-shared/utils';
+import { cursorPaginate } from 'erxes-api-shared/utils';
 
 interface IQueryParams {
   searchValue?: string;
@@ -35,16 +35,16 @@ export const exchangeRateQueries = {
   ) => {
     const filter = await generateFilter(commonQuerySelector, params);
 
-    return {
-      list: await defaultPaginate(
-        models.ExchangeRates.find(filter).sort({ createdAt: -1 }),
-        {
-          page: params.page,
-          perPage: params.perPage,
-        },
-      ),
-      totalCount: await models.ExchangeRates.find(filter).countDocuments(),
-    };
+    const { list, totalCount, pageInfo } = await cursorPaginate({
+      model: models.ExchangeRates,
+      params: {
+        ...params,
+        orderBy: { createdAt: -1 },
+      },
+      query: filter,
+    });
+
+    return { list, totalCount, pageInfo };
   },
 
   async exchangeGetRate(

--- a/backend/plugins/mongolian_api/src/modules/exchangeRates/graphql/schemas/index.ts
+++ b/backend/plugins/mongolian_api/src/modules/exchangeRates/graphql/schemas/index.ts
@@ -1,3 +1,5 @@
+import { GQL_CURSOR_PARAM_DEFS } from 'erxes-api-shared/utils';
+
 const rateFields = `
   _id: String!
   date: Date
@@ -15,6 +17,7 @@ export const types = `
 
   type ExchangeRatesListResponse {
     list: [ExchangeRate],
+    pageInfo: PageInfo,
     totalCount: Int,
   }
 `;
@@ -28,9 +31,8 @@ const rateParams = `
 
 export const queries = `
   exchangeRatesMain(
-    page: Int
-    perPage: Int
     searchValue: String
+    ${GQL_CURSOR_PARAM_DEFS}
   ): ExchangeRatesListResponse
 
   exchangeGetRate(

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryCommandBar.tsx
@@ -1,39 +1,10 @@
-import { IconRefresh } from '@tabler/icons-react';
-import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
 import { useSyncCategory } from '../hooks/useSyncCategory';
-import { CategoryItem, CategoryStatus } from '../types/categoryItem';
+import { CheckSyncedCommandBar } from '../../shared/components/CheckSyncedCommandBar';
 
 export const CheckCategoryCommandBar = () => {
-  const { table } = RecordTable.useRecordTable();
-  const selectedRows = table.getFilteredSelectedRowModel().rows;
-  const selectedCount = selectedRows.length;
   const { syncCategories, loading } = useSyncCategory();
 
-  const handleSync = async () => {
-    const selectedItems = selectedRows.map(
-      (row) => row.original as CategoryItem,
-    );
-
-    await syncCategories(
-      selectedItems,
-      selectedItems[0]?.status as CategoryStatus,
-    );
-
-    table.setRowSelection({});
-  };
-
   return (
-    <CommandBar open={selectedCount > 0}>
-      <CommandBar.Bar>
-        <CommandBar.Value onClose={() => table.setRowSelection({})}>
-          {selectedCount} selected
-        </CommandBar.Value>
-        <Separator.Inline />
-        <Button variant="secondary" disabled={loading} onClick={handleSync}>
-          <IconRefresh />
-          {loading ? 'Syncing...' : 'Sync'}
-        </Button>
-      </CommandBar.Bar>
-    </CommandBar>
+    <CheckSyncedCommandBar sync={syncCategories} loading={loading} />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryCommandBar.tsx
@@ -1,0 +1,39 @@
+import { IconRefresh } from '@tabler/icons-react';
+import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
+import { useSyncCategory } from '../hooks/useSyncCategory';
+import { CategoryItem, CategoryStatus } from '../types/categoryItem';
+
+export const CheckCategoryCommandBar = () => {
+  const { table } = RecordTable.useRecordTable();
+  const selectedRows = table.getFilteredSelectedRowModel().rows;
+  const selectedCount = selectedRows.length;
+  const { syncCategories, loading } = useSyncCategory();
+
+  const handleSync = async () => {
+    const selectedItems = selectedRows.map(
+      (row) => row.original as CategoryItem,
+    );
+
+    await syncCategories(
+      selectedItems,
+      selectedItems[0]?.status as CategoryStatus,
+    );
+
+    table.setRowSelection({});
+  };
+
+  return (
+    <CommandBar open={selectedCount > 0}>
+      <CommandBar.Bar>
+        <CommandBar.Value onClose={() => table.setRowSelection({})}>
+          {selectedCount} selected
+        </CommandBar.Value>
+        <Separator.Inline />
+        <Button variant="secondary" disabled={loading} onClick={handleSync}>
+          <IconRefresh />
+          {loading ? 'Syncing...' : 'Sync'}
+        </Button>
+      </CommandBar.Bar>
+    </CommandBar>
+  );
+};

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryMoreColumn.tsx
@@ -37,5 +37,5 @@ export const CheckCategoryMoreColumnCell = ({
 export const CheckCategoryMoreColumn: ColumnDef<CategoryItem> = {
   id: 'more',
   cell: CheckCategoryMoreColumnCell,
-  size: 33,
+  size: 24,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
@@ -18,10 +18,6 @@ export const CheckCategoryRecordTable = () => {
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
   const isInitialLoading = loading && toCheckCategories === null;
 
-  const handleFetchMore = () => {
-    checkCategory();
-  };
-
   return (
     <RecordTable.Provider
       columns={checkCategoryColumns}
@@ -39,12 +35,12 @@ export const CheckCategoryRecordTable = () => {
           <RecordTable.Header />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
-              handleFetchMore={handleFetchMore}
+              handleFetchMore={checkCategory}
             />
             {loading && <RecordTable.RowSkeleton rows={40} />}
             <RecordTable.RowList />
             <RecordTable.CursorForwardSkeleton
-              handleFetchMore={handleFetchMore}
+              handleFetchMore={checkCategory}
             />
           </RecordTable.Body>
         </RecordTable>
@@ -53,26 +49,28 @@ export const CheckCategoryRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && !toCheckCategories?.length && filteredCategories?.length === 0 && (
-          <div className="absolute inset-0">
-            <div className="h-full w-full px-8 flex justify-center">
-              <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-                <div className="mb-6">
-                  <IconShoppingCartX
-                    size={64}
-                    className="text-muted-foreground mx-auto mb-4"
-                  />
-                  <h3 className="text-xl font-semibold mb-2">
-                    {t('no-category-yet')}
-                  </h3>
-                  <p className="text-muted-foreground max-w-md">
-                    {t('create-first-category')}
-                  </p>
+        {!loading &&
+          !toCheckCategories?.length &&
+          filteredCategories?.length === 0 && (
+            <div className="absolute inset-0">
+              <div className="h-full w-full px-8 flex justify-center">
+                <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
+                  <div className="mb-6">
+                    <IconShoppingCartX
+                      size={64}
+                      className="text-muted-foreground mx-auto mb-4"
+                    />
+                    <h3 className="text-xl font-semibold mb-2">
+                      {t('no-category-yet')}
+                    </h3>
+                    <p className="text-muted-foreground max-w-md">
+                      {t('create-first-category')}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
       </RecordTable.CursorProvider>
       <CheckCategoryCommandBar />
     </RecordTable.Provider>

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
@@ -53,7 +53,7 @@ export const CheckCategoryRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && toCheckCategories === null && filteredCategories?.length === 0 && (
+        {!loading && !toCheckCategories?.length && filteredCategories?.length === 0 && (
           <div className="absolute inset-0">
             <div className="h-full w-full px-8 flex justify-center">
               <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
@@ -16,7 +16,7 @@ export const CheckCategoryRecordTable = () => {
     toCheckCategories,
   } = useCheckCategory();
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
-  const isInitialLoading = loading && !toCheckCategories;
+  const isInitialLoading = loading && toCheckCategories === null;
 
   const handleFetchMore = () => {
     checkCategory();
@@ -53,7 +53,7 @@ export const CheckCategoryRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && !toCheckCategories && filteredCategories?.length === 0 && (
+        {!loading && toCheckCategories === null && filteredCategories?.length === 0 && (
           <div className="absolute inset-0">
             <div className="h-full w-full px-8 flex justify-center">
               <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
@@ -1,9 +1,10 @@
-import { RecordTable, Button } from 'erxes-ui';
+import { RecordTable, Spinner } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { IconShoppingCartX } from '@tabler/icons-react';
 import { CHECK_CATEGORY_CURSOR_SESSION_KEY } from '../constants/checkCategoryCursorSessionKey';
 import { useCheckCategory } from '../hooks/useCheckCategory';
 import { checkCategoryColumns } from './CheckCategoryColumn';
+import { CheckCategoryCommandBar } from './CheckCategoryCommandBar';
 
 export const CheckCategoryRecordTable = () => {
   const { t } = useTranslation('mongolian');
@@ -12,81 +13,68 @@ export const CheckCategoryRecordTable = () => {
     loading,
     pageInfo,
     checkCategory,
-    syncCategories,
-    syncLoading,
     toCheckCategories,
   } = useCheckCategory();
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
+  const isInitialLoading = loading && !toCheckCategories;
 
   const handleFetchMore = () => {
     checkCategory();
   };
 
   return (
-    <div className="m-3 h-full">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold">{t('categories')}</h2>
-        <Button
-          onClick={syncCategories}
-          disabled={
-            syncLoading ||
-            !filteredCategories ||
-            filteredCategories.length === 0
-          }
-        >
-          {syncLoading ? t('syncing') : t('sync')}
-        </Button>
-      </div>
-
-      <RecordTable.Provider
-        columns={checkCategoryColumns}
-        data={filteredCategories || []}
-        className="h-full w-full px-2 overflow-y-auto"
-        stickyColumns={['more', 'checkbox', 'createdAt']}
+    <RecordTable.Provider
+      columns={checkCategoryColumns}
+      data={filteredCategories || []}
+      className="m-3"
+      stickyColumns={['more', 'checkbox', 'createdAt']}
+    >
+      <RecordTable.CursorProvider
+        hasPreviousPage={hasPreviousPage}
+        hasNextPage={hasNextPage}
+        dataLength={filteredCategories?.length}
+        sessionKey={CHECK_CATEGORY_CURSOR_SESSION_KEY}
       >
-        <RecordTable.CursorProvider
-          hasPreviousPage={hasPreviousPage}
-          hasNextPage={hasNextPage}
-          dataLength={filteredCategories?.length}
-          sessionKey={CHECK_CATEGORY_CURSOR_SESSION_KEY}
-        >
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              <RecordTable.CursorBackwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-              {loading && <RecordTable.RowSkeleton rows={40} />}
-              <RecordTable.RowList />
-              <RecordTable.CursorForwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-            </RecordTable.Body>
-          </RecordTable>
-          {!loading &&
-            !toCheckCategories &&
-            filteredCategories?.length === 0 && (
-              <div className="absolute inset-0">
-                <div className="h-full w-full px-8 flex justify-center">
-                  <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-                    <div className="mb-6">
-                      <IconShoppingCartX
-                        size={64}
-                        className="text-muted-foreground mx-auto mb-4"
-                      />
-                      <h3 className="text-xl font-semibold mb-2">
-                        {t('no-category-yet')}
-                      </h3>
-                      <p className="text-muted-foreground max-w-md">
-                        {t('create-first-category')}
-                      </p>
-                    </div>
-                  </div>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.CursorBackwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+            {loading && <RecordTable.RowSkeleton rows={40} />}
+            <RecordTable.RowList />
+            <RecordTable.CursorForwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+          </RecordTable.Body>
+        </RecordTable>
+        {isInitialLoading && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Spinner />
+          </div>
+        )}
+        {!loading && !toCheckCategories && filteredCategories?.length === 0 && (
+          <div className="absolute inset-0">
+            <div className="h-full w-full px-8 flex justify-center">
+              <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
+                <div className="mb-6">
+                  <IconShoppingCartX
+                    size={64}
+                    className="text-muted-foreground mx-auto mb-4"
+                  />
+                  <h3 className="text-xl font-semibold mb-2">
+                    {t('no-category-yet')}
+                  </h3>
+                  <p className="text-muted-foreground max-w-md">
+                    {t('create-first-category')}
+                  </p>
                 </div>
               </div>
-            )}
-        </RecordTable.CursorProvider>
-      </RecordTable.Provider>
-    </div>
+            </div>
+          </div>
+        )}
+      </RecordTable.CursorProvider>
+      <CheckCategoryCommandBar />
+    </RecordTable.Provider>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductCommandBar.tsx
@@ -1,39 +1,10 @@
-import { IconRefresh } from '@tabler/icons-react';
-import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
 import { useSyncProduct } from '../hooks/useSyncProduct';
-import { ProductItem, ProductStatus } from '../types/productItem';
+import { CheckSyncedCommandBar } from '../../shared/components/CheckSyncedCommandBar';
 
 export const CheckProductCommandBar = () => {
-  const { table } = RecordTable.useRecordTable();
-  const selectedRows = table.getFilteredSelectedRowModel().rows;
-  const selectedCount = selectedRows.length;
   const { syncProducts, loading } = useSyncProduct();
 
-  const handleSync = async () => {
-    const selectedItems = selectedRows.map(
-      (row) => row.original as ProductItem,
-    );
-
-    await syncProducts(
-      selectedItems,
-      selectedItems[0]?.status as ProductStatus,
-    );
-
-    table.setRowSelection({});
-  };
-
   return (
-    <CommandBar open={selectedCount > 0}>
-      <CommandBar.Bar>
-        <CommandBar.Value onClose={() => table.setRowSelection({})}>
-          {selectedCount} selected
-        </CommandBar.Value>
-        <Separator.Inline />
-        <Button variant="secondary" disabled={loading} onClick={handleSync}>
-          <IconRefresh />
-          {loading ? 'Syncing...' : 'Sync'}
-        </Button>
-      </CommandBar.Bar>
-    </CommandBar>
+    <CheckSyncedCommandBar sync={syncProducts} loading={loading} />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductCommandBar.tsx
@@ -1,0 +1,39 @@
+import { IconRefresh } from '@tabler/icons-react';
+import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
+import { useSyncProduct } from '../hooks/useSyncProduct';
+import { ProductItem, ProductStatus } from '../types/productItem';
+
+export const CheckProductCommandBar = () => {
+  const { table } = RecordTable.useRecordTable();
+  const selectedRows = table.getFilteredSelectedRowModel().rows;
+  const selectedCount = selectedRows.length;
+  const { syncProducts, loading } = useSyncProduct();
+
+  const handleSync = async () => {
+    const selectedItems = selectedRows.map(
+      (row) => row.original as ProductItem,
+    );
+
+    await syncProducts(
+      selectedItems,
+      selectedItems[0]?.status as ProductStatus,
+    );
+
+    table.setRowSelection({});
+  };
+
+  return (
+    <CommandBar open={selectedCount > 0}>
+      <CommandBar.Bar>
+        <CommandBar.Value onClose={() => table.setRowSelection({})}>
+          {selectedCount} selected
+        </CommandBar.Value>
+        <Separator.Inline />
+        <Button variant="secondary" disabled={loading} onClick={handleSync}>
+          <IconRefresh />
+          {loading ? 'Syncing...' : 'Sync'}
+        </Button>
+      </CommandBar.Bar>
+    </CommandBar>
+  );
+};

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductMoreColumn.tsx
@@ -37,5 +37,5 @@ export const CheckProductMoreColumnCell = ({
 export const CheckProductMoreColumn: ColumnDef<ProductItem> = {
   id: 'more',
   cell: CheckProductMoreColumnCell,
-  size: 33,
+  size: 24,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
@@ -11,7 +11,7 @@ export const CheckProductRecordTable = () => {
     useCheckProduct();
   const { t } = useTranslation('mongolian');
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
-  const isInitialLoading = loading && !toCheckProducts;
+  const isInitialLoading = loading && toCheckProducts === null;
 
   const handleFetchMore = () => {
     checkProduct();
@@ -48,7 +48,7 @@ export const CheckProductRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && !toCheckProducts && filteredProducts?.length === 0 && (
+        {!loading && toCheckProducts === null && filteredProducts?.length === 0 && (
           <div className="absolute inset-0">
             <div className="h-full w-full px-8 flex justify-center">
               <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
@@ -48,7 +48,7 @@ export const CheckProductRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && toCheckProducts === null && filteredProducts?.length === 0 && (
+        {!loading && !toCheckProducts?.length && filteredProducts?.length === 0 && (
           <div className="absolute inset-0">
             <div className="h-full w-full px-8 flex justify-center">
               <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
@@ -13,10 +13,6 @@ export const CheckProductRecordTable = () => {
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
   const isInitialLoading = loading && toCheckProducts === null;
 
-  const handleFetchMore = () => {
-    checkProduct();
-  };
-
   return (
     <RecordTable.Provider
       columns={checkProductColumns}
@@ -34,13 +30,11 @@ export const CheckProductRecordTable = () => {
           <RecordTable.Header />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
-              handleFetchMore={handleFetchMore}
+              handleFetchMore={checkProduct}
             />
             {loading && <RecordTable.RowSkeleton rows={40} />}
             <RecordTable.RowList />
-            <RecordTable.CursorForwardSkeleton
-              handleFetchMore={handleFetchMore}
-            />
+            <RecordTable.CursorForwardSkeleton handleFetchMore={checkProduct} />
           </RecordTable.Body>
         </RecordTable>
         {isInitialLoading && (
@@ -48,26 +42,28 @@ export const CheckProductRecordTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && !toCheckProducts?.length && filteredProducts?.length === 0 && (
-          <div className="absolute inset-0">
-            <div className="h-full w-full px-8 flex justify-center">
-              <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-                <div className="mb-6">
-                  <IconShoppingCartX
-                    size={64}
-                    className="text-muted-foreground mx-auto mb-4"
-                  />
-                  <h3 className="text-xl font-semibold mb-2">
-                    {t('no-product-yet')}
-                  </h3>
-                  <p className="text-muted-foreground max-w-md">
-                    {t('create-first-product')}
-                  </p>
+        {!loading &&
+          !toCheckProducts?.length &&
+          filteredProducts?.length === 0 && (
+            <div className="absolute inset-0">
+              <div className="h-full w-full px-8 flex justify-center">
+                <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
+                  <div className="mb-6">
+                    <IconShoppingCartX
+                      size={64}
+                      className="text-muted-foreground mx-auto mb-4"
+                    />
+                    <h3 className="text-xl font-semibold mb-2">
+                      {t('no-product-yet')}
+                    </h3>
+                    <p className="text-muted-foreground max-w-md">
+                      {t('create-first-product')}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
       </RecordTable.CursorProvider>
       <CheckProductCommandBar />
     </RecordTable.Provider>

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
@@ -1,88 +1,75 @@
-import { RecordTable, Button } from 'erxes-ui';
+import { RecordTable, Spinner } from 'erxes-ui';
 import { IconShoppingCartX } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { CHECK_PRODUCTS_CURSOR_SESSION_KEY } from '../constants/checkProductsCursorSessionKey';
 import { useCheckProduct } from '../hooks/useCheckProduct';
 import { checkProductColumns } from './CheckProductColumn';
+import { CheckProductCommandBar } from './CheckProductCommandBar';
 
 export const CheckProductRecordTable = () => {
-  const {
-    filteredProducts,
-    loading,
-    pageInfo,
-    checkProduct,
-    syncProducts,
-    syncLoading,
-    toCheckProducts,
-  } = useCheckProduct();
-  const { hasPreviousPage, hasNextPage } = pageInfo || {};
+  const { filteredProducts, loading, pageInfo, checkProduct, toCheckProducts } =
+    useCheckProduct();
   const { t } = useTranslation('mongolian');
+  const { hasPreviousPage, hasNextPage } = pageInfo || {};
+  const isInitialLoading = loading && !toCheckProducts;
 
   const handleFetchMore = () => {
     checkProduct();
   };
 
   return (
-    <div className="m-3 h-full">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold">{t('products')}</h2>
-        <Button
-          onClick={syncProducts}
-          disabled={
-            syncLoading || !filteredProducts || filteredProducts.length === 0
-          }
-        >
-          {syncLoading ? t('syncing') : t('sync')}
-        </Button>
-      </div>
-
-      <RecordTable.Provider
-        columns={checkProductColumns}
-        data={filteredProducts || []}
-        className="h-full w-full px-2 overflow-y-auto"
-        stickyColumns={['more', 'checkbox', 'createdAt']}
+    <RecordTable.Provider
+      columns={checkProductColumns}
+      data={filteredProducts || []}
+      className="m-3"
+      stickyColumns={['more', 'checkbox', 'createdAt']}
+    >
+      <RecordTable.CursorProvider
+        hasPreviousPage={hasPreviousPage}
+        hasNextPage={hasNextPage}
+        dataLength={filteredProducts?.length}
+        sessionKey={CHECK_PRODUCTS_CURSOR_SESSION_KEY}
       >
-        <RecordTable.CursorProvider
-          hasPreviousPage={hasPreviousPage}
-          hasNextPage={hasNextPage}
-          dataLength={filteredProducts?.length}
-          sessionKey={CHECK_PRODUCTS_CURSOR_SESSION_KEY}
-        >
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              <RecordTable.CursorBackwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-              {loading && <RecordTable.RowSkeleton rows={40} />}
-              <RecordTable.RowList />
-              <RecordTable.CursorForwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-            </RecordTable.Body>
-          </RecordTable>
-          {!loading && !toCheckProducts && filteredProducts?.length === 0 && (
-            <div className="absolute inset-0">
-              <div className="h-full w-full px-8 flex justify-center">
-                <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
-                  <div className="mb-6">
-                    <IconShoppingCartX
-                      size={64}
-                      className="text-muted-foreground mx-auto mb-4"
-                    />
-                    <h3 className="text-xl font-semibold mb-2">
-                      {t('no-product-yet')}
-                    </h3>
-                    <p className="text-muted-foreground max-w-md">
-                      {t('create-first-product')}
-                    </p>
-                  </div>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.CursorBackwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+            {loading && <RecordTable.RowSkeleton rows={40} />}
+            <RecordTable.RowList />
+            <RecordTable.CursorForwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+          </RecordTable.Body>
+        </RecordTable>
+        {isInitialLoading && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Spinner />
+          </div>
+        )}
+        {!loading && !toCheckProducts && filteredProducts?.length === 0 && (
+          <div className="absolute inset-0">
+            <div className="h-full w-full px-8 flex justify-center">
+              <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center">
+                <div className="mb-6">
+                  <IconShoppingCartX
+                    size={64}
+                    className="text-muted-foreground mx-auto mb-4"
+                  />
+                  <h3 className="text-xl font-semibold mb-2">
+                    {t('no-product-yet')}
+                  </h3>
+                  <p className="text-muted-foreground max-w-md">
+                    {t('create-first-product')}
+                  </p>
                 </div>
               </div>
             </div>
-          )}
-        </RecordTable.CursorProvider>
-      </RecordTable.Provider>
-    </div>
+          </div>
+        )}
+      </RecordTable.CursorProvider>
+      <CheckProductCommandBar />
+    </RecordTable.Provider>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
@@ -1,23 +1,23 @@
 import { IconRefresh } from '@tabler/icons-react';
 import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
 
-interface CheckSyncedCommandBarProps {
-  sync: (...args: any[]) => any;
+interface CheckSyncedCommandBarProps<TData extends { status: string }> {
+  sync: (items: TData[], status: TData['status']) => Promise<unknown>;
   loading: boolean;
 }
 
-export const CheckSyncedCommandBar = ({
+export const CheckSyncedCommandBar = <TData extends { status: string }>({
   sync,
   loading,
-}: CheckSyncedCommandBarProps) => {
+}: CheckSyncedCommandBarProps<TData>) => {
   const { table } = RecordTable.useRecordTable();
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedCount = selectedRows.length;
 
   const handleSync = async () => {
-    const selectedItems = selectedRows.map((row) => row.original);
+    const selectedItems = selectedRows.map((row) => row.original) as TData[];
 
-    await sync(selectedItems, selectedItems[0]?.status);
+    await sync(selectedItems, selectedItems[0]!.status);
 
     table.setRowSelection({});
   };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
@@ -1,0 +1,39 @@
+import { IconRefresh } from '@tabler/icons-react';
+import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
+
+interface CheckSyncedCommandBarProps {
+  sync: (items: any[], status: string) => Promise<any>;
+  loading: boolean;
+}
+
+export const CheckSyncedCommandBar = ({
+  sync,
+  loading,
+}: CheckSyncedCommandBarProps) => {
+  const { table } = RecordTable.useRecordTable();
+  const selectedRows = table.getFilteredSelectedRowModel().rows;
+  const selectedCount = selectedRows.length;
+
+  const handleSync = async () => {
+    const selectedItems = selectedRows.map((row) => row.original);
+
+    await sync(selectedItems, selectedItems[0]?.status);
+
+    table.setRowSelection({});
+  };
+
+  return (
+    <CommandBar open={selectedCount > 0}>
+      <CommandBar.Bar>
+        <CommandBar.Value onClose={() => table.setRowSelection({})}>
+          {selectedCount} selected
+        </CommandBar.Value>
+        <Separator.Inline />
+        <Button variant="secondary" disabled={loading} onClick={handleSync}>
+          <IconRefresh />
+          {loading ? 'Syncing...' : 'Sync'}
+        </Button>
+      </CommandBar.Bar>
+    </CommandBar>
+  );
+};

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
@@ -1,23 +1,28 @@
 import { IconRefresh } from '@tabler/icons-react';
 import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
 
-interface CheckSyncedCommandBarProps<TData extends { status: string }> {
-  sync: (items: TData[], status: TData['status']) => Promise<unknown>;
+interface CheckSyncedCommandBarProps<T extends { status: string }> {
+  sync: (items: T[], status: T['status']) => Promise<T[] | undefined>;
   loading: boolean;
+  onSynced?: (items: T[]) => void;
 }
 
-export const CheckSyncedCommandBar = <TData extends { status: string }>({
+export const CheckSyncedCommandBar = <T extends { status: string }>({
   sync,
   loading,
-}: CheckSyncedCommandBarProps<TData>) => {
+  onSynced,
+}: CheckSyncedCommandBarProps<T>) => {
   const { table } = RecordTable.useRecordTable();
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedCount = selectedRows.length;
 
   const handleSync = async () => {
-    const selectedItems = selectedRows.map((row) => row.original) as TData[];
-
-    await sync(selectedItems, selectedItems[0]!.status);
+    const selectedItems = selectedRows.map((row) => row.original) as T[];
+    const updatedItems = await sync(
+      selectedItems,
+      selectedItems[0]?.status as T['status'],
+    );
+    if (updatedItems) onSynced?.(updatedItems);
 
     table.setRowSelection({});
   };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/shared/components/CheckSyncedCommandBar.tsx
@@ -2,7 +2,7 @@ import { IconRefresh } from '@tabler/icons-react';
 import { Button, CommandBar, RecordTable, Separator } from 'erxes-ui';
 
 interface CheckSyncedCommandBarProps {
-  sync: (items: any[], status: string) => Promise<any>;
+  sync: (...args: any[]) => any;
   loading: boolean;
 }
 

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
@@ -1,183 +1,57 @@
-import { useTranslation } from 'react-i18next';
-import { Cell, ColumnDef } from '@tanstack/react-table';
-import {
-  IconArrowsExchange,
-  IconCalendar,
-  IconCoin,
-  IconCurrencyDollar,
-  IconEdit,
-  IconTrash,
-} from '@tabler/icons-react';
-import dayjs from 'dayjs';
-import {
-  Badge,
-  Button,
-  Combobox,
-  Command,
-  Popover,
-  RecordTable,
-  RecordTableInlineCell,
-  Spinner,
-  TextOverflowTooltip,
-  useQueryState,
-} from 'erxes-ui';
-import { useSetAtom } from 'jotai';
+import { IconArrowsExchange } from '@tabler/icons-react';
+import { RecordTable, Spinner, useQueryState } from 'erxes-ui';
 import { useMemo } from 'react';
-import { EXCHANGE_RATE_ID_QUERY_KEY } from '../constants';
-import { exchangeRateDetailAtom } from '../states/exchangeRatesStates';
-import { IExchangeRate } from '../types';
+import { useTranslation } from 'react-i18next';
+import { EXCHANGE_RATES_CURSOR_SESSION_KEY } from '../constants';
 import { useExchangeRates } from '../hooks/useExchangeRates';
-import { useRemoveExchangeRates } from '../hooks/useRemoveExchangeRates';
 import { AddExchangeRate } from './AddExchangeRate';
 import { ExchangeRatesCommandbar } from './ExchangeRatesCommandbar';
-
-const ExchangeRateDateCell = ({
-  cell,
-}: {
-  cell: Cell<IExchangeRate, unknown>;
-}) => {
-  const [, setOpenId] = useQueryState(EXCHANGE_RATE_ID_QUERY_KEY);
-  const setDetail = useSetAtom(exchangeRateDetailAtom);
-
-  return (
-    <RecordTableInlineCell
-      className="cursor-pointer font-medium"
-      onClick={() => {
-        setDetail(cell.row.original);
-        setOpenId(cell.row.original._id ?? null);
-      }}
-    >
-      {dayjs(cell.row.original.date).format('YYYY-MM-DD')}
-    </RecordTableInlineCell>
-  );
-};
-
-const CurrencyCell = ({ value }: { value?: string }) => (
-  <RecordTableInlineCell>
-    {value ? <Badge variant="secondary">{value}</Badge> : null}
-  </RecordTableInlineCell>
-);
-
-const ExchangeRateMoreCell = ({
-  cell,
-}: {
-  cell: Cell<IExchangeRate, unknown>;
-}) => {
-  const { t } = useTranslation('mongolian');
-  const [, setOpenId] = useQueryState(EXCHANGE_RATE_ID_QUERY_KEY);
-  const setDetail = useSetAtom(exchangeRateDetailAtom);
-  const { remove } = useRemoveExchangeRates();
-
-  const handleEdit = () => {
-    setDetail(cell.row.original);
-    setOpenId(cell.row.original._id ?? null);
-  };
-
-  const handleDelete = () => {
-    const id = cell.row.original._id;
-    if (id) remove([id]);
-  };
-
-  return (
-    <Popover>
-      <Popover.Trigger asChild>
-        <RecordTable.MoreButton className="w-full h-full" />
-      </Popover.Trigger>
-      <Combobox.Content>
-        <Command shouldFilter={false}>
-          <Command.List>
-            <Command.Item value="edit" onSelect={handleEdit}>
-              <IconEdit /> {t('edit')}
-            </Command.Item>
-            <Command.Item value="delete" onSelect={handleDelete}>
-              <IconTrash /> {t('delete')}
-            </Command.Item>
-          </Command.List>
-        </Command>
-      </Combobox.Content>
-    </Popover>
-  );
-};
-
-const columns: ColumnDef<IExchangeRate>[] = [
-  {
-    id: 'more',
-    cell: ({ cell }) => <ExchangeRateMoreCell cell={cell} />,
-    size: 33,
-  },
-  RecordTable.checkboxColumn as ColumnDef<IExchangeRate>,
-  {
-    id: 'date',
-    accessorKey: 'date',
-    header: () => { /* eslint-disable-next-line react-hooks/rules-of-hooks */ const { t } = useTranslation('mongolian'); return <RecordTable.InlineHead label={t('date')} icon={IconCalendar} />; },
-    cell: ({ cell }) => <ExchangeRateDateCell cell={cell} />,
-    size: 200,
-  },
-  {
-    id: 'mainCurrency',
-    accessorKey: 'mainCurrency',
-    header: () => { /* eslint-disable-next-line react-hooks/rules-of-hooks */ const { t } = useTranslation('mongolian'); return <RecordTable.InlineHead label={t('main-currency')} icon={IconCoin} />; },
-    cell: ({ cell }) => <CurrencyCell value={cell.getValue() as string} />,
-    size: 200,
-  },
-  {
-    id: 'rateCurrency',
-    accessorKey: 'rateCurrency',
-    header: () => { /* eslint-disable-next-line react-hooks/rules-of-hooks */ const { t } = useTranslation('mongolian'); return <RecordTable.InlineHead label={t('rate-currency')} icon={IconCurrencyDollar} />; },
-    cell: ({ cell }) => <CurrencyCell value={cell.getValue() as string} />,
-    size: 200,
-  },
-  {
-    id: 'rate',
-    accessorKey: 'rate',
-    header: () => { /* eslint-disable-next-line react-hooks/rules-of-hooks */ const { t } = useTranslation('mongolian'); return <RecordTable.InlineHead label={t('rate')} icon={IconArrowsExchange} />; },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        <TextOverflowTooltip value={String(cell.getValue() ?? '')} />
-      </RecordTableInlineCell>
-    ),
-    size: 150,
-  },
-];
+import { exchangeRatesColumns } from './ExchangeRatesTableColumns';
 
 export const ExchangeRatesTable = () => {
   const { t } = useTranslation('mongolian');
   const [searchValue] = useQueryState<string>('searchValue');
-  const memoizedColumns = useMemo(() => columns, []);
+  const memoizedColumns = useMemo(() => exchangeRatesColumns, []);
 
-  const { rows, totalCount, loading, hasMore, handleLoadMore } =
+  const { rows, totalCount, pageInfo, loading, handleFetchMore } =
     useExchangeRates(searchValue ?? undefined);
 
+  const { hasNextPage, hasPreviousPage } = pageInfo || {};
   const isInitialLoading = loading && rows.length === 0;
 
   return (
-    <div className="flex flex-col flex-auto overflow-hidden">
-      <RecordTable.Provider columns={memoizedColumns} data={rows}>
+    <RecordTable.Provider
+      columns={memoizedColumns}
+      data={rows}
+      className="m-3"
+      stickyColumns={['more', 'checkbox']}
+    >
+      <RecordTable.CursorProvider
+        hasPreviousPage={hasPreviousPage}
+        hasNextPage={hasNextPage}
+        dataLength={rows.length}
+        sessionKey={EXCHANGE_RATES_CURSOR_SESSION_KEY}
+      >
         <RecordTable.Scroll>
           <RecordTable>
             <RecordTable.Header />
             <RecordTable.Body>
+              <RecordTable.CursorBackwardSkeleton
+                handleFetchMore={handleFetchMore}
+              />
+              {loading && rows.length === 0 && (
+                <RecordTable.RowSkeleton rows={40} />
+              )}
               <RecordTable.RowList />
+              <RecordTable.CursorForwardSkeleton
+                handleFetchMore={handleFetchMore}
+              />
             </RecordTable.Body>
           </RecordTable>
 
           {isInitialLoading && (
             <div className="absolute inset-0 flex items-center justify-center">
               <Spinner />
-            </div>
-          )}
-
-          {hasMore && !loading && (
-            <div className="flex justify-center py-4">
-              <Button variant="secondary" onClick={handleLoadMore}>
-                {t('load-more', { count: totalCount - rows.length })}
-              </Button>
-            </div>
-          )}
-
-          {loading && rows.length > 0 && (
-            <div className="flex justify-center py-4">
-              <Spinner size="sm" />
             </div>
           )}
 
@@ -203,8 +77,8 @@ export const ExchangeRatesTable = () => {
             </div>
           )}
         </RecordTable.Scroll>
-        <ExchangeRatesCommandbar />
-      </RecordTable.Provider>
-    </div>
+      </RecordTable.CursorProvider>
+      <ExchangeRatesCommandbar />
+    </RecordTable.Provider>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
@@ -1,6 +1,5 @@
 import { IconArrowsExchange } from '@tabler/icons-react';
-import { RecordTable, Spinner, useQueryState } from 'erxes-ui';
-import { useMemo } from 'react';
+import { RecordTable, useQueryState } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { EXCHANGE_RATES_CURSOR_SESSION_KEY } from '../constants';
 import { useExchangeRates } from '../hooks/useExchangeRates';
@@ -11,7 +10,6 @@ import { exchangeRatesColumns } from './ExchangeRatesTableColumns';
 export const ExchangeRatesTable = () => {
   const { t } = useTranslation('mongolian');
   const [searchValue] = useQueryState<string>('searchValue');
-  const memoizedColumns = useMemo(() => exchangeRatesColumns, []);
 
   const { rows, totalCount, pageInfo, loading, handleFetchMore } =
     useExchangeRates(searchValue ?? undefined);
@@ -21,7 +19,7 @@ export const ExchangeRatesTable = () => {
 
   return (
     <RecordTable.Provider
-      columns={memoizedColumns}
+      columns={exchangeRatesColumns}
       data={rows}
       className="m-3"
       stickyColumns={['more', 'checkbox']}
@@ -48,12 +46,6 @@ export const ExchangeRatesTable = () => {
               />
             </RecordTable.Body>
           </RecordTable>
-
-          {isInitialLoading && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Spinner />
-            </div>
-          )}
 
           {!isInitialLoading && totalCount === 0 && (
             <div className="absolute inset-0 flex items-center justify-center">

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTableColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTableColumns.tsx
@@ -1,0 +1,96 @@
+import {
+  IconArrowsExchange,
+  IconCalendar,
+  IconCoin,
+  IconCurrencyDollar,
+} from '@tabler/icons-react';
+import { Cell, ColumnDef } from '@tanstack/react-table';
+import dayjs from 'dayjs';
+import {
+  Badge,
+  RecordTable,
+  RecordTableInlineCell,
+  TextOverflowTooltip,
+  useQueryState,
+} from 'erxes-ui';
+import { useSetAtom } from 'jotai';
+import { EXCHANGE_RATE_ID_QUERY_KEY } from '../constants';
+import { exchangeRateDetailAtom } from '../states/exchangeRatesStates';
+import { IExchangeRate } from '../types';
+import { exchangeRatesMoreColumn } from './ExchangeRatesTableMoreColumn';
+
+const ExchangeRateDateCell = ({
+  cell,
+}: {
+  cell: Cell<IExchangeRate, unknown>;
+}) => {
+  const [, setOpenId] = useQueryState(EXCHANGE_RATE_ID_QUERY_KEY);
+  const setDetail = useSetAtom(exchangeRateDetailAtom);
+
+  return (
+    <RecordTableInlineCell
+      className="cursor-pointer font-medium"
+      onClick={() => {
+        setDetail(cell.row.original);
+        setOpenId(cell.row.original._id ?? null);
+      }}
+    >
+      {dayjs(cell.row.original.date).format('YYYY-MM-DD')}
+    </RecordTableInlineCell>
+  );
+};
+
+const CurrencyCell = ({ value }: { value?: string }) => (
+  <RecordTableInlineCell>
+    {value ? <Badge variant="secondary">{value}</Badge> : null}
+  </RecordTableInlineCell>
+);
+
+const checkBoxColumn = {
+  ...RecordTable.checkboxColumn,
+  size: 24,
+  minSize: 24,
+} as ColumnDef<IExchangeRate>;
+
+export const exchangeRatesColumns: ColumnDef<IExchangeRate>[] = [
+  exchangeRatesMoreColumn,
+  checkBoxColumn,
+  {
+    id: 'date',
+    accessorKey: 'date',
+    header: () => <RecordTable.InlineHead label="Date" icon={IconCalendar} />,
+    cell: ({ cell }) => <ExchangeRateDateCell cell={cell} />,
+    size: 200,
+  },
+  {
+    id: 'mainCurrency',
+    accessorKey: 'mainCurrency',
+    header: () => (
+      <RecordTable.InlineHead label="Main Currency" icon={IconCoin} />
+    ),
+    cell: ({ cell }) => <CurrencyCell value={cell.getValue() as string} />,
+    size: 200,
+  },
+  {
+    id: 'rateCurrency',
+    accessorKey: 'rateCurrency',
+    header: () => (
+      <RecordTable.InlineHead label="Rate Currency" icon={IconCurrencyDollar} />
+    ),
+    cell: ({ cell }) => <CurrencyCell value={cell.getValue() as string} />,
+    size: 200,
+  },
+  {
+    id: 'rate',
+    accessorKey: 'rate',
+    header: () => (
+      <RecordTable.InlineHead label="Rate" icon={IconArrowsExchange} />
+    ),
+    cell: ({ cell }) => (
+      <RecordTableInlineCell>
+        <TextOverflowTooltip value={String(cell.getValue() ?? '')} />
+      </RecordTableInlineCell>
+    ),
+    size: 150,
+  },
+];

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTableMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTableMoreColumn.tsx
@@ -1,0 +1,61 @@
+import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { Cell } from '@tanstack/react-table';
+import {
+  Combobox,
+  Command,
+  Popover,
+  RecordTable,
+  useQueryState,
+} from 'erxes-ui';
+import { useSetAtom } from 'jotai';
+import { EXCHANGE_RATE_ID_QUERY_KEY } from '../constants';
+import { exchangeRateDetailAtom } from '../states/exchangeRatesStates';
+import { IExchangeRate } from '../types';
+import { useRemoveExchangeRates } from '../hooks/useRemoveExchangeRates';
+
+export const ExchangeRatesMoreColumnCell = ({
+  cell,
+}: {
+  cell: Cell<IExchangeRate, unknown>;
+}) => {
+  const [, setOpenId] = useQueryState(EXCHANGE_RATE_ID_QUERY_KEY);
+  const setDetail = useSetAtom(exchangeRateDetailAtom);
+  const { remove } = useRemoveExchangeRates();
+
+  const handleEdit = () => {
+    setDetail(cell.row.original);
+    setOpenId(cell.row.original._id ?? null);
+  };
+
+  const handleDelete = () => {
+    const id = cell.row.original._id;
+    if (id) remove([id]);
+  };
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <RecordTable.MoreButton className="h-full w-full" />
+      </Popover.Trigger>
+      <Combobox.Content>
+        <Command shouldFilter={false}>
+          <Command.List>
+            <Command.Item value="edit" onSelect={handleEdit}>
+              <IconEdit /> Edit
+            </Command.Item>
+            <Command.Item value="delete" onSelect={handleDelete}>
+              <IconTrash /> Delete
+            </Command.Item>
+          </Command.List>
+        </Command>
+      </Combobox.Content>
+    </Popover>
+  );
+};
+
+export const exchangeRatesMoreColumn = {
+  id: 'more',
+  cell: ExchangeRatesMoreColumnCell,
+  size: 24,
+  minSize: 24,
+};

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/constants/index.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/constants/index.ts
@@ -4,6 +4,8 @@ export const EXCHANGE_RATES_PATH = '/settings/mongolian/exchange-rates';
 
 export const EXCHANGE_RATE_ID_QUERY_KEY = 'exchange_rate_id';
 
+export const EXCHANGE_RATES_CURSOR_SESSION_KEY = 'exchangeRates_cursor';
+
 /** Name of the list query, used for Apollo refetchQueries. */
 export const EXCHANGE_RATES_QUERY_NAME = 'ExchangeRatesMain';
 

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/graphql/queries.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/graphql/queries.ts
@@ -1,4 +1,9 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
+import {
+  GQL_CURSOR_PARAM_DEFS,
+  GQL_PAGE_INFO,
+  GQL_CURSOR_PARAMS,
+} from 'erxes-ui';
 
 /* ---------------- exchange rate fields ---------------- */
 
@@ -16,19 +21,23 @@ const exchangeRateFields = `
 
 export const exchangeRatesMain = gql`
   query ExchangeRatesMain(
-    $page: Int
-    $perPage: Int
     $searchValue: String
+    $orderBy: JSON
+    $sortMode: String
+    $aggregationPipeline: [JSON]
+    ${GQL_CURSOR_PARAM_DEFS}
   ) {
     exchangeRatesMain(
-      page: $page
-      perPage: $perPage
       searchValue: $searchValue
+      orderBy: $orderBy
+      sortMode: $sortMode
+      aggregationPipeline: $aggregationPipeline
+      ${GQL_CURSOR_PARAMS}
     ) {
       list {
         ${exchangeRateFields}
       }
-      totalCount
+      ${GQL_PAGE_INFO}
     }
   }
 `;

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/hooks/useExchangeRates.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/hooks/useExchangeRates.ts
@@ -1,16 +1,29 @@
 import { useQuery } from '@apollo/client';
+import {
+  EnumCursorDirection,
+  mergeCursorData,
+  useRecordTableCursor,
+  validateFetchMore,
+} from 'erxes-ui';
+import { useCallback } from 'react';
+import { EXCHANGE_RATES_CURSOR_SESSION_KEY } from '../constants';
 import { queries } from '../graphql';
 import { MainQueryResponse } from '../types';
 
 export const EXCHANGE_RATES_PER_PAGE = 30;
 
 export const useExchangeRates = (searchValue?: string) => {
+  const { cursor } = useRecordTableCursor({
+    sessionKey: EXCHANGE_RATES_CURSOR_SESSION_KEY,
+  });
+
   const { data, loading, fetchMore } = useQuery<MainQueryResponse>(
     queries.exchangeRatesMain,
     {
       variables: {
-        page: 1,
-        perPage: EXCHANGE_RATES_PER_PAGE,
+        limit: EXCHANGE_RATES_PER_PAGE,
+        orderBy: { createdAt: -1 },
+        cursor: cursor || undefined,
         searchValue: searchValue || undefined,
       },
       fetchPolicy: 'network-only',
@@ -20,31 +33,43 @@ export const useExchangeRates = (searchValue?: string) => {
 
   const rows = data?.exchangeRatesMain?.list || [];
   const totalCount = data?.exchangeRatesMain?.totalCount || 0;
-  const hasMore = rows.length < totalCount;
+  const pageInfo = data?.exchangeRatesMain?.pageInfo;
 
-  const handleLoadMore = () => {
-    if (!hasMore) return;
+  const handleFetchMore = useCallback(
+    ({ direction }: { direction: EnumCursorDirection }) => {
+      if (!validateFetchMore({ direction, pageInfo })) return;
 
-    fetchMore({
-      variables: {
-        page: Math.floor(rows.length / EXCHANGE_RATES_PER_PAGE) + 1,
-        perPage: EXCHANGE_RATES_PER_PAGE,
-        searchValue: searchValue || undefined,
-      },
-      updateQuery: (prev, { fetchMoreResult }) => {
-        if (!fetchMoreResult) return prev;
-        return {
-          exchangeRatesMain: {
-            ...fetchMoreResult.exchangeRatesMain,
-            list: [
-              ...(prev.exchangeRatesMain?.list || []),
-              ...(fetchMoreResult.exchangeRatesMain?.list || []),
-            ],
-          },
-        };
-      },
-    });
+      fetchMore({
+        variables: {
+          cursor:
+            direction === EnumCursorDirection.FORWARD
+              ? pageInfo?.endCursor
+              : pageInfo?.startCursor,
+          limit: EXCHANGE_RATES_PER_PAGE,
+          direction,
+          searchValue: searchValue || undefined,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+
+          return Object.assign({}, prev, {
+            exchangeRatesMain: mergeCursorData({
+              direction,
+              fetchMoreResult: fetchMoreResult.exchangeRatesMain,
+              prevResult: prev.exchangeRatesMain,
+            }),
+          });
+        },
+      });
+    },
+    [fetchMore, pageInfo, searchValue],
+  );
+
+  return {
+    rows,
+    totalCount,
+    pageInfo,
+    loading,
+    handleFetchMore,
   };
-
-  return { rows, totalCount, loading, hasMore, handleLoadMore };
 };

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/hooks/useExchangeRates.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/hooks/useExchangeRates.ts
@@ -52,13 +52,14 @@ export const useExchangeRates = (searchValue?: string) => {
         updateQuery: (prev, { fetchMoreResult }) => {
           if (!fetchMoreResult) return prev;
 
-          return Object.assign({}, prev, {
+          return {
+            ...prev,
             exchangeRatesMain: mergeCursorData({
               direction,
               fetchMoreResult: fetchMoreResult.exchangeRatesMain,
               prevResult: prev.exchangeRatesMain,
             }),
-          });
+          };
         },
       });
     },

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/types.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/types.ts
@@ -9,7 +9,16 @@ export interface IExchangeRate {
 }
 
 export type MainQueryResponse = {
-  exchangeRatesMain: { list: IExchangeRate[]; totalCount: number };
+  exchangeRatesMain: {
+    list: IExchangeRate[];
+    totalCount: number;
+    pageInfo: {
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor: string;
+      endCursor: string;
+    };
+  };
 };
 
 export type CurrencyConfigResponse = {

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/types.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/types.ts
@@ -15,8 +15,8 @@ export type MainQueryResponse = {
     pageInfo: {
       hasNextPage: boolean;
       hasPreviousPage: boolean;
-      startCursor: string;
-      endCursor: string;
+      startCursor: string | null;
+      endCursor: string | null;
     };
   };
 };

--- a/frontend/plugins/mongolian_ui/src/modules/productplaces/components/DefaultFilterConfig.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/productplaces/components/DefaultFilterConfig.tsx
@@ -156,7 +156,7 @@ const DefaultFilterConfig: React.FC<Props> = ({
         </div>
 
         {filters.length === 0 ? (
-          <div className="bg-white rounded-xl border p-10 text-center text-muted-foreground shadow-sm">
+          <div className="rounded-xl border p-10 text-center text-muted-foreground shadow-sm">
             {t('no-filter-configurations')}
           </div>
         ) : (
@@ -164,7 +164,7 @@ const DefaultFilterConfig: React.FC<Props> = ({
             {filters.map((filter, index) => (
               <div
                 key={filter.title}
-                className="bg-white rounded-xl border p-6 shadow-sm space-y-6"
+                className="rounded-xl border p-6 space-y-6"
               >
                 <div className="flex items-center justify-between">
                   <h3 className="font-semibold text-base">{filter.title}</h3>

--- a/frontend/plugins/mongolian_ui/src/modules/productplaces/components/PerConditions.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/productplaces/components/PerConditions.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Label, Select, } from 'erxes-ui';
+import { Button, Input, Label, Select } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { IconTrash } from '@tabler/icons-react';
 import SelectDepartments from '../selects/SelectDepartments';
@@ -17,7 +17,12 @@ type Props = {
 
 const CLEAR_VALUE = '__clear__';
 
-const PerConditions = ({ condition, onChange, onRemove, onAddCondition }: Props) => {
+const PerConditions = ({
+  condition,
+  onChange,
+  onRemove,
+  onAddCondition,
+}: Props) => {
   const { t } = useTranslation('mongolian');
   const onChangeConfig = (key: string, value: any) => {
     onChange(condition.id, { ...condition, [key]: value });
@@ -28,7 +33,7 @@ const PerConditions = ({ condition, onChange, onRemove, onAddCondition }: Props)
   };
 
   return (
-    <div className="rounded border p-4 space-y-6 bg-white">
+    <div className="rounded border p-4 space-y-6">
       <div className="grid grid-cols-2 gap-6">
         <div className="space-y-4">
           <div className="space-y-2">
@@ -88,7 +93,9 @@ const PerConditions = ({ condition, onChange, onRemove, onAddCondition }: Props)
             <SelectSegments
               contentTypes={['core:product']}
               value={condition.segmentId || ''}
-              onValueChange={(segmentId) => onChangeConfig('segmentId', segmentId)}
+              onValueChange={(segmentId) =>
+                onChangeConfig('segmentId', segmentId)
+              }
             />
           </div>
         </div>

--- a/frontend/plugins/mongolian_ui/src/modules/productplaces/components/SplitConfig.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/productplaces/components/SplitConfig.tsx
@@ -174,7 +174,7 @@ const SplitConfig: React.FC = () => {
           activeIndex={activeIndex}
           onSelect={setActiveIndex}
         />
-        <div className="bg-white rounded-xl border p-6 space-y-6">
+        <div className="rounded-xl border p-6 space-y-6">
           <div className="flex flex-col gap-2">
             <Label className="text-sm font-medium">{t('title')}</Label>
             <Input

--- a/frontend/plugins/mongolian_ui/src/pages/CheckCategoryPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/CheckCategoryPage.tsx
@@ -1,6 +1,4 @@
 import { PageContainer, PageSubHeader } from 'erxes-ui';
-import { useTranslation } from 'react-i18next';
-
 import { CheckCategoryRecordTable } from '@/erkhet-sync/check-category/components/CheckCategoryRecordTable';
 import { CheckCategoryHeader } from '@/erkhet-sync/check-category/components/CheckCategoryHeader';
 import { CheckCategoryFilter } from '@/erkhet-sync/check-category/components/CheckCategoryFilter';

--- a/frontend/plugins/mongolian_ui/src/pages/CheckCategoryPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/CheckCategoryPage.tsx
@@ -8,8 +8,7 @@ import { useCheckCategory } from '~/modules/erkhet-sync/check-category/hooks/use
 import CheckButton from '~/modules/erkhet-sync/check-category/components/useCheckButton';
 
 export const CheckCategoryPage = () => {
-  const { t } = useTranslation('mongolian');
-  const { loading, toCheckCategories, setSelectedFilter } = useCheckCategory();
+  const { setSelectedFilter } = useCheckCategory();
 
   const handleFilterClick = (filter: 'create' | 'update' | 'delete') => {
     setSelectedFilter(filter);
@@ -23,13 +22,7 @@ export const CheckCategoryPage = () => {
         <CheckButton />
       </PageSubHeader>
 
-      {toCheckCategories && toCheckCategories.length > 0 ? (
-        <CheckCategoryRecordTable />
-      ) : (
-        <div className="m-3 text-center text-muted-foreground">
-          {loading ? t('checking') : t('no-data-found')}
-        </div>
-      )}
+      <CheckCategoryRecordTable />
     </PageContainer>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/pages/CheckProductsPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/CheckProductsPage.tsx
@@ -8,8 +8,7 @@ import { useCheckProduct } from '~/modules/erkhet-sync/check-products/hooks/useC
 import CheckButton from '~/modules/erkhet-sync/check-products/components/useCheckButton';
 
 export const CheckProductsPage = () => {
-  const { t } = useTranslation('mongolian');
-  const { loading, toCheckProducts, setSelectedFilter } = useCheckProduct();
+  const { setSelectedFilter } = useCheckProduct();
 
   const handleFilterClick = (filter: 'create' | 'update' | 'delete') => {
     setSelectedFilter(filter);
@@ -22,15 +21,7 @@ export const CheckProductsPage = () => {
         <CheckProductFilter onFilterClick={handleFilterClick} />
         <CheckButton />
       </PageSubHeader>
-      {toCheckProducts && toCheckProducts.length > 0 && (
-        <CheckProductRecordTable />
-      )}
-
-      {!toCheckProducts?.length && (
-        <div className="m-3 text-center text-muted-foreground">
-          {loading ? t('checking') : t('no-data-found')}
-        </div>
-      )}
+      <CheckProductRecordTable />
     </PageContainer>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/pages/CheckProductsPage.tsx
+++ b/frontend/plugins/mongolian_ui/src/pages/CheckProductsPage.tsx
@@ -1,6 +1,4 @@
 import { PageContainer, PageSubHeader } from 'erxes-ui';
-import { useTranslation } from 'react-i18next';
-
 import { CheckProductRecordTable } from '@/erkhet-sync/check-products/components/CheckProductRecordTable';
 import { CheckProductHeader } from '@/erkhet-sync/check-products/components/CheckProductHeader';
 import { CheckProductFilter } from '@/erkhet-sync/check-products/components/CheckProductFilter';


### PR DESCRIPTION
### Changes

**Exchange Rates (mongolian_ui + mongolian_api)**
- Replaced offset-based pagination (page/perPage) with cursor-based pagination
- Removed "Load more" button, replaced with scroll-triggered infinite cursor skeletons
- Added session key for scroll position persistence
- Broke ExchangeRatesTable into ExchangeRatesTableColumns and ExchangeRatesTableMoreColumn

**Erkhet Sync (mongolian_ui)**
- Added CheckCategoryCommandBar and CheckProductCommandBar with bulk Sync for selected rows
- Removed old Sync button from page headers
- Added loading spinner overlay to both record tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared “Synced” command bar for batch syncing selected category/product rows (used via new wrapper command bars).
* **Improvements**
  * Upgraded exchange rates to cursor-based pagination end-to-end, including page info and cursor navigation.
  * Refreshed the exchange rates table with shared column definitions and a dedicated “more” actions column.
  * Simplified category/product check pages to always render tables and move sync controls into command bars.
* **Style**
  * Refined loading/empty-state overlays, column sizing, spacing, and updated card styling in product places.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->