### PR TITLE
fix(frontline_api): guard against null user in conversation queries

### DIFF
--- a/backend/plugins/frontline_api/src/conversationQueryBuilder.ts
+++ b/backend/plugins/frontline_api/src/conversationQueryBuilder.ts
@@ -35,7 +35,7 @@ export interface IListArgs {
   skip?: number;
 }
 
-interface IUserArgs {
+export interface IUserArgs {
   _id: string;
   code?: string;
   starredConversationIds?: string[];

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
@@ -8,16 +8,25 @@ import { countByConversations } from '@/inbox/conversationUtils';
 import { CONVERSATION_STATUSES } from '@/inbox/db/definitions/constants';
 import { cursorPaginate,markResolvers } from 'erxes-api-shared/utils';
 import { IContext, IModels } from '~/connectionResolvers';
-import QueryBuilder, { IListArgs } from '~/conversationQueryBuilder';
+import QueryBuilder, { IListArgs, IUserArgs } from '~/conversationQueryBuilder';
 
 const count = async (models: IModels, query: any): Promise<number> => {
   const result = await models.Conversations.countDocuments(query);
   return Number(result);
 };
 
-const toQueryUser = (user: IContext['user']) => {
+const DEFAULT_USER_ARGS: IUserArgs = {
+  _id: '',
+  code: '',
+  starredConversationIds: [],
+  role: '',
+};
+
+const toQueryUser = (
+  user: IContext['user'] | null | undefined,
+): IUserArgs | null => {
   if (!user) {
-    return { _id: '', code: '', starredConversationIds: [], role: '' };
+    return null;
   }
 
   return {
@@ -66,7 +75,12 @@ export const conversationQueries = {
       return { list, totalCount, pageInfo };
     }
 
-    const qb = new QueryBuilder(models, subdomain, params, toQueryUser(user));
+    const qb = new QueryBuilder(
+      models,
+      subdomain,
+      params,
+      toQueryUser(user) ?? DEFAULT_USER_ARGS,
+    );
 
     await qb.buildAllQueries();
 
@@ -153,7 +167,7 @@ export const conversationQueries = {
     const { only } = params;
 
     const response: IConversationRes = {};
-    const _user = toQueryUser(user);
+    const _user = toQueryUser(user) ?? DEFAULT_USER_ARGS;
 
     const qb = new QueryBuilder(models, subdomain, params, _user);
 
@@ -231,7 +245,12 @@ export const conversationQueries = {
     params: IListArgs,
     { user, models, subdomain }: IContext,
   ) {
-    const qb = new QueryBuilder(models, subdomain, params, toQueryUser(user));
+    const qb = new QueryBuilder(
+      models,
+      subdomain,
+      params,
+      toQueryUser(user) ?? DEFAULT_USER_ARGS,
+    );
 
     await qb.buildAllQueries();
 
@@ -246,7 +265,12 @@ export const conversationQueries = {
     params: IListArgs,
     { user, models, subdomain }: IContext,
   ) {
-    const qb = new QueryBuilder(models, subdomain, params, toQueryUser(user));
+    const qb = new QueryBuilder(
+      models,
+      subdomain,
+      params,
+      toQueryUser(user) ?? DEFAULT_USER_ARGS,
+    );
 
     await qb.buildAllQueries();
 
@@ -268,7 +292,7 @@ export const conversationQueries = {
       models,
       subdomain,
       {},
-      toQueryUser(user),
+      toQueryUser(user) ?? DEFAULT_USER_ARGS,
     );
 
     await qb.buildAllQueries();
@@ -279,7 +303,7 @@ export const conversationQueries = {
     const response = await models.Conversations.countDocuments({
       ...integrationsFilter,
       status: { $in: [CONVERSATION_STATUSES.NEW, CONVERSATION_STATUSES.OPEN] },
-      readUserIds: { $ne: user._id },
+      readUserIds: { $ne: user?._id ?? '' },
       $and: [{ $or: qb.userRelevanceQuery() }],
     });
 

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
@@ -15,12 +15,18 @@ const count = async (models: IModels, query: any): Promise<number> => {
   return Number(result);
 };
 
-const toQueryUser = (user: IContext['user']) => ({
-  _id: user._id,
-  code: user.code,
-  starredConversationIds: user.starredConversationIds,
-  role: user.role,
-});
+const toQueryUser = (user: IContext['user']) => {
+  if (!user) {
+    return { _id: '', code: '', starredConversationIds: [], role: '' };
+  }
+
+  return {
+    _id: user._id,
+    code: user.code,
+    starredConversationIds: user.starredConversationIds,
+    role: user.role,
+  };
+};
 
 export const conversationQueries = {
   /**
@@ -262,7 +268,7 @@ export const conversationQueries = {
       models,
       subdomain,
       {},
-      { _id: user._id, code: user.code },
+      toQueryUser(user),
     );
 
     await qb.buildAllQueries();


### PR DESCRIPTION
closes #8563

## Summary by Sourcery

Bug Fixes:
- Handle null user context in frontline API conversation queries to prevent runtime errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread conversation count handling when user data is missing or incomplete.
  * Added safer fallback handling for user-based conversation queries, ensuring they work reliably even when optional user details aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->