### PR TITLE
fix(msdynamic): support syncing POS orders

### DIFF
--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -1,10 +1,6 @@
 import { generateModels } from '~/connectionResolvers';
 import { customerToDynamic } from './utilsCustomer';
-import {
-  dealToDynamic,
-  getConfig,
-  orderToDynamic,
-} from './utils';
+import { dealToDynamic, getConfig, orderToDynamic } from './utils';
 
 const allowTypes: Record<string, string[]> = {
   'core:customer': ['create'],
@@ -80,13 +76,7 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
 
         syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
 
-        await dealToDynamic(
-          subdomain,
-          models,
-          syncLog,
-          deal,
-          foundConfig,
-        );
+        await dealToDynamic(subdomain, models, syncLog, deal, foundConfig);
 
         break;
       }
@@ -100,13 +90,7 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         const config = configsMap[brandId || 'noBrand'];
 
         if (config && !config.useBoard) {
-          await orderToDynamic(
-            subdomain,
-            models,
-            syncLog,
-            updatedDoc,
-            config,
-          );
+          await orderToDynamic(subdomain, models, syncLog, updatedDoc, config);
         }
         break;
       }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -1,6 +1,6 @@
 import { generateModels } from '~/connectionResolvers';
 import { customerToDynamic } from './utilsCustomer';
-import { dealToDynamic, getConfig, orderToDynamic } from './utils';
+import { dealToDynamic, orderToDynamic } from './utils';
 
 const allowTypes: Record<string, string[]> = {
   'core:customer': ['create'],
@@ -18,11 +18,23 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
 
   const models = await generateModels(subdomain);
 
-  const configsMap = await getConfig(subdomain, 'DYNAMIC', {});
+  const dynamicConfigs = await models.Configs.getConfigs('DYNAMIC');
 
-  if (!configsMap || !Object.keys(configsMap).length) {
+  if (!dynamicConfigs?.length) {
     return;
   }
+
+  const configsMap = dynamicConfigs.reduce(
+    (acc, conf) => {
+      const sub = conf.subId || 'noBrand';
+      acc[sub] = conf.value;
+      if (sub === 'noBrand' && typeof conf.value === 'object') {
+        Object.assign(acc, conf.value);
+      }
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
 
   const contentId = updatedDocument?._id || object?._id;
 
@@ -75,9 +87,7 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         }
 
         syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
-
         await dealToDynamic(subdomain, models, syncLog, deal, foundConfig);
-
         break;
       }
 
@@ -99,16 +109,11 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         break;
     }
   } catch (e: any) {
-    console.error('MSDynamic error:', e);
-
+    console.error(`MSDynamic error:`, e);
     if (syncLog?._id) {
       await models.SyncLogsMSD.updateOne(
         { _id: syncLog._id },
-        {
-          $set: {
-            error: e?.message || 'Unknown error',
-          },
-        },
+        { $set: { error: e?.message || 'Unknown error' } },
       );
     }
   }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -1,6 +1,10 @@
 import { generateModels } from '~/connectionResolvers';
 import { customerToDynamic } from './utilsCustomer';
-import { dealToDynamic, orderToDynamic } from './utils';
+import {
+  dealToDynamic,
+  getConfig,
+  orderToDynamic,
+} from './utils';
 
 const allowTypes: Record<string, string[]> = {
   'core:customer': ['create'],
@@ -18,23 +22,11 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
 
   const models = await generateModels(subdomain);
 
-  const dynamicConfigs = await models.Configs.getConfigs('DYNAMIC');
+  const configsMap = await getConfig(subdomain, 'DYNAMIC', {});
 
-  if (!dynamicConfigs?.length) {
+  if (!configsMap || !Object.keys(configsMap).length) {
     return;
   }
-
-  const configsMap = dynamicConfigs.reduce(
-    (acc, conf) => {
-      const sub = conf.subId || 'noBrand';
-      acc[sub] = conf.value;
-      if (sub === 'noBrand' && typeof conf.value === 'object') {
-        Object.assign(acc, conf.value);
-      }
-      return acc;
-    },
-    {} as Record<string, any>,
-  );
 
   const contentId = updatedDocument?._id || object?._id;
 
@@ -87,7 +79,15 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         }
 
         syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
-        await dealToDynamic(subdomain, models, syncLog, deal, foundConfig);
+
+        await dealToDynamic(
+          subdomain,
+          models,
+          syncLog,
+          deal,
+          foundConfig,
+        );
+
         break;
       }
 
@@ -100,7 +100,13 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         const config = configsMap[brandId || 'noBrand'];
 
         if (config && !config.useBoard) {
-          await orderToDynamic(subdomain, models, syncLog, updatedDoc, config);
+          await orderToDynamic(
+            subdomain,
+            models,
+            syncLog,
+            updatedDoc,
+            config,
+          );
         }
         break;
       }
@@ -109,11 +115,16 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         break;
     }
   } catch (e: any) {
-    console.error(`MSDynamic error:`, e);
+    console.error('MSDynamic error:', e);
+
     if (syncLog?._id) {
       await models.SyncLogsMSD.updateOne(
         { _id: syncLog._id },
-        { $set: { error: e?.message || 'Unknown error' } },
+        {
+          $set: {
+            error: e?.message || 'Unknown error',
+          },
+        },
       );
     }
   }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
@@ -100,80 +100,74 @@ export const msdynamicSyncMutations = {
   },
 
   async toSendMsdOrders(
-  _root,
-  { orderIds }: { orderIds: string[] },
-  { subdomain, user, checkPermission }: IContext,
-) {
-  await checkPermission('msdSync');
+    _root,
+    { orderIds }: { orderIds: string[] },
+    { subdomain, user, checkPermission }: IContext,
+  ) {
+    await checkPermission('msdSync');
 
-  const models = await generateModels(subdomain);
+    const models = await generateModels(subdomain);
 
-  const orders = await sendTRPCMessage({
-    subdomain,
-    pluginName: 'pos',
-    module: 'orders',
-    action: 'find',
-    input: {
-      query: {
-        _id: { $in: orderIds },
+    const orders = await sendTRPCMessage({
+      subdomain,
+      pluginName: 'pos',
+      module: 'orders',
+      action: 'find',
+      input: {
+        query: {
+          _id: { $in: orderIds },
+        },
       },
-    },
-    defaultValue: [],
-  });
+      defaultValue: [],
+    });
 
-  if (!Array.isArray(orders)) {
-    throw new Error(
-      `Expected orders to be an array but got ${typeof orders}`,
-    );
-  }
-
-  const results: any[] = [];
-
-  for (const order of orders) {
-    try {
-      const config = await getDynamicConfig(
-        models,
-        order.scopeBrandIds?.[0],
+    if (!Array.isArray(orders)) {
+      throw new Error(
+        `Expected orders to be an array but got ${typeof orders}`,
       );
-
-      const syncLog = await models.SyncLogsMSD.syncLogsAdd({
-        contentType: 'pos:order',
-        contentId: order._id,
-        createdAt: new Date(),
-        createdBy: user?._id,
-        consumeData: order,
-        consumeStr: JSON.stringify(order),
-      });
-
-      const response = await orderToDynamic(
-        subdomain,
-        models,
-        syncLog,
-        order,
-        config,
-      );
-
-      results.push({
-        _id: order._id,
-        isSynced: true,
-        syncedDate: response?.Order_Date,
-        syncedBillNumber: response?.No,
-        syncedCustomer: response?.Sell_to_Customer_No,
-      });
-    } catch (e: any) {
-      console.error(
-        `[MSD] Failed to sync order ${order._id}`,
-        e,
-      );
-
-      results.push({
-        _id: order._id,
-        isSynced: false,
-        error: e?.message || 'Unknown error',
-      });
     }
-  }
 
-  return results;
-},
+    const results: any[] = [];
+
+    for (const order of orders) {
+      try {
+        const config = await getDynamicConfig(models, order.scopeBrandIds?.[0]);
+
+        const syncLog = await models.SyncLogsMSD.syncLogsAdd({
+          contentType: 'pos:order',
+          contentId: order._id,
+          createdAt: new Date(),
+          createdBy: user?._id,
+          consumeData: order,
+          consumeStr: JSON.stringify(order),
+        });
+
+        const response = await orderToDynamic(
+          subdomain,
+          models,
+          syncLog,
+          order,
+          config,
+        );
+
+        results.push({
+          _id: order._id,
+          isSynced: true,
+          syncedDate: response?.Order_Date,
+          syncedBillNumber: response?.No,
+          syncedCustomer: response?.Sell_to_Customer_No,
+        });
+      } catch (e: any) {
+        console.error(`[MSD] Failed to sync order ${order._id}`, e);
+
+        results.push({
+          _id: order._id,
+          isSynced: false,
+          error: e?.message || 'Unknown error',
+        });
+      }
+    }
+
+    return results;
+  },
 };

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
@@ -100,62 +100,80 @@ export const msdynamicSyncMutations = {
   },
 
   async toSendMsdOrders(
-    _root,
-    { orderIds }: { orderIds: string[] },
-    { subdomain, user, checkPermission }: IContext,
-  ) {
-    await checkPermission('msdSync');
+  _root,
+  { orderIds }: { orderIds: string[] },
+  { subdomain, user, checkPermission }: IContext,
+) {
+  await checkPermission('msdSync');
 
-    const models = await generateModels(subdomain);
+  const models = await generateModels(subdomain);
 
-    const order = await sendTRPCMessage({
-      subdomain,
-      pluginName: 'pos',
-      module: 'orders',
-      action: 'findOne',
-      input: { _id: { $in: orderIds } },
-      defaultValue: {},
-    });
+  const orders = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'pos',
+    module: 'orders',
+    action: 'find',
+    input: {
+      query: {
+        _id: { $in: orderIds },
+      },
+    },
+    defaultValue: [],
+  });
 
-    if (!order?._id) {
-      throw new Error('Order not found');
-    }
+  if (!Array.isArray(orders)) {
+    throw new Error(
+      `Expected orders to be an array but got ${typeof orders}`,
+    );
+  }
 
-    const config = await getDynamicConfig(models, order.scopeBrandIds?.[0]);
+  const results: any[] = [];
 
-    const syncLog = await models.SyncLogsMSD.syncLogsAdd({
-      contentType: 'pos:order',
-      contentId: order._id,
-      createdAt: new Date(),
-      createdBy: user?._id,
-      consumeData: order,
-      consumeStr: JSON.stringify(order),
-    });
-
-    let response;
-
+  for (const order of orders) {
     try {
-      response = await orderToDynamic(
+      const config = await getDynamicConfig(
+        models,
+        order.scopeBrandIds?.[0],
+      );
+
+      const syncLog = await models.SyncLogsMSD.syncLogsAdd({
+        contentType: 'pos:order',
+        contentId: order._id,
+        createdAt: new Date(),
+        createdBy: user?._id,
+        consumeData: order,
+        consumeStr: JSON.stringify(order),
+      });
+
+      const response = await orderToDynamic(
         subdomain,
         models,
         syncLog,
         order,
         config,
       );
-    } catch (e: any) {
-      await models.SyncLogsMSD.updateOne(
-        { _id: syncLog._id },
-        { $set: { error: e?.message } },
-      );
-      throw e;
-    }
 
-    return {
-      _id: order._id,
-      isSynced: true,
-      syncedDate: response?.Order_Date,
-      syncedBillNumber: response?.No,
-      syncedCustomer: response?.Sell_to_Customer_No,
-    };
-  },
+      results.push({
+        _id: order._id,
+        isSynced: true,
+        syncedDate: response?.Order_Date,
+        syncedBillNumber: response?.No,
+        syncedCustomer: response?.Sell_to_Customer_No,
+      });
+    } catch (e: any) {
+      console.error(
+        `[MSD] Failed to sync order ${order._id}`,
+        e,
+      );
+
+      results.push({
+        _id: order._id,
+        isSynced: false,
+        error: e?.message || 'Unknown error',
+      });
+    }
+  }
+
+  return results;
+},
 };

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
@@ -110,7 +110,7 @@ export const msdynamicSyncMutations = {
 
     const orders = await sendTRPCMessage({
       subdomain,
-      pluginName: 'pos',
+      pluginName: 'sales',
       module: 'orders',
       action: 'find',
       input: {

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/schema/msdynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/schema/msdynamic.ts
@@ -81,6 +81,6 @@ export const mutations = `
   toCheckMsdProducts(brandId: String): JSON
   toSyncMsdProducts(brandId: String, action: String, products: [JSON]): JSON
   toSyncMsdCustomers(brandId: String, action: String, customers: [JSON]): JSON
-  toSendMsdOrders(orderIds: [String]): MsdCheckResponse
+  toSendMsdOrders(orderIds: [String]): [MsdCheckResponse]
   toCheckMsdSynced(ids: [String]): [MsdCheckResponse]
 `;

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
@@ -349,8 +349,8 @@ export const dealToDynamic = async (
     const sendData: any = {
       Sell_to_Customer_No:
         customerType === 'company'
-          ? msdCustomer?.No ?? config.defaultUserCode
-          : custCode ?? config.defaultUserCode,
+          ? (msdCustomer?.No ?? config.defaultUserCode)
+          : (custCode ?? config.defaultUserCode),
       Sell_to_Phone_No: customer?.primaryPhone ?? '',
       Sell_to_E_Mail: customer?.primaryEmail ?? '',
       External_Document_No: deal.number ?? deal.name.split(':').pop().trim(),
@@ -435,18 +435,18 @@ export const dealToDynamic = async (
         const lineNo = orderItemsMsdNo[item._id] || '';
         const product = productById[item.productId];
 
-if (!product) {
-  await models.SyncLogsMSD.updateOne(
-    { _id: syncLog._id },
-    {
-      $set: {
-        error: `Product not found: ${item.productId}`,
-      },
-    },
-  );
+        if (!product) {
+          await models.SyncLogsMSD.updateOne(
+            { _id: syncLog._id },
+            {
+              $set: {
+                error: `Product not found: ${item.productId}`,
+              },
+            },
+          );
 
-  continue;
-}
+          continue;
+        }
         const sendSalesLine: any = {
           Document_No: responseSale.No,
           Type: 'Item',
@@ -691,10 +691,10 @@ export const orderToDynamic = async (
       body: JSON.stringify(sendData),
     }).then((res) => res.json());
     if (responseSale?.error) {
-  throw new Error(
-    responseSale.error.message || 'MS Dynamic returned an error',
-  );
-}
+      throw new Error(
+        responseSale.error.message || 'MS Dynamic returned an error',
+      );
+    }
     const lineNoById = {};
 
     if (responseSale) {
@@ -869,20 +869,20 @@ export const orderToDynamic = async (
     );
 
     return responseSale;
-  }  catch (e: any) {
-  await models.SyncLogsMSD.updateOne(
-    { _id: syncLog._id },
-    {
-      $set: {
-        error: e?.message || 'Unknown error',
+  } catch (e: any) {
+    await models.SyncLogsMSD.updateOne(
+      { _id: syncLog._id },
+      {
+        $set: {
+          error: e?.message || 'Unknown error',
+        },
       },
-    },
-  );
+    );
 
-  console.error(e);
+    console.error(e);
 
-  throw e;
-}
+    throw e;
+  }
 };
 
 const getPriceForList = (prods, exchangeRates) => {

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
@@ -435,18 +435,18 @@ export const dealToDynamic = async (
         const lineNo = orderItemsMsdNo[item._id] || '';
         const product = productById[item.productId];
 
-        if (!product) {
-          await models.SyncLogsMSD.updateOne(
-            { _id: syncLog._id },
-            {
-              $set: {
-                error: `not found product ${product._id}`,
-              },
-            },
-          );
-          continue;
-        }
+if (!product) {
+  await models.SyncLogsMSD.updateOne(
+    { _id: syncLog._id },
+    {
+      $set: {
+        error: `Product not found: ${item.productId}`,
+      },
+    },
+  );
 
+  continue;
+}
         const sendSalesLine: any = {
           Document_No: responseSale.No,
           Type: 'Item',
@@ -690,7 +690,11 @@ export const orderToDynamic = async (
       headers: postHeaders,
       body: JSON.stringify(sendData),
     }).then((res) => res.json());
-
+    if (responseSale?.error) {
+  throw new Error(
+    responseSale.error.message || 'MS Dynamic returned an error',
+  );
+}
     const lineNoById = {};
 
     if (responseSale) {
@@ -865,13 +869,20 @@ export const orderToDynamic = async (
     );
 
     return responseSale;
-  } catch (e) {
-    await models.SyncLogsMSD.updateOne(
-      { _id: syncLog._id },
-      { $set: { error: e.message } },
-    );
-    console.log(e, 'error');
-  }
+  }  catch (e: any) {
+  await models.SyncLogsMSD.updateOne(
+    { _id: syncLog._id },
+    {
+      $set: {
+        error: e?.message || 'Unknown error',
+      },
+    },
+  );
+
+  console.error(e);
+
+  throw e;
+}
 };
 
 const getPriceForList = (prods, exchangeRates) => {


### PR DESCRIPTION
## Summary by Sourcery

Support syncing multiple POS orders to MS Dynamics and improve error handling and logging for order synchronization.

New Features:
- Allow syncing multiple POS orders in a single toSendMsdOrders operation and return per-order sync results.

Bug Fixes:
- Propagate MS Dynamics API errors during order sync and persist descriptive error messages in SyncLogsMSD.
- Handle missing products in order lines with clearer error messages tied to the product ID instead of failing silently or ambiguously.

Enhancements:
- Improve robustness of POS order fetching by validating the response shape before processing.
- Record per-order sync status and key MS Dynamics fields (date, bill number, customer) for better traceability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The order sync action now processes multiple order IDs in one request and returns an array of per-order results.
  * Updated the GraphQL mutation to return a list of responses instead of a single object.
* **Bug Fixes**
  * Improved per-order failure handling: syncing one order won’t block others, and errors are captured per item.
  * Added stronger validation and clearer error surfacing for sales sync responses and product lookup issues.
  * Enhanced after-mutation dynamic-config loading and standardized error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->