### PR TITLE
fix(frontline): pass pipelineId and channelId to ticket create sheet trigger

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsBoard.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsBoard.tsx
@@ -115,6 +115,8 @@ export const TicketsBoard = () => {
           <TicketsBoardCards
             column={column}
             canCreateTicket={permissions.canCreateTicket}
+            pipelineId={pipelineId || undefined}
+            channelId={channelId || undefined}
           />
         </Board>
       )}
@@ -125,9 +127,13 @@ export const TicketsBoard = () => {
 export const TicketsBoardCards = ({
   column,
   canCreateTicket,
+  pipelineId,
+  channelId,
 }: {
   column: BoardColumnProps;
   canCreateTicket: boolean;
+  pipelineId?: string;
+  channelId?: string;
 }) => {
   const [ticketCards, setTicketCards] = useAtom(fetchedTicketsState);
   const [ticketCountByBoard, setTicketCountByBoard] = useAtom(
@@ -193,7 +199,13 @@ export const TicketsBoardCards = ({
             )}
           </span>
         </h4>
-        {canCreateTicket && <TicketCreateSheetTrigger statusId={column.id} />}
+        {canCreateTicket && (
+          <TicketCreateSheetTrigger
+            statusId={column.id}
+            pipelineId={pipelineId}
+            channelId={channelId}
+          />
+        )}
       </Board.Header>
       <Board.Cards id={column.id} items={boardCards.map((ticket) => ticket.id)}>
         {loading ? (
@@ -249,12 +261,20 @@ export const TicketCardsFetchMore = ({
   );
 };
 
-const TicketCreateSheetTrigger = ({ statusId }: { statusId: string }) => {
+const TicketCreateSheetTrigger = ({
+  statusId,
+  pipelineId,
+  channelId,
+}: {
+  statusId: string;
+  pipelineId?: string;
+  channelId?: string;
+}) => {
   const setOpenCreateticket = useSetAtom(ticketCreateSheetState);
   const setDefaultValues = useSetAtom(ticketCreateDefaultValuesState);
 
   const handleClick = () => {
-    setDefaultValues({ statusId });
+    setDefaultValues({ statusId, pipelineId, channelId });
     setOpenCreateticket(true);
   };
 


### PR DESCRIPTION
…trigger

## Summary by Sourcery

Bug Fixes:
- Ensure ticket creation sheet receives pipelineId and channelId so new tickets are created with the correct context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket creation now carries over the current pipeline and channel context from the board, helping prefill new tickets more accurately.
  * Create-ticket actions are only shown when ticket creation is available for that column.
* **Bug Fixes**
  * Improved consistency when starting a new ticket from a board column by including all relevant board context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->