### PR TITLE
feat(ui): add login password toggle and split org switcher

### DIFF
--- a/apps/posclient-front/modules/auth/components/login.tsx
+++ b/apps/posclient-front/modules/auth/components/login.tsx
@@ -5,7 +5,7 @@ import SyncConfig from "@/modules/settings/SyncConfig"
 import { configAtom } from "@/store/config.store"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useAtom } from "jotai"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { Eye, EyeOff } from "lucide-react"
 import * as z from "zod"
@@ -24,6 +24,8 @@ import { Input } from "@/components/ui/input"
 
 import ChooseConfig from "../chooseConfig"
 import { IHandleLogin } from "../login"
+
+const PASSWORD_REVEAL_TIMEOUT = 10000
 
 const FormSchema = z.object({
   email: z
@@ -52,6 +54,15 @@ const Login = ({
     resolver: zodResolver(FormSchema),
   })
   const onSubmit = (data: z.infer<typeof FormSchema>) => login(data)
+
+  useEffect(() => {
+    if (!showPassword) return
+    const timer = setTimeout(
+      () => setShowPassword(false),
+      PASSWORD_REVEAL_TIMEOUT,
+    )
+    return () => clearTimeout(timer)
+  }, [showPassword])
 
   return (
     <>

--- a/apps/posclient-front/modules/auth/components/login.tsx
+++ b/apps/posclient-front/modules/auth/components/login.tsx
@@ -5,7 +5,9 @@ import SyncConfig from "@/modules/settings/SyncConfig"
 import { configAtom } from "@/store/config.store"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useAtom } from "jotai"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
+import { Eye, EyeOff } from "lucide-react"
 import * as z from "zod"
 
 import { getEnv } from "@/lib/utils"
@@ -45,6 +47,7 @@ const Login = ({
 }) => {
   const env = getEnv()
   const [config] = useAtom(configAtom)
+  const [showPassword, setShowPassword] = useState(false)
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
   })
@@ -77,7 +80,29 @@ const Login = ({
                 <FormItem>
                   <FormLabel>Password</FormLabel>
                   <FormControl>
-                    <Input type="password" {...field} />
+                    <div className="relative">
+                      <Input
+                        type={showPassword ? "text" : "password"}
+                        className="pr-10"
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        aria-label={
+                          showPassword ? "Hide password" : "Show password"
+                        }
+                        className="absolute inset-y-0 right-1 my-auto h-8 w-8 text-muted-foreground hover:text-foreground"
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/frontend/core-ui/src/modules/auth/login/components/CredentialLoginForm.tsx
+++ b/frontend/core-ui/src/modules/auth/login/components/CredentialLoginForm.tsx
@@ -2,13 +2,24 @@ import { Button, Form, Input } from 'erxes-ui';
 import { useLogin } from '@/auth/login/hooks/useLogin';
 import { useSignInUpForm } from '@/auth/login/hooks/useLoginForm';
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
+
+const PASSWORD_REVEAL_TIMEOUT = 10000;
 
 export const CredentialLoginForm = () => {
   const { form } = useSignInUpForm();
   const { handleCrendentialsLogin } = useLogin();
   const [showPassword, setShowPassword] = useState(false);
+
+  useEffect(() => {
+    if (!showPassword) return;
+    const timer = setTimeout(
+      () => setShowPassword(false),
+      PASSWORD_REVEAL_TIMEOUT,
+    );
+    return () => clearTimeout(timer);
+  }, [showPassword]);
 
   return (
     <Form {...form}>

--- a/frontend/core-ui/src/modules/auth/login/components/CredentialLoginForm.tsx
+++ b/frontend/core-ui/src/modules/auth/login/components/CredentialLoginForm.tsx
@@ -2,10 +2,13 @@ import { Button, Form, Input } from 'erxes-ui';
 import { useLogin } from '@/auth/login/hooks/useLogin';
 import { useSignInUpForm } from '@/auth/login/hooks/useLoginForm';
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
 
 export const CredentialLoginForm = () => {
   const { form } = useSignInUpForm();
   const { handleCrendentialsLogin } = useLogin();
+  const [showPassword, setShowPassword] = useState(false);
 
   return (
     <Form {...form}>
@@ -41,11 +44,30 @@ export const CredentialLoginForm = () => {
                 Password
               </Form.Label>
               <Form.Control>
-                <Input
-                  type="password"
-                  placeholder="Enter your password"
-                  {...field}
-                />
+                <div className="relative">
+                  <Input
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="Enter your password"
+                    className="pr-9"
+                    {...field}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    aria-label={
+                      showPassword ? 'Hide password' : 'Show password'
+                    }
+                    className="absolute inset-y-0 right-1 my-auto size-6 rounded-sm p-0 text-accent-foreground/60 hover:text-foreground"
+                  >
+                    {showPassword ? (
+                      <IconEyeOff size={15} stroke={1.75} />
+                    ) : (
+                      <IconEye size={15} stroke={1.75} />
+                    )}
+                  </Button>
+                </div>
               </Form.Control>
               <Form.Message />
             </Form.Item>

--- a/frontend/core-ui/src/modules/navigation/components/Organization.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/Organization.tsx
@@ -1,6 +1,6 @@
 import { currentOrganizationState } from 'ui-modules';
 
-import { cn, DropdownMenu, Sidebar, TextOverflowTooltip } from 'erxes-ui';
+import { Button, cn, DropdownMenu, TextOverflowTooltip } from 'erxes-ui';
 
 import { useAtom } from 'jotai';
 import { IconSelector } from '@tabler/icons-react';
@@ -11,61 +11,72 @@ import { ThemeSelector } from '@/navigation/components/ThemeSelector';
 import { SelectLanguages } from '@/navigation/components/SelectLanguages';
 import { useTranslation } from 'react-i18next';
 import { OrgLogoIcon } from '@/auth/components/Logo';
+import { AppPath } from '@/types/paths/AppPath';
 
 export function Organization() {
   const [currentOrganization] = useAtom(currentOrganizationState);
   const { handleLogout } = useAuth();
   const { t } = useTranslation('organization');
 
+  const hasOrgName =
+    !!currentOrganization?.name || !!currentOrganization?.orgShortName;
+
   return (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Sidebar.MenuButton
-          size="lg"
-          className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground h-auto p-2"
-        >
-          <div className="flex size-8 rounded-lg  items-center justify-center overflow-hidden flex-none shadow-xs">
-            <OrgLogoIcon className="size-7 text-primary flex-none" />
-          </div>
-          <TextOverflowTooltip
-            value={
-              currentOrganization?.name
-                ? currentOrganization.name
-                : currentOrganization?.orgShortName || 'erxes'
-            }
-            className={cn('font-medium text-sm', {
-              'text-accent-foreground font-normal':
-                !currentOrganization?.name &&
-                !currentOrganization?.orgShortName,
-            })}
-          />
-          <IconSelector className="ml-auto size-4 text-accent-foreground" />
-        </Sidebar.MenuButton>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="start" className="space-y-1">
-        <User />
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item asChild>
-          <Link to="/settings" className="text-sm">
-            {t('settings')}
-          </Link>
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <ThemeSelector />
-        <SelectLanguages />
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item className="text-sm" onClick={() => handleLogout()}>
-          {t('logout')}
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <DropdownMenu.Label className="flex items-center gap-2">
-          {t('version')}
-          <span className="text-primary ml-auto tracking-wider">
-            3.0.0-beta.1
-          </span>
-        </DropdownMenu.Label>
-      </DropdownMenu.Content>
-    </DropdownMenu>
+    <div className="flex w-full items-center gap-1 ">
+      <Link
+        to={AppPath.Index}
+        aria-label={t('home')}
+        className="flex flex-1 basis-1/2 min-w-0 items-center gap-2 rounded p-2"
+      >
+        <div className="flex size-8 rounded-lg items-center justify-center overflow-hidden flex-none shadow-xs">
+          <OrgLogoIcon className="size-7 text-primary flex-none" />
+        </div>
+        <TextOverflowTooltip
+          value={
+            currentOrganization?.name
+              ? currentOrganization.name
+              : currentOrganization?.orgShortName || 'erxes'
+          }
+          className={cn('font-medium text-sm', {
+            'text-accent-foreground font-normal': !hasOrgName,
+          })}
+        />
+      </Link>
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button
+            variant="ghost"
+            type="button"
+            className="flex flex-1 basis-1/2 h-auto items-center justify-start gap-2 rounded p-2 font-medium text-sm text-foreground hover:bg-transparent outline-none focus-visible:outline-none data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+          >
+            <IconSelector className="ml-auto text-accent-foreground" />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" className="space-y-1 ml-2">
+          <User />
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item asChild>
+            <Link to="/settings" className="text-sm">
+              {t('settings')}
+            </Link>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <ThemeSelector />
+          <SelectLanguages />
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item className="text-sm" onClick={() => handleLogout()}>
+            {t('logout')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Label className="flex items-center gap-2">
+            {t('version')}
+            <span className="text-primary ml-auto tracking-wider">
+              3.0.0-beta.1
+            </span>
+          </DropdownMenu.Label>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </div>
   );
 }
 


### PR DESCRIPTION
- Add show/hide password eye toggle to core-ui and posclient-front login forms
- Split organization switcher: logo links home, chevron opens the dropdown menu

## Summary by Sourcery

Add password visibility toggles to login forms and separate organization logo navigation from the account dropdown menu in the UI.

New Features:
- Introduce a show/hide password toggle on the core-ui credential login form.
- Add a password visibility toggle to the POS client login password field.
- Make the organization logo in the sidebar navigate to the home page while the chevron opens the organization/user dropdown menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggles to login forms, including an auto-hide timeout for safer handling.
* **Refactor**
  * Improved organization navigation by updating the trigger and home/logo link behavior, along with refined dropdown alignment and tooltip styling for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->