### PR TITLE
fix(payment): find TDB transactions by response.order.id

### DIFF
--- a/backend/plugins/payment_api/src/apis/tdb/api.ts
+++ b/backend/plugins/payment_api/src/apis/tdb/api.ts
@@ -80,8 +80,8 @@ export const tdbCallbackHandler = async (
     $or: [
       { code: ID },
       { code: Number(ID) },
-      { 'details.tdbOrderId': ID },
-      { 'details.tdbOrderId': Number(ID) },
+      { 'response.order.id': ID },
+      { 'response.order.id': Number(ID) },
     ],
   });
 
@@ -210,7 +210,7 @@ export class TDBAPI extends BaseAPI {
   private cacheTTL: number; // in seconds
 
   constructor(config: ITDBConfig, domain: string = '') {
-    super({ apiUrl: config.apiUrl || PAYMENTS.tdb?.apiUrl || 'https://acsmc.tdbmlabs.mn:8000' });
+    super({ apiUrl: config.apiUrl || PAYMENTS.tdb.apiUrl || 'https://acsmc.tdbmlabs.mn:8000' });
     this.username = config.username;
     this.password = config.password;
     this.domain = domain;

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -62,7 +62,6 @@ export const loadInvoiceClass = (models: IModels) => {
           transaction.response = response;
           transaction.details = {
             ...transaction.details,
-            tdbOrderId: response.order?.id,
           };
           await transaction.save();
 


### PR DESCRIPTION
## Summary by Sourcery

Update TDB payment transaction lookup and configuration handling.

Bug Fixes:
- Match TDB callback transactions using `response.order.id` instead of the deprecated `details.tdbOrderId`.
- Ensure TDB API URL falls back to `PAYMENTS.tdb.apiUrl` without optional chaining to avoid undefined configuration access.

Enhancements:
- Remove redundant storage of `tdbOrderId` in transaction details, relying on the response payload instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction matching so payment callbacks are found using the current order ID location.
  * Streamlined payment API configuration by using the standard TDB API URL setting directly.
  * Removed an extra transaction field from invoice creation to keep saved payment data cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->