### PR TITLE
feat: msdynamic_ui add user custom fields for customer code and location code

### DIFF
--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicConfigFormFields.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicConfigFormFields.tsx
@@ -50,6 +50,11 @@ const DEFAULT_FIELDS: MSDynamicTextFieldName[] = [
   'defaultCompanyCode',
 ];
 
+const CUSTOM_FIELDS: MSDynamicTextFieldName[] = [
+  'custCode',
+  'userLocationCode',
+];
+
 const getSingleSelectValue = (value: string | string[]) =>
   Array.isArray(value) ? value[0] || '' : value;
 
@@ -163,6 +168,16 @@ export const MSDynamicConfigFormFields = ({
 
         <MSDynamicFieldSection title="Defaults">
           {DEFAULT_FIELDS.map((name) => (
+            <MSDynamicTextField
+              key={name}
+              form={form}
+              name={name}
+              loading={loading}
+            />
+          ))}
+        </MSDynamicFieldSection>
+        <MSDynamicFieldSection title="Custom Fields">
+          {CUSTOM_FIELDS.map((name) => (
             <MSDynamicTextField
               key={name}
               form={form}

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/constants/constants.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/constants/constants.ts
@@ -41,4 +41,6 @@ export const KEY_LABELS: Record<string, string> = {
   stageId: 'Stage',
   posConf: 'POS config',
   productUrl: 'Product URL',
+  custCode: 'Customer Code field',
+  userLocationCode: 'User Location Code field',
 };

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/addMSDynamicConfigSchema.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/addMSDynamicConfigSchema.ts
@@ -34,4 +34,6 @@ export const addMSDynamicConfigSchema = z.object({
   stageId: z.string(),
   posConf: z.string(),
   productUrl: z.string(),
+  custCode: z.string().optional(),
+  userLocationCode: z.string().optional(),
 });

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/index.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/index.ts
@@ -51,6 +51,8 @@ export const createEmptyMSDynamicConfig = (): IMSDynamicConfig => ({
   stageId: '',
   posConf: '',
   productUrl: '',
+  custCode: '',
+  userLocationCode: '',
 });
 
 export const normalizeMSDynamicConfig = (
@@ -109,4 +111,6 @@ export const toMSDynamicFormValues = (
   stageId: row.stageId,
   posConf: row.posConf,
   productUrl: row.productUrl,
+  custCode: row.custCode,
+  userLocationCode: row.userLocationCode,
 });

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/types.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/types.ts
@@ -37,8 +37,8 @@ export type IMSDynamicConfig = {
   stageId: string;
   posConf: string;
   productUrl: string;
-  custCode?: string;               
-  userLocationCode?: string; 
+  custCode: string;               
+  userLocationCode: string; 
 };
 
 export type IMSDynamicConfigMap = Record<string, IMSDynamicConfig>;

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/types.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/types/types.ts
@@ -37,6 +37,8 @@ export type IMSDynamicConfig = {
   stageId: string;
   posConf: string;
   productUrl: string;
+  custCode?: string;               
+  userLocationCode?: string; 
 };
 
 export type IMSDynamicConfigMap = Record<string, IMSDynamicConfig>;


### PR DESCRIPTION
## Summary by Sourcery

Add configurable custom fields for MS Dynamic customer and user location codes in the Mongolian UI plugin.

New Features:
- Introduce new MSDynamic custom fields for customer code and user location code in the configuration form.
- Persist customer code and user location code values in the MS Dynamic configuration model and normalization utilities.

Enhancements:
- Extend MS Dynamic configuration schema, defaults, and labels to support the new custom customer and location code fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two new optional configuration fields: Customer Code and User Location Code in MS Dynamic settings. These fields are now available in the configuration form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->