### PR TITLE
fix(mongolian): allow public access to msdProductsRemainder query

### DIFF
--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/queries/dynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/queries/dynamic.ts
@@ -204,3 +204,6 @@ export const msdynamicQueries = {
     }));
   },
 };
+(msdynamicQueries.msdProductsRemainder as any).wrapperConfig = {
+  skipPermission: true,
+};


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enable public access to the msdProductsRemainder query by skipping permission validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted access behavior for the product remainder query so it can return results without an unnecessary permission check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->