### PR TITLE
fix(shared): add SaaS active addon helper

### DIFF
--- a/backend/erxes-api-shared/src/utils/saas/definition.ts
+++ b/backend/erxes-api-shared/src/utils/saas/definition.ts
@@ -142,6 +142,8 @@ export const saasAddonSchema = new mongoose.Schema({
     type: String,
     label: 'Төлбөр төлөгдсөн талаарх тайлбар',
   },
+  createdAt: { type: Date },
+  isCanceled: { type: Boolean },
 });
 
 export const saasBundleSchema = new mongoose.Schema({

--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -371,7 +371,7 @@ export const getSaasOrganizationActiveAddons = async ({
       $or: [{ expiryDate: { $gt: new Date() } }, { interval: 'oneTime' }],
     })
     .sort({ createdAt: -1 })
-    .lean<ISaasAddon[]>();
+    .lean() as ISaasAddon[];
 
   const bundleTypes = Array.from(
     new Set(addons.map((addon) => addon.kind).filter(Boolean)),

--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -14,6 +14,7 @@ import {
 } from './definition';
 import {
   IOrganization,
+  ISaasAddon,
   ISaasBundle,
   ISaasOrganizationPlanHistory,
 } from './types';
@@ -344,6 +345,53 @@ export const getSaasOrganizationPlanHistories = async ({
   return histories.map((history) => ({
     ...history,
     bundle: history.bundleId ? bundleById.get(history.bundleId) : undefined,
+  }));
+};
+
+export const getSaasOrganizationActiveAddons = async ({
+  organizationId,
+}: {
+  organizationId: string;
+}): Promise<ISaasAddon[]> => {
+  await getSaasCoreConnection();
+
+  const installation = await coreModelInstallations
+    .findOne({ organizationId }, { _id: 1 })
+    .lean();
+
+  if (!installation?._id) {
+    return [];
+  }
+
+  const addons = await coreModelAddons
+    .find({
+      installationId: String(installation._id),
+      paymentStatus: 'complete',
+      isCanceled: { $ne: true },
+      $or: [{ expiryDate: { $gt: new Date() } }, { interval: 'oneTime' }],
+    })
+    .sort({ createdAt: -1 })
+    .lean<ISaasAddon[]>();
+
+  const bundleTypes = Array.from(
+    new Set(addons.map((addon) => addon.kind).filter(Boolean)),
+  );
+
+  if (!bundleTypes.length) {
+    return addons;
+  }
+
+  const bundles = await coreModelBundles
+    .find({ type: { $in: bundleTypes } })
+    .lean();
+
+  const bundleByType = new Map<string, ISaasBundle>(
+    bundles.map((bundle: any) => [String(bundle.type), bundle as ISaasBundle]),
+  );
+
+  return addons.map((addon) => ({
+    ...addon,
+    bundle: addon.kind ? bundleByType.get(addon.kind) : undefined,
   }));
 };
 

--- a/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
+++ b/backend/erxes-api-shared/src/utils/saas/saas-mongo-connection.ts
@@ -363,7 +363,7 @@ export const getSaasOrganizationActiveAddons = async ({
     return [];
   }
 
-  const addons = await coreModelAddons
+  const addons = (await coreModelAddons
     .find({
       installationId: String(installation._id),
       paymentStatus: 'complete',
@@ -371,7 +371,7 @@ export const getSaasOrganizationActiveAddons = async ({
       $or: [{ expiryDate: { $gt: new Date() } }, { interval: 'oneTime' }],
     })
     .sort({ createdAt: -1 })
-    .lean() as ISaasAddon[];
+    .lean()) as ISaasAddon[];
 
   const bundleTypes = Array.from(
     new Set(addons.map((addon) => addon.kind).filter(Boolean)),

--- a/backend/erxes-api-shared/src/utils/saas/types.ts
+++ b/backend/erxes-api-shared/src/utils/saas/types.ts
@@ -37,6 +37,22 @@ export interface ISaasBundle {
   pluginsLimits?: Record<string, unknown>;
 }
 
+export interface ISaasAddon {
+  _id?: string;
+  kind?: string;
+  quantity?: number;
+  installationId?: string;
+  subscriptionId?: string;
+  expiryDate?: Date;
+  interval?: string;
+  paymentStatus?: string;
+  paymentStatusMessage?: string;
+  isCanceled?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+  bundle?: ISaasBundle;
+}
+
 export interface ISaasOrganizationPlanHistory {
   _id?: string;
   organizationId: string;
@@ -48,6 +64,10 @@ export interface ISaasOrganizationPlanHistory {
   interval?: string;
   pluginsLimitsSnapshot?: Record<string, unknown>;
   assistantLimit?: number;
+  stripeCheckoutSessionId?: string;
+  stripePaymentIntentId?: string;
+  stripeSubscriptionId?: string;
+  stripeInvoiceId?: string;
   startsAt?: Date;
   endsAt?: Date;
   createdAt?: Date;


### PR DESCRIPTION
## Why

`agent_api` needs a shared SaaS helper that can read active paid add-ons from the core SaaS database. Paid AI Assistant bundle add-ons can exist in `addons`, while assistant access code needs typed add-on records and Stripe subscription ids to avoid double-counting plan-history coverage.

## What Changed

- Add `ISaasAddon` and missing Stripe id fields to SaaS shared types.
- Include `createdAt` and `isCanceled` on the shared add-on schema.
- Add `getSaasOrganizationActiveAddons`, which resolves an organization installation, reads active complete add-ons, filters canceled/expired rows, and attaches bundle metadata by add-on kind.
- Cast the active add-on query result instead of using a generic on untyped `.lean()`, so plugin builds like `tourism_api` compile.

## Verification

- `pnpm nx build erxes-api-shared` passed.
- `pnpm nx build tourism_api` passed.
- `git diff --check` passed.

## Summary by Sourcery

Add shared SaaS helper and types to expose active paid add-ons for an organization installation.

New Features:
- Introduce ISaasAddon shared type to represent SaaS add-on records including bundle metadata.
- Add getSaasOrganizationActiveAddons helper to return active, non-canceled SaaS add-ons for an organization.

Enhancements:
- Extend SaaS organization plan history type with Stripe identifiers for checkout sessions, payment intents, subscriptions, and invoices.
- Update SaaS add-on schema and shared types to track cancellation status and creation timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SaaS add-on tracking with clearer status and date information.
  * Added support for viewing the active add-ons tied to an organization, including related bundle details when available.

* **Bug Fixes**
  * Better filtering of add-ons so canceled or inactive items are excluded from active results.
  * Enhanced payment and subscription reference handling for more reliable billing history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->