### PR TITLE
fix(core): product category parent selection & order consistency

### DIFF
--- a/backend/core-api/src/modules/products/db/models/Categories.ts
+++ b/backend/core-api/src/modules/products/db/models/Categories.ts
@@ -80,11 +80,13 @@ export const loadProductCategoryClass = (
     public static async createProductCategory(doc: IProductCategory) {
       await this.checkCodeDuplication(doc.code);
 
-      const parentCategory = await models.ProductCategories.findOne({
-        _id: doc.parentId,
-      }).lean();
+      const parentCategory = doc.parentId
+        ? await models.ProductCategories.findOne({ _id: doc.parentId }).lean()
+        : null;
 
-      // Generatingg order
+      doc.parentId = parentCategory?._id || '';
+
+      // Generating order
       doc.order = await this.generateOrder(parentCategory, doc);
 
       const category = await models.ProductCategories.create({
@@ -114,30 +116,51 @@ export const loadProductCategoryClass = (
         await this.checkCodeDuplication(doc.code);
       }
 
-      const parentCategory = await models.ProductCategories.findOne({
-        _id: doc.parentId,
-      }).lean();
+      let parentId =
+        doc.parentId !== undefined ? doc.parentId : category.parentId;
 
-      if (parentCategory?.parentId === _id) {
-        throw new Error('Cannot change category');
+      if (parentId === _id) {
+        parentId = '';
       }
 
-      // Generatingg  order
+      const parentCategory = parentId
+        ? await models.ProductCategories.findOne({ _id: parentId }).lean()
+        : null;
+
+      doc.parentId = parentCategory?._id || '';
+
+      if (
+        parentCategory &&
+        category.order &&
+        parentCategory.order?.startsWith(category.order)
+      ) {
+        throw new Error('Cannot move a category under its own descendant');
+      }
+
+      // Generating order
       doc.order = await this.generateOrder(parentCategory, doc);
 
-      const childCategories = await models.ProductCategories.find({
-        $and: [
-          { order: { $regex: new RegExp(`^${escapeRegExp(category.order)}`) } },
-          { _id: { $ne: _id } },
-        ],
-      });
+      const orderChanged = !!category.order && category.order !== doc.order;
+
+      const childCategories = orderChanged
+        ? await models.ProductCategories.find({
+            $and: [
+              {
+                order: {
+                  $regex: new RegExp(`^${escapeRegExp(category.order)}`),
+                },
+              },
+              { _id: { $ne: _id } },
+            ],
+          })
+        : [];
 
       await models.ProductCategories.updateOne({ _id }, { $set: doc });
 
-      // updating child categories order
+      // updating child categories order by swapping the old order prefix
       for (const childCategory of childCategories) {
-        let order = childCategory.order;
-        order = order.replace(category.order, doc.order);
+        const order =
+          doc.order + childCategory.order.slice(category.order.length);
 
         await models.ProductCategories.updateOne(
           { _id: childCategory._id },

--- a/backend/core-api/src/modules/products/db/models/Categories.ts
+++ b/backend/core-api/src/modules/products/db/models/Categories.ts
@@ -116,8 +116,7 @@ export const loadProductCategoryClass = (
         await this.checkCodeDuplication(doc.code);
       }
 
-      let parentId =
-        doc.parentId !== undefined ? doc.parentId : category.parentId;
+      let parentId = doc.parentId ?? category.parentId;
 
       if (parentId === _id) {
         parentId = '';

--- a/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
+++ b/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
@@ -73,11 +73,9 @@ export const SelectCategory = React.forwardRef<
                 category={category}
                 selected={selectedCategory?._id === category._id}
                 onSelect={handleSelect}
-                hasChildren={
-                  availableCategories.find(
-                    (c: IProductCategory) => c.parentId === category._id,
-                  ) !== undefined
-                }
+                hasChildren={availableCategories.some(
+                  (c: IProductCategory) => c.parentId === category._id,
+                )}
               />
             ))}
           </Command.List>

--- a/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
+++ b/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 
 import {
   Avatar,
@@ -20,29 +20,38 @@ export const SelectCategory = React.forwardRef<
     open?: boolean;
     setOpen?: (open: boolean) => void;
     id?: string;
+    excludeCategoryId?: string;
   }
->(({ onSelect, selected, id, ...props }, ref) => {
-  const [selectedCategory, setSelectedCategory] = useState<IProductCategory>();
-  const { productCategories, error, loading } = useProductCategories({
-    onCompleted: ({
-      productCategories,
-    }: {
-      productCategories: IProductCategory[];
-    }) => {
-      setSelectedCategory(
-        productCategories?.find(
-          (category: IProductCategory) => category._id === selected,
-        ),
-      );
-    },
+>(({ onSelect, selected, id, excludeCategoryId, ...props }, ref) => {
+  const { productCategories, error, loading } = useProductCategories();
+
+  const selectedCategory = useMemo(
+    () =>
+      (productCategories || []).find(
+        (category: IProductCategory) => category._id === selected,
+      ),
+    [productCategories, selected],
+  );
+
+  const excludedCategory = excludeCategoryId
+    ? (productCategories || []).find(
+        (c: IProductCategory) => c._id === excludeCategoryId,
+      )
+    : undefined;
+
+  const availableCategories: IProductCategory[] = (
+    productCategories || []
+  ).filter((category: IProductCategory) => {
+    if (!excludeCategoryId) return true;
+    if (category._id === excludeCategoryId) return false;
+    return !(
+      excludedCategory?.order &&
+      category.order?.startsWith(excludedCategory.order)
+    );
   });
 
   const handleSelect = (categoryId: string) => {
-    const category = productCategories?.find(
-      (category: IProductCategory) => category._id === categoryId,
-    );
-    setSelectedCategory(category);
-    onSelect(categoryId);
+    onSelect(categoryId === selected ? '' : categoryId);
   };
 
   return (
@@ -58,14 +67,14 @@ export const SelectCategory = React.forwardRef<
           <Command.Input />
           <Command.List>
             <Combobox.Empty error={error} loading={loading} />
-            {productCategories?.map((category: IProductCategory) => (
+            {availableCategories.map((category: IProductCategory) => (
               <SelectCategoryItem
                 key={category._id}
                 category={category}
                 selected={selectedCategory?._id === category._id}
                 onSelect={handleSelect}
                 hasChildren={
-                  productCategories.find(
+                  availableCategories.find(
                     (c: IProductCategory) => c.parentId === category._id,
                   ) !== undefined
                 }

--- a/frontend/core-ui/src/modules/products/product-category/detail/components/CategoryDetailSheet.tsx
+++ b/frontend/core-ui/src/modules/products/product-category/detail/components/CategoryDetailSheet.tsx
@@ -83,6 +83,8 @@ export const CategoryDetailSheet = () => {
       if (value) cleanData[key] = value;
     });
     cleanData.attachment = attachment || undefined;
+
+    cleanData.parentId = data.parentId || '';
     const fieldsToUpdate = Object.keys(cleanData);
     productCategoriesEdit(
       {

--- a/frontend/core-ui/src/modules/products/product-category/detail/components/CategoryUpdateCoreFields.tsx
+++ b/frontend/core-ui/src/modules/products/product-category/detail/components/CategoryUpdateCoreFields.tsx
@@ -23,7 +23,11 @@ export const CategoriesUpdateCoreFields: React.FC<
         ...prevValues,
         code: categoryDetail.code,
         name: categoryDetail.name,
-        parentId: categoryDetail.parentId || '',
+        parentId:
+          categoryDetail.parentId &&
+          categoryDetail.parentId !== categoryDetail._id
+            ? categoryDetail.parentId
+            : '',
         maskType: categoryDetail.maskType || '',
       }));
     }
@@ -79,6 +83,7 @@ export const CategoriesUpdateCoreFields: React.FC<
               <SelectCategory
                 selected={field.value}
                 onSelect={(val) => field.onChange(val || '')}
+                excludeCategoryId={categoryDetail?._id}
               />
             </Form.Control>
             <Form.Message />


### PR DESCRIPTION
- SelectCategory: derive the displayed parent reactively from the selected value instead of a one-shot onCompleted, so opening a different category no longer shows an empty/stale parent
- SelectCategory: clicking the selected category toggles it off, and exclude the edited category + its descendants to prevent cycles
- Edit form: always send parentId so an emptied parent can be cleared, and treat a self-referential parentId as no parent on load
- Categories model: keep parentId and order in sync (resolve dangling refs, heal self-parent, block descendant cycles with a clear error), and guard the child-order cascade against an empty order rewriting every category

## Summary by Sourcery

Ensure product category parent selection is consistent, cycle-safe, and keeps ordering in sync across backend and frontend.

Bug Fixes:
- Normalize and validate parentId when creating or updating product categories to avoid dangling or self-referential parents and invalid order hierarchies.
- Prevent moving a category under its own descendant and avoid unintentionally rewriting child category orders when the parent order has not changed.
- Fix the category selector so the displayed parent stays in sync with the current selection, allows toggling the selection off, and excludes the edited category and its descendants to avoid cycles.
- Ensure clearing a category’s parent in the edit form actually removes the parent on save and ignores self-parent values on load.

Enhancements:
- Optimize child category order updates by only recalculating and cascading order changes when a category’s order actually changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category selector now supports excluding a specified category and its descendants from the available options.

* **Bug Fixes**
  * Improved category hierarchy validation to prevent moving a category under its own descendants.
  * Selecting the currently active category now clears the selection.
  * Parent category updates now reliably include `parentId` (including the empty “no parent” case) and the selector omits the current category where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->