### PR TITLE
fix(loyalty): resolve voucher owner column for client portal users

### DIFF
--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
@@ -1,5 +1,6 @@
 import { IconUser, IconTag, IconClock } from '@tabler/icons-react';
 import { ColumnDef } from '@tanstack/table-core';
+import { useQuery } from '@apollo/client';
 import {
   RecordTable,
   RecordTableInlineCell,
@@ -10,8 +11,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IVoucher } from '@/loyalties/vouchers/types/voucher';
+import { VOUCHER_CP_USER_QUERY } from '@/loyalties/vouchers/graphql/queries/queries';
 import { CustomersInline } from 'ui-modules/modules/contacts/components/CustomersInline';
 import { CompaniesInline } from 'ui-modules/modules/contacts/components/CompaniesInline';
+import { MembersInline } from 'ui-modules';
 import { VoucherEditSheet } from './VoucherEditSheet';
 
 const CreatedAtCell = ({ voucher }: { voucher: IVoucher }) => {
@@ -40,6 +43,42 @@ const CreatedAtCell = ({ voucher }: { voucher: IVoucher }) => {
 
 export const generateOtherPaymentColumns = (_summary?: any) => [];
 
+// Client portal users have no inline component in `ui-modules`, so resolve them
+// here: prefer the linked erxes customer (matching the backend `getLoyaltyOwner`
+// behaviour) and otherwise fall back to the client portal user's own name.
+const CpUserOwner = ({ ownerId }: { ownerId: string }) => {
+  const { data, loading } = useQuery(VOUCHER_CP_USER_QUERY, {
+    variables: { _id: ownerId },
+    skip: !ownerId,
+  });
+
+  const cpUser = data?.getClientPortalUser;
+
+  if (cpUser?.erxesCustomerId) {
+    return (
+      <CustomersInline customerIds={[cpUser.erxesCustomerId]} placeholder="—" />
+    );
+  }
+
+  if (loading) return <>—</>;
+
+  const name =
+    [cpUser?.firstName, cpUser?.lastName].filter(Boolean).join(' ') ||
+    cpUser?.email ||
+    cpUser?.phone;
+
+  return <>{name || '—'}</>;
+};
+
+const renderOwnerContent = (ownerId: string, ownerType?: string) => {
+  if (ownerType === 'company')
+    return <CompaniesInline companyIds={[ownerId]} placeholder="—" />;
+  if (ownerType === 'user')
+    return <MembersInline memberIds={[ownerId]} placeholder="—" />;
+  if (ownerType === 'cpUser') return <CpUserOwner ownerId={ownerId} />;
+  return <CustomersInline customerIds={[ownerId]} placeholder="—" />;
+};
+
 const OwnerCell = ({
   ownerId,
   ownerType,
@@ -51,11 +90,7 @@ const OwnerCell = ({
 
   return (
     <RecordTableInlineCell>
-      {ownerType === 'company' ? (
-        <CompaniesInline companyIds={[ownerId]} placeholder="—" />
-      ) : (
-        <CustomersInline customerIds={[ownerId]} placeholder="—" />
-      )}
+      {renderOwnerContent(ownerId, ownerType)}
     </RecordTableInlineCell>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/graphql/queries/queries.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/graphql/queries/queries.ts
@@ -41,6 +41,19 @@ export const VOUCHERS_QUERY = gql`
   }
 `;
 
+export const VOUCHER_CP_USER_QUERY = gql`
+  query VoucherOwnerCpUser($_id: String!) {
+    getClientPortalUser(_id: $_id) {
+      _id
+      firstName
+      lastName
+      email
+      phone
+      erxesCustomerId
+    }
+  }
+`;
+
 export const VOUCHER_COMPANIES_QUERY = gql`
   query VoucherCompanies($limit: Int, $searchValue: String) {
     companies(limit: $limit, searchValue: $searchValue) {


### PR DESCRIPTION
The vouchers table showed "—" for owners whose ownerType is cpUser because the id was passed to CustomersInline, which can't resolve a client-portal-user id. Add a cpUser branch that resolves the linked erxes customer (matching backend getLoyaltyOwner) and falls back to the cp user's own name. Also route ownerType "user" to MembersInline.

## Summary by Sourcery

Handle voucher owner display for client portal and internal users in the vouchers table.

Bug Fixes:
- Fix voucher owner column showing an empty placeholder for client portal (cpUser) owners by resolving their associated customer or basic profile info.
- Correct ownerType "user" vouchers to display via the members inline component instead of customer inline.

Enhancements:
- Introduce a dedicated owner rendering helper that routes vouchers to the appropriate inline component based on owner type, including companies, users, client portal users, and customers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voucher lists now show owner details for client-portal users, including linked customer information when available.
  * Owner names can now display from profile data such as name, email, or phone if a linked customer is not found.

* **Bug Fixes**
  * Improved owner display handling so voucher ownership is shown correctly across more owner types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->