### PR TITLE
fix(navigation): reset active plugin on home click and refine switche…

### DIFF
--- a/frontend/core-ui/src/modules/navigation/components/Organization.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/Organization.tsx
@@ -9,7 +9,7 @@ import {
 } from 'erxes-ui';
 
 import { useAtom, useSetAtom } from 'jotai';
-import { IconSelector } from '@tabler/icons-react';
+import { IconDotsVertical } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { User } from '@/navigation/components/User';
@@ -18,12 +18,14 @@ import { SelectLanguages } from '@/navigation/components/SelectLanguages';
 import { useTranslation } from 'react-i18next';
 import { OrgLogoIcon } from '@/auth/components/Logo';
 import { AppPath } from '@/types/paths/AppPath';
+import { useAppVersion } from '@/navigation/hooks/useAppVersion';
 
 export function Organization() {
   const [currentOrganization] = useAtom(currentOrganizationState);
   const setActivePlugin = useSetAtom(activePluginState);
   const { handleLogout } = useAuth();
   const { t } = useTranslation('organization');
+  const version = useAppVersion();
 
   const hasOrgName =
     !!currentOrganization?.name || !!currentOrganization?.orgShortName;
@@ -34,7 +36,7 @@ export function Organization() {
         to={AppPath.Index}
         aria-label={t('home')}
         onClick={() => setActivePlugin('')}
-        className="flex flex-1 basis-1/2 min-w-0 items-center gap-2 rounded p-1 transition-colors hover:bg-accent-foreground/10"
+        className="flex flex-4 min-w-0 items-center gap-2 rounded p-1 transition-colors hover:bg-accent-foreground/10"
       >
         <div className="flex size-8 rounded-lg items-center justify-center overflow-hidden flex-none shadow-xs">
           <OrgLogoIcon className="size-7 text-primary flex-none" />
@@ -55,9 +57,9 @@ export function Organization() {
           <Button
             variant="ghost"
             type="button"
-            className="flex flex-1 basis-1/2 h-auto items-center justify-start gap-2 rounded p-1 font-medium text-sm text-foreground transition-colors hover:bg-accent-foreground/10 outline-none focus-visible:outline-none data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className="flex flex-1 h-auto items-center justify-center gap-2 rounded p-1 font-medium text-sm text-foreground transition-colors hover:bg-accent-foreground/10 outline-none focus-visible:outline-none data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
           >
-            <IconSelector className="ml-auto text-accent-foreground" />
+            <IconDotsVertical className="text-foreground" stroke={2} />
           </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="end" className="space-y-1 ml-2">
@@ -79,7 +81,7 @@ export function Organization() {
           <DropdownMenu.Label className="flex items-center gap-2">
             {t('version')}
             <span className="text-primary ml-auto tracking-wider">
-              3.0.0-beta.1
+              {version}
             </span>
           </DropdownMenu.Label>
         </DropdownMenu.Content>

--- a/frontend/core-ui/src/modules/navigation/components/Organization.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/Organization.tsx
@@ -1,8 +1,14 @@
 import { currentOrganizationState } from 'ui-modules';
 
-import { Button, cn, DropdownMenu, TextOverflowTooltip } from 'erxes-ui';
+import {
+  activePluginState,
+  Button,
+  cn,
+  DropdownMenu,
+  TextOverflowTooltip,
+} from 'erxes-ui';
 
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { IconSelector } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/auth/hooks/useAuth';
@@ -15,6 +21,7 @@ import { AppPath } from '@/types/paths/AppPath';
 
 export function Organization() {
   const [currentOrganization] = useAtom(currentOrganizationState);
+  const setActivePlugin = useSetAtom(activePluginState);
   const { handleLogout } = useAuth();
   const { t } = useTranslation('organization');
 
@@ -22,11 +29,12 @@ export function Organization() {
     !!currentOrganization?.name || !!currentOrganization?.orgShortName;
 
   return (
-    <div className="flex w-full items-center gap-1 ">
+    <div className="flex w-full items-stretch gap-1">
       <Link
         to={AppPath.Index}
         aria-label={t('home')}
-        className="flex flex-1 basis-1/2 min-w-0 items-center gap-2 rounded p-2"
+        onClick={() => setActivePlugin('')}
+        className="flex flex-1 basis-1/2 min-w-0 items-center gap-2 rounded p-1 transition-colors hover:bg-accent-foreground/10"
       >
         <div className="flex size-8 rounded-lg items-center justify-center overflow-hidden flex-none shadow-xs">
           <OrgLogoIcon className="size-7 text-primary flex-none" />
@@ -47,7 +55,7 @@ export function Organization() {
           <Button
             variant="ghost"
             type="button"
-            className="flex flex-1 basis-1/2 h-auto items-center justify-start gap-2 rounded p-2 font-medium text-sm text-foreground hover:bg-transparent outline-none focus-visible:outline-none data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className="flex flex-1 basis-1/2 h-auto items-center justify-start gap-2 rounded p-1 font-medium text-sm text-foreground transition-colors hover:bg-accent-foreground/10 outline-none focus-visible:outline-none data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
           >
             <IconSelector className="ml-auto text-accent-foreground" />
           </Button>

--- a/frontend/core-ui/src/modules/navigation/graphql/queries/getEnvConfig.tsx
+++ b/frontend/core-ui/src/modules/navigation/graphql/queries/getEnvConfig.tsx
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export const GET_ENV_CONFIG = gql`
+  query ConfigsGetEnv {
+    configsGetEnv {
+      RELEASE
+    }
+  }
+`;

--- a/frontend/core-ui/src/modules/navigation/hooks/useAppVersion.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/useAppVersion.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@apollo/client';
+import { GET_ENV_CONFIG } from '@/navigation/graphql/queries/getEnvConfig';
+
+const DEFAULT_VERSION = '3.0.0-beta.1';
+
+interface EnvConfigResponse {
+  configsGetEnv: {
+    RELEASE: string | null;
+  } | null;
+}
+
+export function useAppVersion(): string {
+  const { data } = useQuery<EnvConfigResponse>(GET_ENV_CONFIG);
+
+  return data?.configsGetEnv?.RELEASE || DEFAULT_VERSION;
+}


### PR DESCRIPTION
…r hover

- Clear the activePlugin localStorage value when the home/logo link is clicked
- Restore a hover highlight on both the home link and dropdown trigger so the two halves are clearly distinguishable
- Equalize the height of both halves and trim their vertical padding

## Summary by Sourcery

Reset active plugin selection when navigating home and refine the organization switcher layout and hover behavior for clearer interaction.

Bug Fixes:
- Clear the stored active plugin when the home/logo link is clicked to avoid stale plugin selection after returning home.

Enhancements:
- Align sizing and padding of the home link and organization dropdown trigger and reintroduce hover highlighting to better distinguish the two interactive areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking the home link now resets the active plugin, returning the app to a clean default state.
  * The organization dropdown label now displays the current app version from environment configuration (with a beta fallback when unavailable).
* **Style**
  * Updated organization navigation layout, spacing, and hover/focus/sidebar-open behavior for the container and trigger button.
  * Switched the dropdown trigger icon to the vertical dots variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->