### PR TITLE
feat(accounting): add reserve remainders (Нөөц үлдэгдэл) UI

### DIFF
--- a/backend/plugins/accounting_api/src/modules/inventories/db/models/ReserveRems.ts
+++ b/backend/plugins/accounting_api/src/modules/inventories/db/models/ReserveRems.ts
@@ -9,7 +9,7 @@ export interface IReserveRemModel extends Model<IReserveRemDocument> {
   reserveRemAdd(doc: IReserveRem): Promise<IReserveRemDocument>;
   reserveRemEdit(
     _id: string,
-    doc: IReserveRem,
+    doc: Partial<IReserveRem>,
     user: IUserDocument,
   ): Promise<IReserveRemDocument>;
   reserveRemsRemove(_ids: string[]): Promise<JSON>;
@@ -31,7 +31,7 @@ export const loadReserveRemClass = (models: IModels, _subdomain: string) => {
 
     public static async reserveRemEdit(
       _id: string,
-      doc: IReserveRem,
+      doc: Partial<IReserveRem>,
       user: IUserDocument,
     ) {
       return await models.ReserveRems.updateOne(

--- a/backend/plugins/accounting_api/src/modules/inventories/graphql/resolvers/mutations/reserveRems.ts
+++ b/backend/plugins/accounting_api/src/modules/inventories/graphql/resolvers/mutations/reserveRems.ts
@@ -127,15 +127,9 @@ const reserveRemsMutations = {
     { models, user }: IContext,
   ) => {
     const { _id, ...params } = doc;
-    const reserveRem = await models.ReserveRems.getReserveRem({ _id });
-    return await models.ReserveRems.reserveRemEdit(
-      _id,
-      {
-        ...reserveRem,
-        ...params,
-      },
-      user,
-    );
+    await models.ReserveRems.getReserveRem({ _id });
+    await models.ReserveRems.reserveRemEdit(_id, params, user);
+    return await models.ReserveRems.findOne({ _id }).lean();
   },
 
   reserveRemsRemove: async (

--- a/backend/plugins/accounting_api/src/modules/inventories/graphql/schemas/reserveRems.ts
+++ b/backend/plugins/accounting_api/src/modules/inventories/graphql/schemas/reserveRems.ts
@@ -55,5 +55,5 @@ export const planCreateParams = `
 export const mutations = `
   reserveRemsAdd(${planCreateParams}): [ReserveRem]
   reserveRemsRemove(_ids: [String]): JSON
-  reserveRemEdit(_id: String!, remainder: Float): ReserveRem
+  reserveRemEdit(_id: String!, branchId: String, departmentId: String, productId: String, uom: String, remainder: Float): ReserveRem
 `;

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemColumns.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemColumns.tsx
@@ -1,0 +1,113 @@
+import {
+  IconBox,
+  IconBuildingWarehouse,
+  IconHierarchy2,
+  IconRuler2,
+  IconStack2,
+} from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+import {
+  NumberField,
+  RecordTable,
+  RecordTableInlineCell,
+  TextOverflowTooltip,
+} from 'erxes-ui';
+import { useReserveRemEdit } from '../hooks/useReserveRemEdit';
+import { IReserveRem } from '../types/ReserveRem';
+import { reserveRemMoreColumn } from './ReserveRemMoreColumn';
+
+const RemainderField = ({ reserveRem }: { reserveRem: IReserveRem }) => {
+  const { editReserveRem } = useReserveRemEdit();
+
+  return (
+    <NumberField
+      value={reserveRem.remainder ?? 0}
+      scope={`reserveRem-${reserveRem._id}-remainder`}
+      onSave={(value) => {
+        editReserveRem({
+          variables: { _id: reserveRem._id, remainder: value },
+        });
+      }}
+      className="shadow-none rounded-none px-2"
+    />
+  );
+};
+
+export const reserveRemColumns: ColumnDef<IReserveRem>[] = [
+  reserveRemMoreColumn,
+  RecordTable.checkboxColumn as ColumnDef<IReserveRem>,
+  {
+    id: 'product',
+    accessorKey: 'product',
+    header: () => <RecordTable.InlineHead icon={IconBox} label="Бараа" />,
+    cell: ({ row }) => {
+      const code = row.original.product?.code;
+      const name = row.original.product?.name;
+      const value = [code, name].filter(Boolean).join(' - ') || '';
+      return (
+        <RecordTableInlineCell>
+          <TextOverflowTooltip value={value} />
+        </RecordTableInlineCell>
+      );
+    },
+    size: 320,
+  },
+  {
+    id: 'branch',
+    accessorKey: 'branch',
+    header: () => (
+      <RecordTable.InlineHead icon={IconBuildingWarehouse} label="Салбар" />
+    ),
+    cell: ({ row }) => {
+      const code = row.original.branch?.code;
+      const title = row.original.branch?.title;
+      const value = [code, title].filter(Boolean).join(' - ') || '';
+      return (
+        <RecordTableInlineCell>
+          <TextOverflowTooltip value={value} />
+        </RecordTableInlineCell>
+      );
+    },
+    size: 240,
+  },
+  {
+    id: 'department',
+    accessorKey: 'department',
+    header: () => (
+      <RecordTable.InlineHead icon={IconHierarchy2} label="Хэлтэс" />
+    ),
+    cell: ({ row }) => {
+      const code = row.original.department?.code;
+      const title = row.original.department?.title;
+      const value = [code, title].filter(Boolean).join(' - ') || '';
+      return (
+        <RecordTableInlineCell>
+          <TextOverflowTooltip value={value} />
+        </RecordTableInlineCell>
+      );
+    },
+    size: 240,
+  },
+  {
+    id: 'uom',
+    accessorKey: 'uom',
+    header: () => (
+      <RecordTable.InlineHead icon={IconRuler2} label="Хэмжих нэгж" />
+    ),
+    cell: ({ getValue }) => (
+      <RecordTableInlineCell>
+        <TextOverflowTooltip value={(getValue() as string) ?? ''} />
+      </RecordTableInlineCell>
+    ),
+    size: 120,
+  },
+  {
+    id: 'remainder',
+    accessorKey: 'remainder',
+    header: () => (
+      <RecordTable.InlineHead icon={IconStack2} label="Нөөц үлдэгдэл" />
+    ),
+    cell: ({ row }) => <RemainderField reserveRem={row.original} />,
+    size: 160,
+  },
+];

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemFilters.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemFilters.tsx
@@ -1,0 +1,119 @@
+import { IconSearch } from '@tabler/icons-react';
+import { Combobox, Command, Filter, useMultiQueryState } from 'erxes-ui';
+import {
+  SelectBranches,
+  SelectCategory,
+  SelectDepartments,
+  SelectProduct,
+} from 'ui-modules';
+import { useTranslation } from 'react-i18next';
+import { useReserveRemQueryParams } from '../hooks/useReserveRems';
+
+const ReserveRemFilterPopover = () => {
+  const { t } = useTranslation('accounting');
+  const queryParams = useReserveRemQueryParams();
+  const hasFilters = Object.values(queryParams || {}).some(
+    (value) => value !== null && value !== undefined && value !== '',
+  );
+
+  return (
+    <>
+      <Filter.Popover scope="reserve-rems-filter">
+        <Filter.Trigger isFiltered={hasFilters} />
+        <Combobox.Content>
+          <Filter.View>
+            <Command>
+              <Filter.CommandInput
+                placeholder={t('filter')}
+                variant="secondary"
+                className="bg-background"
+              />
+              <Command.List className="p-1">
+                <Filter.Item value="searchValue" inDialog>
+                  <IconSearch />
+                  {t('search')}
+                </Filter.Item>
+                <SelectCategory.FilterItem
+                  value="categoryId"
+                  label={t('category')}
+                />
+                <SelectProduct.FilterItem
+                  value="productId"
+                  label={t('product')}
+                />
+                <SelectBranches.FilterItem value="branchId" label="Салбар" />
+                <SelectDepartments.FilterItem
+                  value="departmentId"
+                  label="Хэлтэс"
+                />
+              </Command.List>
+            </Command>
+          </Filter.View>
+          <SelectCategory.FilterView filterKey="categoryId" mode="single" />
+          <SelectProduct.FilterView filterKey="productId" mode="single" />
+          <SelectBranches.FilterView mode="single" filterKey="branchId" />
+          <SelectDepartments.FilterView
+            mode="single"
+            filterKey="departmentId"
+          />
+        </Combobox.Content>
+      </Filter.Popover>
+      <Filter.Dialog>
+        <Filter.View filterKey="searchValue" inDialog>
+          <Filter.DialogStringView filterKey="searchValue" />
+        </Filter.View>
+      </Filter.Dialog>
+    </>
+  );
+};
+
+export const ReserveRemFilter = ({
+  afterBar,
+}: {
+  afterBar?: React.ReactNode;
+}) => {
+  const { t } = useTranslation('accounting');
+  const [queries] = useMultiQueryState<{
+    searchValue: string;
+  }>(['searchValue']);
+
+  const { searchValue } = queries;
+
+  return (
+    <Filter id="reserve-rems-filter">
+      <Filter.Bar>
+        <Filter.BarItem queryKey="searchValue">
+          <Filter.BarName>
+            <IconSearch />
+            {t('search')}
+          </Filter.BarName>
+          <Filter.BarButton filterKey="searchValue" inDialog>
+            {searchValue}
+          </Filter.BarButton>
+        </Filter.BarItem>
+        <SelectCategory.FilterBar
+          filterKey="categoryId"
+          label={t('category')}
+          mode="single"
+        />
+        <SelectProduct.FilterBar
+          filterKey="productId"
+          label={t('product')}
+          mode="single"
+        />
+        <SelectBranches.FilterBar
+          label="Салбар"
+          filterKey="branchId"
+          mode="single"
+        />
+        <SelectDepartments.FilterBar
+          label="Хэлтэс"
+          filterKey="departmentId"
+          mode="single"
+        />
+        <ReserveRemFilterPopover />
+        {afterBar && <>{afterBar}</>}
+      </Filter.Bar>
+    </Filter>
+  );
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemForm.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemForm.tsx
@@ -1,0 +1,182 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { IconPlus } from '@tabler/icons-react';
+import { Button, Form, Input, ScrollArea, Sheet, Spinner } from 'erxes-ui';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import {
+  SelectBranches,
+  SelectCategory,
+  SelectDepartments,
+  SelectProduct,
+} from 'ui-modules';
+import { useReserveRemAdd } from '../hooks/useReserveRemAdd';
+import { reserveRemSchema, TReserveRemForm } from '../types/reserveRemForm';
+
+export const AddReserveRem = () => {
+  const { t } = useTranslation('accounting');
+  const [open, setOpen] = useState(false);
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <Sheet.Trigger asChild>
+        <Button>
+          <IconPlus />
+          {t('add-reserve-remainder')}
+        </Button>
+      </Sheet.Trigger>
+      <Sheet.View className="p-0 flex flex-col gap-0 transition-all duration-100 ease-out overflow-hidden flex-none">
+        <Sheet.Header className="flex-row gap-3 items-center p-3 space-y-0 border-b">
+          <Sheet.Title>{t('add-reserve-remainder')}</Sheet.Title>
+          <Sheet.Close />
+          <Sheet.Description className="sr-only">
+            {t('set-reserve-remainder-for-products')}
+          </Sheet.Description>
+        </Sheet.Header>
+        <Sheet.Content className="overflow-hidden flex-auto">
+          <ScrollArea className="h-full">
+            <AddReserveRemForm setOpen={setOpen} />
+          </ScrollArea>
+        </Sheet.Content>
+      </Sheet.View>
+    </Sheet>
+  );
+};
+
+const AddReserveRemForm = ({
+  setOpen,
+}: {
+  setOpen: (open: boolean) => void;
+}) => {
+  const { t } = useTranslation('accounting');
+  const form = useForm<TReserveRemForm>({
+    resolver: zodResolver(reserveRemSchema),
+    defaultValues: {
+      branchIds: [],
+      departmentIds: [],
+      remainder: 0,
+    },
+  });
+
+  const { addReserveRem, loading } = useReserveRemAdd();
+
+  const onSubmit = (data: TReserveRemForm) => {
+    addReserveRem({
+      variables: { ...data },
+      onCompleted: () => {
+        setOpen(false);
+        form.reset();
+      },
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex flex-col flex-auto overflow-auto"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
+        <div className="p-5 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <Form.Field
+              control={form.control}
+              name="branchIds"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t('branch')}</Form.Label>
+                  <SelectBranches.FormItem
+                    mode="multiple"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  />
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
+              name="departmentIds"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t('department')}</Form.Label>
+                  <SelectDepartments.FormItem
+                    mode="multiple"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  />
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
+          </div>
+
+          <Form.Field
+            control={form.control}
+            name="productCategoryId"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>{t('product-category')}</Form.Label>
+                <SelectCategory
+                  selected={field.value}
+                  onSelect={field.onChange}
+                />
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="productId"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>{t('product')}</Form.Label>
+                <SelectProduct.FormItem
+                  mode="single"
+                  value={field.value}
+                  onValueChange={field.onChange}
+                />
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="remainder"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>{t('reserve-remainder')}</Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    value={field.value ?? ''}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === ''
+                          ? undefined
+                          : Number(e.target.value),
+                      )
+                    }
+                  />
+                </Form.Control>
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+        </div>
+
+        <Sheet.Footer className="p-5 border-t bg-muted/30">
+          <Sheet.Close asChild>
+            <Button variant="outline" type="button" size="lg">
+              {t('cancel')}
+            </Button>
+          </Sheet.Close>
+          <Button type="submit" size="lg" disabled={loading}>
+            {loading && <Spinner />}
+            {t('save')}
+          </Button>
+        </Sheet.Footer>
+      </form>
+    </Form>
+  );
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemForm.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { IconPlus } from '@tabler/icons-react';
-import { Button, Form, Input, ScrollArea, Sheet, Spinner } from 'erxes-ui';
+import { Button, Form, Sheet } from 'erxes-ui';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -12,33 +12,31 @@ import {
 } from 'ui-modules';
 import { useReserveRemAdd } from '../hooks/useReserveRemAdd';
 import { reserveRemSchema, TReserveRemForm } from '../types/reserveRemForm';
+import {
+  RemainderFormField,
+  ReserveRemFormFooter,
+  ReserveRemSheet,
+} from './ReserveRemFormParts';
 
 export const AddReserveRem = () => {
   const { t } = useTranslation('accounting');
   const [open, setOpen] = useState(false);
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <Sheet.Trigger asChild>
-        <Button>
-          <IconPlus />
-          {t('add-reserve-remainder')}
-        </Button>
-      </Sheet.Trigger>
-      <Sheet.View className="p-0 flex flex-col gap-0 transition-all duration-100 ease-out overflow-hidden flex-none">
-        <Sheet.Header className="flex-row gap-3 items-center p-3 space-y-0 border-b">
-          <Sheet.Title>{t('add-reserve-remainder')}</Sheet.Title>
-          <Sheet.Close />
-          <Sheet.Description className="sr-only">
-            {t('set-reserve-remainder-for-products')}
-          </Sheet.Description>
-        </Sheet.Header>
-        <Sheet.Content className="overflow-hidden flex-auto">
-          <ScrollArea className="h-full">
-            <AddReserveRemForm setOpen={setOpen} />
-          </ScrollArea>
-        </Sheet.Content>
-      </Sheet.View>
-    </Sheet>
+    <ReserveRemSheet
+      open={open}
+      onOpenChange={setOpen}
+      title={t('add-reserve-remainder')}
+      trigger={
+        <Sheet.Trigger asChild>
+          <Button>
+            <IconPlus />
+            {t('add-reserve-remainder')}
+          </Button>
+        </Sheet.Trigger>
+      }
+    >
+      <AddReserveRemForm setOpen={setOpen} />
+    </ReserveRemSheet>
   );
 };
 
@@ -140,42 +138,10 @@ const AddReserveRemForm = ({
             )}
           />
 
-          <Form.Field
-            control={form.control}
-            name="remainder"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>{t('reserve-remainder')}</Form.Label>
-                <Form.Control>
-                  <Input
-                    type="number"
-                    value={field.value ?? ''}
-                    onChange={(e) =>
-                      field.onChange(
-                        e.target.value === ''
-                          ? undefined
-                          : Number(e.target.value),
-                      )
-                    }
-                  />
-                </Form.Control>
-                <Form.Message />
-              </Form.Item>
-            )}
-          />
+          <RemainderFormField control={form.control} />
         </div>
 
-        <Sheet.Footer className="p-5 border-t bg-muted/30">
-          <Sheet.Close asChild>
-            <Button variant="outline" type="button" size="lg">
-              {t('cancel')}
-            </Button>
-          </Sheet.Close>
-          <Button type="submit" size="lg" disabled={loading}>
-            {loading && <Spinner />}
-            {t('save')}
-          </Button>
-        </Sheet.Footer>
+        <ReserveRemFormFooter loading={loading} />
       </form>
     </Form>
   );

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemFormParts.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemFormParts.tsx
@@ -1,0 +1,80 @@
+import { Button, Form, Input, ScrollArea, Sheet, Spinner } from 'erxes-ui';
+import { ReactNode } from 'react';
+import { Control } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+export const ReserveRemSheet = ({
+  open,
+  onOpenChange,
+  title,
+  trigger,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  trigger?: ReactNode;
+  children: ReactNode;
+}) => (
+  <Sheet open={open} onOpenChange={onOpenChange}>
+    {trigger}
+    <Sheet.View className="p-0 flex flex-col gap-0 transition-all duration-100 ease-out overflow-hidden flex-none">
+      <Sheet.Header className="flex-row gap-3 items-center p-3 space-y-0 border-b">
+        <Sheet.Title>{title}</Sheet.Title>
+        <Sheet.Close />
+        <Sheet.Description className="sr-only">{title}</Sheet.Description>
+      </Sheet.Header>
+      <Sheet.Content className="overflow-hidden flex-auto">
+        <ScrollArea className="h-full">{children}</ScrollArea>
+      </Sheet.Content>
+    </Sheet.View>
+  </Sheet>
+);
+
+export const RemainderFormField = ({
+  control,
+}: {
+  control: Control<any>;
+}) => {
+  const { t } = useTranslation('accounting');
+  return (
+    <Form.Field
+      control={control}
+      name="remainder"
+      render={({ field }) => (
+        <Form.Item>
+          <Form.Label>{t('reserve-remainder')}</Form.Label>
+          <Form.Control>
+            <Input
+              type="number"
+              value={field.value ?? ''}
+              onChange={(e) =>
+                field.onChange(
+                  e.target.value === '' ? undefined : Number(e.target.value),
+                )
+              }
+            />
+          </Form.Control>
+          <Form.Message />
+        </Form.Item>
+      )}
+    />
+  );
+};
+
+export const ReserveRemFormFooter = ({ loading }: { loading: boolean }) => {
+  const { t } = useTranslation('accounting');
+  return (
+    <Sheet.Footer className="p-5 border-t bg-muted/30">
+      <Sheet.Close asChild>
+        <Button variant="outline" type="button" size="lg">
+          {t('cancel')}
+        </Button>
+      </Sheet.Close>
+      <Button type="submit" size="lg" disabled={loading}>
+        {loading && <Spinner />}
+        {t('save')}
+      </Button>
+    </Sheet.Footer>
+  );
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
@@ -4,6 +4,7 @@ import {
   Combobox,
   Command,
   Form,
+  Input,
   Popover,
   RecordTable,
   useConfirm,
@@ -11,6 +12,7 @@ import {
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { SelectBranches, SelectDepartments, SelectProduct } from 'ui-modules';
 import { useReserveRemEdit } from '../hooks/useReserveRemEdit';
 import { useReserveRemsRemove } from '../hooks/useReserveRemsRemove';
 import { IReserveRem } from '../types/ReserveRem';
@@ -73,7 +75,13 @@ const ReserveRemMoreColumnCell = ({
   );
 };
 
-type TEditForm = { remainder: number };
+type TEditForm = {
+  branchId?: string;
+  departmentId?: string;
+  productId?: string;
+  uom?: string;
+  remainder: number;
+};
 
 const EditReserveRemSheet = ({
   open,
@@ -87,18 +95,21 @@ const EditReserveRemSheet = ({
   const { t } = useTranslation('accounting');
   const { editReserveRem, loading } = useReserveRemEdit();
   const form = useForm<TEditForm>({
-    values: { remainder: reserveRem.remainder ?? 0 },
+    values: {
+      branchId: reserveRem.branchId,
+      departmentId: reserveRem.departmentId,
+      productId: reserveRem.productId,
+      uom: reserveRem.uom,
+      remainder: reserveRem.remainder ?? 0,
+    },
   });
 
   const onSubmit = (data: TEditForm) => {
     editReserveRem({
-      variables: { _id: reserveRem._id, remainder: data.remainder },
+      variables: { _id: reserveRem._id, ...data },
       onCompleted: () => setOpen(false),
     });
   };
-
-  const labelOf = (parts: (string | undefined)[]) =>
-    parts.filter(Boolean).join(' - ');
 
   return (
     <ReserveRemSheet
@@ -112,27 +123,66 @@ const EditReserveRemSheet = ({
           onSubmit={form.handleSubmit(onSubmit)}
         >
           <div className="p-5 space-y-4">
-            <ReadOnlyField
-              label={t('product')}
-              value={labelOf([reserveRem.product?.code, reserveRem.product?.name])}
+            <Form.Field
+              control={form.control}
+              name="productId"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t('product')}</Form.Label>
+                  <SelectProduct.FormItem
+                    mode="single"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  />
+                  <Form.Message />
+                </Form.Item>
+              )}
             />
             <div className="grid grid-cols-2 gap-4">
-              <ReadOnlyField
-                label={t('branch')}
-                value={labelOf([
-                  reserveRem.branch?.code,
-                  reserveRem.branch?.title,
-                ])}
+              <Form.Field
+                control={form.control}
+                name="branchId"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>{t('branch')}</Form.Label>
+                    <SelectBranches.FormItem
+                      mode="single"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
-              <ReadOnlyField
-                label={t('department')}
-                value={labelOf([
-                  reserveRem.department?.code,
-                  reserveRem.department?.title,
-                ])}
+              <Form.Field
+                control={form.control}
+                name="departmentId"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>{t('department')}</Form.Label>
+                    <SelectDepartments.FormItem
+                      mode="single"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                    <Form.Message />
+                  </Form.Item>
+                )}
               />
             </div>
-            <ReadOnlyField label={t('uom')} value={reserveRem.uom ?? ''} />
+            <Form.Field
+              control={form.control}
+              name="uom"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t('uom')}</Form.Label>
+                  <Form.Control>
+                    <Input {...field} value={field.value ?? ''} />
+                  </Form.Control>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
             <RemainderFormField control={form.control} />
           </div>
           <ReserveRemFormFooter loading={loading} />
@@ -141,19 +191,6 @@ const EditReserveRemSheet = ({
     </ReserveRemSheet>
   );
 };
-
-const ReadOnlyField = ({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) => (
-  <div className="space-y-1">
-    <p className="text-sm font-medium">{label}</p>
-    <p className="text-sm text-muted-foreground break-all">{value || '-'}</p>
-  </div>
-);
 
 export const reserveRemMoreColumn = {
   id: 'more',

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
@@ -1,16 +1,11 @@
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import {
-  Button,
   Combobox,
   Command,
   Form,
-  Input,
   Popover,
   RecordTable,
-  ScrollArea,
-  Sheet,
-  Spinner,
   useConfirm,
 } from 'erxes-ui';
 import { useState } from 'react';
@@ -19,6 +14,11 @@ import { useTranslation } from 'react-i18next';
 import { useReserveRemEdit } from '../hooks/useReserveRemEdit';
 import { useReserveRemsRemove } from '../hooks/useReserveRemsRemove';
 import { IReserveRem } from '../types/ReserveRem';
+import {
+  RemainderFormField,
+  ReserveRemFormFooter,
+  ReserveRemSheet,
+} from './ReserveRemFormParts';
 
 const ReserveRemMoreColumnCell = ({
   cell,
@@ -97,90 +97,48 @@ const EditReserveRemSheet = ({
     });
   };
 
-  const productLabel = [reserveRem.product?.code, reserveRem.product?.name]
-    .filter(Boolean)
-    .join(' - ');
-  const branchLabel = [reserveRem.branch?.code, reserveRem.branch?.title]
-    .filter(Boolean)
-    .join(' - ');
-  const departmentLabel = [
-    reserveRem.department?.code,
-    reserveRem.department?.title,
-  ]
-    .filter(Boolean)
-    .join(' - ');
+  const labelOf = (parts: (string | undefined)[]) =>
+    parts.filter(Boolean).join(' - ');
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <Sheet.View className="p-0 flex flex-col gap-0 transition-all duration-100 ease-out overflow-hidden flex-none">
-        <Sheet.Header className="flex-row gap-3 items-center p-3 space-y-0 border-b">
-          <Sheet.Title>{t('edit-reserve-remainder')}</Sheet.Title>
-          <Sheet.Close />
-          <Sheet.Description className="sr-only">
-            {t('edit-reserve-remainder')}
-          </Sheet.Description>
-        </Sheet.Header>
-        <Sheet.Content className="overflow-hidden flex-auto">
-          <ScrollArea className="h-full">
-            <Form {...form}>
-              <form
-                className="flex flex-col flex-auto overflow-auto"
-                onSubmit={form.handleSubmit(onSubmit)}
-              >
-                <div className="p-5 space-y-4">
-                  <ReadOnlyField label={t('product')} value={productLabel} />
-                  <div className="grid grid-cols-2 gap-4">
-                    <ReadOnlyField label={t('branch')} value={branchLabel} />
-                    <ReadOnlyField
-                      label={t('department')}
-                      value={departmentLabel}
-                    />
-                  </div>
-                  <ReadOnlyField
-                    label={t('uom')}
-                    value={reserveRem.uom ?? ''}
-                  />
-                  <Form.Field
-                    control={form.control}
-                    name="remainder"
-                    render={({ field }) => (
-                      <Form.Item>
-                        <Form.Label>{t('reserve-remainder')}</Form.Label>
-                        <Form.Control>
-                          <Input
-                            type="number"
-                            value={field.value ?? ''}
-                            onChange={(e) =>
-                              field.onChange(
-                                e.target.value === ''
-                                  ? 0
-                                  : Number(e.target.value),
-                              )
-                            }
-                          />
-                        </Form.Control>
-                        <Form.Message />
-                      </Form.Item>
-                    )}
-                  />
-                </div>
-                <Sheet.Footer className="p-5 border-t bg-muted/30">
-                  <Sheet.Close asChild>
-                    <Button variant="outline" type="button" size="lg">
-                      {t('cancel')}
-                    </Button>
-                  </Sheet.Close>
-                  <Button type="submit" size="lg" disabled={loading}>
-                    {loading && <Spinner />}
-                    {t('save')}
-                  </Button>
-                </Sheet.Footer>
-              </form>
-            </Form>
-          </ScrollArea>
-        </Sheet.Content>
-      </Sheet.View>
-    </Sheet>
+    <ReserveRemSheet
+      open={open}
+      onOpenChange={setOpen}
+      title={t('edit-reserve-remainder')}
+    >
+      <Form {...form}>
+        <form
+          className="flex flex-col flex-auto overflow-auto"
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+          <div className="p-5 space-y-4">
+            <ReadOnlyField
+              label={t('product')}
+              value={labelOf([reserveRem.product?.code, reserveRem.product?.name])}
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <ReadOnlyField
+                label={t('branch')}
+                value={labelOf([
+                  reserveRem.branch?.code,
+                  reserveRem.branch?.title,
+                ])}
+              />
+              <ReadOnlyField
+                label={t('department')}
+                value={labelOf([
+                  reserveRem.department?.code,
+                  reserveRem.department?.title,
+                ])}
+              />
+            </div>
+            <ReadOnlyField label={t('uom')} value={reserveRem.uom ?? ''} />
+            <RemainderFormField control={form.control} />
+          </div>
+          <ReserveRemFormFooter loading={loading} />
+        </form>
+      </Form>
+    </ReserveRemSheet>
   );
 };
 

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemMoreColumn.tsx
@@ -1,0 +1,204 @@
+import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { Cell } from '@tanstack/react-table';
+import {
+  Button,
+  Combobox,
+  Command,
+  Form,
+  Input,
+  Popover,
+  RecordTable,
+  ScrollArea,
+  Sheet,
+  Spinner,
+  useConfirm,
+} from 'erxes-ui';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useReserveRemEdit } from '../hooks/useReserveRemEdit';
+import { useReserveRemsRemove } from '../hooks/useReserveRemsRemove';
+import { IReserveRem } from '../types/ReserveRem';
+
+const ReserveRemMoreColumnCell = ({
+  cell,
+}: {
+  cell: Cell<IReserveRem, unknown>;
+}) => {
+  const { t } = useTranslation('accounting');
+  const { confirm } = useConfirm();
+  const { removeReserveRems } = useReserveRemsRemove();
+  const [editOpen, setEditOpen] = useState(false);
+
+  const reserveRem = cell.row.original;
+
+  const handleDelete = () =>
+    confirm({
+      message: t('are-you-sure'),
+      options: {
+        okLabel: t('delete'),
+        cancelLabel: t('cancel'),
+      },
+    }).then(() => {
+      removeReserveRems({
+        variables: { _ids: [reserveRem._id] },
+      });
+    });
+
+  return (
+    <>
+      <Popover>
+        <Popover.Trigger asChild>
+          <RecordTable.MoreButton className="w-full h-full" />
+        </Popover.Trigger>
+        <Combobox.Content>
+          <Command shouldFilter={false}>
+            <Command.List>
+              <Command.Item value="edit" onSelect={() => setEditOpen(true)}>
+                <IconEdit /> {t('edit')}
+              </Command.Item>
+              <Command.Item value="delete" onSelect={handleDelete}>
+                <IconTrash /> {t('delete')}
+              </Command.Item>
+            </Command.List>
+          </Command>
+        </Combobox.Content>
+      </Popover>
+      <EditReserveRemSheet
+        open={editOpen}
+        setOpen={setEditOpen}
+        reserveRem={reserveRem}
+      />
+    </>
+  );
+};
+
+type TEditForm = { remainder: number };
+
+const EditReserveRemSheet = ({
+  open,
+  setOpen,
+  reserveRem,
+}: {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  reserveRem: IReserveRem;
+}) => {
+  const { t } = useTranslation('accounting');
+  const { editReserveRem, loading } = useReserveRemEdit();
+  const form = useForm<TEditForm>({
+    values: { remainder: reserveRem.remainder ?? 0 },
+  });
+
+  const onSubmit = (data: TEditForm) => {
+    editReserveRem({
+      variables: { _id: reserveRem._id, remainder: data.remainder },
+      onCompleted: () => setOpen(false),
+    });
+  };
+
+  const productLabel = [reserveRem.product?.code, reserveRem.product?.name]
+    .filter(Boolean)
+    .join(' - ');
+  const branchLabel = [reserveRem.branch?.code, reserveRem.branch?.title]
+    .filter(Boolean)
+    .join(' - ');
+  const departmentLabel = [
+    reserveRem.department?.code,
+    reserveRem.department?.title,
+  ]
+    .filter(Boolean)
+    .join(' - ');
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <Sheet.View className="p-0 flex flex-col gap-0 transition-all duration-100 ease-out overflow-hidden flex-none">
+        <Sheet.Header className="flex-row gap-3 items-center p-3 space-y-0 border-b">
+          <Sheet.Title>{t('edit-reserve-remainder')}</Sheet.Title>
+          <Sheet.Close />
+          <Sheet.Description className="sr-only">
+            {t('edit-reserve-remainder')}
+          </Sheet.Description>
+        </Sheet.Header>
+        <Sheet.Content className="overflow-hidden flex-auto">
+          <ScrollArea className="h-full">
+            <Form {...form}>
+              <form
+                className="flex flex-col flex-auto overflow-auto"
+                onSubmit={form.handleSubmit(onSubmit)}
+              >
+                <div className="p-5 space-y-4">
+                  <ReadOnlyField label={t('product')} value={productLabel} />
+                  <div className="grid grid-cols-2 gap-4">
+                    <ReadOnlyField label={t('branch')} value={branchLabel} />
+                    <ReadOnlyField
+                      label={t('department')}
+                      value={departmentLabel}
+                    />
+                  </div>
+                  <ReadOnlyField
+                    label={t('uom')}
+                    value={reserveRem.uom ?? ''}
+                  />
+                  <Form.Field
+                    control={form.control}
+                    name="remainder"
+                    render={({ field }) => (
+                      <Form.Item>
+                        <Form.Label>{t('reserve-remainder')}</Form.Label>
+                        <Form.Control>
+                          <Input
+                            type="number"
+                            value={field.value ?? ''}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value === ''
+                                  ? 0
+                                  : Number(e.target.value),
+                              )
+                            }
+                          />
+                        </Form.Control>
+                        <Form.Message />
+                      </Form.Item>
+                    )}
+                  />
+                </div>
+                <Sheet.Footer className="p-5 border-t bg-muted/30">
+                  <Sheet.Close asChild>
+                    <Button variant="outline" type="button" size="lg">
+                      {t('cancel')}
+                    </Button>
+                  </Sheet.Close>
+                  <Button type="submit" size="lg" disabled={loading}>
+                    {loading && <Spinner />}
+                    {t('save')}
+                  </Button>
+                </Sheet.Footer>
+              </form>
+            </Form>
+          </ScrollArea>
+        </Sheet.Content>
+      </Sheet.View>
+    </Sheet>
+  );
+};
+
+const ReadOnlyField = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) => (
+  <div className="space-y-1">
+    <p className="text-sm font-medium">{label}</p>
+    <p className="text-sm text-muted-foreground break-all">{value || '-'}</p>
+  </div>
+);
+
+export const reserveRemMoreColumn = {
+  id: 'more',
+  cell: ReserveRemMoreColumnCell,
+  size: 33,
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemTable.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemTable.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import {
+  Button,
+  CommandBar,
+  RecordTable,
+  Separator,
+  Skeleton,
+  Table,
+  useConfirm,
+} from 'erxes-ui';
+import { IconTrash } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+import { useReserveRems } from '../hooks/useReserveRems';
+import { useReserveRemsRemove } from '../hooks/useReserveRemsRemove';
+import { reserveRemColumns } from './ReserveRemColumns';
+
+const ReserveRemInitialSkeleton = ({ rows = 20 }: { rows?: number }) => {
+  const rowKeys = useMemo(
+    () => Array.from({ length: rows }, (_, i) => `skeleton-row-${i}`),
+    [rows],
+  );
+  return (
+    <>
+      {rowKeys.map((rowKey) => (
+        <Table.Row key={rowKey} className="h-cell">
+          {reserveRemColumns.map((col, colIndex) => (
+            <Table.Cell
+              key={`${rowKey}-${col.id ?? colIndex}`}
+              className="border-r-0 px-2"
+            >
+              <Skeleton className="h-4 w-full min-w-4" />
+            </Table.Cell>
+          ))}
+        </Table.Row>
+      ))}
+    </>
+  );
+};
+
+export const ReserveRemTable = () => {
+  const { reserveRems, loading, totalCount, handleFetchMore } =
+    useReserveRems();
+
+  const isFetchingMore = loading && (reserveRems?.length ?? 0) > 0;
+  const isInitialLoading = loading && !isFetchingMore;
+
+  return (
+    <RecordTable.Provider
+      columns={reserveRemColumns}
+      data={isInitialLoading ? [] : reserveRems || []}
+      stickyColumns={['more', 'checkbox', 'product']}
+      className="m-3"
+    >
+      <RecordTable.Scroll>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.RowList />
+            {isInitialLoading && <ReserveRemInitialSkeleton rows={20} />}
+            {!isInitialLoading && totalCount > (reserveRems?.length ?? 0) && (
+              <RecordTable.RowSkeleton
+                rows={4}
+                handleInView={handleFetchMore}
+              />
+            )}
+          </RecordTable.Body>
+        </RecordTable>
+      </RecordTable.Scroll>
+      <ReserveRemCommandbar />
+    </RecordTable.Provider>
+  );
+};
+
+const ReserveRemCommandbar = () => {
+  const { t } = useTranslation('accounting');
+  const { table } = RecordTable.useRecordTable();
+  const { confirm } = useConfirm();
+  const { removeReserveRems, loading } = useReserveRemsRemove();
+  const selectedRows = table.getFilteredSelectedRowModel().rows;
+
+  const handleDelete = () =>
+    confirm({
+      message: t('are-you-sure'),
+      options: {
+        okLabel: t('delete'),
+        cancelLabel: t('cancel'),
+      },
+    }).then(() => {
+      removeReserveRems({
+        variables: {
+          _ids: selectedRows.map((row) => row.original._id),
+        },
+        onCompleted: () => {
+          table.setRowSelection({});
+        },
+      });
+    });
+
+  return (
+    <CommandBar open={selectedRows.length > 0}>
+      <CommandBar.Bar>
+        <CommandBar.Value onClose={() => table.setRowSelection({})}>
+          {selectedRows.length} {t('selected')}
+        </CommandBar.Value>
+        <Separator.Inline />
+        <Button variant="secondary" disabled={loading} onClick={handleDelete}>
+          <IconTrash />
+          {t('delete')}
+        </Button>
+      </CommandBar.Bar>
+    </CommandBar>
+  );
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemsTotalCount.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/components/ReserveRemsTotalCount.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from 'erxes-ui';
+import { useReserveRems } from '../hooks/useReserveRems';
+
+export const ReserveRemsTotalCount = () => {
+  const { totalCount, loading } = useReserveRems();
+
+  return (
+    <span className="text-sm text-muted-foreground">
+      {loading ? (
+        <Skeleton className="size-4" />
+      ) : (
+        `${totalCount ?? 0} records found`
+      )}
+    </span>
+  );
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemMutations.ts
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemMutations.ts
@@ -1,0 +1,36 @@
+import { gql } from '@apollo/client';
+import { reserveRemFields } from './reserveRemQueries';
+
+export const RESERVE_REMS_ADD = gql`
+  mutation ReserveRemsAdd(
+    $departmentIds: [String]
+    $branchIds: [String]
+    $productCategoryId: String
+    $productId: String
+    $remainder: Float
+  ) {
+    reserveRemsAdd(
+      departmentIds: $departmentIds
+      branchIds: $branchIds
+      productCategoryId: $productCategoryId
+      productId: $productId
+      remainder: $remainder
+    ) {
+      ${reserveRemFields}
+    }
+  }
+`;
+
+export const RESERVE_REM_EDIT = gql`
+  mutation ReserveRemEdit($_id: String!, $remainder: Float) {
+    reserveRemEdit(_id: $_id, remainder: $remainder) {
+      ${reserveRemFields}
+    }
+  }
+`;
+
+export const RESERVE_REMS_REMOVE = gql`
+  mutation ReserveRemsRemove($_ids: [String]) {
+    reserveRemsRemove(_ids: $_ids)
+  }
+`;

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemMutations.ts
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemMutations.ts
@@ -22,8 +22,22 @@ export const RESERVE_REMS_ADD = gql`
 `;
 
 export const RESERVE_REM_EDIT = gql`
-  mutation ReserveRemEdit($_id: String!, $remainder: Float) {
-    reserveRemEdit(_id: $_id, remainder: $remainder) {
+  mutation ReserveRemEdit(
+    $_id: String!
+    $branchId: String
+    $departmentId: String
+    $productId: String
+    $uom: String
+    $remainder: Float
+  ) {
+    reserveRemEdit(
+      _id: $_id
+      branchId: $branchId
+      departmentId: $departmentId
+      productId: $productId
+      uom: $uom
+      remainder: $remainder
+    ) {
       ${reserveRemFields}
     }
   }

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemQueries.ts
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/graphql/reserveRemQueries.ts
@@ -1,0 +1,74 @@
+import { gql } from '@apollo/client';
+
+export const reserveRemFields = `
+  _id
+  branchId
+  departmentId
+  productId
+  uom
+  remainder
+  createdAt
+  modifiedAt
+
+  product {
+    _id
+    code
+    name
+  }
+  branch {
+    _id
+    code
+    title
+  }
+  department {
+    _id
+    code
+    title
+  }
+  modifiedUser {
+    _id
+    details {
+      avatar
+      fullName
+    }
+  }
+`;
+
+const reserveRemFilterParamDefs = `
+  $searchValue: String
+  $branchId: String
+  $departmentId: String
+  $productId: String
+  $productCategoryId: String
+`;
+
+const reserveRemFilterParams = `
+  searchValue: $searchValue
+  branchId: $branchId
+  departmentId: $departmentId
+  productId: $productId
+  productCategoryId: $productCategoryId
+`;
+
+const commonParamDefs = `
+  $page: Int
+  $perPage: Int
+  $sortField: String
+  $sortDirection: Int
+`;
+
+const commonParams = `
+  page: $page
+  perPage: $perPage
+  sortField: $sortField
+  sortDirection: $sortDirection
+`;
+
+export const RESERVE_REMS_QUERY = gql`
+  query ReserveRems(${reserveRemFilterParamDefs}, ${commonParamDefs}) {
+    reserveRems(${reserveRemFilterParams}, ${commonParams}) {
+      ${reserveRemFields}
+    }
+    reserveRemsCount(${reserveRemFilterParams})
+  }
+`;

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemAdd.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemAdd.tsx
@@ -1,0 +1,36 @@
+import { OperationVariables, useMutation } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import { RESERVE_REMS_ADD } from '../graphql/reserveRemMutations';
+
+export const useReserveRemAdd = (options?: OperationVariables) => {
+  const { t } = useTranslation('accounting');
+  const [_addReserveRem, { loading }] = useMutation(RESERVE_REMS_ADD, options);
+
+  const addReserveRem = (options?: OperationVariables) => {
+    return _addReserveRem({
+      ...options,
+      onError: (error: Error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+        options?.onError?.(error);
+      },
+      onCompleted: (data) => {
+        toast({
+          title: t('success'),
+          description: t('reserve-remainder-created'),
+        });
+        options?.onCompleted?.(data);
+      },
+      refetchQueries: ['ReserveRems'],
+    });
+  };
+
+  return {
+    addReserveRem,
+    loading,
+  };
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemEdit.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemEdit.tsx
@@ -1,0 +1,35 @@
+import { OperationVariables, useMutation } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import { RESERVE_REM_EDIT } from '../graphql/reserveRemMutations';
+
+export const useReserveRemEdit = () => {
+  const { t } = useTranslation('accounting');
+  const [_editReserveRem, { loading }] = useMutation(RESERVE_REM_EDIT);
+
+  const editReserveRem = (options: OperationVariables) => {
+    return _editReserveRem({
+      ...options,
+      onError: (error: Error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+        options?.onError?.(error);
+      },
+      onCompleted: (data) => {
+        toast({
+          title: t('success'),
+          description: t('reserve-remainder-updated'),
+        });
+        options?.onCompleted?.(data);
+      },
+    });
+  };
+
+  return {
+    editReserveRem,
+    loading,
+  };
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemEdit.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemEdit.tsx
@@ -25,6 +25,7 @@ export const useReserveRemEdit = () => {
         });
         options?.onCompleted?.(data);
       },
+      refetchQueries: ['ReserveRems'],
     });
   };
 

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRems.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRems.tsx
@@ -1,0 +1,93 @@
+import { OperationVariables, useQuery } from '@apollo/client';
+import { useMultiQueryState } from 'erxes-ui';
+import { ACC_TRS__PER_PAGE } from '../../../transactions/types/constants';
+import { RESERVE_REMS_QUERY } from '../graphql/reserveRemQueries';
+import { IReserveRem } from '../types/ReserveRem';
+
+type ReserveRemQueryParams = {
+  searchValue: string;
+  branchId: string;
+  departmentId: string;
+  productId: string;
+  categoryId: string;
+};
+
+const RESERVE_REM_FILTER_KEYS: (keyof ReserveRemQueryParams)[] = [
+  'searchValue',
+  'branchId',
+  'departmentId',
+  'productId',
+  'categoryId',
+];
+
+export const useReserveRemQueryParams = () => {
+  const [queryParams] =
+    useMultiQueryState<ReserveRemQueryParams>(RESERVE_REM_FILTER_KEYS);
+  return queryParams;
+};
+
+export const useReserveRemVariables = () => {
+  const queryParams = useReserveRemQueryParams() || {};
+  const variables: Record<string, any> = {};
+
+  if (queryParams.searchValue) variables.searchValue = queryParams.searchValue;
+  if (queryParams.branchId) variables.branchId = queryParams.branchId;
+  if (queryParams.departmentId)
+    variables.departmentId = queryParams.departmentId;
+  if (queryParams.productId) variables.productId = queryParams.productId;
+  if (queryParams.categoryId)
+    variables.productCategoryId = queryParams.categoryId;
+
+  return variables;
+};
+
+export const useReserveRems = (options?: OperationVariables) => {
+  const filterVariables = useReserveRemVariables();
+
+  const { data, loading, error, fetchMore } = useQuery<{
+    reserveRems: IReserveRem[];
+    reserveRemsCount: number;
+  }>(RESERVE_REMS_QUERY, {
+    ...options,
+    variables: {
+      page: 1,
+      perPage: ACC_TRS__PER_PAGE,
+      ...filterVariables,
+      ...options?.variables,
+    },
+  });
+
+  const reserveRems = data?.reserveRems;
+  const totalCount = data?.reserveRemsCount ?? 0;
+
+  const handleFetchMore = () => {
+    if ((reserveRems?.length ?? 0) < totalCount) {
+      fetchMore({
+        variables: {
+          ...filterVariables,
+          ...options?.variables,
+          perPage: ACC_TRS__PER_PAGE,
+          page: Math.ceil((reserveRems?.length ?? 0) / ACC_TRS__PER_PAGE) + 1,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return {
+            ...fetchMoreResult,
+            reserveRems: [
+              ...(prev.reserveRems ?? []),
+              ...(fetchMoreResult.reserveRems ?? []),
+            ],
+          };
+        },
+      });
+    }
+  };
+
+  return {
+    reserveRems,
+    totalCount,
+    loading,
+    error,
+    handleFetchMore,
+  };
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemsRemove.tsx
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/hooks/useReserveRemsRemove.tsx
@@ -1,0 +1,36 @@
+import { OperationVariables, useMutation } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import { RESERVE_REMS_REMOVE } from '../graphql/reserveRemMutations';
+
+export const useReserveRemsRemove = () => {
+  const { t } = useTranslation('accounting');
+  const [_removeReserveRems, { loading }] = useMutation(RESERVE_REMS_REMOVE);
+
+  const removeReserveRems = (options: OperationVariables) => {
+    return _removeReserveRems({
+      ...options,
+      onError: (error: Error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+        options?.onError?.(error);
+      },
+      onCompleted: (data) => {
+        toast({
+          title: t('success'),
+          description: t('reserve-remainder-deleted'),
+        });
+        options?.onCompleted?.(data);
+      },
+      refetchQueries: ['ReserveRems'],
+    });
+  };
+
+  return {
+    removeReserveRems,
+    loading,
+  };
+};

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/types/ReserveRem.ts
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/types/ReserveRem.ts
@@ -1,0 +1,33 @@
+export interface IReserveRem {
+  _id: string;
+  branchId?: string;
+  departmentId?: string;
+  productId?: string;
+  uom?: string;
+  remainder?: number;
+  createdAt?: Date;
+  modifiedAt?: Date;
+
+  product?: {
+    _id: string;
+    code: string;
+    name: string;
+  };
+  branch?: {
+    _id: string;
+    code: string;
+    title: string;
+  };
+  department?: {
+    _id: string;
+    code: string;
+    title: string;
+  };
+  modifiedUser?: {
+    _id: string;
+    details?: {
+      avatar?: string;
+      fullName?: string;
+    };
+  };
+}

--- a/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/types/reserveRemForm.ts
+++ b/frontend/plugins/accounting_ui/src/modules/inventories/reserveRemainders/types/reserveRemForm.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const reserveRemSchema = z
+  .object({
+    branchIds: z.array(z.string()).optional(),
+    departmentIds: z.array(z.string()).optional(),
+    productCategoryId: z.string().optional(),
+    productId: z.string().optional(),
+    remainder: z.number({ invalid_type_error: 'Remainder is required' }),
+  })
+  .refine((data) => !!data.productCategoryId || !!data.productId, {
+    message: 'Must fill product category or product',
+    path: ['productCategoryId'],
+  });
+
+export type TReserveRemForm = z.infer<typeof reserveRemSchema>;

--- a/frontend/plugins/accounting_ui/src/pages/inventories/ReserveRemaindersPage.tsx
+++ b/frontend/plugins/accounting_ui/src/pages/inventories/ReserveRemaindersPage.tsx
@@ -1,5 +1,25 @@
-import { AdjustmentHome } from '~/modules/adjustments/components/Home';
+import { PageSubHeader } from 'erxes-ui';
+import { ReserveRemFilter } from '~/modules/inventories/reserveRemainders/components/ReserveRemFilters';
+import { AddReserveRem } from '~/modules/inventories/reserveRemainders/components/ReserveRemForm';
+import { ReserveRemTable } from '~/modules/inventories/reserveRemainders/components/ReserveRemTable';
+import { ReserveRemsTotalCount } from '~/modules/inventories/reserveRemainders/components/ReserveRemsTotalCount';
+import { AccountingHeader } from '~/modules/layout/components/Header';
+import { AccountingLayout } from '~/modules/layout/components/Layout';
 
 export const ReserveRemaindersPage = () => {
-  return <AdjustmentHome />;
+  return (
+    <AccountingLayout>
+      <AccountingHeader
+        returnLink="/accounting/inventories/reserve-remainders"
+        returnText="Reserve Remainders"
+        skipSettings={true}
+      >
+        <AddReserveRem />
+      </AccountingHeader>
+      <PageSubHeader>
+        <ReserveRemFilter afterBar={<ReserveRemsTotalCount />} />
+      </PageSubHeader>
+      <ReserveRemTable />
+    </AccountingLayout>
+  );
 };


### PR DESCRIPTION
Build the reserve-remainders inventory page on top of the existing reserveRems backend (queries: reserveRems/reserveRemsCount; mutations: reserveRemsAdd/reserveRemEdit/reserveRemsRemove).

- Flat RecordTable list with page-based pagination, search/branch/ department/category/product filters, total count.
- Inline-editable remainder cell (NumberField).
- Add form as a slide-in Sheet (multi branches/departments, category or product, remainder).
- Per-row "more" action column (before checkbox) with edit (remainder via Sheet) and delete (single-row, confirm).
- CommandBar bulk delete for selected rows.
- Replace the ReserveRemaindersPage placeholder with the real page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reserve remainders workspace with search, category/product/branch/department filters, live record count, and an incrementally loading table.
  * Added an “Add reserve remainder” slide-over form and a dedicated row action menu for editing and deleting.
  * Enabled inline remainder editing and multi-row selection with bulk delete.
* **Bug Fixes**
  * Improved remainder edit/update behavior by validating and returning the updated record after edits.
  * Strengthened form validation to prevent invalid remainder submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->