### PR TITLE
fix(content_ui): improve posts filter correctness and UX

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesFilter.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { IconHash, IconSearch } from '@tabler/icons-react';
+import {
+  Combobox,
+  Command,
+  Filter,
+  Popover,
+  useFilterContext,
+  useFilterQueryState,
+} from 'erxes-ui';
+import { CATEGORIES_CURSOR_SESSION_KEY } from '../constants/categoriesCursorSessionKey';
+import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
+import { CategoriesTotalCount } from './CategoriesTotalCount';
+
+const CATEGORY_STATUS_OPTIONS = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+] as const;
+
+type CategoryStatusFilterValue =
+  (typeof CATEGORY_STATUS_OPTIONS)[number]['value'];
+
+const CategoryStatusFilterItem = () => (
+  <Filter.Item value="status">
+    <IconHash />
+    Status
+  </Filter.Item>
+);
+
+const CategoryStatusCommand = ({
+  value,
+  onValueChange,
+}: {
+  value: CategoryStatusFilterValue | null;
+  onValueChange: (value: CategoryStatusFilterValue) => void;
+}) => (
+  <Command>
+    <Command.Input placeholder="Search status" />
+    <Command.Empty>
+      <span className="text-muted-foreground">No statuses found</span>
+    </Command.Empty>
+    <Command.List>
+      {CATEGORY_STATUS_OPTIONS.map((status) => (
+        <Command.Item
+          key={status.value}
+          value={status.value}
+          onSelect={() => onValueChange(status.value)}
+        >
+          <span className="font-medium">{status.label}</span>
+          <Combobox.Check checked={status.value === value} />
+        </Command.Item>
+      ))}
+    </Command.List>
+  </Command>
+);
+
+const CategoryStatusFilterView = () => {
+  const { resetFilterState, sessionKey } = useFilterContext();
+  const [status, setStatus] = useFilterQueryState<CategoryStatusFilterValue>(
+    'status',
+    sessionKey ?? '',
+  );
+
+  return (
+    <Filter.View filterKey="status">
+      <CategoryStatusCommand
+        value={status}
+        onValueChange={(value) => {
+          setStatus(value);
+          resetFilterState();
+        }}
+      />
+    </Filter.View>
+  );
+};
+
+const CategoryStatusFilterBar = () => {
+  const { sessionKey } = useFilterContext();
+  const [status, setStatus] = useFilterQueryState<CategoryStatusFilterValue>(
+    'status',
+    sessionKey ?? '',
+  );
+  const [open, setOpen] = useState(false);
+  const selectedStatus = CATEGORY_STATUS_OPTIONS.find(
+    (option) => option.value === status,
+  );
+
+  return (
+    <Filter.BarItem queryKey="status">
+      <Filter.BarName>
+        <IconHash />
+        Status
+      </Filter.BarName>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <Filter.BarButton filterKey="status">
+            {selectedStatus?.label || 'Select status'}
+          </Filter.BarButton>
+        </Popover.Trigger>
+        <Combobox.Content>
+          <CategoryStatusCommand
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value);
+              setOpen(false);
+            }}
+          />
+        </Combobox.Content>
+      </Popover>
+    </Filter.BarItem>
+  );
+};
+
+export const CategoriesFilter = () => {
+  const [searchValue] = useFilterQueryState<string>('searchValue');
+
+  return (
+    <Filter id="categories-filter" sessionKey={CATEGORIES_CURSOR_SESSION_KEY}>
+      <Filter.Bar>
+        <Filter.BarItem queryKey="searchValue">
+          <Filter.BarName>
+            <IconSearch />
+            Search
+          </Filter.BarName>
+          <Filter.BarButton filterKey="searchValue" inDialog>
+            {searchValue}
+          </Filter.BarButton>
+        </Filter.BarItem>
+        <CategoryStatusFilterBar />
+        <SimpleSearchFilterPopover
+          extraQueryKeys={['status']}
+          extraItems={<CategoryStatusFilterItem />}
+          extraViews={<CategoryStatusFilterView />}
+        />
+        <CategoriesTotalCount />
+      </Filter.Bar>
+    </Filter>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesFilter.tsx
@@ -8,24 +8,28 @@ import {
   useFilterContext,
   useFilterQueryState,
 } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
 import { CATEGORIES_CURSOR_SESSION_KEY } from '../constants/categoriesCursorSessionKey';
 import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
 import { CategoriesTotalCount } from './CategoriesTotalCount';
 
 const CATEGORY_STATUS_OPTIONS = [
-  { value: 'active', label: 'Active' },
-  { value: 'inactive', label: 'Inactive' },
+  { value: 'active', labelKey: 'active' },
+  { value: 'inactive', labelKey: 'inactive' },
 ] as const;
 
 type CategoryStatusFilterValue =
   (typeof CATEGORY_STATUS_OPTIONS)[number]['value'];
 
-const CategoryStatusFilterItem = () => (
-  <Filter.Item value="status">
-    <IconHash />
-    Status
-  </Filter.Item>
-);
+const CategoryStatusFilterItem = () => {
+  const { t } = useTranslation('content');
+  return (
+    <Filter.Item value="status">
+      <IconHash />
+      {t('status')}
+    </Filter.Item>
+  );
+};
 
 const CategoryStatusCommand = ({
   value,
@@ -33,26 +37,29 @@ const CategoryStatusCommand = ({
 }: {
   value: CategoryStatusFilterValue | null;
   onValueChange: (value: CategoryStatusFilterValue) => void;
-}) => (
-  <Command>
-    <Command.Input placeholder="Search status" />
-    <Command.Empty>
-      <span className="text-muted-foreground">No statuses found</span>
-    </Command.Empty>
-    <Command.List>
-      {CATEGORY_STATUS_OPTIONS.map((status) => (
-        <Command.Item
-          key={status.value}
-          value={status.value}
-          onSelect={() => onValueChange(status.value)}
-        >
-          <span className="font-medium">{status.label}</span>
-          <Combobox.Check checked={status.value === value} />
-        </Command.Item>
-      ))}
-    </Command.List>
-  </Command>
-);
+}) => {
+  const { t } = useTranslation('content');
+  return (
+    <Command>
+      <Command.Input placeholder={t('search-status')} />
+      <Command.Empty>
+        <span className="text-muted-foreground">{t('no-statuses-found')}</span>
+      </Command.Empty>
+      <Command.List>
+        {CATEGORY_STATUS_OPTIONS.map((status) => (
+          <Command.Item
+            key={status.value}
+            value={status.value}
+            onSelect={() => onValueChange(status.value)}
+          >
+            <span className="font-medium">{t(status.labelKey)}</span>
+            <Combobox.Check checked={status.value === value} />
+          </Command.Item>
+        ))}
+      </Command.List>
+    </Command>
+  );
+};
 
 const CategoryStatusFilterView = () => {
   const { resetFilterState, sessionKey } = useFilterContext();
@@ -75,6 +82,7 @@ const CategoryStatusFilterView = () => {
 };
 
 const CategoryStatusFilterBar = () => {
+  const { t } = useTranslation('content');
   const { sessionKey } = useFilterContext();
   const [status, setStatus] = useFilterQueryState<CategoryStatusFilterValue>(
     'status',
@@ -89,12 +97,12 @@ const CategoryStatusFilterBar = () => {
     <Filter.BarItem queryKey="status">
       <Filter.BarName>
         <IconHash />
-        Status
+        {t('status')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="status">
-            {selectedStatus?.label || 'Select status'}
+            {selectedStatus ? t(selectedStatus.labelKey) : t('select-status')}
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>
@@ -112,6 +120,7 @@ const CategoryStatusFilterBar = () => {
 };
 
 export const CategoriesFilter = () => {
+  const { t } = useTranslation('content');
   const [searchValue] = useFilterQueryState<string>('searchValue');
 
   return (
@@ -120,7 +129,7 @@ export const CategoriesFilter = () => {
         <Filter.BarItem queryKey="searchValue">
           <Filter.BarName>
             <IconSearch />
-            Search
+            {t('search')}
           </Filter.BarName>
           <Filter.BarButton filterKey="searchValue" inDialog>
             {searchValue}

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
@@ -1,5 +1,5 @@
 import { IconArticle } from '@tabler/icons-react';
-import { RecordTable } from 'erxes-ui';
+import { RecordTable, useMultiQueryState } from 'erxes-ui';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../../shared/EmptyState';
@@ -55,6 +55,11 @@ export const CategoriesRecordTable = ({
   onBulkDelete,
 }: CategoriesRecordTableProps) => {
   const { t } = useTranslation('content');
+  const [{ searchValue, status }] = useMultiQueryState<{
+    searchValue: string;
+    status: string;
+  }>(['searchValue', 'status']);
+  const isFiltered = !!searchValue || !!status;
   const { categories, loading, refetch, pageInfo, handleFetchMore } =
     useCategories({
       variables: {
@@ -81,13 +86,20 @@ export const CategoriesRecordTable = ({
       </div>
       {!loading && categories.length === 0 ? (
         <div className="rounded-lg overflow-hidden">
-          <EmptyState
-            icon={IconArticle}
-            title={t('no-categories-yet')}
-            description={t('no-categories-yet-desc')}
-            actionLabel={t('add-category')}
-            onAction={onAdd}
-          />
+          {isFiltered ? (
+            <EmptyState
+              icon={IconArticle}
+              title={t('no-categories-found')}
+            />
+          ) : (
+            <EmptyState
+              icon={IconArticle}
+              title={t('no-categories-yet')}
+              description={t('no-categories-yet-desc')}
+              actionLabel={t('add-category')}
+              onAction={onAdd}
+            />
+          )}
         </div>
       ) : (
         <div className="overflow-hidden flex-auto p-3">

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
@@ -8,6 +8,8 @@ import { useCategoriesColumns } from './CategoriesColumn';
 import { useCategories } from '../hooks/useCategoriesEnhanced';
 import { CategoriesCommandBar } from './categories-command-bar/CategoriesCommandbar';
 import { ICategory } from '@/cms/categories/types';
+import { CategoriesFilter } from './CategoriesFilter';
+import { CATEGORIES_CURSOR_SESSION_KEY } from '../constants/categoriesCursorSessionKey';
 
 const naturalSort = (a: string, b: string) =>
   a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
@@ -42,7 +44,7 @@ function sortCategoriesAsTree(
 interface CategoriesRecordTableProps {
   clientPortalId: string;
   onAdd?: () => void;
-  onEdit?: (category: any) => void;
+  onEdit?: (category: ICategory) => void;
   onBulkDelete?: (ids: string[]) => Promise<void>;
 }
 
@@ -53,7 +55,7 @@ export const CategoriesRecordTable = ({
   onBulkDelete,
 }: CategoriesRecordTableProps) => {
   const { t } = useTranslation('content');
-  const { categories, totalCount, loading, refetch, pageInfo, handleFetchMore } =
+  const { categories, loading, refetch, pageInfo, handleFetchMore } =
     useCategories({
       variables: {
         clientPortalId,
@@ -74,6 +76,9 @@ export const CategoriesRecordTable = ({
 
   return (
     <>
+      <div className="px-4 pt-2">
+        <CategoriesFilter />
+      </div>
       {!loading && categories.length === 0 ? (
         <div className="rounded-lg overflow-hidden">
           <EmptyState
@@ -85,49 +90,41 @@ export const CategoriesRecordTable = ({
           />
         </div>
       ) : (
-        <>
-          {!loading && categories.length > 0 && (
-            <div className="flex pt-2 pl-4 justify-between items-center mb-2">
-              <div className="text-sm text-gray-600">
-                {t('found-x-categories', { count: totalCount })}
-              </div>
-            </div>
-          )}
-          <div className="overflow-hidden flex-auto p-3">
-            <div className="h-full">
-              <RecordTable.Provider
-                columns={columns}
-                data={treeCategories}
-                className="h-full"
-                stickyColumns={['more', 'checkbox', 'name']}
+        <div className="overflow-hidden flex-auto p-3">
+          <div className="h-full">
+            <RecordTable.Provider
+              columns={columns}
+              data={treeCategories}
+              className="h-full"
+              stickyColumns={['more', 'checkbox', 'name']}
+            >
+              <RecordTable.CursorProvider
+                hasPreviousPage={hasPreviousPage}
+                hasNextPage={hasNextPage}
+                dataLength={categories?.length}
+                sessionKey={CATEGORIES_CURSOR_SESSION_KEY}
               >
-                <RecordTable.CursorProvider
-                  hasPreviousPage={hasPreviousPage}
-                  hasNextPage={hasNextPage}
-                  dataLength={categories?.length}
-                >
-                  <RecordTable>
-                    <RecordTable.Header />
-                    <RecordTable.Body>
-                      <RecordTable.CursorBackwardSkeleton
-                        handleFetchMore={handleFetchMore}
-                      />
-                      {loading && <RecordTable.RowSkeleton rows={40} />}
-                      <RecordTable.RowList />
-                      <RecordTable.CursorForwardSkeleton
-                        handleFetchMore={handleFetchMore}
-                      />
-                    </RecordTable.Body>
-                  </RecordTable>
-                </RecordTable.CursorProvider>
-                <CategoriesCommandBar
-                  clientPortalId={clientPortalId}
-                  onBulkDelete={onBulkDelete}
-                />
-              </RecordTable.Provider>
-            </div>
+                <RecordTable>
+                  <RecordTable.Header />
+                  <RecordTable.Body>
+                    <RecordTable.CursorBackwardSkeleton
+                      handleFetchMore={handleFetchMore}
+                    />
+                    {loading && <RecordTable.RowSkeleton rows={40} />}
+                    <RecordTable.RowList />
+                    <RecordTable.CursorForwardSkeleton
+                      handleFetchMore={handleFetchMore}
+                    />
+                  </RecordTable.Body>
+                </RecordTable>
+              </RecordTable.CursorProvider>
+              <CategoriesCommandBar
+                clientPortalId={clientPortalId}
+                onBulkDelete={onBulkDelete}
+              />
+            </RecordTable.Provider>
           </div>
-        </>
+        </div>
       )}
     </>
   );

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesTotalCount.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesTotalCount.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue } from 'jotai';
 import { CmsRecordCount } from '~/modules/cms/shared/components/CmsRecordCount';
-import { postsTotalCountAtom } from '../states/postsCounts';
+import { categoriesTotalCountAtom } from '../states/categoriesCounts';
 
-export const PostsTotalCount = () => {
-  const totalCount = useAtomValue(postsTotalCountAtom);
+export const CategoriesTotalCount = () => {
+  const totalCount = useAtomValue(categoriesTotalCountAtom);
   return <CmsRecordCount totalCount={totalCount} />;
 };

--- a/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
@@ -2,7 +2,6 @@ import { QueryHookOptions, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   IRecordTableCursorPageInfo,
-  parseDateRangeFromString,
   useMultiQueryState,
   validateFetchMore,
 } from 'erxes-ui';
@@ -11,26 +10,26 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { categoriesTotalCountAtom } from '../states/categoriesCounts';
 import { useEffect } from 'react';
 import { cmsLanguageAtom } from '../../shared/states/cmsLanguageState';
-import { ICategory } from '../types/CategoriesType';
+import { ICategory } from '../types';
+
+interface CategoriesQueryResult {
+  cmsCategories?: {
+    list?: ICategory[];
+    totalCount?: number;
+    pageInfo?: IRecordTableCursorPageInfo;
+  };
+}
 
 export const CATEGORIES_PER_PAGE = 30;
 
 export const useCategoriesVariables = (
-  variables?: QueryHookOptions<{
-    cmsCategories: {
-      list: ICategory[];
-      totalCount: number;
-      pageInfo: IRecordTableCursorPageInfo;
-    };
-  }>['variables'],
+  variables?: QueryHookOptions<CategoriesQueryResult>['variables'],
 ) => {
   const language = useAtomValue(cmsLanguageAtom);
-  const [{ searchValue, status, createdAt, updatedAt }] = useMultiQueryState<{
+  const [{ searchValue, status }] = useMultiQueryState<{
     searchValue: string;
     status: string;
-    createdAt: string;
-    updatedAt: string;
-  }>(['searchValue', 'status', 'createdAt', 'updatedAt']);
+  }>(['searchValue', 'status']);
 
   return {
     limit: CATEGORIES_PER_PAGE,
@@ -39,17 +38,7 @@ export const useCategoriesVariables = (
     sortDirection: 'asc',
     language,
     searchValue: searchValue || undefined,
-    status: status && status !== 'all' ? status : undefined,
-    dateFilters: {
-      createdAt: {
-        gte: parseDateRangeFromString(createdAt)?.from,
-        lte: parseDateRangeFromString(createdAt)?.to,
-      },
-      updatedAt: {
-        gte: parseDateRangeFromString(updatedAt)?.from,
-        lte: parseDateRangeFromString(updatedAt)?.to,
-      },
-    },
+    status: status || undefined,
     ...variables,
   };
 };
@@ -57,29 +46,26 @@ export const useCategoriesVariables = (
 export const useCategories = (options?: QueryHookOptions) => {
   const setCategoriesTotalCount = useSetAtom(categoriesTotalCountAtom);
   const variables = useCategoriesVariables(options?.variables);
-  const { data, loading, fetchMore, refetch } = useQuery<{
-    cmsCategories: {
-      list: ICategory[];
-      totalCount: number;
-      pageInfo: IRecordTableCursorPageInfo;
-    };
-  }>(CMS_CATEGORIES, {
-    ...options,
-    variables: {
-      ...options?.variables,
-      ...variables,
+  const { data, loading, fetchMore, refetch } = useQuery<CategoriesQueryResult>(
+    CMS_CATEGORIES,
+    {
+      ...options,
+      variables: {
+        ...options?.variables,
+        ...variables,
+      },
+      fetchPolicy: 'network-only',
     },
-    fetchPolicy: 'network-only',
-  });
+  );
 
   const {
     list: categories = [],
-    totalCount = 0,
+    totalCount,
     pageInfo,
   } = data?.cmsCategories || {};
+  const safeTotalCount = totalCount ?? 0;
   useEffect(() => {
-    if (!totalCount) return;
-    setCategoriesTotalCount(totalCount);
+    setCategoriesTotalCount(totalCount ?? null);
   }, [totalCount, setCategoriesTotalCount]);
 
   const handleFetchMore = ({
@@ -143,7 +129,7 @@ export const useCategories = (options?: QueryHookOptions) => {
   return {
     loading,
     categories,
-    totalCount,
+    totalCount: safeTotalCount,
     handleFetchMore,
     pageInfo,
     refetch,

--- a/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
@@ -66,6 +66,9 @@ export const useCategories = (options?: QueryHookOptions) => {
   const safeTotalCount = totalCount ?? 0;
   useEffect(() => {
     setCategoriesTotalCount(totalCount ?? null);
+    return () => {
+      setCategoriesTotalCount(null);
+    };
   }, [totalCount, setCategoriesTotalCount]);
 
   const handleFetchMore = ({

--- a/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/hooks/useCategoriesEnhanced.tsx
@@ -20,10 +20,21 @@ interface CategoriesQueryResult {
   };
 }
 
+interface CategoriesQueryVariables {
+  clientPortalId?: string;
+  language?: string;
+  searchValue?: string;
+  status?: string;
+  limit?: number;
+  cursor?: string;
+  sortField?: string;
+  sortDirection?: string;
+}
+
 export const CATEGORIES_PER_PAGE = 30;
 
 export const useCategoriesVariables = (
-  variables?: QueryHookOptions<CategoriesQueryResult>['variables'],
+  variables?: CategoriesQueryVariables,
 ) => {
   const language = useAtomValue(cmsLanguageAtom);
   const [{ searchValue, status }] = useMultiQueryState<{
@@ -43,7 +54,9 @@ export const useCategoriesVariables = (
   };
 };
 
-export const useCategories = (options?: QueryHookOptions) => {
+export const useCategories = (
+  options?: QueryHookOptions<CategoriesQueryResult, CategoriesQueryVariables>,
+) => {
   const setCategoriesTotalCount = useSetAtom(categoriesTotalCountAtom);
   const variables = useCategoriesVariables(options?.variables);
   const { data, loading, fetchMore, refetch } = useQuery<CategoriesQueryResult>(

--- a/frontend/plugins/content_ui/src/modules/cms/categories/states/categoriesCounts.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/states/categoriesCounts.ts
@@ -1,3 +1,3 @@
 import { atom } from 'jotai';
 
-export const categoriesTotalCountAtom = atom(0);
+export const categoriesTotalCountAtom = atom<number | null>(null);

--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -9,7 +9,11 @@ import {
   toast,
   MultipleSelector,
 } from 'erxes-ui';
-import { useEffect } from 'react';
+import {
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -41,6 +45,10 @@ export function WebsiteDrawer({
 }: WebsiteDrawerProps) {
   const { t } = useTranslation('content');
   const isEditing = !!website;
+  const languagesSelectorRef = useRef<HTMLDivElement>(null);
+  const defaultLanguageTriggerRef = useRef<HTMLButtonElement>(null);
+  const saveButtonRef = useRef<HTMLButtonElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   const {
     clientPortals,
@@ -197,9 +205,59 @@ export function WebsiteDrawer({
     });
   };
 
+  const handleSheetEscapeKeyDown = (event: KeyboardEvent) => {
+    const target = event.target;
+
+    if (
+      target instanceof HTMLInputElement &&
+      languagesSelectorRef.current?.contains(target)
+    ) {
+      event.preventDefault();
+    }
+  };
+
+  const focusAfterLanguagesSelector = () => {
+    const defaultLanguageTrigger = defaultLanguageTriggerRef.current;
+
+    if (defaultLanguageTrigger && !defaultLanguageTrigger.disabled) {
+      defaultLanguageTrigger.focus();
+      return;
+    }
+
+    const saveButton = saveButtonRef.current;
+
+    if (saveButton && !saveButton.disabled) {
+      saveButton.focus();
+      return;
+    }
+
+    cancelButtonRef.current?.focus();
+  };
+
+  const handleLanguagesSelectorKeyDownCapture = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (event.key !== 'Tab' || event.shiftKey) {
+      return;
+    }
+
+    const target = event.target;
+
+    if (
+      target instanceof HTMLElement &&
+      languagesSelectorRef.current?.contains(target)
+    ) {
+      event.preventDefault();
+      focusAfterLanguagesSelector();
+    }
+  };
+
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
-      <Sheet.View className="sm:max-w-lg p-0 bg-background">
+      <Sheet.View
+        className="sm:max-w-lg p-0 bg-background"
+        onEscapeKeyDown={handleSheetEscapeKeyDown}
+      >
         <Sheet.Header className="border-b gap-3">
           <Sheet.Title>{isEditing ? t('edit-cms') : t('new-cms')}</Sheet.Title>
           <Sheet.Close />
@@ -286,29 +344,37 @@ export function WebsiteDrawer({
                 <Form.Item>
                   <Form.Label>{t('languages')}</Form.Label>
                   <Form.Control>
-                    <MultipleSelector
-                      defaultOptions={LANGUAGES}
-                      onSearchSync={(term) =>
-                        LANGUAGES.filter(
-                          (o) =>
-                            o.label
-                              .toLowerCase()
-                              .includes(term.toLowerCase()) ||
-                            o.value.toLowerCase().includes(term.toLowerCase()),
-                        )
-                      }
-                      triggerSearchOnFocus
-                      value={(field.value || []).map((lng) => ({
-                        value: lng,
-                        label:
-                          LANGUAGES.find((l) => l.value === lng)?.label || lng,
-                      }))}
-                      onChange={(val) =>
-                        field.onChange(val.map((v) => v.value))
-                      }
-                      placeholder={t('select-languages')}
-                      commandProps={{ shouldFilter: false }}
-                    />
+                    <div
+                      ref={languagesSelectorRef}
+                      onKeyDownCapture={handleLanguagesSelectorKeyDownCapture}
+                    >
+                      <MultipleSelector
+                        defaultOptions={LANGUAGES}
+                        onSearchSync={(term) =>
+                          LANGUAGES.filter(
+                            (o) =>
+                              o.label
+                                .toLowerCase()
+                                .includes(term.toLowerCase()) ||
+                              o.value
+                                .toLowerCase()
+                                .includes(term.toLowerCase()),
+                          )
+                        }
+                        triggerSearchOnFocus
+                        value={(field.value || []).map((lng) => ({
+                          value: lng,
+                          label:
+                            LANGUAGES.find((l) => l.value === lng)?.label ||
+                            lng,
+                        }))}
+                        onChange={(val) =>
+                          field.onChange(val.map((v) => v.value))
+                        }
+                        placeholder={t('select-languages')}
+                        commandProps={{ shouldFilter: false }}
+                      />
+                    </div>
                   </Form.Control>
                   <Form.Message className="text-destructive" />
                 </Form.Item>
@@ -332,7 +398,7 @@ export function WebsiteDrawer({
                         onValueChange={field.onChange}
                         disabled={available.length === 0}
                       >
-                        <Select.Trigger>
+                        <Select.Trigger ref={defaultLanguageTriggerRef}>
                           <Select.Value placeholder={t('select-default-language')} />
                         </Select.Trigger>
                         <Select.Content>
@@ -351,7 +417,11 @@ export function WebsiteDrawer({
             />
 
             <div className="flex justify-end space-x-2">
-              <Button type="submit" disabled={saving || savingUpdate}>
+              <Button
+                ref={saveButtonRef}
+                type="submit"
+                disabled={saving || savingUpdate}
+              >
                 {saving || savingUpdate
                   ? isEditing
                     ? t('saving')
@@ -361,7 +431,7 @@ export function WebsiteDrawer({
                   : t('create-cms')}
               </Button>
 
-              <Button onClick={onClose} variant="outline">
+              <Button ref={cancelButtonRef} type="button" onClick={onClose} variant="outline">
                 {t('cancel')}
               </Button>
             </div>

--- a/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/components/websites/WebsiteDrawer.tsx
@@ -209,7 +209,7 @@ export function WebsiteDrawer({
     const target = event.target;
 
     if (
-      target instanceof HTMLInputElement &&
+      target instanceof HTMLElement &&
       languagesSelectorRef.current?.contains(target)
     ) {
       event.preventDefault();
@@ -241,12 +241,17 @@ export function WebsiteDrawer({
       return;
     }
 
-    const target = event.target;
+    const selectorEl = languagesSelectorRef.current;
+    if (!selectorEl) return;
 
-    if (
-      target instanceof HTMLElement &&
-      languagesSelectorRef.current?.contains(target)
-    ) {
+    const focusable = Array.from(
+      selectorEl.querySelectorAll<HTMLElement>(
+        'a[href]:not([disabled]), button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const lastFocusable = focusable[focusable.length - 1];
+
+    if (event.target instanceof HTMLElement && event.target === lastFocusable) {
       event.preventDefault();
       focusAfterLanguagesSelector();
     }

--- a/frontend/plugins/content_ui/src/modules/cms/hooks/useTags.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/hooks/useTags.ts
@@ -250,8 +250,13 @@ export function useTags({
   const totalCount = data?.cmsTags?.totalCount || 0;
 
   useEffect(() => {
+    setTagsTotalCount(null);
+  }, [variables, setTagsTotalCount]);
+
+  useEffect(() => {
+    if (skip) return;
     setTagsTotalCount(data?.cmsTags?.totalCount ?? null);
-  }, [data?.cmsTags?.totalCount, setTagsTotalCount]);
+  }, [skip, data?.cmsTags?.totalCount, setTagsTotalCount]);
 
   return {
     tags,

--- a/frontend/plugins/content_ui/src/modules/cms/hooks/useTags.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/hooks/useTags.ts
@@ -1,5 +1,5 @@
 import { ApolloError, useQuery } from '@apollo/client';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { CMS_TAGS } from '../graphql/queries';
 import { cmsLanguageAtom } from '../shared/states/cmsLanguageState';
@@ -10,6 +10,7 @@ import {
   validateFetchMore,
 } from 'erxes-ui';
 import { TAGS_CURSOR_SESSION_KEY } from '../tags/constants/tagsCursorSessionKey';
+import { tagsTotalCountAtom } from '../tags/states/tagsCounts';
 
 export interface CmsTag {
   _id: string;
@@ -49,6 +50,14 @@ interface UseTagsResult {
 
 export const TAGS_PER_PAGE = 30;
 
+interface CmsTagsQueryResult {
+  cmsTags?: {
+    tags?: CmsTag[];
+    totalCount?: number;
+    pageInfo?: IRecordTableCursorPageInfo;
+  };
+}
+
 export function useTags({
   clientPortalId,
   type,
@@ -64,6 +73,7 @@ export function useTags({
   skip = false,
 }: UseTagsProps): UseTagsResult {
   const language = useAtomValue(cmsLanguageAtom);
+  const setTagsTotalCount = useSetAtom(tagsTotalCountAtom);
   const fetchedCursorsRef = useRef<Set<string>>(new Set());
   const fetchingMoreRef = useRef(false);
   const { cursor: tableCursor } = useRecordTableCursor({
@@ -101,13 +111,14 @@ export function useTags({
     ],
   );
 
-  const { data, loading, error, refetch, fetchMore } = useQuery(CMS_TAGS, {
-    variables,
-    skip,
-    errorPolicy: 'all',
-    fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
-  });
+  const { data, loading, error, refetch, fetchMore } =
+    useQuery<CmsTagsQueryResult>(CMS_TAGS, {
+      variables,
+      skip,
+      errorPolicy: 'all',
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+    });
 
   useEffect(() => {
     fetchedCursorsRef.current.clear();
@@ -237,6 +248,10 @@ export function useTags({
 
   const tags = data?.cmsTags?.tags || [];
   const totalCount = data?.cmsTags?.totalCount || 0;
+
+  useEffect(() => {
+    setTagsTotalCount(data?.cmsTags?.totalCount ?? null);
+  }, [data?.cmsTags?.totalCount, setTagsTotalCount]);
 
   return {
     tags,

--- a/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
@@ -8,13 +8,14 @@ import { IPage } from './types/pageTypes';
 import { EmptyState } from '../shared/EmptyState';
 import { PagesHeader } from './components/PagesHeader';
 import { CmsSidebar } from '../shared/CmsSidebar';
+import { PagesFilter } from './components/PagesFilter';
 
 export function Page() {
   const { t } = useTranslation('content');
   const { websiteId } = useParams();
   const navigate = useNavigate();
 
-  const { pages, totalCount, loading } = usePages({
+  const { pages, loading } = usePages({
     variables: {
       clientPortalId: websiteId || '',
     },
@@ -42,10 +43,8 @@ export function Page() {
       <div className="flex overflow-hidden flex-auto">
         <CmsSidebar />
         <div className="flex flex-col w-full overflow-hidden flex-auto">
-          <div className="flex pt-2 pl-4 justify-between items-center mb-2">
-            <div className="text-sm text-gray-600">
-              {t('found-x-pages', { count: totalCount })}
-            </div>
+          <div className="px-4 pt-2">
+            <PagesFilter />
           </div>
           {!loading && (!pages || pages.length === 0) ? (
             <div className="rounded-lg overflow-hidden">

--- a/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/Page.tsx
@@ -1,11 +1,9 @@
 import { Button, PageContainer, Kbd } from 'erxes-ui';
-import { IconArticle, IconPlus } from '@tabler/icons-react';
+import { IconPlus } from '@tabler/icons-react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { usePages } from './hooks/usePages';
 import { PagesRecordTable } from './components/PagesRecordTable';
 import { IPage } from './types/pageTypes';
-import { EmptyState } from '../shared/EmptyState';
 import { PagesHeader } from './components/PagesHeader';
 import { CmsSidebar } from '../shared/CmsSidebar';
 import { PagesFilter } from './components/PagesFilter';
@@ -14,12 +12,6 @@ export function Page() {
   const { t } = useTranslation('content');
   const { websiteId } = useParams();
   const navigate = useNavigate();
-
-  const { pages, loading } = usePages({
-    variables: {
-      clientPortalId: websiteId || '',
-    },
-  });
 
   const headerActions = (
     <div>
@@ -46,28 +38,11 @@ export function Page() {
           <div className="px-4 pt-2">
             <PagesFilter />
           </div>
-          {!loading && (!pages || pages.length === 0) ? (
-            <div className="rounded-lg overflow-hidden">
-              <EmptyState
-                icon={IconArticle}
-                title={t('no-pages-yet')}
-                description={t('no-pages-yet-desc')}
-                actionLabel={t('add-page')}
-                onAction={() =>
-                  navigate(`/content/cms/${websiteId}/pages/detail`)
-                }
-              />
-            </div>
-          ) : (
-            <div className="overflow-hidden flex-auto p-3">
-              <div className="h-full">
-                <PagesRecordTable
-                  clientPortalId={websiteId || ''}
-                  onEditPage={handleEditPage}
-                />
-              </div>
-            </div>
-          )}
+          <PagesRecordTable
+            clientPortalId={websiteId || ''}
+            onEditPage={handleEditPage}
+            onAdd={() => navigate(`/content/cms/${websiteId}/pages/detail`)}
+          />
         </div>
       </div>
     </PageContainer>

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesFilter.tsx
@@ -1,0 +1,27 @@
+import { IconSearch } from '@tabler/icons-react';
+import { Filter, useFilterQueryState } from 'erxes-ui';
+import { PAGES_CURSOR_SESSION_KEY } from '../constants/pagesCursorSessionKey';
+import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
+import { PagesTotalCount } from './PagesTotalCount';
+
+export const PagesFilter = () => {
+  const [searchValue] = useFilterQueryState<string>('searchValue');
+
+  return (
+    <Filter id="pages-filter" sessionKey={PAGES_CURSOR_SESSION_KEY}>
+      <Filter.Bar>
+        <Filter.BarItem queryKey="searchValue">
+          <Filter.BarName>
+            <IconSearch />
+            Search
+          </Filter.BarName>
+          <Filter.BarButton filterKey="searchValue" inDialog>
+            {searchValue}
+          </Filter.BarButton>
+        </Filter.BarItem>
+        <SimpleSearchFilterPopover />
+        <PagesTotalCount />
+      </Filter.Bar>
+    </Filter>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesFilter.tsx
@@ -1,10 +1,12 @@
 import { IconSearch } from '@tabler/icons-react';
 import { Filter, useFilterQueryState } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
 import { PAGES_CURSOR_SESSION_KEY } from '../constants/pagesCursorSessionKey';
 import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
 import { PagesTotalCount } from './PagesTotalCount';
 
 export const PagesFilter = () => {
+  const { t } = useTranslation('content');
   const [searchValue] = useFilterQueryState<string>('searchValue');
 
   return (
@@ -13,7 +15,7 @@ export const PagesFilter = () => {
         <Filter.BarItem queryKey="searchValue">
           <Filter.BarName>
             <IconSearch />
-            Search
+            {t('search')}
           </Filter.BarName>
           <Filter.BarButton filterKey="searchValue" inDialog>
             {searchValue}

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
@@ -4,10 +4,11 @@ import { usePagesColumns } from './PagesColumn';
 import { PagesCommandbar } from './pages-command-bar/PagesCommandBar';
 import { PAGES_CURSOR_SESSION_KEY } from '../constants/pagesCursorSessionKey';
 import { usePages } from '../hooks/usePages';
+import { IPage } from '../types/pageTypes';
 
 interface PagesRecordTableProps {
   clientPortalId: string;
-  onEditPage?: (page: any) => void;
+  onEditPage?: (page: IPage) => void;
 }
 
 export const PagesRecordTable = ({

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
@@ -1,20 +1,27 @@
-import { RecordTable } from 'erxes-ui';
+import { IconArticle } from '@tabler/icons-react';
+import { RecordTable, useFilterQueryState } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
 import { usePagesColumns } from './PagesColumn';
 
 import { PagesCommandbar } from './pages-command-bar/PagesCommandBar';
 import { PAGES_CURSOR_SESSION_KEY } from '../constants/pagesCursorSessionKey';
 import { usePages } from '../hooks/usePages';
 import { IPage } from '../types/pageTypes';
+import { EmptyState } from '../../shared/EmptyState';
 
 interface PagesRecordTableProps {
   clientPortalId: string;
   onEditPage?: (page: IPage) => void;
+  onAdd?: () => void;
 }
 
 export const PagesRecordTable = ({
   clientPortalId,
   onEditPage,
+  onAdd,
 }: PagesRecordTableProps) => {
+  const { t } = useTranslation('content');
+  const [searchValue] = useFilterQueryState<string>('searchValue');
   const { pages, loading, refetch, pageInfo, handleFetchMore } = usePages({
     variables: {
       clientPortalId,
@@ -23,34 +30,56 @@ export const PagesRecordTable = ({
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
   const columns = usePagesColumns(onEditPage, refetch, pages);
 
+  if (!loading && (!pages || pages.length === 0)) {
+    return (
+      <div className="rounded-lg overflow-hidden">
+        {searchValue ? (
+          <EmptyState icon={IconArticle} title={t('no-pages-found')} />
+        ) : (
+          <EmptyState
+            icon={IconArticle}
+            title={t('no-pages-yet')}
+            description={t('no-pages-yet-desc')}
+            actionLabel={t('add-page')}
+            onAction={onAdd}
+          />
+        )}
+      </div>
+    );
+  }
+
   return (
-    <RecordTable.Provider
-      columns={columns}
-      data={pages || []}
-      className="h-full"
-      stickyColumns={['more', 'checkbox', 'name']}
-    >
-      <RecordTable.CursorProvider
-        hasPreviousPage={hasPreviousPage}
-        hasNextPage={hasNextPage}
-        dataLength={pages?.length}
-        sessionKey={PAGES_CURSOR_SESSION_KEY}
-      >
-        <RecordTable>
-          <RecordTable.Header />
-          <RecordTable.Body>
-            <RecordTable.CursorBackwardSkeleton
-              handleFetchMore={handleFetchMore}
-            />
-            {loading && <RecordTable.RowSkeleton rows={40} />}
-            <RecordTable.RowList />
-            <RecordTable.CursorForwardSkeleton
-              handleFetchMore={handleFetchMore}
-            />
-          </RecordTable.Body>
-        </RecordTable>
-      </RecordTable.CursorProvider>
-      <PagesCommandbar clientPortalId={clientPortalId} refetch={refetch} />
-    </RecordTable.Provider>
+    <div className="overflow-hidden flex-auto p-3">
+      <div className="h-full">
+        <RecordTable.Provider
+          columns={columns}
+          data={pages || []}
+          className="h-full"
+          stickyColumns={['more', 'checkbox', 'name']}
+        >
+          <RecordTable.CursorProvider
+            hasPreviousPage={hasPreviousPage}
+            hasNextPage={hasNextPage}
+            dataLength={pages?.length}
+            sessionKey={PAGES_CURSOR_SESSION_KEY}
+          >
+            <RecordTable>
+              <RecordTable.Header />
+              <RecordTable.Body>
+                <RecordTable.CursorBackwardSkeleton
+                  handleFetchMore={handleFetchMore}
+                />
+                {loading && <RecordTable.RowSkeleton rows={40} />}
+                <RecordTable.RowList />
+                <RecordTable.CursorForwardSkeleton
+                  handleFetchMore={handleFetchMore}
+                />
+              </RecordTable.Body>
+            </RecordTable>
+          </RecordTable.CursorProvider>
+          <PagesCommandbar clientPortalId={clientPortalId} refetch={refetch} />
+        </RecordTable.Provider>
+      </div>
+    </div>
   );
 };

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesTotalCount.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesTotalCount.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue } from 'jotai';
 import { CmsRecordCount } from '~/modules/cms/shared/components/CmsRecordCount';
-import { postsTotalCountAtom } from '../states/postsCounts';
+import { pagesTotalCountAtom } from '../states/pagesCounts';
 
-export const PostsTotalCount = () => {
-  const totalCount = useAtomValue(postsTotalCountAtom);
+export const PagesTotalCount = () => {
+  const totalCount = useAtomValue(pagesTotalCountAtom);
   return <CmsRecordCount totalCount={totalCount} />;
 };

--- a/frontend/plugins/content_ui/src/modules/cms/pages/hooks/usePages.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/hooks/usePages.ts
@@ -2,7 +2,6 @@ import { QueryHookOptions, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   IRecordTableCursorPageInfo,
-  parseDateRangeFromString,
   useMultiQueryState,
   useRecordTableCursor,
   validateFetchMore,
@@ -26,14 +25,9 @@ export const usePagesVariables = (
     };
   }>['variables'],
 ) => {
-  const [{ name, path, createdAt, updatedAt, publishedDate }] =
-    useMultiQueryState<{
-      name: string[];
-      path: string;
-      createdAt: string;
-      updatedAt: string;
-      publishedDate: string;
-    }>(['name', 'path', 'createdAt', 'updatedAt', 'publishedDate']);
+  const [{ searchValue }] = useMultiQueryState<{ searchValue: string }>([
+    'searchValue',
+  ]);
 
   const language = useAtomValue(cmsLanguageAtom);
 
@@ -45,22 +39,7 @@ export const usePagesVariables = (
     limit: PAGES_PER_PAGE,
     cursor,
     language,
-    name: name || undefined,
-    path: path || undefined,
-    dateFilters: {
-      createdAt: {
-        gte: parseDateRangeFromString(createdAt)?.from,
-        lte: parseDateRangeFromString(createdAt)?.to,
-      },
-      updatedAt: {
-        gte: parseDateRangeFromString(updatedAt)?.from,
-        lte: parseDateRangeFromString(updatedAt)?.to,
-      },
-      publishedDate: {
-        gte: parseDateRangeFromString(publishedDate)?.from,
-        lte: parseDateRangeFromString(publishedDate)?.to,
-      },
-    },
+    searchValue: searchValue || undefined,
     ...variables,
   };
 };
@@ -83,10 +62,10 @@ export const usePages = (options?: QueryHookOptions) => {
     fetchPolicy: 'network-only',
   });
 
-  const { pages = [], totalCount = 0, pageInfo } = data?.cmsPageList || {};
+  const { pages = [], totalCount, pageInfo } = data?.cmsPageList || {};
+  const safeTotalCount = totalCount ?? 0;
   useEffect(() => {
-    if (!totalCount) return;
-    setPagesTotalCount(totalCount);
+    setPagesTotalCount(totalCount ?? null);
   }, [totalCount, setPagesTotalCount]);
 
   const handleFetchMore = ({
@@ -150,7 +129,7 @@ export const usePages = (options?: QueryHookOptions) => {
   return {
     loading,
     pages,
-    totalCount,
+    totalCount: safeTotalCount,
     handleFetchMore,
     pageInfo,
     refetch,

--- a/frontend/plugins/content_ui/src/modules/cms/pages/hooks/usePages.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/hooks/usePages.ts
@@ -66,6 +66,9 @@ export const usePages = (options?: QueryHookOptions) => {
   const safeTotalCount = totalCount ?? 0;
   useEffect(() => {
     setPagesTotalCount(totalCount ?? null);
+    return () => {
+      setPagesTotalCount(null);
+    };
   }, [totalCount, setPagesTotalCount]);
 
   const handleFetchMore = ({

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostFilter.tsx
@@ -93,7 +93,9 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
           <SelectTags.FilterView clientPortalId={clientPortalId || ''} />
           <SelectCategories.FilterView clientPortalId={clientPortalId} />
           <SelectStatus.FilterView />
-          <SelectType.FilterView clientPortalId={clientPortalId} />
+          <Filter.View filterKey="type">
+            <SelectType.FilterView clientPortalId={clientPortalId} />
+          </Filter.View>
           <Filter.View filterKey="created">
             <Filter.DateView filterKey="created" />
           </Filter.View>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostFilter.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useRef } from 'react';
 import {
+  IconCalendarCheck,
   IconCalendarPlus,
   IconCalendarUp,
-  IconLabel,
   IconSearch,
 } from '@tabler/icons-react';
 
@@ -11,6 +12,7 @@ import {
   Filter,
   useFilterQueryState,
   useMultiQueryState,
+  useQueryState,
 } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { PostsHotKeyScope } from '../types/PostsHotKeyScope';
@@ -19,7 +21,7 @@ import { useIsPostsLeadSessionKey } from '../hooks/usePostsLeadSessionKey';
 import { SelectStatus } from './selects/SelectStatus';
 import { SelectTags } from './selects/SelectTags';
 import { SelectCategories } from './selects/SelectCategories';
-import { useCustomTypes } from '../../custom-types/hooks/useCustomTypes';
+import { SelectType } from './selects/SelectType';
 
 interface PostsFilterPopoverProps {
   clientPortalId?: string;
@@ -32,7 +34,7 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
     searchValue: string;
     status: string;
     type: string;
-    categories: string;
+    categories: string[];
     created: string;
     updated: string;
     publishedDate: string;
@@ -69,10 +71,7 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
                   {t('search')}
                 </Filter.Item>
                 <SelectStatus.FilterItem />
-                <Filter.Item value="type" inDialog>
-                  <IconLabel />
-                  {t('type')}
-                </Filter.Item>
+                <SelectType.FilterItem />
                 <SelectTags.FilterItem />
                 <SelectCategories.FilterItem />
                 <Command.Separator className="my-1" />
@@ -85,7 +84,7 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
                   {t('updated-at')}
                 </Filter.Item>
                 <Filter.Item value="publishedDate">
-                  <IconCalendarPlus />
+                  <IconCalendarCheck />
                   {t('publish-date')}
                 </Filter.Item>
               </Command.List>
@@ -94,6 +93,7 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
           <SelectTags.FilterView clientPortalId={clientPortalId || ''} />
           <SelectCategories.FilterView clientPortalId={clientPortalId} />
           <SelectStatus.FilterView />
+          <SelectType.FilterView clientPortalId={clientPortalId} />
           <Filter.View filterKey="created">
             <Filter.DateView filterKey="created" />
           </Filter.View>
@@ -113,7 +113,7 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
           <SelectStatus.FilterView />
         </Filter.View>
         <Filter.View filterKey="type" inDialog>
-          <Filter.DialogStringView filterKey="type" />
+          <SelectType.FilterView clientPortalId={clientPortalId} />
         </Filter.View>
         <Filter.View filterKey="categories" inDialog>
           <SelectCategories.FilterView clientPortalId={clientPortalId} />
@@ -138,15 +138,47 @@ const PostsFilterPopover = ({ clientPortalId }: PostsFilterPopoverProps) => {
 export const PostsFilter = ({ clientPortalId }: { clientPortalId: string }) => {
   const { t } = useTranslation('content');
   const [searchValue] = useFilterQueryState<string>('searchValue');
-  const [type] = useFilterQueryState<string>('type');
   const { sessionKey } = useIsPostsLeadSessionKey();
-  const { customTypes } = useCustomTypes({ clientPortalId });
-  const typeLabel =
-    type === 'post'
-      ? 'Post'
-      : customTypes.find((t) => t.code === type)?.pluralLabel ||
-        customTypes.find((t) => t.code === type)?.label ||
-        type;
+
+  // Enforce mutual exclusivity: setting one date filter clears the other two
+  const [created, setCreated] = useQueryState<string>('created');
+  const [updated, setUpdated] = useQueryState<string>('updated');
+  const [publishedDate, setPublishedDate] = useQueryState<string>('publishedDate');
+
+  const prevCreated = useRef(created);
+  const prevUpdated = useRef(updated);
+  const prevPublishedDate = useRef(publishedDate);
+
+  // On mount: apply priority (created > updated > publishedDate) to clear conflicts from URL
+  useEffect(() => {
+    if (created) {
+      if (updated) setUpdated(null);
+      if (publishedDate) setPublishedDate(null);
+    } else if (updated && publishedDate) {
+      setPublishedDate(null);
+    }
+    prevCreated.current = created;
+    prevUpdated.current = updated;
+    prevPublishedDate.current = publishedDate;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // On change: enforce mutual exclusivity
+  useEffect(() => {
+    if (created !== prevCreated.current && created) {
+      setUpdated(null);
+      setPublishedDate(null);
+    } else if (updated !== prevUpdated.current && updated) {
+      setCreated(null);
+      setPublishedDate(null);
+    } else if (publishedDate !== prevPublishedDate.current && publishedDate) {
+      setCreated(null);
+      setUpdated(null);
+    }
+    prevCreated.current = created;
+    prevUpdated.current = updated;
+    prevPublishedDate.current = publishedDate;
+  }, [created, updated, publishedDate]);
 
   return (
     <Filter id="posts-filter" sessionKey={sessionKey}>
@@ -161,15 +193,7 @@ export const PostsFilter = ({ clientPortalId }: { clientPortalId: string }) => {
           </Filter.BarButton>
         </Filter.BarItem>
         <SelectStatus.FilterBar />
-        <Filter.BarItem queryKey="type">
-          <Filter.BarName>
-            <IconLabel />
-            {t('type')}
-          </Filter.BarName>
-          <Filter.BarButton filterKey="type" inDialog>
-            {typeLabel}
-          </Filter.BarButton>
-        </Filter.BarItem>
+        <SelectType.FilterBar clientPortalId={clientPortalId || undefined} />
         <SelectTags.FilterBar clientPortalId={clientPortalId} />
         <SelectCategories.FilterBar clientPortalId={clientPortalId} />
         <Filter.BarItem queryKey="created">
@@ -188,7 +212,7 @@ export const PostsFilter = ({ clientPortalId }: { clientPortalId: string }) => {
         </Filter.BarItem>
         <Filter.BarItem queryKey="publishedDate">
           <Filter.BarName>
-            <IconCalendarPlus />
+            <IconCalendarCheck />
             {t('publish-date')}
           </Filter.BarName>
           <Filter.Date filterKey="publishedDate" />

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectCategories.tsx
@@ -242,12 +242,10 @@ export const SelectCategoriesFilterView = ({
 };
 
 export const SelectCategoriesFilterBar = ({
-  iconOnly,
   onValueChange,
   mode = 'single',
   clientPortalId,
 }: {
-  iconOnly?: boolean;
   onValueChange?: (value: string[] | string) => void;
   mode?: 'single' | 'multiple';
   clientPortalId?: string;
@@ -260,7 +258,10 @@ export const SelectCategoriesFilterBar = ({
 
   return (
     <Filter.BarItem queryKey={'categories'}>
-      <Filter.BarName>{t('categories')}</Filter.BarName>
+      <Filter.BarName>
+        <IconFolder />
+        {t('categories')}
+      </Filter.BarName>
       <SelectCategoriesProvider
         mode={mode}
         value={categories || (mode === 'single' ? '' : [])}

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectShared.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectShared.tsx
@@ -1,7 +1,10 @@
 import {
+  cn,
   RecordTableInlineCell,
   Combobox,
+  Command,
   Popover,
+  PopoverScoped,
   Badge,
   Filter,
   Form,
@@ -146,3 +149,145 @@ export const SelectContent = ({
     </Combobox.Content>
   );
 };
+
+export const SelectItemValueBase = ({
+  label,
+  placeholder,
+  className,
+}: {
+  label?: string;
+  placeholder?: string;
+  className?: string;
+}) => {
+  if (!label) {
+    return (
+      <span className="text-accent-foreground/80">{placeholder || 'Select...'}</span>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <p className={cn('font-medium text-sm', className)}>{label}</p>
+    </div>
+  );
+};
+
+export const SelectCommandList = ({
+  loading,
+  error,
+  placeholder,
+  loadingText,
+  emptyText,
+  errorText,
+  children,
+}: {
+  loading?: boolean;
+  error?: unknown;
+  placeholder?: string;
+  loadingText?: string;
+  emptyText?: string;
+  errorText?: string;
+  children?: React.ReactNode;
+}) => {
+  let body: React.ReactNode;
+  if (loading) {
+    body = (
+      <Command.List>
+        <div className="flex items-center justify-center py-4 h-32">
+          <span className="text-muted-foreground">{loadingText || 'Loading...'}</span>
+        </div>
+      </Command.List>
+    );
+  } else if (error) {
+    body = (
+      <Command.List>
+        <div className="flex items-center justify-center py-4 h-32">
+          <span className="text-muted-foreground">{errorText || 'Failed to load'}</span>
+        </div>
+      </Command.List>
+    );
+  } else {
+    body = (
+      <>
+        <Command.Empty>
+          <span className="text-muted-foreground">{emptyText || 'No results found'}</span>
+        </Command.Empty>
+        <Command.List>{children}</Command.List>
+      </>
+    );
+  }
+  return (
+    <Command>
+      <Command.Input placeholder={placeholder || 'Search...'} />
+      {body}
+    </Command>
+  );
+};
+
+export const SelectFormPopover = ({
+  open,
+  onOpenChange,
+  className,
+  children,
+  content,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+  children: React.ReactNode;
+  content: React.ReactNode;
+}) => (
+  <Popover open={open} onOpenChange={onOpenChange}>
+    <Form.Control>
+      <Combobox.Trigger className={cn('w-full shadow-xs', className)}>
+        {children}
+      </Combobox.Trigger>
+    </Form.Control>
+    <Combobox.Content>{content}</Combobox.Content>
+  </Popover>
+);
+
+export const SelectBarPopover = ({
+  open,
+  onOpenChange,
+  filterKey,
+  children,
+  content,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filterKey: string;
+  children: React.ReactNode;
+  content: React.ReactNode;
+}) => (
+  <Popover open={open} onOpenChange={onOpenChange}>
+    <Popover.Trigger asChild>
+      <Filter.BarButton filterKey={filterKey}>{children}</Filter.BarButton>
+    </Popover.Trigger>
+    <Combobox.Content>{content}</Combobox.Content>
+  </Popover>
+);
+
+export const SelectRootPopover = ({
+  open,
+  onOpenChange,
+  scope,
+  variant,
+  disabled,
+  children,
+  content,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope?: string;
+  variant: SelectTriggerVariantType;
+  disabled?: boolean;
+  children: React.ReactNode;
+  content: React.ReactNode;
+}) => (
+  <PopoverScoped open={open} onOpenChange={onOpenChange} scope={scope}>
+    <SelectTrigger variant={variant} disabled={disabled}>
+      {children}
+    </SelectTrigger>
+    <SelectContent variant={variant}>{content}</SelectContent>
+  </PopoverScoped>
+);

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectTags.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectTags.tsx
@@ -66,12 +66,14 @@ export const SelectTagsProvider = ({
   children,
   mode = 'single',
   clientPortalId,
+  open,
 }: {
   value: string | string[];
   onValueChange: (tag: string) => void;
   children: React.ReactNode;
   mode?: 'single' | 'multiple';
   clientPortalId?: string;
+  open?: boolean;
 }) => {
   const language = useAtomValue(cmsLanguageAtom);
   const fetchedCursorsRef = useRef<Set<string>>(new Set());
@@ -141,8 +143,9 @@ export const SelectTagsProvider = ({
   }, [fetchMore, pageInfo?.endCursor, pageInfo?.hasNextPage, variables]);
 
   useEffect(() => {
+    if (open === false) return;
     fetchRemainingTags();
-  }, [fetchRemainingTags]);
+  }, [fetchRemainingTags, open]);
 
   const tags = useMemo(() => data?.cmsTags?.tags || [], [data?.cmsTags?.tags]);
 
@@ -329,6 +332,7 @@ export const SelectTagsFilterBar = ({
         mode={mode}
         value={tags || (mode === 'single' ? '' : [])}
         clientPortalId={clientPortalId}
+        open={open}
         onValueChange={(value) => {
           if (value.length > 0) {
             setTags(value as string[] | string);

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectType.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectType.tsx
@@ -1,0 +1,318 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  Combobox,
+  Command,
+  Filter,
+  useFilterContext,
+  useQueryState,
+} from 'erxes-ui';
+
+import { IconLabel } from '@tabler/icons-react';
+import { useCustomTypes } from '../../../custom-types/hooks/useCustomTypes';
+import {
+  SelectTriggerVariantType,
+  SelectItemValueBase,
+  SelectCommandList,
+  SelectFormPopover,
+  SelectBarPopover,
+  SelectRootPopover,
+} from './SelectShared';
+
+interface IType {
+  value: string;
+  label: string;
+}
+
+interface SelectTypeContextType {
+  value: string;
+  onValueChange: (type: string) => void;
+  types: IType[];
+  loading: boolean;
+  error?: unknown;
+}
+
+const SelectTypeContext = createContext<SelectTypeContextType | null>(null);
+
+const useSelectTypeContext = () => {
+  const context = useContext(SelectTypeContext);
+  if (!context) {
+    throw new Error(
+      'useSelectTypeContext must be used within SelectTypeProvider',
+    );
+  }
+  return context;
+};
+
+export const SelectTypeProvider = ({
+  value,
+  onValueChange,
+  children,
+  clientPortalId,
+}: {
+  value: string;
+  onValueChange: (type: string) => void;
+  children: React.ReactNode;
+  clientPortalId?: string;
+}) => {
+  const { customTypes, loading, error } = useCustomTypes({ clientPortalId });
+
+  const types = useMemo<IType[]>(
+    () => [
+      { value: 'post', label: 'Post' },
+      ...customTypes.map((t) => ({
+        value: t.code,
+        label: t.pluralLabel || t.label,
+      })),
+    ],
+    [customTypes],
+  );
+
+  const handleValueChange = useCallback(
+    (type: string) => {
+      onValueChange?.(type);
+    },
+    [onValueChange],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      value: value || '',
+      onValueChange: handleValueChange,
+      types,
+      loading,
+      error,
+    }),
+    [value, handleValueChange, types, loading, error],
+  );
+
+  return (
+    <SelectTypeContext.Provider value={contextValue}>
+      {children}
+    </SelectTypeContext.Provider>
+  );
+};
+
+const SelectTypeValue = ({
+  placeholder,
+  className,
+}: {
+  placeholder?: string;
+  className?: string;
+}) => {
+  const { value, types } = useSelectTypeContext();
+  const selectedType = types.find((t) => t.value === value);
+  return (
+    <SelectItemValueBase
+      label={selectedType?.label}
+      placeholder={placeholder || 'Select type'}
+      className={className}
+    />
+  );
+};
+
+const SelectTypeCommandItem = ({ type }: { type: IType }) => {
+  const { onValueChange, value } = useSelectTypeContext();
+  const isChecked = value === type.value;
+
+  return (
+    <Command.Item
+      value={type.value}
+      onSelect={() => {
+        onValueChange(type.value);
+      }}
+    >
+      <span className="font-medium">{type.label}</span>
+      <Combobox.Check checked={isChecked} />
+    </Command.Item>
+  );
+};
+
+const SelectTypeContent = () => {
+  const { types, loading, error } = useSelectTypeContext();
+  return (
+    <SelectCommandList
+      loading={loading}
+      error={error}
+      placeholder="Search type"
+      loadingText="Loading types..."
+      emptyText="No types found"
+      errorText="Failed to load types"
+    >
+      {types.map((type) => (
+        <SelectTypeCommandItem key={type.value} type={type} />
+      ))}
+    </SelectCommandList>
+  );
+};
+
+export const SelectTypeFilterItem = () => {
+  return (
+    <Filter.Item value="type">
+      <IconLabel />
+      Type
+    </Filter.Item>
+  );
+};
+
+export const SelectTypeFilterView = ({
+  onValueChange,
+  queryKey,
+  clientPortalId,
+}: {
+  onValueChange?: (value: string) => void;
+  queryKey?: string;
+  clientPortalId?: string;
+}) => {
+  const [type, setType] = useQueryState<string>(queryKey || 'type');
+  const { resetFilterState } = useFilterContext();
+
+  return (
+    <Filter.View filterKey={queryKey || 'type'}>
+      <SelectTypeProvider
+        value={type || ''}
+        clientPortalId={clientPortalId}
+        onValueChange={(value) => {
+          setType(value || null);
+          resetFilterState();
+          onValueChange?.(value);
+        }}
+      >
+        <SelectTypeContent />
+      </SelectTypeProvider>
+    </Filter.View>
+  );
+};
+
+export const SelectTypeFilterBar = ({
+  onValueChange,
+  clientPortalId,
+}: {
+  onValueChange?: (value: string) => void;
+  clientPortalId?: string;
+}) => {
+  const [type, setType] = useQueryState<string>('type');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Filter.BarItem queryKey={'type'}>
+      <Filter.BarName>
+        <IconLabel />
+        Type
+      </Filter.BarName>
+      <SelectTypeProvider
+        value={type || ''}
+        clientPortalId={clientPortalId}
+        onValueChange={(value) => {
+          setType(value || null);
+          setOpen(false);
+          onValueChange?.(value);
+        }}
+      >
+        <SelectBarPopover
+          open={open}
+          onOpenChange={setOpen}
+          filterKey="type"
+          content={<SelectTypeContent />}
+        >
+          <SelectTypeValue />
+        </SelectBarPopover>
+      </SelectTypeProvider>
+    </Filter.BarItem>
+  );
+};
+
+export const SelectTypeFormItem = ({
+  onValueChange,
+  className,
+  placeholder,
+  clientPortalId,
+  ...props
+}: Omit<React.ComponentProps<typeof SelectTypeProvider>, 'children'> & {
+  className?: string;
+  placeholder?: string;
+  clientPortalId?: string;
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SelectTypeProvider
+      clientPortalId={clientPortalId}
+      onValueChange={(value) => {
+        onValueChange?.(value);
+        setOpen(false);
+      }}
+      {...props}
+    >
+      <SelectFormPopover
+        open={open}
+        onOpenChange={setOpen}
+        className={className}
+        content={<SelectTypeContent />}
+      >
+        <SelectTypeValue placeholder={placeholder} />
+      </SelectFormPopover>
+    </SelectTypeProvider>
+  );
+};
+
+SelectTypeFormItem.displayName = 'SelectTypeFormItem';
+
+const SelectTypeRoot = ({
+  value,
+  variant = 'form',
+  scope,
+  onValueChange,
+  disabled,
+  clientPortalId,
+}: {
+  value: string;
+  variant?: `${SelectTriggerVariantType}`;
+  scope?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  clientPortalId?: string;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      onValueChange?.(value);
+      setOpen(false);
+    },
+    [onValueChange],
+  );
+
+  return (
+    <SelectTypeProvider
+      value={value}
+      clientPortalId={clientPortalId}
+      onValueChange={handleValueChange}
+    >
+      <SelectRootPopover
+        open={open}
+        onOpenChange={setOpen}
+        scope={scope}
+        variant={variant}
+        disabled={disabled}
+        content={<SelectTypeContent />}
+      >
+        <SelectTypeValue />
+      </SelectRootPopover>
+    </SelectTypeProvider>
+  );
+};
+
+export const SelectType = Object.assign(SelectTypeRoot, {
+  Provider: SelectTypeProvider,
+  Value: SelectTypeValue,
+  Content: SelectTypeContent,
+  FilterItem: SelectTypeFilterItem,
+  FilterView: SelectTypeFilterView,
+  FilterBar: SelectTypeFilterBar,
+  FormItem: SelectTypeFormItem,
+});

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectType.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/selects/SelectType.tsx
@@ -173,19 +173,17 @@ export const SelectTypeFilterView = ({
   const { resetFilterState } = useFilterContext();
 
   return (
-    <Filter.View filterKey={queryKey || 'type'}>
-      <SelectTypeProvider
-        value={type || ''}
-        clientPortalId={clientPortalId}
-        onValueChange={(value) => {
-          setType(value || null);
-          resetFilterState();
-          onValueChange?.(value);
-        }}
-      >
-        <SelectTypeContent />
-      </SelectTypeProvider>
-    </Filter.View>
+    <SelectTypeProvider
+      value={type || ''}
+      clientPortalId={clientPortalId}
+      onValueChange={(value) => {
+        setType(value || null);
+        resetFilterState();
+        onValueChange?.(value);
+      }}
+    >
+      <SelectTypeContent />
+    </SelectTypeProvider>
   );
 };
 

--- a/frontend/plugins/content_ui/src/modules/cms/posts/hooks/usePosts.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/hooks/usePosts.tsx
@@ -46,7 +46,7 @@ export const usePostsVariables = (
     searchValue: string;
     status: string;
     type: string;
-    categories: string;
+    categories: string | string[];
     created: string;
     updated: string;
     publishedDate: string;
@@ -81,17 +81,25 @@ export const usePostsVariables = (
       : undefined;
 
   if (created) {
+    const parsed = parseDateRangeFromString(created);
     dateField = 'createdAt';
-    dateFrom = parseDateRangeFromString(created)?.from;
-    dateTo = parseDateRangeFromString(created)?.to;
+    dateFrom = parsed?.from;
+    dateTo = parsed?.to;
   } else if (updated) {
+    const parsed = parseDateRangeFromString(updated);
     dateField = 'updatedAt';
-    dateFrom = parseDateRangeFromString(updated)?.from;
-    dateTo = parseDateRangeFromString(updated)?.to;
+    dateFrom = parsed?.from;
+    dateTo = parsed?.to;
   } else if (publishedDate) {
+    const parsed = parseDateRangeFromString(publishedDate);
     dateField = 'publishedDate';
-    dateFrom = parseDateRangeFromString(publishedDate)?.from;
-    dateTo = parseDateRangeFromString(publishedDate)?.to;
+    dateFrom = parsed?.from;
+    dateTo = parsed?.to;
+  }
+
+  let categoryIds: string[] | undefined;
+  if (categories) {
+    categoryIds = Array.isArray(categories) ? categories : [categories];
   }
 
   return {
@@ -100,10 +108,10 @@ export const usePostsVariables = (
     sortField: sortField || 'createdAt',
     sortDirection: parsedSortDirection ?? '-1',
     searchValue: searchValue || undefined,
-    status: status && status !== 'all' ? status : undefined,
-    type: type || 'post',
+    status: status || undefined,
+    type: type || undefined,
     tagIds: tags || undefined,
-    categoryIds: categories || undefined,
+    categoryIds,
     dateField: dateField || undefined,
     dateFrom: dateFrom || undefined,
     dateTo: dateTo || undefined,

--- a/frontend/plugins/content_ui/src/modules/cms/posts/hooks/usePosts.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/hooks/usePosts.tsx
@@ -108,7 +108,7 @@ export const usePostsVariables = (
     sortField: sortField || 'createdAt',
     sortDirection: parsedSortDirection ?? '-1',
     searchValue: searchValue || undefined,
-    status: status || undefined,
+    status: status === 'all' ? undefined : status || undefined,
     type: type || undefined,
     tagIds: tags || undefined,
     categoryIds,

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsRecordCount.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsRecordCount.tsx
@@ -6,7 +6,7 @@ export const CmsRecordCount = ({
 }: {
   totalCount: number | null | undefined;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('content');
   return (
     <div className="text-muted-foreground font-medium text-sm whitespace-nowrap h-7 leading-7">
       {isUndefinedOrNull(totalCount) ? (

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsRecordCount.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/CmsRecordCount.tsx
@@ -1,0 +1,19 @@
+import { isUndefinedOrNull, Skeleton } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+export const CmsRecordCount = ({
+  totalCount,
+}: {
+  totalCount: number | null | undefined;
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="text-muted-foreground font-medium text-sm whitespace-nowrap h-7 leading-7">
+      {isUndefinedOrNull(totalCount) ? (
+        <Skeleton className="w-20 h-4 inline-block mt-1.5" />
+      ) : (
+        t('records-found', { count: totalCount })
+      )}
+    </div>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/SimpleSearchFilterPopover.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/SimpleSearchFilterPopover.tsx
@@ -1,0 +1,53 @@
+import { IconSearch } from '@tabler/icons-react';
+import { Combobox, Command, Filter, useMultiQueryState } from 'erxes-ui';
+
+export const SimpleSearchFilterPopover = ({
+  extraQueryKeys = [],
+  extraItems,
+  extraViews,
+}: {
+  extraQueryKeys?: string[];
+  extraItems?: React.ReactNode;
+  extraViews?: React.ReactNode;
+} = {}) => {
+  const [queries] = useMultiQueryState<Record<string, unknown>>([
+    'searchValue',
+    ...extraQueryKeys,
+  ]);
+
+  const hasFilters = Object.values(queries || {}).some((value) =>
+    typeof value === 'string' ? value.trim().length > 0 : value != null,
+  );
+
+  return (
+    <>
+      <Filter.Popover>
+        <Filter.Trigger isFiltered={hasFilters} />
+        <Combobox.Content>
+          <Filter.View>
+            <Command>
+              <Filter.CommandInput
+                placeholder="Filter"
+                variant="secondary"
+                className="bg-background"
+              />
+              <Command.List className="p-1">
+                <Filter.Item value="searchValue" inDialog>
+                  <IconSearch />
+                  Search
+                </Filter.Item>
+                {extraItems}
+              </Command.List>
+            </Command>
+          </Filter.View>
+          {extraViews}
+        </Combobox.Content>
+      </Filter.Popover>
+      <Filter.Dialog>
+        <Filter.View filterKey="searchValue" inDialog>
+          <Filter.DialogStringView filterKey="searchValue" />
+        </Filter.View>
+      </Filter.Dialog>
+    </>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/shared/components/SimpleSearchFilterPopover.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/components/SimpleSearchFilterPopover.tsx
@@ -1,5 +1,6 @@
 import { IconSearch } from '@tabler/icons-react';
 import { Combobox, Command, Filter, useMultiQueryState } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
 
 export const SimpleSearchFilterPopover = ({
   extraQueryKeys = [],
@@ -10,6 +11,7 @@ export const SimpleSearchFilterPopover = ({
   extraItems?: React.ReactNode;
   extraViews?: React.ReactNode;
 } = {}) => {
+  const { t } = useTranslation('content');
   const [queries] = useMultiQueryState<Record<string, unknown>>([
     'searchValue',
     ...extraQueryKeys,
@@ -27,14 +29,14 @@ export const SimpleSearchFilterPopover = ({
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder="Filter"
+                placeholder={t('filter')}
                 variant="secondary"
                 className="bg-background"
               />
               <Command.List className="p-1">
                 <Filter.Item value="searchValue" inDialog>
                   <IconSearch />
-                  Search
+                  {t('search')}
                 </Filter.Item>
                 {extraItems}
               </Command.List>
@@ -47,6 +49,7 @@ export const SimpleSearchFilterPopover = ({
         <Filter.View filterKey="searchValue" inDialog>
           <Filter.DialogStringView filterKey="searchValue" />
         </Filter.View>
+        {extraViews}
       </Filter.Dialog>
     </>
   );

--- a/frontend/plugins/content_ui/src/modules/cms/tags/Tag.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/Tag.tsx
@@ -1,5 +1,5 @@
 import { IconPlus, IconTags } from '@tabler/icons-react';
-import { Button, Kbd, PageContainer } from 'erxes-ui';
+import { Button, Kbd, PageContainer, useFilterQueryState } from 'erxes-ui';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { CmsSidebar } from '../shared/CmsSidebar';
 import { EmptyState } from '../shared/EmptyState';
 import { HeaderLanguageTabs } from '../shared/HeaderLanguageTabs';
 import { TagsHeader } from './components/TagsHeader';
+import { TagsFilter } from './components/TagsFilter';
 import { TagsRecordTable } from './components/TagsRecordTable';
 import { useRemoveTag } from './hooks/useRemoveTag';
 import { TagDrawer } from './TagDrawer';
@@ -16,12 +17,14 @@ import { CmsTag } from './types/tagTypes';
 export function Tag() {
   const { t } = useTranslation('content');
   const { websiteId } = useParams();
+  const [searchValue] = useFilterQueryState<string>('searchValue');
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedTag, setSelectedTag] = useState<CmsTag | undefined>(undefined);
   const [refetchTrigger, setRefetchTrigger] = useState(0);
 
-  const { tags, totalCount, loading } = useTags({
+  const { tags, loading } = useTags({
     clientPortalId: websiteId || '',
+    searchValue: searchValue || undefined,
   });
   const { removeTag } = useRemoveTag();
 
@@ -63,10 +66,8 @@ export function Tag() {
       <div className="flex overflow-hidden flex-auto">
         <CmsSidebar />
         <div className="flex flex-col w-full overflow-hidden flex-auto">
-          <div className="flex pt-2 pl-4 justify-between items-center mb-2">
-            <div className="text-sm text-gray-600">
-              {t('found-x-tags', { count: totalCount })}
-            </div>
+          <div className="px-4 pt-2">
+            <TagsFilter />
           </div>
           {!loading && (!tags || tags.length === 0) ? (
             <div className="rounded-lg overflow-hidden">
@@ -84,6 +85,7 @@ export function Tag() {
                 <TagsRecordTable
                   key={refetchTrigger}
                   clientPortalId={websiteId || ''}
+                  searchValue={searchValue || undefined}
                   onEdit={handleEditTag}
                   onBulkDelete={handleBulkDelete}
                 />

--- a/frontend/plugins/content_ui/src/modules/cms/tags/Tag.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/Tag.tsx
@@ -71,13 +71,20 @@ export function Tag() {
           </div>
           {!loading && (!tags || tags.length === 0) ? (
             <div className="rounded-lg overflow-hidden">
-              <EmptyState
-                icon={IconTags}
-                title={t('no-tags-yet')}
-                description={t('no-tags-yet-desc')}
-                actionLabel={t('add-tag')}
-                onAction={handleAddTag}
-              />
+              {searchValue ? (
+                <EmptyState
+                  icon={IconTags}
+                  title={t('no-tags-found')}
+                />
+              ) : (
+                <EmptyState
+                  icon={IconTags}
+                  title={t('no-tags-yet')}
+                  description={t('no-tags-yet-desc')}
+                  actionLabel={t('add-tag')}
+                  onAction={handleAddTag}
+                />
+              )}
             </div>
           ) : (
             <div className="overflow-hidden flex-auto p-3">

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsFilter.tsx
@@ -1,0 +1,27 @@
+import { IconSearch } from '@tabler/icons-react';
+import { Filter, useFilterQueryState } from 'erxes-ui';
+import { TAGS_CURSOR_SESSION_KEY } from '../constants/tagsCursorSessionKey';
+import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
+import { TagsTotalCount } from './TagsTotalCount';
+
+export const TagsFilter = () => {
+  const [searchValue] = useFilterQueryState<string>('searchValue');
+
+  return (
+    <Filter id="tags-filter" sessionKey={TAGS_CURSOR_SESSION_KEY}>
+      <Filter.Bar>
+        <Filter.BarItem queryKey="searchValue">
+          <Filter.BarName>
+            <IconSearch />
+            Search
+          </Filter.BarName>
+          <Filter.BarButton filterKey="searchValue" inDialog>
+            {searchValue}
+          </Filter.BarButton>
+        </Filter.BarItem>
+        <SimpleSearchFilterPopover />
+        <TagsTotalCount />
+      </Filter.Bar>
+    </Filter>
+  );
+};

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsFilter.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsFilter.tsx
@@ -1,10 +1,12 @@
 import { IconSearch } from '@tabler/icons-react';
 import { Filter, useFilterQueryState } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
 import { TAGS_CURSOR_SESSION_KEY } from '../constants/tagsCursorSessionKey';
 import { SimpleSearchFilterPopover } from '~/modules/cms/shared/components/SimpleSearchFilterPopover';
 import { TagsTotalCount } from './TagsTotalCount';
 
 export const TagsFilter = () => {
+  const { t } = useTranslation('content');
   const [searchValue] = useFilterQueryState<string>('searchValue');
 
   return (
@@ -13,7 +15,7 @@ export const TagsFilter = () => {
         <Filter.BarItem queryKey="searchValue">
           <Filter.BarName>
             <IconSearch />
-            Search
+            {t('search')}
           </Filter.BarName>
           <Filter.BarButton filterKey="searchValue" inDialog>
             {searchValue}

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsRecordTable.tsx
@@ -3,20 +3,24 @@ import { useTagsColumns } from './TagsColumn';
 import { TagsCommandBar } from './tags-command-bar/TagsCommandBar';
 import { useTags } from '../../hooks/useTags';
 import { TAGS_CURSOR_SESSION_KEY } from '../constants/tagsCursorSessionKey';
+import { CmsTag } from '../types/tagTypes';
 
 interface TagsRecordTableProps {
   clientPortalId: string;
-  onEdit?: (tag: any) => void;
+  searchValue?: string;
+  onEdit?: (tag: CmsTag) => void;
   onBulkDelete?: (ids: string[]) => Promise<void> | void;
 }
 
 export const TagsRecordTable = ({
   clientPortalId,
+  searchValue,
   onEdit,
   onBulkDelete,
 }: TagsRecordTableProps) => {
   const { tags, loading, refetch, pageInfo, handleFetchMore } = useTags({
     clientPortalId,
+    searchValue,
   });
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
 

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsTotalCount.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsTotalCount.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue } from 'jotai';
 import { CmsRecordCount } from '~/modules/cms/shared/components/CmsRecordCount';
-import { postsTotalCountAtom } from '../states/postsCounts';
+import { tagsTotalCountAtom } from '../states/tagsCounts';
 
-export const PostsTotalCount = () => {
-  const totalCount = useAtomValue(postsTotalCountAtom);
+export const TagsTotalCount = () => {
+  const totalCount = useAtomValue(tagsTotalCountAtom);
   return <CmsRecordCount totalCount={totalCount} />;
 };

--- a/frontend/plugins/content_ui/src/modules/cms/tags/graphql/queries.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/graphql/queries.ts
@@ -29,6 +29,7 @@ export const CMS_TAGS = gql`
       aggregationPipeline: $aggregationPipeline
       sortDirection: $sortDirection
     ) {
+      totalCount
       tags {
         _id
         colorCode

--- a/frontend/plugins/content_ui/src/modules/cms/tags/states/tagsCounts.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/states/tagsCounts.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const tagsTotalCountAtom = atom<number | null>(null);


### PR DESCRIPTION
## Summary

- Add filter bars and filter popover to Posts, Pages, Tags, and Categories list views
- Add `SelectType` component for filtering posts by custom type
- Add `SimpleSearchFilterPopover` shared component to reduce filter duplication across CMS record tables
- Add `CmsRecordCount` shared component for consistent total count display
- Add per-entity total count atoms and components (PostsTotalCount, CategoriesTotalCount, PagesTotalCount, TagsTotalCount)
- Add `sessionKey` to cursor providers for correct pagination state persistence
- Improve `WebsiteDrawer` keyboard navigation (Tab order, focus management)
- Fix `useTags` to use typed query and expose `skip` option
- Fix date filter mutual exclusivity in PostsFilter (created/updated/publishedDate)

## Test plan

- [x] Posts list: filter by status, type, tags, categories, created/updated/publishedDate
- [x] Pages list: filter bar appears and filters work
- [x] Tags list: filter bar appears and filters work
- [x] Categories list: filter bar appears and filters work
- [x] WebsiteDrawer: Tab key correctly moves focus through language selector → default language → save → cancel
- [ ] Pagination session keys persist correctly when navigating between pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filter bars with search and popover/dialog selectors for CMS categories, pages, and tags, including “records found” count indicators.
  * Introduced shared search popover and reusable record count components.
  * Enhanced posts filtering with a dedicated type selector and improved date-filter selection behavior.
* **Bug Fixes**
  * Improved empty/loading states and kept list totals synchronized with active filters.
  * Refined website drawer keyboard navigation and focus handling.
  * Ensured tag loading happens only when the selector is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->