### PR TITLE
fix(logs): make revert preview a read-only query so it stops self-logging

### DIFF
--- a/backend/core-api/src/modules/logs/AGENTS.md
+++ b/backend/core-api/src/modules/logs/AGENTS.md
@@ -70,6 +70,12 @@ recoverable — but it's auth-agnostic (agent and human run under the same user)
 4. **Revert** — `logsRevertProcess(processId, dryRun, force, skipConflicts,
 resolutions)` → `revert/revertByProcessId.ts` reverse-replays the process's
    entries (dedup → authorize → plan → conflicts → dry-run/apply → marker).
+   **Preview is a separate `logsRevertPreview(processId)` QUERY** that runs the
+   same engine with `dryRun:true`. It exists because every mutation is
+   audit-logged: running the on-open silent dry-run through the mutation spawned a
+   phantom `logsRevertProcess` log on every log view (looked like the revert
+   "fired by itself"). Queries are not journaled, so the preview leaves no trail;
+   only the actual apply (the mutation) is recorded.
 
 ### Always on
 
@@ -141,10 +147,12 @@ is still honored when present.
   for Mongo data-change logs AND the GraphQL mutation log of the same request;
   excludes the `logsRevertProcess` log). Plain-language for non-technical users
   (no "revert/field/processId" jargon; field names humanized, values formatted,
-  IDs shown only as a quiet reference). On open it **silently dry-runs** to detect
-  an already-undone action and shows an "Already undone" notice instead of the
-  button. Otherwise: one-click "Undo this change" → dry-run preview → confirm, or
-  the `RevertConflictResolver` when a record was edited in the meantime.
+  IDs shown only as a quiet reference). On open it **silently dry-runs** (via the
+  read-only `logsRevertPreview` query — NOT the mutation, so it is not
+  audit-logged) to detect an already-undone action and shows an "Already undone"
+  notice instead of the button. Otherwise: one-click "Undo this change" → dry-run
+  preview → confirm, or the `RevertConflictResolver` when a record was edited in
+  the meantime.
 - `components/RevertConflictResolver.tsx` — the merge UI (erxes-ui `ToggleGroup`).
   Calm amber "warning" tone (not destructive red). Per changed field: a segmented
   Restore-previous / Keep-current toggle + a `Previous → Current` comparison where
@@ -153,8 +161,10 @@ is still honored when present.
   entity Badge + short id when more than one conflicts.
 - `utils/revertFormat.ts` — pure plain-language formatters shared by both
   (`formatValue`, `entityNoun`, `humanizeField`, `shortId`, `kindInfo`, `conflictKey`).
-- `hooks/useRevertProcess.tsx` (`preview`/`apply`) · `graphql/revertMutations.ts`
-  (`LOGS_REVERT_PROCESS`) · `components/LogDetailView.tsx` (renders the panel) ·
+- `hooks/useRevertProcess.tsx` (`preview` = `logsRevertPreview` query / `apply` =
+  `logsRevertProcess` mutation) · `graphql/revertMutations.ts`
+  (`LOGS_REVERT_PROCESS`) · `graphql/revertQueries.ts` (`LOGS_REVERT_PREVIEW`) ·
+  `components/LogDetailView.tsx` (renders the panel) ·
   `components/LogDetailPrimitives.tsx` (JSON viewer made dark-theme-readable).
 
 ---

--- a/backend/core-api/src/modules/logs/graphql/resolvers/queries.ts
+++ b/backend/core-api/src/modules/logs/graphql/resolvers/queries.ts
@@ -3,6 +3,7 @@ import { ILogDocument } from 'erxes-api-shared/core-types';
 import { cursorPaginate, getPlugin, getPlugins } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import { sanitizeLogValue } from '../../sanitize';
+import { revertByProcessId } from '../../revert/revertByProcessId';
 
 const operatorMap = {
   ne: '$ne',
@@ -263,6 +264,26 @@ export const logQueries = {
       totalCount,
       pageInfo,
     };
+  },
+
+  /**
+   * Read-only preview of a point-in-time revert (what "Undo this change" would
+   * restore, plus conflicts / unrevertables / alreadyReverted). Deliberately a
+   * QUERY, not the `logsRevertProcess` mutation: the log-detail panel dry-runs
+   * this silently on open to detect an already-undone action, and every mutation
+   * is audit-logged — so running the preview as a mutation spawned a phantom
+   * `logsRevertProcess` log on every log view (looking like the revert "fired by
+   * itself"). Queries are not journaled, so the preview leaves no audit trail;
+   * only the actual apply (the mutation) is recorded.
+   */
+  async logsRevertPreview(
+    _root: unknown,
+    { processId }: { processId: string },
+    context: IContext,
+  ) {
+    await requireLogsReadAccess(context.checkPermission);
+
+    return await revertByProcessId(context, { processId, dryRun: true });
   },
 
   async logDetail(

--- a/backend/core-api/src/modules/logs/graphql/schema/index.ts
+++ b/backend/core-api/src/modules/logs/graphql/schema/index.ts
@@ -139,6 +139,7 @@ export const queries = `
     logsMainList(${commonQueryParams}):MainLogsList
     logsGetContentTypes: [LogContentType!]!
     logDetail(_id:String!):Log
+    logsRevertPreview(processId: String!): LogRevertResult
 `;
 
 export const mutations = `

--- a/frontend/core-ui/src/modules/logs/graphql/revertQueries.ts
+++ b/frontend/core-ui/src/modules/logs/graphql/revertQueries.ts
@@ -1,0 +1,39 @@
+import { gql } from '@apollo/client';
+
+/**
+ * Read-only preview of a point-in-time revert. Returns the same shape as the
+ * `logsRevertProcess` mutation (what would be restored, conflicts, unrevertable,
+ * alreadyReverted) WITHOUT mutating or being audit-logged — so the log-detail
+ * panel can silently dry-run it on open without spawning a phantom
+ * `logsRevertProcess` log entry. The apply step still uses the mutation.
+ */
+export const LOGS_REVERT_PREVIEW = gql`
+  query LogsRevertPreview($processId: String!) {
+    logsRevertPreview(processId: $processId) {
+      processId
+      dryRun
+      alreadyReverted
+      reverted {
+        contentType
+        docId
+        kind
+      }
+      conflicts {
+        contentType
+        docId
+        mongooseName
+        fields {
+          field
+          revertValue
+          currentValue
+        }
+      }
+      unrevertable {
+        contentType
+        docId
+        action
+        reason
+      }
+    }
+  }
+`;

--- a/frontend/core-ui/src/modules/logs/hooks/useRevertProcess.tsx
+++ b/frontend/core-ui/src/modules/logs/hooks/useRevertProcess.tsx
@@ -1,5 +1,6 @@
-import { useMutation } from '@apollo/client';
+import { useLazyQuery, useMutation } from '@apollo/client';
 import { LOGS_REVERT_PROCESS } from '@/logs/graphql/revertMutations';
+import { LOGS_REVERT_PREVIEW } from '@/logs/graphql/revertQueries';
 
 export interface IRevertField {
   field: string;
@@ -48,26 +49,40 @@ export interface IDocResolution {
   fields: IFieldResolution[];
 }
 
-/** Hook exposing `preview`/`apply` for the point-in-time revert mutation. */
+/** Hook exposing `preview`/`apply` for the point-in-time revert. */
 export const useRevertProcess = () => {
-  const [run, { loading }] = useMutation(LOGS_REVERT_PROCESS);
+  // Preview is a read-only QUERY (not audit-logged), so the panel's silent
+  // on-open dry-run never spawns a phantom `logsRevertProcess` log. Only `apply`
+  // uses the mutation, which is correctly recorded as a real change.
+  const [runPreview, { loading: previewLoading }] = useLazyQuery(
+    LOGS_REVERT_PREVIEW,
+    { fetchPolicy: 'network-only' },
+  );
+  const [runApply, { loading: applyLoading }] = useMutation(
+    LOGS_REVERT_PROCESS,
+  );
 
-  /** Run the revert mutation and return its typed result. */
-  const call = async (variables: {
-    processId: string;
-    dryRun?: boolean;
-    resolutions?: IDocResolution[];
-  }): Promise<IRevertResult> => {
-    const { data } = await run({ variables });
+  /** Preview the plan without writing anything (read-only, un-logged). */
+  const preview = async (processId: string): Promise<IRevertResult> => {
+    // useLazyQuery resolves (not rejects) with `.error` on failure; re-throw so
+    // callers' try/catch and error toasts keep the mutation's throw semantics.
+    const { data, error } = await runPreview({ variables: { processId } });
+    if (error) {
+      throw error;
+    }
+    return data.logsRevertPreview as IRevertResult;
+  };
+
+  /** Apply the revert, optionally with per-field merge resolutions. */
+  const apply = async (
+    processId: string,
+    resolutions?: IDocResolution[],
+  ): Promise<IRevertResult> => {
+    const { data } = await runApply({
+      variables: { processId, dryRun: false, resolutions },
+    });
     return data.logsRevertProcess as IRevertResult;
   };
 
-  /** Preview the plan without writing anything. */
-  const preview = (processId: string) => call({ processId, dryRun: true });
-
-  /** Apply the revert, optionally with per-field merge resolutions. */
-  const apply = (processId: string, resolutions?: IDocResolution[]) =>
-    call({ processId, dryRun: false, resolutions });
-
-  return { preview, apply, loading };
+  return { preview, apply, loading: previewLoading || applyLoading };
 };


### PR DESCRIPTION
## Problem

On the **System Logs → log detail** page, the *"Undo this change"* panel
(`LogRevertPanel`) silently **dry-runs on open** to detect whether a change was
already undone (so it can show an "Already undone" notice up front). That silent
dry-run went through the **`logsRevertProcess` mutation**.

But **every GraphQL mutation is audit-logged** (`withLogging` in
`erxes-api-shared/.../apollo/wrapperResolvers.ts` writes a `Logs` row with
`source:'graphql', action:'mutation', payload.mutationName`). So:

1. You open a revertable log's detail.
2. `LogRevertPanel`'s `useEffect` fires `logsRevertProcess(dryRun:true)` — no click.
3. That mutation is audited → a **brand-new `logsRevertProcess` log row** appears.
4. It shows up in the logs list → looks like the revert **"fired by itself"**, and
   the audit trail fills with phantom preview entries.

No data was ever mutated (it's `dryRun`), but the log spam and the "automatic
firing" perception are real. This is exactly the `logsRevertProcess`
`dryRun:true` entries observed in production.

> The product `status:'deleted'` churn seen alongside this is **unrelated** — that
> is the normal `removeProducts` soft-delete (`updateMany $set status:deleted`,
> double-logged by the manual `sendDbEventLog` + the change-stream auto-capture).
> The revert preview only *reads* those logs; it does not delete anything.

## Fix

A read-only preview should be a **query**, not a mutation. Queries bypass the
mutation audit wrapper entirely (only the `Mutation` root is wrapped by
`withLogging`), so the preview leaves no audit trail — while the actual apply
stays a mutation and is correctly recorded.

- **Backend:** new `logsRevertPreview(processId): LogRevertResult` query that runs
  the same engine (`revertByProcessId(context, { processId, dryRun: true })`),
  gated by `logsRead` like the sibling log queries.
- **Frontend:** `useRevertProcess` now previews via the query (`useLazyQuery`,
  `network-only`) and applies via the existing `logsRevertProcess` mutation. The
  lazy query resolves (not rejects) with `.error`, so it's re-thrown to preserve
  the previous try/catch + error-toast semantics. Public hook shape
  (`{ preview, apply, loading }`) is unchanged, so `LogRevertPanel` needs no edits.
- Docs (`modules/logs/AGENTS.md`) updated to describe the query-based preview.

## Testing

- `tsc --noEmit` on **core-api** (from source): **0 errors in touched files**
  (only an unrelated pre-existing missing-dep in `documents/barcode.ts`).
- `tsc --noEmit` on **core-ui**: **0 errors in touched files**
  (`useRevertProcess.tsx`, `revertQueries.ts`). The 3 `LogRevertPanel.tsx`
  `processId: string | undefined` errors are **pre-existing on `main`** (verified
  by re-checking with the unmodified files) and out of scope.

No new tests added (the revert engine has no wired jest target on `main`, and the
change is a read/write split with no new logic to mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split log revert preview into a read-only GraphQL query to avoid self-logging while keeping the actual revert as a mutation.

New Features:
- Add a logsRevertPreview GraphQL query and corresponding frontend query for read-only revert previews that mirror the existing mutation result shape.

Enhancements:
- Update the useRevertProcess hook to use the new query for previews and the existing mutation only for applying reverts, preserving the public hook API.
- Document the query-based revert preview behavior and wiring in the logs module agent documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only revert preview for log entries, letting users review the outcome before confirming changes.
  * The undo flow now shows conflicts, unrevertable items, and already-reverted status more clearly.

* **Bug Fixes**
  * Previewing a revert no longer creates a change record, avoiding duplicate or phantom revert entries.
  * Loading state now reflects both preview and apply actions for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->