### PR TITLE
Feat cms2

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/@types/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/@types/cms.ts
@@ -9,6 +9,9 @@ export const CMS_POST_URL_FIELDS = ['_id', 'count', 'slug'] as const;
 export type CMSPostUrlField = (typeof CMS_POST_URL_FIELDS)[number];
 export const CMS_DEFAULT_POST_URL_FIELD: CMSPostUrlField = '_id';
 export const CMS_DEFAULT_POST_URL_PREFIX = '/posts';
+export const CMS_ACCESS_POLICIES = ['open', 'assigned'] as const;
+export type CmsAccessPolicy = (typeof CMS_ACCESS_POLICIES)[number];
+export const CMS_DEFAULT_ACCESS_POLICY: CmsAccessPolicy = 'open';
 export const MENU_LINK_TYPES = [
   'URL',
   'PAGE',
@@ -42,6 +45,8 @@ export interface IContentCMS {
   languages?: string[];
   postUrlField?: CMSPostUrlField;
   postUrlPrefix?: string;
+  accessPolicy?: CmsAccessPolicy;
+  assignedMemberIds?: string[];
 }
 
 export interface IContentCMSDocument extends IContentCMS, Document {
@@ -72,6 +77,8 @@ export interface IContentCMSInput {
   languages?: string[];
   postUrlField?: CMSPostUrlField;
   postUrlPrefix?: string;
+  accessPolicy?: CmsAccessPolicy;
+  assignedMemberIds?: string[];
 }
 
 export interface ICMSMenu {

--- a/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/definitions/cms.ts
@@ -1,4 +1,6 @@
 import {
+  CMS_ACCESS_POLICIES,
+  CMS_DEFAULT_ACCESS_POLICY,
   ICMSMenuDocument,
   ICMSPageDocument,
   IContentCMSDocument,
@@ -35,6 +37,13 @@ export const cmsSchema = new mongoose.Schema<IContentCMSDocument>(
     languages: { type: [String], optional: true },
     postUrlField: { type: String, optional: true, default: '_id' },
     postUrlPrefix: { type: String, optional: true, default: '/posts' },
+    accessPolicy: {
+      type: String,
+      enum: CMS_ACCESS_POLICIES,
+      optional: true,
+      default: CMS_DEFAULT_ACCESS_POLICY,
+    },
+    assignedMemberIds: { type: [String], optional: true, default: [] },
   },
   { timestamps: true },
 );

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/cms.ts
@@ -2,6 +2,7 @@ import { IContext } from '~/connectionResolvers';
 import { IContentCMSInput } from '@/cms/@types/cms';
 import { Resolver } from 'erxes-api-shared/core-types';
 import { requireClientPortalId } from '@/cms/graphql/utils/clientPortal';
+import { assertCmsDocAccess } from '@/cms/utils/cms-access';
 
 export const contentCmsMutations: Record<string, Resolver> = {
   contentCreateCMS: async (
@@ -30,15 +31,21 @@ export const contentCmsMutations: Record<string, Resolver> = {
   contentUpdateCMS: async (
     _parent: any,
     { id, input }: { id: string; input: IContentCMSInput },
-    { models }: IContext,
+    context: IContext,
   ) => {
+    const { models } = context;
+    const existing = await models.CMS.getContentCMS(id);
+    assertCmsDocAccess(context, existing);
     return models.CMS.updateContentCMS(id, input);
   },
   contentDeleteCMS: async (
     _parent: any,
     { id }: { id: string },
-    { models }: IContext,
+    context: IContext,
   ) => {
+    const { models } = context;
+    const existing = await models.CMS.getContentCMS(id);
+    assertCmsDocAccess(context, existing);
     return models.CMS.deleteContentCMS(id);
   },
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/page.ts
@@ -5,6 +5,7 @@ import {
   assertOwnedDocument,
   requireClientPortalId,
 } from '@/cms/graphql/utils/clientPortal';
+import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -44,6 +45,8 @@ const mutations : Record<string, Resolver> = {
     const { user, models, subdomain } = context;
     const { input } = args;
     const { translations, language, ...pageInput } = input;
+
+    await assertCmsAccessByClientPortal(context, pageInput.clientPortalId);
 
     pageInput.createdUserId = user._id;
 
@@ -147,6 +150,11 @@ const mutations : Record<string, Resolver> = {
       throw new Error('Page not found');
     }
 
+    await assertCmsAccessByClientPortal(
+      context,
+      pageInput.clientPortalId || existingPage.clientPortalId,
+    );
+
     if (language && pageInput.clientPortalId) {
       const defaultLanguage = await getDefaultLanguage(
         models,
@@ -208,6 +216,14 @@ const mutations : Record<string, Resolver> = {
   ): Promise<any> {
     const { models } = context;
     const { _id } = args;
+
+    const existingPage = await models.Pages.findOne({ _id }).lean();
+
+    if (!existingPage) {
+      throw new Error('Page not found');
+    }
+
+    await assertCmsAccessByClientPortal(context, existingPage.clientPortalId);
 
     await models.Translations.deleteMany({ objectId: _id, type: 'page' });
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
@@ -14,6 +14,7 @@ import {
 } from '@/cms/utils/permissions';
 import { CMS_POST_ACTIONS } from '~/meta/permissions';
 import { preparePdfAttachmentPages } from '@/cms/utils/pdfAttachments';
+import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -46,6 +47,8 @@ export const postMutations: Record<string, Resolver> = {
     const { models, user, subdomain } = context;
     const { input } = args;
     const { translations, language, ...postInput } = input;
+
+    await assertCmsAccessByClientPortal(context, postInput.clientPortalId);
 
     await requireCmsPermission(context, [
       CMS_POST_ACTIONS.createPublished,
@@ -196,6 +199,8 @@ export const postMutations: Record<string, Resolver> = {
       throw new Error('Post not found');
     }
 
+    await assertCmsAccessByClientPortal(context, existingPost.clientPortalId);
+
     await assertCmsDocumentAccess({
       context,
       actions:
@@ -280,6 +285,8 @@ export const postMutations: Record<string, Resolver> = {
       throw new Error('Post not found');
     }
 
+    await assertCmsAccessByClientPortal(context, post.clientPortalId);
+
     await assertCmsDocumentAccess({
       context,
       actions: CMS_POST_ACTIONS.remove,
@@ -308,6 +315,7 @@ export const postMutations: Record<string, Resolver> = {
     }
 
     for (const post of posts) {
+      await assertCmsAccessByClientPortal(context, post.clientPortalId);
       await assertCmsDocumentAccess({
         context,
         actions: CMS_POST_ACTIONS.remove,
@@ -330,6 +338,8 @@ export const postMutations: Record<string, Resolver> = {
     if (!post) {
       throw new Error('Post not found');
     }
+
+    await assertCmsAccessByClientPortal(context, post.clientPortalId);
 
     await assertCmsDocumentAccess({
       context,
@@ -356,6 +366,8 @@ export const postMutations: Record<string, Resolver> = {
     if (!post) {
       throw new Error('Post not found');
     }
+
+    await assertCmsAccessByClientPortal(context, post.clientPortalId);
 
     await assertCmsDocumentAccess({
       context,

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/cms.ts
@@ -1,14 +1,19 @@
 import { IContext } from '~/connectionResolvers';
+import { assertCmsDocAccess } from '@/cms/utils/cms-access';
 
 export const contentCmsQueries = {
+  // The CMS list stays visible to everyone ("show all"); per-CMS access is
+  // enforced when a member tries to open or manage a specific CMS.
   contentCMSList: async (_parent: any, _args: any, { models }: IContext) => {
     return models.CMS.getContentCMSs();
   },
   contentCMS: async (
     _parent: any,
     { id }: { id: string },
-    { models }: IContext,
+    context: IContext,
   ) => {
-    return models.CMS.getContentCMS(id);
+    const cms = await context.models.CMS.getContentCMS(id);
+    assertCmsDocAccess(context, cms);
+    return cms;
   },
 };

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
@@ -2,6 +2,7 @@ import { IContext } from '~/connectionResolvers';
 import { BaseQueryResolver, FIELD_MAPPINGS } from '@/cms/utils/base-resolvers';
 import { getQueryBuilder } from '@/cms/utils/query-builders';
 import { Resolver } from 'erxes-api-shared/core-types';
+import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
 class PageQueryResolver extends BaseQueryResolver {
   async cmsPages(_parent: any, args: any, context: IContext) {
@@ -9,6 +10,8 @@ class PageQueryResolver extends BaseQueryResolver {
     const { models } = context;
 
     if (!clientPortalId) throw new Error('clientPortalId is required');
+
+    await assertCmsAccessByClientPortal(context, clientPortalId);
 
     const orderBy = args.orderBy || { createdAt: -1 };
 
@@ -31,6 +34,8 @@ class PageQueryResolver extends BaseQueryResolver {
     const { models } = context;
 
     if (!clientPortalId) throw new Error('clientPortalId is required');
+
+    await assertCmsAccessByClientPortal(context, clientPortalId);
 
     const orderBy = args.orderBy || { createdAt: -1 };
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/posts.ts
@@ -15,6 +15,7 @@ import {
   requireCmsPermission,
 } from '@/cms/utils/permissions';
 import { CMS_POST_ACTIONS } from '~/meta/permissions';
+import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 
 const applyFieldConstraint = (query: any, field: string, value: any) => {
   if (query[field] === undefined || query[field] === value) {
@@ -282,6 +283,9 @@ class PostQueryResolver extends BaseQueryResolver {
    */
   async cmsPosts(_parent: any, args: any, context: IContext): Promise<any> {
     const { language, clientPortalId } = args;
+
+    await assertCmsAccessByClientPortal(context, clientPortalId);
+
     const { models } = context;
 
     const readAccess = await getCmsReadAccess(context, clientPortalId, language);
@@ -335,6 +339,8 @@ class PostQueryResolver extends BaseQueryResolver {
   async cmsPostList(_parent: any, args: any, context: IContext): Promise<any> {
     const { language, clientPortalId } = args;
     const { models } = context;
+
+    await assertCmsAccessByClientPortal(context, clientPortalId);
 
     const readAccess = await getCmsReadAccess(context, clientPortalId, language);
 

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/cms.ts
@@ -22,6 +22,8 @@ export const types = `
     languages: [String]
     postUrlField: String
     postUrlPrefix: String
+    accessPolicy: String
+    assignedMemberIds: [String]
     createdAt: Date
     updatedAt: Date
 
@@ -51,6 +53,8 @@ export const inputs = `
     languages: [String]
     postUrlField: String
     postUrlPrefix: String
+    accessPolicy: String
+    assignedMemberIds: [String]
   }
 `;
 

--- a/backend/plugins/content_api/src/modules/cms/utils/cms-access.ts
+++ b/backend/plugins/content_api/src/modules/cms/utils/cms-access.ts
@@ -1,0 +1,91 @@
+import { IContext } from '~/connectionResolvers';
+import { IContentCMSDocument } from '@/cms/@types/cms';
+
+/**
+ * Per-CMS team-member access control.
+ *
+ * Each CMS has an `accessPolicy`:
+ *   - 'open'     => any logged-in team member with content access can use it
+ *                  (this is the default, so existing CMSs keep working).
+ *   - 'assigned' => only the team members listed in `assignedMemberIds`,
+ *                  plus owners, can use it.
+ *
+ * Owners (`user.isOwner`) always bypass the policy.
+ */
+
+type CmsAccessDoc = Pick<
+  IContentCMSDocument,
+  'accessPolicy' | 'assignedMemberIds'
+>;
+
+export const canAccessCmsDoc = (
+  context: IContext,
+  cms?: CmsAccessDoc | null,
+): boolean => {
+  const { user } = context;
+
+  if (!user?._id) {
+    return false;
+  }
+
+  if (user.isOwner) {
+    return true;
+  }
+
+  // Unknown / not-yet-configured CMS is treated as open.
+  if (!cms || cms.accessPolicy !== 'assigned') {
+    return true;
+  }
+
+  return (cms.assignedMemberIds || []).includes(user._id);
+};
+
+export const assertCmsDocAccess = (
+  context: IContext,
+  cms?: CmsAccessDoc | null,
+): void => {
+  if (!context.user?._id) {
+    throw new Error('Login required');
+  }
+
+  if (!canAccessCmsDoc(context, cms)) {
+    throw new Error('You do not have access to this CMS');
+  }
+};
+
+/**
+ * Resolve a CMS by its clientPortalId and assert access. Results are cached on
+ * the request context so repeated checks within one request stay cheap.
+ */
+export const assertCmsAccessByClientPortal = async (
+  context: IContext,
+  clientPortalId?: string,
+): Promise<void> => {
+  if (!context.user?._id) {
+    throw new Error('Login required');
+  }
+
+  if (context.user.isOwner) {
+    return;
+  }
+
+  if (!clientPortalId) {
+    // Nothing to scope against; fall back to the generic logged-in check.
+    return;
+  }
+
+  const cache: Record<string, CmsAccessDoc | null> =
+    (context as any).__cmsAccessByClientPortal ||
+    ((context as any).__cmsAccessByClientPortal = {});
+
+  let cms = cache[clientPortalId];
+
+  if (cms === undefined) {
+    cms = await context.models.CMS.findOne({ clientPortalId })
+      .select({ accessPolicy: 1, assignedMemberIds: 1 })
+      .lean();
+    cache[clientPortalId] = cms;
+  }
+
+  assertCmsDocAccess(context, cms);
+};

--- a/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-fields/types/customFieldTypes.ts
@@ -11,7 +11,8 @@ export type FieldType =
   | 'file'
   | 'image'
   | 'spreadsheet'
-  | 'richText';
+  | 'richText'
+  | 'products';
 
 export interface ICustomField {
   _id: string;
@@ -55,4 +56,5 @@ export const FIELD_TYPES: { value: FieldType; label: string }[] = [
   { value: 'image', label: 'Image' },
   { value: 'spreadsheet', label: 'Spreadsheet (Excel paste)' },
   { value: 'richText', label: 'Rich Text (Editor)' },
+  { value: 'products', label: 'Products' },
 ];

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/mutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/mutations.ts
@@ -43,6 +43,8 @@ export const CONTENT_CREATE_CMS = gql`
       name
       postUrlField
       postUrlPrefix
+      accessPolicy
+      assignedMemberIds
       updatedAt
       content
     }
@@ -92,6 +94,8 @@ export const CONTENT_UPDATE_CMS = gql`
       name
       postUrlField
       postUrlPrefix
+      accessPolicy
+      assignedMemberIds
       updatedAt
       content
     }

--- a/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/graphql/queries.ts
@@ -13,6 +13,8 @@ export const CONTENT_CMS_LIST = gql`
       language
       postUrlField
       postUrlPrefix
+      accessPolicy
+      assignedMemberIds
       description
       domain
       publicUrl

--- a/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
@@ -13,6 +13,7 @@ import {
 import { REACT_APP_API_URL } from 'erxes-ui/utils';
 import { useEffect } from 'react';
 import { IconUpload, IconX, IconPaperclip } from '@tabler/icons-react';
+import { SelectProduct } from 'ui-modules';
 import { SpreadsheetInput } from './SpreadsheetInput';
 
 export interface FieldDefinition {
@@ -350,6 +351,27 @@ export const CustomFieldInput = ({
             onChange={(urls) => onChange(urls)}
           />
         );
+
+      case 'products': {
+        const selectedProductIds = Array.isArray(value)
+          ? value
+          : value
+            ? [value as string]
+            : [];
+        return (
+          <SelectProduct
+            mode="multiple"
+            value={selectedProductIds}
+            onValueChange={(val) =>
+              onChange(Array.isArray(val) ? val : val ? [val] : [])
+            }
+            placeholder={
+              field.placeholder || `Select ${field.label.toLowerCase()}`
+            }
+            className="w-full"
+          />
+        );
+      }
 
       case 'richText':
         return (

--- a/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/components/SettingsForm.tsx
@@ -3,10 +3,13 @@ import {
   IconChartBar,
   IconCheck,
   IconLink,
+  IconLock,
   IconPhoto,
   IconTrash,
+  IconUsers,
   IconWorld,
 } from '@tabler/icons-react';
+import { SelectMember } from 'ui-modules';
 import {
   Badge,
   Button,
@@ -529,6 +532,70 @@ export const SettingsForm = ({
             onChange={(value) => updateSetting('favicon', value)}
           />
         </Field>
+      </SettingsSection>
+
+      <SettingsSection
+        id="access"
+        title="Access Control"
+        badge={<Badge variant="secondary">Team</Badge>}
+      >
+        <Field
+          label="Who can manage this CMS"
+          hint="Owners always have full access. Choose whether everyone or only assigned team members can manage this CMS and its content."
+        >
+          <div className="grid gap-2 md:grid-cols-2">
+            <RobotsOption
+              checked={settings.accessPolicy === 'open'}
+              title="Open access"
+              description="Any team member with content access"
+              onClick={() => updateSetting('accessPolicy', 'open')}
+            />
+            <RobotsOption
+              checked={settings.accessPolicy === 'assigned'}
+              title="Assigned members only"
+              description="Only assigned team members (and owners)"
+              onClick={() => updateSetting('accessPolicy', 'assigned')}
+            />
+          </div>
+        </Field>
+
+        {settings.accessPolicy === 'assigned' ? (
+          <Field
+            label="Assigned Team Members"
+            hint="These team members get access to this CMS. Members who are not assigned will be blocked from opening or editing it."
+          >
+            <SelectMember
+              mode="multiple"
+              value={settings.assignedMemberIds}
+              onValueChange={(value) =>
+                updateSetting(
+                  'assignedMemberIds',
+                  Array.isArray(value) ? value : value ? [value] : [],
+                )
+              }
+              placeholder="Select team members"
+            />
+            <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              {settings.assignedMemberIds.length ? (
+                <>
+                  <IconUsers className="size-4 shrink-0" />
+                  <span>
+                    {settings.assignedMemberIds.length} member
+                    {settings.assignedMemberIds.length === 1 ? '' : 's'} assigned
+                  </span>
+                </>
+              ) : (
+                <>
+                  <IconLock className="size-4 shrink-0" />
+                  <span>
+                    No members assigned — only owners will be able to access
+                    this CMS.
+                  </span>
+                </>
+              )}
+            </div>
+          </Field>
+        ) : null}
       </SettingsSection>
 
       <SettingsSection

--- a/frontend/plugins/content_ui/src/modules/cms/settings/constants/defaultSettings.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/constants/defaultSettings.ts
@@ -23,4 +23,6 @@ export const DEFAULT_SETTINGS: SettingsFormState = {
   defaultLanguage: '',
   siteLogo: null,
   favicon: null,
+  accessPolicy: 'open',
+  assignedMemberIds: [],
 };

--- a/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/hooks/useSettingsForm.ts
@@ -140,6 +140,9 @@ export const useSettingsForm = () => {
         cms?.language || languages[0] || DEFAULT_SETTINGS.defaultLanguage,
       siteLogo: cms?.siteLogo || DEFAULT_SETTINGS.siteLogo,
       favicon: cms?.favicon || DEFAULT_SETTINGS.favicon,
+      accessPolicy:
+        cms?.accessPolicy === 'assigned' ? 'assigned' : 'open',
+      assignedMemberIds: cms?.assignedMemberIds || [],
     });
     setHydratedSettingsKey(hydrationKey);
   }, [
@@ -186,6 +189,9 @@ export const useSettingsForm = () => {
       postUrlPrefix: settings.postUrlPrefix,
       siteLogo: settings.siteLogo,
       favicon: settings.favicon,
+      accessPolicy: settings.accessPolicy,
+      assignedMemberIds:
+        settings.accessPolicy === 'assigned' ? settings.assignedMemberIds : [],
     };
 
     return includeContent

--- a/frontend/plugins/content_ui/src/modules/cms/settings/types/settingsTypes.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/settings/types/settingsTypes.ts
@@ -29,7 +29,11 @@ export type SettingsFormState = {
   defaultLanguage: string;
   siteLogo: CmsAttachment | null;
   favicon: CmsAttachment | null;
+  accessPolicy: CmsAccessPolicy;
+  assignedMemberIds: string[];
 };
+
+export type CmsAccessPolicy = 'open' | 'assigned';
 
 export type ClientPortalOption = {
   _id: string;
@@ -61,6 +65,8 @@ export type CmsSettingsData = {
   postUrlPrefix?: string;
   siteLogo?: CmsAttachment | null;
   favicon?: CmsAttachment | null;
+  accessPolicy?: CmsAccessPolicy;
+  assignedMemberIds?: string[];
 };
 
 export type UpdateSetting = <TKey extends keyof SettingsFormState>(

--- a/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/Cms.tsx
@@ -6,11 +6,14 @@ import {
   IconFileText,
   IconLayoutGrid,
   IconList,
+  IconLock,
   IconPlus,
 } from '@tabler/icons-react';
-import { Button, Spinner, ToggleGroup } from 'erxes-ui';
+import { Button, Spinner, ToggleGroup, toast } from 'erxes-ui';
 import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
+import { currentUserState } from 'ui-modules';
 import { WebsiteDrawer } from '../components/websites/WebsiteDrawer';
 import { CONTENT_CMS_LIST } from '../graphql/queries';
 import { IWebsite } from '../types';
@@ -40,9 +43,15 @@ export function Cms() {
   const { data, loading, refetch } = useQuery<{
     contentCMSList: IWebsite[];
   }>(CONTENT_CMS_LIST);
+  const currentUser = useAtomValue(currentUserState);
   const cmsList = data?.contentCMSList || [];
   const displayWebsites: IWebsite[] = cmsList;
   const onlyCms = cmsList.length === 1 ? cmsList[0] : null;
+
+  const canAccessWebsite = (website: IWebsite) =>
+    !!currentUser?.isOwner ||
+    website.accessPolicy !== 'assigned' ||
+    (website.assignedMemberIds || []).includes(currentUser?._id || '');
 
   const handleWebsiteCreatedOrUpdated = () => {
     refetch();
@@ -56,11 +65,30 @@ export function Cms() {
   };
 
   const handleEditWebsite = (website: IWebsite) => {
+    if (!canAccessWebsite(website)) {
+      toast({
+        title: 'Access restricted',
+        description:
+          'This CMS is limited to assigned team members. Ask an owner to add you.',
+        variant: 'destructive',
+      });
+      return;
+    }
     setEditingWebsite(website);
     setIsWebsiteDrawerOpen(true);
   };
 
   const handleWebsiteClick = (website: IWebsite) => {
+    if (!canAccessWebsite(website)) {
+      toast({
+        title: 'Access restricted',
+        description:
+          'This CMS is limited to assigned team members. Ask an owner to add you.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
     if (!website.clientPortalId) {
       navigate('/content/cms');
       return;
@@ -86,7 +114,7 @@ export function Cms() {
     </div>
   );
 
-  if (!loading && onlyCms?.clientPortalId) {
+  if (!loading && onlyCms?.clientPortalId && canAccessWebsite(onlyCms)) {
     return (
       <Navigate to={`/content/cms/${onlyCms.clientPortalId}/posts`} replace />
     );
@@ -173,6 +201,15 @@ export function Cms() {
                       <div className="absolute bottom-2 right-2">
                         <div className="px-2 py-1 bg-white/90 rounded text-xs font-medium text-gray-700">
                           {website.domain}
+                        </div>
+                      </div>
+                    )}
+
+                    {!canAccessWebsite(website) && (
+                      <div className="absolute top-2 left-2">
+                        <div className="flex items-center gap-1 px-2 py-1 bg-black/60 rounded text-xs font-medium text-white">
+                          <IconLock className="w-3 h-3" />
+                          <span>Restricted</span>
                         </div>
                       </div>
                     )}

--- a/frontend/plugins/content_ui/src/modules/cms/types/index.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/types/index.ts
@@ -14,4 +14,6 @@ export interface IWebsite {
   language?: string;
   postUrlField?: '_id' | 'count' | 'slug';
   postUrlPrefix?: string;
+  accessPolicy?: 'open' | 'assigned';
+  assignedMemberIds?: string[];
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce per-CMS access control with team-assigned permissions and enforce it across CMS settings, UI, and API operations.

New Features:
- Add configurable CMS access policies (open vs assigned members) with support for assigning specific team members in CMS settings.
- Enable CMS posts custom fields to reference multiple products via a new products field type.

Enhancements:
- Surface access restrictions in the CMS list and navigation, blocking unauthorized users from opening or editing restricted CMS instances.
- Centralize CMS access checks in backend utilities and apply them to CMS, page, and post queries and mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CMS access control options: open access or assigned-members-only.
  * Added support for assigning specific team members to a CMS.
  * Added a new products custom field type in the content editor.

* **Bug Fixes**
  * Restricted CMS pages, posts, and settings to users with the right portal or document access.
  * Prevented unauthorized editing, deleting, and viewing of CMS content.
  * Improved the CMS UI to clearly show restricted items and access messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->