### PR TITLE
fix(ai-knowledge): Mongolian/mixed knowledge files fail to index — Mongo text-index language override

### DIFF
--- a/backend/services/automations/src/mongo/knowledgeChunk.ts
+++ b/backend/services/automations/src/mongo/knowledgeChunk.ts
@@ -131,6 +131,14 @@ knowledgeChunkSchema.index(
   {
     name: 'knowledge_chunk_text_search',
     default_language: 'none',
+    // Chunk docs carry a human `language` field ('mn' | 'mixed' | 'en' |
+    // 'unknown') for retrieval filtering. Without an explicit override, Mongo
+    // treats that field as the per-document text-search language override and
+    // rejects any value outside its built-in set — so a Mongolian ('mn') or
+    // 'mixed' chunk fails to insert with "language override unsupported: mn".
+    // Point the override at a field that doesn't exist so every doc falls back
+    // to default_language: 'none' (we do our own tokenization anyway).
+    language_override: 'textSearchLanguage',
     weights: {
       title: 8,
       keywords: 6,


### PR DESCRIPTION
## Problem

AI-agent knowledge files whose content is Mongolian (or mixed MN/EN) fail to index in the automations knowledge base with a per-file error:

```
language override unsupported: mn
language override unsupported: mixed
```

(Seen on real "erxes Academy" agent files: a .md detected as `mn` and a .txt detected as `mixed`, both stuck at 0 chunks / status `failed`.)

## Root cause

The chunker fully supports `mn`/`mixed` (`TAiKnowledgeLanguage` and `normalizeLanguage` accept them), and each `KnowledgeChunks` document stores that value in a `language` field for retrieval filtering.

But the `knowledge_chunk_text_search` text index sets `default_language: 'none'` **without a `language_override`**. By default MongoDB uses a document's `language` field as its *per-document text-search language override*, and only accepts values from its built-in language set (english, spanish, … — no Mongolian, no "mixed"). So inserting a chunk with `language: 'mn'` throws MongoServerError 17262 *"language override unsupported: mn"*, failing the whole file index. This is purely the text index rejecting the value — nothing in our own pipeline.

## Fix

Point the text index's `language_override` at a field name that isn't a real language, so Mongo stops interpreting the semantic `language` field as the override and every doc falls back to `default_language: 'none'` (we do our own tokenization/term extraction anyway; MongoDB stemming isn't used for these languages):

```js
language_override: 'textSearchLanguage',
```

The `language` field is untouched and still available to `retrieve.ts` for filtering. Fixes MN + "mixed" + "unknown" in one line.

## ⚠️ Required deploy step (index recreation)

Mongo can't change an existing index's options in place, and a collection allows only one text index — so the existing index must be dropped once so the model recreates it with the new option. Per tenant DB:

```js
db.knowledge_chunks.dropIndex('knowledge_chunk_text_search')
```

On next boot the model re-creates it with `language_override`. Then re-index affected agent files (`automationsAiAgentReindex`). Recommend wiring this drop into saas-migrations. Without the drop, the code change is a no-op (createIndexes will conflict-and-skip on the existing index).

## Test

- Before: MN/mixed files → `failed`, `language override unsupported`.
- After (index recreated): same files chunk + index successfully; keyword retrieval unaffected for existing EN docs (`default_language: 'none'` was already in effect for them).

## Summary by Sourcery

Bug Fixes:
- Prevent knowledge chunk indexing failures for Mongolian, mixed, and other non-Mongo text-search languages by decoupling the semantic language field from MongoDB's language override setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving knowledge chunks by preventing MongoDB text-search language validation errors.
  * Inserts now work correctly for content with unsupported or mixed language values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->