### PR TITLE
fix(loyalty): resolve owner column for client portal users across mod…

### DIFF
--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
@@ -43,9 +43,6 @@ const CreatedAtCell = ({ voucher }: { voucher: IVoucher }) => {
 
 export const generateOtherPaymentColumns = (_summary?: any) => [];
 
-// Client portal users have no inline component in `ui-modules`, so resolve them
-// here: prefer the linked erxes customer (matching the backend `getLoyaltyOwner`
-// behaviour) and otherwise fall back to the client portal user's own name.
 const CpUserOwner = ({ ownerId }: { ownerId: string }) => {
   const { data, loading } = useQuery(VOUCHER_CP_USER_QUERY, {
     variables: { _id: ownerId },
@@ -60,23 +57,23 @@ const CpUserOwner = ({ ownerId }: { ownerId: string }) => {
     );
   }
 
-  if (loading) return <>—</>;
+  if (loading) return <></>;
 
   const name =
     [cpUser?.firstName, cpUser?.lastName].filter(Boolean).join(' ') ||
     cpUser?.email ||
     cpUser?.phone;
 
-  return <>{name || '—'}</>;
+  return <>{name || ''}</>;
 };
 
 const renderOwnerContent = (ownerId: string, ownerType?: string) => {
   if (ownerType === 'company')
-    return <CompaniesInline companyIds={[ownerId]} placeholder="—" />;
+    return <CompaniesInline companyIds={[ownerId]} placeholder="" />;
   if (ownerType === 'user')
-    return <MembersInline memberIds={[ownerId]} placeholder="—" />;
+    return <MembersInline memberIds={[ownerId]} placeholder="" />;
   if (ownerType === 'cpUser') return <CpUserOwner ownerId={ownerId} />;
-  return <CustomersInline customerIds={[ownerId]} placeholder="—" />;
+  return <CustomersInline customerIds={[ownerId]} placeholder="" />;
 };
 
 const OwnerCell = ({
@@ -101,7 +98,9 @@ export const firstVoucherColumns: ColumnDef<IVoucher>[] = [
     accessorKey: 'createdAt',
     header: () => {
       const { t } = useTranslation('loyalty');
-      return <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />;
+      return (
+        <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />
+      );
     },
     cell: ({ row }) => <CreatedAtCell voucher={row.original} />,
   },


### PR DESCRIPTION
…ules

The spins, donates and lotteries owner columns showed "—" for cpUser owners (lotteries also missed team-member owners) because a client portal user id was passed to CustomersInline, which can't resolve it.

Extract a shared LoyaltyOwner component that resolves every owner type (customer, company, user, cpUser) — for cpUser it prefers the linked erxes customer, matching the backend getLoyaltyOwner behaviour — and reuse it in the voucher, spin, donate and lottery columns, removing the duplicated per-module logic.

## Summary by Sourcery

Centralize loyalty record owner resolution in a shared component and fix owner display for client portal and team-member owners across loyalty modules.

Bug Fixes:
- Ensure owner columns in vouchers, spins, donates, and lotteries correctly resolve and display client portal user owners instead of showing empty values.
- Restore missing team-member owner resolution for loyalty records so user-owned entries display properly.

Enhancements:
- Introduce a shared LoyaltyOwner component used by voucher, spin, donate, and lottery tables to consistently render owners for customers, companies, users, and client portal users.
- Simplify loyalty table column implementations by removing duplicated owner resolution logic and related GraphQL queries from individual modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voucher owner name display during loading and empty states by showing a blank value instead of an em dash.
  * Updated inline owner fields to use empty placeholders for a cleaner, more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->