### PR TITLE
fix(automations): resolve dashed plugin names to underscore MF containers

### DIFF
--- a/frontend/core-ui/src/modules/automations/components/common/RenderPluginsComponentWrapper.tsx
+++ b/frontend/core-ui/src/modules/automations/components/common/RenderPluginsComponentWrapper.tsx
@@ -24,6 +24,11 @@ export const RenderPluginsComponentWrapper = ({
 
   const { isEnabled } = useAutomationsRemoteModules(pluginName);
 
+  // Dashed plugin names map to underscore MF container names (see
+  // useAutomationsRemoteModules / core-api get-frontend-plugins `remoteName()`),
+  // so the remote is "erxes_agent_ui", never "erxes-agent_ui".
+  const remoteContainerName = `${pluginName.replace(/-/g, '_')}_ui`;
+
   if (!isEnabled) {
     return (
       <p className="flex flex-row gap-2 items-center size-full justify-center">
@@ -41,7 +46,7 @@ export const RenderPluginsComponentWrapper = ({
         )}
       >
         <RenderPluginsComponent
-          pluginName={`${pluginName}_ui`}
+          pluginName={remoteContainerName}
           remoteModuleName="automationsWidget"
           props={{
             ...props,

--- a/frontend/core-ui/src/modules/automations/components/common/RenderPluginsComponentWrapper.tsx
+++ b/frontend/core-ui/src/modules/automations/components/common/RenderPluginsComponentWrapper.tsx
@@ -27,7 +27,7 @@ export const RenderPluginsComponentWrapper = ({
   // Dashed plugin names map to underscore MF container names (see
   // useAutomationsRemoteModules / core-api get-frontend-plugins `remoteName()`),
   // so the remote is "erxes_agent_ui", never "erxes-agent_ui".
-  const remoteContainerName = `${pluginName.replace(/-/g, '_')}_ui`;
+  const remoteContainerName = `${pluginName.replaceAll('-', '_')}_ui`;
 
   if (!isEnabled) {
     return (

--- a/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
+++ b/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
@@ -15,7 +15,7 @@ export const useAutomationsRemoteModules = (pluginName: string) => {
   // in its underscore form ("erxes_agent"). Automation node types keep the real
   // dashed name, so normalize before matching. Mirrors core-api's
   // get-frontend-plugins `remoteName()`.
-  const normalizedName = pluginName.replace(/-/g, '_');
+  const normalizedName = pluginName.replaceAll('-', '_');
 
   const result = plugins
     .filter(({ name }) => name === normalizedName)

--- a/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
+++ b/frontend/core-ui/src/modules/automations/utils/useAutomationsModules.ts
@@ -10,8 +10,15 @@ export const useAutomationsRemoteModules = (pluginName: string) => {
 
   const plugins = Object.values(pluginsMetaData);
 
+  // Module-federation container names can't contain dashes, so a dashed plugin
+  // name (e.g. "erxes-agent") is registered — and stored in pluginsConfigState —
+  // in its underscore form ("erxes_agent"). Automation node types keep the real
+  // dashed name, so normalize before matching. Mirrors core-api's
+  // get-frontend-plugins `remoteName()`.
+  const normalizedName = pluginName.replace(/-/g, '_');
+
   const result = plugins
-    .filter(({ name }) => name === pluginName)
+    .filter(({ name }) => name === normalizedName)
     .flatMap((plugin) =>
       (plugin.modules || [])
         .filter((module) => module.hasAutomation)


### PR DESCRIPTION
## Problem

An automation action/trigger contributed by a plugin whose name contains a dash (today: **`erxes-agent`**) renders as **"Plugin erxes-agent disabled"** in the automations builder, even though the plugin is installed, enabled, and its chat works.

## Root cause

Module-federation container names can't contain dashes, so `core-api`'s `/get-frontend-plugins` maps the plugin name to underscores:

```js
const remoteName = (p) => `${p.replace(/-/g, '_')}_ui`;   // erxes-agent -> erxes_agent_ui
```

So `pluginsConfigState` stores `CONFIG.name = 'erxes_agent'` and the runtime remote is `erxes_agent_ui`. But the **automation node type** keeps the real dashed service name (`erxes-agent:...`) — that prefix is the backend service id used to route the action RPC and cannot change.

`useAutomationsRemoteModules` / `RenderPluginsComponentWrapper` then used the raw dashed `pluginName` **without normalizing**, so:

1. `useAutomationsRemoteModules('erxes-agent')` compares `CONFIG.name` (`'erxes_agent'`) against `'erxes-agent'` → no match → `isEnabled = false` → "disabled" fallback.
2. Even past that, `loadRemote('erxes-agent_ui/automationsWidget')` misses the real container `erxes_agent_ui`.

Dashless plugins (sales, frontline, loyalty, operation) are unaffected — which is why this only manifested on `erxes-agent`.

## Fix

Normalize `-` → `_` at the two automation call sites, mirroring core-api's `remoteName()`:

- `useAutomationsModules.ts` — normalize before the `CONFIG.name` match.
- `RenderPluginsComponentWrapper.tsx` — normalize when building the `_ui` remote container name.

Idempotent for dashless/underscore names, so every existing plugin is unaffected. All wrapper call sites (action config, node content, trigger content, history name/result) funnel through these two.

## Paired change

The consuming plugin (`erxes-agent_ui`, maintained in erxes-private) ships the `automationsWidget` this loads. This core normalization is what lets it resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize dashed plugin names to their underscore module-federation container equivalents in automations so plugin-provided automation widgets resolve correctly.

Bug Fixes:
- Fix automations plugin enablement detection by matching plugin metadata against a dash-to-underscore-normalized name.
- Ensure automation plugin widgets load from the correct underscore-based module-federation container instead of using dashed plugin names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how automation plugin names are interpreted, so dashed plugin names now correctly resolve to the corresponding loaded remote module and related metadata.
  * Fixed cases where automation plugins could fail to load or display due to formatting mismatches between plugin naming and retrieved metadata.
  * Ensured the existing enabled/disabled checks and the loading, warning, and error UI behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->