### PR TITLE
feat(erxes-api-shared): SaaS plan-history assistant-limit read helpers

### DIFF
--- a/backend/erxes-api-shared/src/utils/saas/definition.ts
+++ b/backend/erxes-api-shared/src/utils/saas/definition.ts
@@ -275,3 +275,36 @@ export const experiencesSchema = new mongoose.Schema({
   onboardingDescription: { type: String, label: 'Onboarding description' },
   features: { type: String, label: 'Features' },
 });
+
+export const saasOrganizationPlanHistorySchema = new mongoose.Schema(
+  {
+    organizationId: { type: String, index: true },
+    source: { type: String, index: true },
+    status: { type: String, index: true },
+
+    isNext: { type: Boolean },
+    productId: { type: String },
+    bundleId: { type: String },
+    interval: { type: String },
+    description: { type: String },
+
+    pluginsLimitsSnapshot: { type: mongoose.Schema.Types.Mixed },
+    assistantLimit: { type: Number },
+
+    stripeCheckoutSessionId: {
+      type: String,
+      index: true,
+      unique: true,
+      sparse: true,
+    },
+    stripePaymentIntentId: { type: String, index: true },
+    stripeSubscriptionId: { type: String, index: true },
+    stripeInvoiceId: { type: String, index: true },
+
+    startsAt: { type: Date },
+    endsAt: { type: Date },
+  },
+  {
+    timestamps: true,
+  },
+);

--- a/backend/erxes-api-shared/src/utils/saas/index.ts
+++ b/backend/erxes-api-shared/src/utils/saas/index.ts
@@ -1,1 +1,2 @@
 export * from './saas-mongo-connection';
+export * from './types';

--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -3,6 +3,7 @@ import { getEnv } from '../utils';
 import {
   saasAddonSchema,
   saasBundleSchema,
+  saasOrganizationPlanHistorySchema,
   endPointSchema,
   experiencesSchema,
   saasInstallationSchema,
@@ -11,7 +12,11 @@ import {
   saasPromoCodeSchema,
   saasUserSchema,
 } from './definition';
-import { IOrganization } from './types';
+import {
+  IOrganization,
+  ISaasBundle,
+  ISaasOrganizationPlanHistory,
+} from './types';
 import { redis } from '../redis';
 import { mongooseConnectionOptions } from '../mongo';
 
@@ -24,6 +29,7 @@ export let coreModelEndpoints: any;
 export let coreModelPromoCodes: any;
 export let coreModelPlugins: any;
 export let coreModelExperiences: any;
+export let coreModelOrganizationPlanHistories: mongoose.Model<ISaasOrganizationPlanHistory>;
 
 export const getSaasCoreConnection = async (): Promise<void> => {
   if (coreModelOrganizations) {
@@ -31,6 +37,17 @@ export const getSaasCoreConnection = async (): Promise<void> => {
   }
 
   const CORE_MONGO_URL = getEnv({ name: 'CORE_MONGO_URL' });
+
+  // Guard before handing the URL to mongoose: an empty/invalid CORE_MONGO_URL
+  // makes mongoose.createConnection throw AND emit an unhandled 'error' event
+  // that crashes the whole process, bypassing callers' try/catch. Failing fast
+  // here keeps the rejection catchable (e.g. SaaS limit checks fall back to the
+  // enterprise/unlimited path when SaaS core isn't configured locally).
+  if (!/^mongodb(\+srv)?:\/\//.test(CORE_MONGO_URL)) {
+    throw new Error(
+      'CORE_MONGO_URL is not configured (expected a mongodb:// connection string)',
+    );
+  }
 
   const coreConnection = await mongoose.createConnection(
     CORE_MONGO_URL,
@@ -56,6 +73,11 @@ export const getSaasCoreConnection = async (): Promise<void> => {
   coreModelAddons = coreConnection.model('addons', saasAddonSchema);
   coreModelBundles = coreConnection.model('bundles', saasBundleSchema);
   coreModelPlugins = coreConnection.model('plugins', saasPluginSchema);
+  coreModelOrganizationPlanHistories =
+    coreConnection.model<ISaasOrganizationPlanHistory>(
+      'organization_plan_histories',
+      saasOrganizationPlanHistorySchema as any,
+    );
 };
 
 export const ORGANIZATION_ID_MAPPING: { [key: string]: string } = {};
@@ -282,6 +304,45 @@ export const getSaasOrganizationDetail = async ({
     charge,
     setupService,
   };
+};
+
+export const getSaasOrganizationPlanHistories = async ({
+  organizationId,
+  statuses = ['active'],
+}: {
+  organizationId: string;
+  statuses?: string[];
+}): Promise<ISaasOrganizationPlanHistory[]> => {
+  await getSaasCoreConnection();
+
+  const histories = await coreModelOrganizationPlanHistories
+    .find({
+      organizationId,
+      ...(statuses.length ? { status: { $in: statuses } } : {}),
+    })
+    .sort({ createdAt: -1 })
+    .lean<ISaasOrganizationPlanHistory[]>();
+
+  const bundleIds = Array.from(
+    new Set(histories.map((history) => history.bundleId).filter(Boolean)),
+  );
+
+  if (!bundleIds.length) {
+    return histories;
+  }
+
+  const bundles = await coreModelBundles
+    .find({ _id: { $in: bundleIds } })
+    .lean();
+
+  const bundleById = new Map<string, ISaasBundle>(
+    bundles.map((bundle: any) => [String(bundle._id), bundle as ISaasBundle]),
+  );
+
+  return histories.map((history) => ({
+    ...history,
+    bundle: history.bundleId ? bundleById.get(history.bundleId) : undefined,
+  }));
 };
 
 export const removeOrgsCache = (source: string) => {

--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -286,7 +286,9 @@ export const getSaasOrganizationDetail = async ({
   }
 
   if (organization?.bundleId) {
-    const bundle = await coreModelBundles.findOne({ _id: organization.bundleId });
+    const bundle = await coreModelBundles.findOne({
+      _id: organization.bundleId,
+    });
 
     if (bundle) {
       organization.bundle = {

--- a/backend/erxes-api-shared/src/utils/saas/types.ts
+++ b/backend/erxes-api-shared/src/utils/saas/types.ts
@@ -1,4 +1,5 @@
 export interface IOrganization {
+  _id?: string;
   name: string;
   subdomain: string;
   ownerId: string;
@@ -16,6 +17,8 @@ export interface IOrganization {
   dnsStatus?: string;
   backgroundColor?: string;
   isWhiteLabel?: boolean;
+  isNext?: boolean;
+  bundleId?: string;
   domain?: string;
   textColor?: string;
   lastActiveDate?: Date;
@@ -24,4 +27,30 @@ export interface IOrganization {
   promoCodes?: string[];
   partnerKey?: string;
   awsSesAccountStatus?: string;
+}
+
+export interface ISaasBundle {
+  _id?: string;
+  title?: string;
+  type?: string;
+  isFree?: boolean;
+  pluginsLimits?: Record<string, unknown>;
+}
+
+export interface ISaasOrganizationPlanHistory {
+  _id?: string;
+  organizationId: string;
+  source?: string;
+  status?: string;
+  isNext?: boolean;
+  productId?: string;
+  bundleId?: string;
+  interval?: string;
+  pluginsLimitsSnapshot?: Record<string, unknown>;
+  assistantLimit?: number;
+  startsAt?: Date;
+  endsAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+  bundle?: ISaasBundle;
 }


### PR DESCRIPTION
Core-side of the AI-assistant limit feature. Adds the shared SaaS billing primitives that `agent_api` (in erxes-private) reads to enforce per-tenant AI-assistant limits. Scoped to `backend/erxes-api-shared/src/utils/saas/` only.

### Changes
- **types.ts** — `ISaasBundle` + `ISaasOrganizationPlanHistory` (incl. `assistantLimit`, `pluginsLimitsSnapshot`); `IOrganization` gains `_id` / `isNext` / `bundleId`.
- **definition.ts** — `saasOrganizationPlanHistorySchema` for `organization_plan_histories` (`assistantLimit` + timestamps).
- **saas-mongo-connection.ts** — `coreModelOrganizationPlanHistories`, `getSaasOrganizationPlanHistories` (bundle-joined), and a guard in `getSaasCoreConnection` so an empty/invalid `CORE_MONGO_URL` throws catchably instead of crashing the process via an unhandled connection `error` event.
- **index.ts** — export the saas types.

### Verification
- `nx build erxes-api-shared` succeeds.

### Context
This is the core half of a split (per repo-separation rule): agent_api + agent_ui consumers live in **erxes-private** and pick these helpers up via the shared-lib sync. The erxes-private PR depends on this landing + syncing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce shared SaaS billing primitives and helpers to read organization plan history, including assistant limits, from the core MongoDB connection.

New Features:
- Add SaaS organization plan history retrieval helper that joins plan history records with their associated bundles.
- Define shared types for SaaS bundles and organization plan history, including assistant limit and plugin limits snapshot fields, and extend the organization type with plan-related attributes.
- Expose SaaS types through the shared SaaS utils index for downstream consumers.

Enhancements:
- Add schema and MongoDB model for SaaS organization plan histories with timestamps and billing-related metadata.
- Harden SaaS core Mongo connection by validating CORE_MONGO_URL up front to fail fast with a catchable error instead of crashing the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving organization plan history with plan details, limits snapshots, start/end dates, and associated bundle information.
  * Expanded shared SaaS types to include bundles and organization plan history records.
* **Bug Fixes**
  * Added fail-fast validation for the core database connection URL to prevent unhandled runtime connection errors.
* **Refactor**
  * Updated shared exports to make the new SaaS types and history lookup utilities available across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->