### PR TITLE
feat(frontline): filter cpTicketGetNotes by current ticket status

### DIFF
--- a/backend/plugins/frontline_api/src/modules/ticket/@types/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/@types/note.ts
@@ -5,6 +5,7 @@ export interface INote {
   contentId: string;
   createdBy: string;
   mentions?: string[];
+  statusId?: string;
 }
 
 export interface INoteDocument extends INote, Document {

--- a/backend/plugins/frontline_api/src/modules/ticket/db/definitions/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/definitions/note.ts
@@ -6,6 +6,7 @@ export const noteSchema = new Schema(
     contentId: { type: String, required: true },
     createdBy: { type: String, required: true },
     mentions: { type: [String], default: [] },
+    statusId: { type: String },
   },
   {
     timestamps: true,

--- a/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
@@ -53,6 +53,16 @@ export const loadNoteClass = (models: IModels) => {
       subdomain: string;
       userId: string;
     }): Promise<INoteDocument> {
+      if (doc.contentId && !doc.statusId) {
+        const ticket = await models.Ticket.findOne(
+          { _id: doc.contentId },
+          { statusId: 1 },
+        ).lean();
+        if (ticket?.statusId) {
+          doc.statusId = ticket.statusId;
+        }
+      }
+
       const note = await models.Note.create(doc);
 
       await models.Activity.createActivity({

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/clientPortal.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/clientPortal.ts
@@ -56,7 +56,18 @@ export const cpTicketQueries = {
     { ticketId }: { ticketId: string },
     { models }: IContext,
   ) => {
-    return models.Note.find({ contentId: ticketId }).sort({ createdAt: -1 }).lean();
+    const ticket = await models.Ticket.findOne(
+      { _id: ticketId },
+      { statusId: 1 },
+    ).lean();
+
+    const filter: Record<string, any> = { contentId: ticketId };
+
+    if (ticket?.statusId) {
+      filter.statusId = ticket.statusId;
+    }
+
+    return models.Note.find(filter).sort({ createdAt: -1 }).lean();
   },
 };
 

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/note.ts
@@ -5,6 +5,7 @@ export const types = `
         contentId: String
         createdBy: String
         mentions: [String]
+        statusId: String
 
         createdAt: String
         updatedAt: String

--- a/backend/plugins/frontline_api/src/modules/ticket/types/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/types/note.ts
@@ -5,6 +5,7 @@ export interface INote {
   contentId: string;
   createdBy: string;
   mentions?: string[];
+  statusId?: string;
 }
 
 export interface INoteDocument extends INote, Document {

--- a/backend/plugins/sales_api/src/modules/sales/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/utils.ts
@@ -684,6 +684,7 @@ export const generateAmounts = (productsData, useTick = true) => {
   return amountsMap;
 };
 
+
 export const checkNumberConfig = async (
   numberConfig: string,
   numberSize: string,

--- a/backend/plugins/sales_api/src/modules/sales/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/utils.ts
@@ -684,7 +684,6 @@ export const generateAmounts = (productsData, useTick = true) => {
   return amountsMap;
 };
 
-
 export const checkNumberConfig = async (
   numberConfig: string,
   numberSize: string,

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineConfig.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineConfig.tsx
@@ -33,7 +33,10 @@ const PipelineConfig = ({
                 />
               </div>
               <Form.Control>
-                <Input {...field} placeholder={t('enter-number-configuration')} />
+                <Input
+                  {...field}
+                  placeholder={t('enter-number-configuration')}
+                />
               </Form.Control>
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineConfig.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineConfig.tsx
@@ -1,0 +1,81 @@
+import { Form, Input } from 'erxes-ui';
+import { UseFormReturn } from 'react-hook-form';
+import {
+  BOARD_NAMES_CONFIGS,
+  BOARD_NUMBERS,
+} from '@/pipelines/constants/pipelines';
+import Attribution from './Attribution';
+import { useTranslation } from 'react-i18next';
+import { TUpdatePipelineForm } from '@/pipelines/types';
+
+const PipelineConfig = ({
+  form,
+}: {
+  form: UseFormReturn<TUpdatePipelineForm>;
+}) => {
+  const { control } = form;
+  const { t } = useTranslation('frontline');
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-4 justify-between mb-4">
+        <Form.Field
+          control={control as any}
+          name="numberConfig"
+          render={({ field }) => (
+            <Form.Item className="flex-1">
+              <div className="flex justify-between items-center">
+                <Form.Label>{t('number-configuration')}</Form.Label>
+                <Attribution
+                  config={BOARD_NUMBERS}
+                  onChange={field.onChange}
+                  value={field.value ?? ''}
+                />
+              </div>
+              <Form.Control>
+                <Input {...field} placeholder={t('enter-number-configuration')} />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={control as any}
+          name="numberSize"
+          render={({ field }) => (
+            <Form.Item className="w-48">
+              <Form.Label>{t('fractional-part')}</Form.Label>
+              <Form.Control>
+                <Input {...field} placeholder="1-8" />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      </div>
+
+      <Form.Field
+        control={control as any}
+        name="nameConfig"
+        render={({ field }) => (
+          <Form.Item>
+            <div className="flex justify-between items-center">
+              <Form.Label>{t('name-configuration')}</Form.Label>
+              <Attribution
+                config={BOARD_NAMES_CONFIGS}
+                onChange={field.onChange}
+                value={field.value ?? ''}
+              />
+            </div>
+            <Form.Control>
+              <Input {...field} placeholder={t('enter-name-configuration')} />
+            </Form.Control>
+            <Form.Message />
+          </Form.Item>
+        )}
+      />
+    </>
+  );
+};
+
+export default PipelineConfig;

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineDetail.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineDetail.tsx
@@ -12,6 +12,7 @@ import { TUpdatePipelineForm } from '@/pipelines/types';
 import { PipelineConfigs } from './configs/components/PipelineConfigs';
 import { TicketStatusesButton } from '@/status/components/TicketStatusesButton';
 import { PipelinePermissions } from '@/pipelines/components/permissions/components/PipelinePermissions';
+import PipelineConfig from './PipelineConfig';
 
 export const PipelineDetail = () => {
   const { t } = useTranslation('frontline');
@@ -32,6 +33,9 @@ export const PipelineDetail = () => {
       name: pipeline?.name || '',
       description: pipeline?.description || '',
       _id: pipelineId || '',
+      numberConfig: pipeline?.numberConfig || '',
+      numberSize: pipeline?.numberSize || '',
+      nameConfig: pipeline?.nameConfig || '',
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pipeline]);
@@ -56,6 +60,7 @@ export const PipelineDetail = () => {
               <Form {...form}>
                 <div className="flex flex-col gap-2 ">
                   <CreatePipelineForm form={form} />
+                  <PipelineConfig form={form} />
                   <span className="flex justify-end">
                     <Button type="submit">{t('update')}</Button>
                   </span>

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/mutations/updatePipeline.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/mutations/updatePipeline.ts
@@ -13,6 +13,9 @@ export const UPDATE_PIPELINE = gql`
     $isCheckDepartment: Boolean
     $visibility: String
     $memberIds: [String]
+    $numberConfig: String
+    $numberSize: String
+    $nameConfig: String
   ) {
     updatePipeline(
       _id: $_id
@@ -26,6 +29,9 @@ export const UPDATE_PIPELINE = gql`
       isCheckDepartment: $isCheckDepartment
       visibility: $visibility
       memberIds: $memberIds
+      numberConfig: $numberConfig
+      numberSize: $numberSize
+      nameConfig: $nameConfig
     ) {
       _id
       name
@@ -42,6 +48,9 @@ export const UPDATE_PIPELINE = gql`
       isCheckDepartment
       visibility
       memberIds
+      numberConfig
+      numberSize
+      nameConfig
     }
   }
 `;

--- a/frontend/plugins/frontline_ui/src/modules/settings/schema/pipeline.ts
+++ b/frontend/plugins/frontline_ui/src/modules/settings/schema/pipeline.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 const PIPELINE_FORM_BASE_SCHEMA = z.object({
   name: z.string(),
   description: z.string().optional(),
+  numberConfig: z.string().optional(),
+  numberSize: z.string().optional(),
+  nameConfig: z.string().optional(),
 });
 
 export const CREATE_PIPELINE_FORM_SCHEMA = PIPELINE_FORM_BASE_SCHEMA.extend({


### PR DESCRIPTION
## Summary by Sourcery

Filter client portal ticket notes by the ticket’s current status and introduce configurable numbering and naming options for pipelines.

New Features:
- Add statusId metadata to ticket notes and use it to filter notes returned for a client portal ticket based on the ticket’s current status.
- Introduce configurable number and name formats for pipelines, including number configuration, size, and name configuration fields in the update flow and UI.

Enhancements:
- Automatically populate note statusId from the associated ticket when creating notes to keep note status in sync with ticket status.
- Extend pipeline forms and validation schemas to support the new number and name configuration options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline configuration options for numbering and naming, including size and format settings.
  * Pipeline settings and edit screens now show and save these new configuration fields.
  * Notes now support an optional status value, which is included in note details where available.

* **Bug Fixes**
  * Note retrieval in the client portal now respects ticket status when available, improving consistency in displayed notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->