### PR TITLE
fix(core-ui): automation morecolumn edit button breaks navigation until refresh

### DIFF
--- a/frontend/core-ui/src/modules/automations/components/list/AutomationColumns.tsx
+++ b/frontend/core-ui/src/modules/automations/components/list/AutomationColumns.tsx
@@ -77,14 +77,16 @@ export const getAutomationColumns: (
             className="w-[100px] min-w-0 [&>button]:cursor-pointer"
             onClick={(e) => e.stopPropagation()}
           >
-            <DropdownMenu.Item asChild>
+            <DropdownMenu.Item
+              asChild
+              onSelect={() =>
+                navigate(`/automations/edit/${cell.row.original._id}`)
+              }
+            >
               <Button
                 variant="ghost"
                 size="sm"
                 className="w-full justify-start"
-                onClick={() =>
-                  navigate(`/automations/edit/${cell.row.original._id}`)
-                }
               >
                 <IconEdit className="size-4" />
                 {t('edit')}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix automation edit action in the More menu so that navigation works reliably without requiring a page refresh after use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of the edit action in automation dropdown menus for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->