### PR TITLE
Fixed the pipeline refresh jump

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-navigations/TicketNavigations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-navigations/TicketNavigations.tsx
@@ -55,7 +55,15 @@ export function TicketNavigations() {
   const [channelId, setChannelId] = useQueryState<string | null>('channelId');
 
   useEffect(() => {
-    if (!channelId && channels?.[0]?._id) {
+    if (!channels?.length || !channels[0]?._id) {
+      return;
+    }
+
+    const hasSelectedChannel = channels.some(
+      (channel) => channel._id === channelId,
+    );
+
+    if (!channelId || !hasSelectedChannel) {
       setChannelId(channels[0]._id);
     }
   }, [channels, setChannelId, channelId]);
@@ -115,7 +123,9 @@ const Pipelines = () => {
                     setPipelineId(pipeline._id);
                   }}
                 >
-                  <span className="capitalize min-w-0 truncate">{pipeline.name}</span>
+                  <span className="capitalize min-w-0 truncate">
+                    {pipeline.name}
+                  </span>
                 </Sidebar.MenuButton>
               </Sidebar.MenuItem>
             ))

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-navigations/TicketNavigations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-navigations/TicketNavigations.tsx
@@ -5,10 +5,8 @@ import {
   Collapsible,
   IconComponent,
   NavigationMenuGroup,
-  NavigationMenuLinkItem,
   Sidebar,
   Skeleton,
-  TextOverflowTooltip,
   useQueryState,
 } from 'erxes-ui';
 import { IChannel } from '@/channels/types';
@@ -57,7 +55,9 @@ export function TicketNavigations() {
   const [channelId, setChannelId] = useQueryState<string | null>('channelId');
 
   useEffect(() => {
-    !channelId && channels?.[0]?._id && setChannelId(channels[0]._id);
+    if (!channelId && channels?.[0]?._id) {
+      setChannelId(channels[0]._id);
+    }
   }, [channels, setChannelId, channelId]);
   return (
     <>
@@ -88,11 +88,18 @@ const Pipelines = () => {
     },
   });
   useEffect(() => {
-    if (channelId && pipelines) {
-      setPipelineId(pipelines?.[0] ? pipelines?.[0]?._id : null);
+    if (!channelId || !pipelines) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channelId, pipelines]);
+
+    const hasSelectedPipeline = pipelines.some(
+      (pipeline) => pipeline._id === pipelineId,
+    );
+
+    if (!pipelineId || !hasSelectedPipeline) {
+      setPipelineId(pipelines[0]?._id || null);
+    }
+  }, [channelId, pipelines, pipelineId, setPipelineId]);
   return (
     <Collapsible.Content className="pt-1">
       <Sidebar.GroupContent>


### PR DESCRIPTION
## Summary by Sourcery

Ensure ticket navigation selects and preserves a valid channel and pipeline when data changes.

Bug Fixes:
- Prevent automatic pipeline selection from resetting or jumping when a previously selected pipeline is still valid.
- Guard initial channel selection and pipeline updates to only run when required data is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline selection handling so your selected pipeline is preserved across data refreshes. The interface now avoids resetting the pipeline choice when the currently selected pipeline is still available, and only falls back to a default when the selection is missing or no longer valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->