### PR TITLE
feat(sidebar): add three-step collapse state (expanded/compact/collap…

### DIFF
--- a/frontend/core-ui/src/modules/app/components/MainLayout.tsx
+++ b/frontend/core-ui/src/modules/app/components/MainLayout.tsx
@@ -4,13 +4,13 @@ import { Sidebar, useQueryState } from 'erxes-ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useAtom } from 'jotai';
 import { Outlet, useLocation } from 'react-router';
-import { mainSidebarOpenState } from '../states/mainSidebarState';
+import { mainSidebarCollapseState } from '../states/mainSidebarState';
 import { FloatingWidgets } from '@/widgets/components/FloatingWidgets';
 
 export const DefaultLayout = () => {
   const location = useLocation();
   const isSettings = location.pathname.includes('/settings');
-  const [mainSidebarOpen, setMainSidebarOpen] = useAtom(mainSidebarOpenState);
+  const [collapseState, setCollapseState] = useAtom(mainSidebarCollapseState);
   const [inPreview] = useQueryState<boolean>('inPreview');
 
   if (inPreview) {
@@ -20,8 +20,8 @@ export const DefaultLayout = () => {
   return (
     <Sidebar.Provider
       className="w-screen"
-      open={mainSidebarOpen}
-      onOpenChange={setMainSidebarOpen}
+      collapseState={collapseState}
+      onCollapseStateChange={setCollapseState}
     >
       <Sidebar collapsible="offcanvas" variant="sidebar" className="p-0">
         <SidebarAnimationContainer isSettings={isSettings}>

--- a/frontend/core-ui/src/modules/app/states/mainSidebarState.tsx
+++ b/frontend/core-ui/src/modules/app/states/mainSidebarState.tsx
@@ -1,8 +1,10 @@
 import { atomWithStorage } from 'jotai/utils';
 
-export const mainSidebarOpenState = atomWithStorage(
-  'mainSidebarOpenState',
-  true,
+export type SidebarCollapseState = 'expanded' | 'compact' | 'collapsed';
+
+export const mainSidebarCollapseState = atomWithStorage<SidebarCollapseState>(
+  'mainSidebarCollapseState',
+  'expanded',
   undefined,
   {
     getOnInit: true,

--- a/frontend/libs/erxes-ui/src/components/sidebar.tsx
+++ b/frontend/libs/erxes-ui/src/components/sidebar.tsx
@@ -21,14 +21,24 @@ import { AppHotkeyScope } from 'erxes-ui/modules/hotkey/types/AppHotkeyScope';
 import { ScrollArea } from './scroll-area';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar:state';
+const SIDEBAR_COLLAPSE_COOKIE_NAME = 'sidebar:collapse';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
+const SIDEBAR_WIDTH_COMPACT = '12rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
+type CollapseState = 'expanded' | 'compact' | 'collapsed';
+
+const COLLAPSE_ORDER: CollapseState[] = ['expanded', 'compact', 'collapsed'];
+
+const nextCollapseState = (prev: CollapseState): CollapseState =>
+  COLLAPSE_ORDER[(COLLAPSE_ORDER.indexOf(prev) + 1) % COLLAPSE_ORDER.length];
+
 type ISidebarContext = {
   state: 'expanded' | 'collapsed';
+  collapseState: CollapseState;
   open: boolean;
   setOpen: (open: boolean) => void;
   openMobile: boolean;
@@ -54,6 +64,9 @@ const SidebarProvider = React.forwardRef<
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    collapseState?: CollapseState;
+    defaultCollapseState?: CollapseState;
+    onCollapseStateChange?: (state: CollapseState) => void;
   }
 >(
   (
@@ -61,6 +74,9 @@ const SidebarProvider = React.forwardRef<
       defaultOpen = true,
       open: openProp,
       onOpenChange: setOpenProp,
+      collapseState: collapseStateProp,
+      defaultCollapseState,
+      onCollapseStateChange,
       className,
       style,
       children,
@@ -71,31 +87,67 @@ const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
 
+    const threeStep =
+      collapseStateProp !== undefined || defaultCollapseState !== undefined;
+
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen);
-    const open = openProp ?? _open;
+    const openControlled = openProp ?? _open;
+
+    const [_collapseState, _setCollapseState] = React.useState<CollapseState>(
+      defaultCollapseState ?? (defaultOpen ? 'expanded' : 'collapsed'),
+    );
+    const collapseState: CollapseState = threeStep
+      ? collapseStateProp ?? _collapseState
+      : openControlled
+      ? 'expanded'
+      : 'collapsed';
+
+    const open = threeStep ? collapseState === 'expanded' : openControlled;
+
+    const setCollapseState = React.useCallback(
+      (value: CollapseState | ((value: CollapseState) => CollapseState)) => {
+        const next = typeof value === 'function' ? value(collapseState) : value;
+        if (onCollapseStateChange) {
+          onCollapseStateChange(next);
+        } else {
+          _setCollapseState(next);
+        }
+        document.cookie = `${SIDEBAR_COLLAPSE_COOKIE_NAME}=${next}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      },
+      [onCollapseStateChange, collapseState],
+    );
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === 'function' ? value(open) : value;
+        if (threeStep) {
+          setCollapseState(openState ? 'expanded' : 'collapsed');
+          return;
+        }
         if (setOpenProp) {
           setOpenProp(openState);
         } else {
           _setOpen(openState);
         }
 
-        // This sets the cookie to keep the sidebar state.
         document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
       },
-      [setOpenProp, open],
+      [setOpenProp, open, threeStep, setCollapseState],
     );
 
-    // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-      return isMobile
-        ? setOpenMobile((open) => !open)
-        : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+      if (isMobile) {
+        setOpenMobile((open) => !open);
+        return;
+      }
+      if (threeStep) {
+        setCollapseState((prev) => nextCollapseState(prev));
+        return;
+      }
+      setOpen((open) => !open);
+    }, [isMobile, threeStep, setCollapseState, setOpen, setOpenMobile]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
 
@@ -105,13 +157,12 @@ const SidebarProvider = React.forwardRef<
       AppHotkeyScope.Sidebar,
     );
 
-    // We add a state so that we can do data-state="expanded" or "collapsed".
-    // This makes it easier to style the sidebar with Tailwind classes.
-    const state = open ? 'expanded' : 'collapsed';
+    const state = collapseState === 'collapsed' ? 'collapsed' : 'expanded';
 
     const contextValue = React.useMemo<ISidebarContext>(
       () => ({
         state,
+        collapseState,
         open,
         setOpen,
         isMobile,
@@ -121,6 +172,7 @@ const SidebarProvider = React.forwardRef<
       }),
       [
         state,
+        collapseState,
         open,
         setOpen,
         isMobile,
@@ -137,6 +189,7 @@ const SidebarProvider = React.forwardRef<
             style={
               {
                 '--sidebar-width': SIDEBAR_WIDTH,
+                '--sidebar-width-compact': SIDEBAR_WIDTH_COMPACT,
                 '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
                 ...style,
               } as React.CSSProperties
@@ -176,7 +229,15 @@ const SidebarRoot = React.forwardRef<
     },
     ref,
   ) => {
-    const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+    const { isMobile, state, collapseState, openMobile, setOpenMobile } =
+      useSidebar();
+
+    let dataCollapsible = '';
+    if (collapseState === 'compact') {
+      dataCollapsible = 'compact';
+    } else if (state === 'collapsed') {
+      dataCollapsible = collapsible;
+    }
 
     if (collapsible === 'none') {
       return (
@@ -218,7 +279,7 @@ const SidebarRoot = React.forwardRef<
         ref={ref}
         className="group peer hidden text-foreground md:block"
         data-state={state}
-        data-collapsible={state === 'collapsed' ? collapsible : ''}
+        data-collapsible={dataCollapsible}
         data-variant={variant}
         data-side={side}
       >
@@ -227,6 +288,7 @@ const SidebarRoot = React.forwardRef<
           className={cn(
             'relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
             'group-data-[collapsible=offcanvas]:w-0',
+            'group-data-[collapsible=compact]:w-(--sidebar-width-compact)',
             'group-data-[side=right]:rotate-180',
             variant === 'floating' || variant === 'inset'
               ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
@@ -236,6 +298,7 @@ const SidebarRoot = React.forwardRef<
         <div
           className={cn(
             'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+            'group-data-[collapsible=compact]:w-(--sidebar-width-compact)',
             side === 'left'
               ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
               : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -264,7 +327,7 @@ const SidebarTrigger = React.forwardRef<
   React.ElementRef<typeof Button>,
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
-  const { toggleSidebar, open } = useSidebar();
+  const { toggleSidebar, collapseState } = useSidebar();
 
   return (
     <Button
@@ -279,10 +342,10 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      {open ? (
-        <IconLayoutSidebarLeftCollapse />
-      ) : (
+      {collapseState === 'collapsed' ? (
         <IconLayoutSidebarLeftExpand />
+      ) : (
+        <IconLayoutSidebarLeftCollapse />
       )}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>

--- a/frontend/libs/erxes-ui/src/components/sidebar.tsx
+++ b/frontend/libs/erxes-ui/src/components/sidebar.tsx
@@ -98,11 +98,12 @@ const SidebarProvider = React.forwardRef<
     const [_collapseState, _setCollapseState] = React.useState<CollapseState>(
       defaultCollapseState ?? (defaultOpen ? 'expanded' : 'collapsed'),
     );
-    const collapseState: CollapseState = threeStep
-      ? (collapseStateProp ?? _collapseState)
-      : openControlled
-        ? 'expanded'
-        : 'collapsed';
+    let collapseState: CollapseState;
+    if (threeStep) {
+      collapseState = collapseStateProp ?? _collapseState;
+    } else {
+      collapseState = openControlled ? 'expanded' : 'collapsed';
+    }
 
     const open = threeStep ? collapseState === 'expanded' : openControlled;
 

--- a/frontend/libs/erxes-ui/src/components/sidebar.tsx
+++ b/frontend/libs/erxes-ui/src/components/sidebar.tsx
@@ -99,10 +99,10 @@ const SidebarProvider = React.forwardRef<
       defaultCollapseState ?? (defaultOpen ? 'expanded' : 'collapsed'),
     );
     const collapseState: CollapseState = threeStep
-      ? collapseStateProp ?? _collapseState
+      ? (collapseStateProp ?? _collapseState)
       : openControlled
-      ? 'expanded'
-      : 'collapsed';
+        ? 'expanded'
+        : 'collapsed';
 
     const open = threeStep ? collapseState === 'expanded' : openControlled;
 


### PR DESCRIPTION
…sed)

## Summary by Sourcery

Introduce a three-state sidebar collapse mode and wire main layout state to track expanded, compact, and collapsed variants.

New Features:
- Add three-step sidebar collapse states (expanded, compact, collapsed) with persisted collapse state cookie.
- Expose collapseState control props on SidebarProvider and integrate a new compact width variant into layout styling.
- Update main application layout to drive the sidebar via a collapse state atom instead of a simple open/closed flag.

Enhancements:
- Adjust sidebar trigger icon logic and data attributes to reflect the three-state collapse mode while preserving mobile behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar behavior now supports three states: expanded, compact, and collapsed.
  * The sidebar trigger and layout now reflect the new compact mode for a more flexible experience.

* **Changes**
  * Sidebar state is now persisted with the new multi-state model, while existing open/close behavior remains supported where applicable.
  * Main layout wiring was updated to use the new sidebar state consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->