### PR TITLE
Fix/pos order product code name

### DIFF
--- a/backend/core-api/src/modules/products/db/models/Products.ts
+++ b/backend/core-api/src/modules/products/db/models/Products.ts
@@ -526,7 +526,15 @@ export const loadProductClass = (
       const fields = ['name', 'code', 'unitPrice', 'categoryId', 'type'];
 
       for (const field of fields) {
-        if (!productFields[field]) {
+        const value = productFields[field];
+        // unitPrice may legitimately be 0 (e.g. services), so only treat
+        // null/undefined/empty as missing for it
+        const isMissing =
+          field === 'unitPrice'
+            ? value === undefined || value === null || (value as any) === ''
+            : !value;
+
+        if (isMissing) {
           throw new Error(
             `Can not merge products. Must choose ${field} field.`,
           );

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -488,7 +488,10 @@ const queries = {
     const orderDetail = order as any;
 
     for (const item of orderDetail.items || []) {
-      item.productName = productById[item.productId]?.name || 'unknown';
+      const product = productById[item.productId];
+      item.productName = product
+        ? [product.code, product.name].filter(Boolean).join(' - ')
+        : 'unknown';
     }
 
     return orderDetail;

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -1,11 +1,26 @@
 import { IconPlus } from '@tabler/icons-react';
 
-import { ApolloError } from '@apollo/client';
+import { ApolloCache, ApolloError } from '@apollo/client';
 import { Row } from '@tanstack/table-core';
 import { Button, CommandBar, RecordTable, Separator, toast } from 'erxes-ui';
 import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
 import { ProductMerge } from './ProductMerge';
+
+const updateProductsTagCache = (
+  cache: ApolloCache<unknown>,
+  productIds: string[],
+  newSelectedTagIds: string[],
+) => {
+  productIds.forEach((productId) => {
+    cache.modify({
+      id: cache.identify({ __typename: 'Product', _id: productId }),
+      fields: {
+        tagIds: () => newSelectedTagIds,
+      },
+    });
+  });
+};
 
 export const ProductCommandBar = () => {
   const { table } = RecordTable.useRecordTable();
@@ -41,19 +56,8 @@ export const ProductCommandBar = () => {
               }
               targetIds={productIds}
               options={(newSelectedTagIds) => ({
-                update: (cache) => {
-                  productIds.forEach((productId) => {
-                    cache.modify({
-                      id: cache.identify({
-                        __typename: 'Product',
-                        _id: productId,
-                      }),
-                      fields: {
-                        tagIds: () => newSelectedTagIds,
-                      },
-                    });
-                  });
-                },
+                update: (cache) =>
+                  updateProductsTagCache(cache, productIds, newSelectedTagIds),
                 onError: (e: ApolloError) => {
                   toast({
                     title: 'Error',

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -5,6 +5,7 @@ import { Row } from '@tanstack/table-core';
 import { Button, CommandBar, RecordTable, Separator, toast } from 'erxes-ui';
 import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
+import { ProductMerge } from './ProductMerge';
 
 export const ProductCommandBar = () => {
   const { table } = RecordTable.useRecordTable();
@@ -39,7 +40,7 @@ export const ProductCommandBar = () => {
                 ) || []
               }
               targetIds={productIds}
-              options={(newSelectedTagIds, action, changedTagId) => ({
+              options={(newSelectedTagIds) => ({
                 update: (cache) => {
                   productIds.forEach((productId) => {
                     cache.modify({
@@ -48,13 +49,7 @@ export const ProductCommandBar = () => {
                         _id: productId,
                       }),
                       fields: {
-                        tagIds: (existingTagIds) => {
-                          const ids = (existingTagIds as string[]) ?? [];
-                          if (action === 'remove' && changedTagId) {
-                            return ids.filter((id) => id !== changedTagId);
-                          }
-                          return [...new Set([...ids, ...newSelectedTagIds])];
-                        },
+                        tagIds: () => newSelectedTagIds,
                       },
                     });
                   });
@@ -80,6 +75,11 @@ export const ProductCommandBar = () => {
             ids={productIds}
           />
         </Can>
+        <Separator.Inline />
+        <ProductMerge
+          productIds={productIds}
+          products={selectedRows.map((row: Row<IProduct>) => row.original)}
+        />
         <Separator.Inline />
         <ProductsDelete productIds={productIds} />
         <Separator.Inline />

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
@@ -1,0 +1,432 @@
+import { useMutation } from '@apollo/client';
+import { IconArrowMerge, IconCheck } from '@tabler/icons-react';
+import { Button, cn, Input, ScrollArea, Sheet, Spinner, toast } from 'erxes-ui';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Can, IProduct } from 'ui-modules';
+import { productsMutations, productsQueries } from '../../graphql';
+
+type MergeField = {
+  key: string;
+  label: string;
+  required?: boolean;
+  getValue: (product: any) => any;
+  getDisplay: (product: any) => string;
+};
+
+const MERGE_FIELDS: MergeField[] = [
+  {
+    key: 'name',
+    label: 'Name',
+    required: true,
+    getValue: (p) => p.name,
+    getDisplay: (p) => p.name ?? '',
+  },
+  {
+    key: 'code',
+    label: 'Code',
+    required: true,
+    getValue: (p) => p.code,
+    getDisplay: (p) => p.code ?? '',
+  },
+  {
+    key: 'type',
+    label: 'Type',
+    required: true,
+    getValue: (p) => p.type,
+    getDisplay: (p) => p.type ?? '',
+  },
+  {
+    key: 'unitPrice',
+    label: 'Unit price',
+    required: true,
+    getValue: (p) => p.unitPrice,
+    getDisplay: (p) => (p.unitPrice ?? 0).toLocaleString(),
+  },
+  {
+    key: 'categoryId',
+    label: 'Category',
+    required: true,
+    getValue: (p) => p.categoryId,
+    getDisplay: (p) => p.category?.name ?? p.categoryId ?? '',
+  },
+  {
+    key: 'shortName',
+    label: 'Short name',
+    getValue: (p) => p.shortName,
+    getDisplay: (p) => p.shortName ?? '',
+  },
+  {
+    key: 'uom',
+    label: 'UOM',
+    getValue: (p) => p.uom,
+    getDisplay: (p) => p.uom ?? '',
+  },
+  {
+    key: 'description',
+    label: 'Description',
+    getValue: (p) => p.description,
+    getDisplay: (p) => toPlainText(p.description),
+  },
+];
+
+const hasValue = (value: any) =>
+  value !== null && value !== undefined && value !== '';
+
+// description is stored as rich-text (blocknote) JSON; show readable plain text
+const toPlainText = (raw: any): string => {
+  if (!raw || typeof raw !== 'string') return raw ?? '';
+  try {
+    const blocks = JSON.parse(raw);
+    if (Array.isArray(blocks)) {
+      const text = blocks
+        .map((block: any) =>
+          Array.isArray(block?.content)
+            ? block.content.map((c: any) => c?.text ?? '').join('')
+            : '',
+        )
+        .join(' ')
+        .trim();
+      return text || raw;
+    }
+  } catch {
+    // not JSON, use as-is
+  }
+  return raw;
+};
+
+const propertiesEntries = (product: any): [string, any][] =>
+  Object.entries(product?.propertiesData || {}).filter(([, v]) => hasValue(v));
+
+const propertyDisplay = (value: any) =>
+  typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+export const ProductMerge = ({
+  productIds,
+  products,
+}: {
+  productIds: string[];
+  products: IProduct[];
+}) => {
+  const { t } = useTranslation('product');
+  const [open, setOpen] = useState(false);
+  const canMerge = products.length === 2;
+
+  return (
+    <Can action="productsMerge">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <Sheet.Trigger asChild>
+          <Button variant="secondary" disabled={!canMerge}>
+            <IconArrowMerge />
+            {t('merge', 'Merge')}
+          </Button>
+        </Sheet.Trigger>
+        <Sheet.View className="flex flex-col gap-0 p-0 sm:max-w-4xl">
+          <Sheet.Header className="flex-row items-center gap-3 space-y-0 border-b p-3">
+            <Sheet.Title>{t('merge-products', 'Merge products')}</Sheet.Title>
+            <Sheet.Close />
+            <Sheet.Description className="sr-only">
+              {t('merge-products', 'Merge products')}
+            </Sheet.Description>
+          </Sheet.Header>
+          {canMerge && (
+            <ProductMergeBody
+              productIds={productIds}
+              products={products}
+              setOpen={setOpen}
+            />
+          )}
+        </Sheet.View>
+      </Sheet>
+    </Can>
+  );
+};
+
+const SourceCell = ({
+  display,
+  selectable,
+  selected,
+  onSelect,
+}: {
+  display?: string;
+  selectable: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) => {
+  if (!hasValue(display)) {
+    return (
+      <div className="min-w-0 px-2 py-1.5 text-sm text-muted-foreground/40">
+        —
+      </div>
+    );
+  }
+
+  if (!selectable) {
+    return (
+      <div className="min-w-0 truncate px-2 py-1.5 text-sm text-muted-foreground">
+        {display}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-left text-sm transition-colors',
+        selected
+          ? 'border-primary bg-primary/5 font-medium text-primary'
+          : 'border-border hover:border-primary/40 hover:bg-accent',
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-3.5 shrink-0 items-center justify-center rounded-full border',
+          selected
+            ? 'border-primary bg-primary text-white'
+            : 'border-muted-foreground/40 bg-background',
+        )}
+      >
+        {selected && <IconCheck className="size-2.5" />}
+      </span>
+      <span className="truncate">{display}</span>
+    </button>
+  );
+};
+
+const ResultCell = ({ display }: { display?: string }) => (
+  <div className="min-w-0 self-stretch border-l pl-4">
+    <div
+      className={cn(
+        'truncate px-2 py-1.5 text-sm font-semibold',
+        !hasValue(display) && 'font-normal text-muted-foreground/40',
+      )}
+    >
+      {hasValue(display) ? display : '—'}
+    </div>
+  </div>
+);
+
+const ProductMergeBody = ({
+  productIds,
+  products,
+  setOpen,
+}: {
+  productIds: string[];
+  products: IProduct[];
+  setOpen: (open: boolean) => void;
+}) => {
+  const { t } = useTranslation('product');
+  const [productA, productB] = products;
+
+  const initValues = useMemo(() => {
+    const values: Record<string, any> = {};
+    for (const field of MERGE_FIELDS) {
+      const a = field.getValue(productA);
+      const b = field.getValue(productB);
+      values[field.key] = hasValue(a) ? a : b;
+    }
+    return values;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [productA?._id, productB?._id]);
+
+  const [value, setValue] = useState<Record<string, any>>(initValues);
+  useEffect(() => setValue(initValues), [initValues]);
+
+  const mergedProperties = useMemo(() => {
+    const aProperties = (productA as any)?.propertiesData || {};
+    return [
+      ...propertiesEntries(productA),
+      ...propertiesEntries(productB).filter(([key]) => !(key in aProperties)),
+    ];
+  }, [productA, productB]);
+
+  const [mergeProducts, { loading }] = useMutation(
+    productsMutations.productsMerge,
+    { refetchQueries: [productsQueries.productsMain] },
+  );
+
+  const handleSave = () => {
+    const missing = MERGE_FIELDS.filter(
+      (f) => f.required && !hasValue(value[f.key]),
+    );
+    if (missing.length) {
+      toast({
+        title: t('error', 'Error'),
+        description: `${t('required', 'Required')}: ${missing
+          .map((f) => f.label)
+          .join(', ')}`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    mergeProducts({
+      variables: { productIds, productFields: value },
+      onCompleted: () => {
+        toast({ title: t('success', 'Success'), variant: 'success' });
+        setOpen(false);
+      },
+      onError: (error) =>
+        toast({
+          title: t('error', 'Error'),
+          description: error.message,
+          variant: 'destructive',
+        }),
+    });
+  };
+
+  const resolvedDisplay = (field: MergeField) => {
+    const current = value[field.key];
+    if (!hasValue(current)) return '';
+    const match = products.find((p) => field.getValue(p) === current);
+    return match ? field.getDisplay(match) : String(current);
+  };
+
+  const grid = 'grid grid-cols-[minmax(90px,130px)_1fr_1fr_1fr] gap-x-3';
+
+  return (
+    <>
+      <Sheet.Content className="min-h-0 flex-auto overflow-hidden">
+        <ScrollArea className="h-full">
+          <div className="p-6">
+            <div className="overflow-hidden rounded-xl border">
+              <div
+                className={cn(
+                  grid,
+                  'items-center border-b bg-muted/30 px-4 py-3',
+                )}
+              >
+                <span />
+                <span className="min-w-0 truncate px-2 text-sm font-semibold">
+                  {(productA as any)?.name}
+                </span>
+                <span className="min-w-0 truncate px-2 text-sm font-semibold">
+                  {(productB as any)?.name}
+                </span>
+                <span className="flex min-w-0 items-center gap-1.5 truncate self-stretch border-l py-0.5 pl-6 text-sm font-semibold text-primary">
+                  <IconArrowMerge className="size-4 shrink-0" />
+                  {t('new-product', 'New product')}
+                </span>
+              </div>
+
+              <div className="divide-y">
+                {MERGE_FIELDS.map((field) => {
+                  const a = field.getValue(productA);
+                  const b = field.getValue(productB);
+                  const bothEmpty = !hasValue(a) && !hasValue(b);
+                  if (bothEmpty && !field.required) return null;
+
+                  const differ = hasValue(a) && hasValue(b) && a !== b;
+                  const isNumber = field.key === 'unitPrice';
+
+                  return (
+                    <div
+                      key={field.key}
+                      className={cn(grid, 'items-center px-4 py-2')}
+                    >
+                      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        {field.label}
+                        {field.required && (
+                          <span className="ml-0.5 text-destructive">*</span>
+                        )}
+                      </span>
+                      <SourceCell
+                        display={
+                          hasValue(a) ? field.getDisplay(productA) : undefined
+                        }
+                        selectable={differ}
+                        selected={differ && value[field.key] === a}
+                        onSelect={() =>
+                          setValue((prev) => ({ ...prev, [field.key]: a }))
+                        }
+                      />
+                      <SourceCell
+                        display={
+                          hasValue(b) ? field.getDisplay(productB) : undefined
+                        }
+                        selectable={differ}
+                        selected={differ && value[field.key] === b}
+                        onSelect={() =>
+                          setValue((prev) => ({ ...prev, [field.key]: b }))
+                        }
+                      />
+                      {bothEmpty ? (
+                        <div className="self-stretch border-l pl-4">
+                          <Input
+                            className="h-8"
+                            type={isNumber ? 'number' : 'text'}
+                            placeholder={t('enter-value', 'Enter value')}
+                            value={value[field.key] ?? ''}
+                            onChange={(e) =>
+                              setValue((prev) => ({
+                                ...prev,
+                                [field.key]: isNumber
+                                  ? e.target.value === ''
+                                    ? ''
+                                    : Number(e.target.value)
+                                  : e.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                      ) : (
+                        <ResultCell display={resolvedDisplay(field)} />
+                      )}
+                    </div>
+                  );
+                })}
+
+                {mergedProperties.length > 0 && (
+                  <div className={cn(grid, 'items-start px-4 py-2')}>
+                    <span className="pt-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t('properties', 'Properties')}
+                    </span>
+                    {[productA, productB].map((product, index) => {
+                      const entries = propertiesEntries(product);
+                      return (
+                        <div
+                          key={index}
+                          className="flex min-w-0 flex-col gap-0.5 px-2 py-1.5 text-sm text-muted-foreground"
+                        >
+                          {entries.length
+                            ? entries.map(([key, v]) => (
+                                <span key={key} className="truncate">
+                                  {key}: {propertyDisplay(v)}
+                                </span>
+                              ))
+                            : '—'}
+                        </div>
+                      );
+                    })}
+                    <div className="min-w-0 self-stretch border-l pl-4">
+                      <div className="flex min-w-0 flex-col gap-0.5 px-2 py-1.5 text-sm font-semibold">
+                        {mergedProperties.map(([key, v]) => (
+                          <span key={key} className="truncate">
+                            {key}: {propertyDisplay(v)}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </ScrollArea>
+      </Sheet.Content>
+      <Sheet.Footer className="flex justify-end border-t p-5">
+        <Sheet.Close asChild>
+          <Button variant="secondary" type="button">
+            {t('discard', 'Discard')}
+          </Button>
+        </Sheet.Close>
+        <Button onClick={handleSave} disabled={loading}>
+          {loading && <Spinner />}
+          {t('save', 'Save')}
+        </Button>
+      </Sheet.Footer>
+    </>
+  );
+};

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
@@ -359,16 +359,17 @@ const ProductMergeBody = ({
                             type={isNumber ? 'number' : 'text'}
                             placeholder={t('enter-value', 'Enter value')}
                             value={value[field.key] ?? ''}
-                            onChange={(e) =>
+                            onChange={(e) => {
+                              const raw = e.target.value;
+                              let nextValue: string | number = raw;
+                              if (isNumber) {
+                                nextValue = raw === '' ? '' : Number(raw);
+                              }
                               setValue((prev) => ({
                                 ...prev,
-                                [field.key]: isNumber
-                                  ? e.target.value === ''
-                                    ? ''
-                                    : Number(e.target.value)
-                                  : e.target.value,
-                              }))
-                            }
+                                [field.key]: nextValue,
+                              }));
+                            }}
                           />
                         </div>
                       ) : (
@@ -383,11 +384,14 @@ const ProductMergeBody = ({
                     <span className="pt-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                       {t('properties', 'Properties')}
                     </span>
-                    {[productA, productB].map((product, index) => {
+                    {[
+                      { side: 'source-a', product: productA },
+                      { side: 'source-b', product: productB },
+                    ].map(({ side, product }) => {
                       const entries = propertiesEntries(product);
                       return (
                         <div
-                          key={index}
+                          key={side}
                           className="flex min-w-0 flex-col gap-0.5 px-2 py-1.5 text-sm text-muted-foreground"
                         >
                           {entries.length

--- a/frontend/core-ui/src/modules/products/graphql/ProductsMutations.tsx
+++ b/frontend/core-ui/src/modules/products/graphql/ProductsMutations.tsx
@@ -194,9 +194,18 @@ const productsEdit = gql`
   }
 `;
 
+const productsMerge = gql`
+  mutation ProductsMerge($productIds: [String], $productFields: JSON) {
+    productsMerge(productIds: $productIds, productFields: $productFields) {
+      _id
+    }
+  }
+`;
+
 export const productsMutations = {
   productsEdit,
   productsAdd,
   categoryEdit,
   categoryRemove,
+  productsMerge,
 };

--- a/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
+++ b/frontend/core-ui/src/modules/products/product-category/components/SelectCategory.tsx
@@ -133,12 +133,8 @@ export const SelectCategoryBadge = ({
         <div className="text-muted-foreground">{code}</div>
         <TextOverflowTooltip value={name} className="flex-auto" />
       </div>
-      {!selected ? (
-        productCount > 0 && (
-          <div className="text-muted-foreground ml-auto">{productCount}</div>
-        )
-      ) : (
-        <Combobox.Check checked={selected} />
+      {!selected && productCount > 0 && (
+        <div className="text-muted-foreground ml-auto">{productCount}</div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary by Sourcery

Add product merge capability in the products UI and ensure merged products have valid required fields while improving product display in POS orders and minor UI behaviors.

New Features:
- Introduce a product merge workflow in the products command bar that allows merging two products into a new one via a guided comparison UI.
- Add a GraphQL mutation for merging products and wire it into the frontend mutation set.

Bug Fixes:
- Ensure POS order items display both product code and name when available instead of only the name or a generic placeholder.
- Fix validation for product merging so unitPrice can be zero without being treated as missing.

Enhancements:
- Simplify tag update behavior in the product command bar to directly replace tag IDs with the selected set.
- Refine the product category selection badge to show product counts only when not selected and remove the checkbox from the non-selected state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a product merge action with a merge dialog that combines exactly two products and lets users resolve each field before saving.

* **Bug Fixes**
  * Product prices can now be set to `0`.
  * Order details now display product names using both code and name when available.
  * Category badges now show the product-count badge only when not selected (and only when the count is greater than 0).
  * Improved tag selection updates to reflect the newly selected tags consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->