### PR TITLE
feat(loyalty_ui): add default values to i18n t() calls in loyalty plugin

### DIFF
--- a/frontend/plugins/loyalty_ui/src/LoyaltySettingsNavigation.tsx
+++ b/frontend/plugins/loyalty_ui/src/LoyaltySettingsNavigation.tsx
@@ -12,12 +12,12 @@ export const LoyaltySettingsNavigation = () => {
           <SettingsNavigationMenuLinkItem
             pathPrefix={LoyaltySettingsPaths.Loyalty}
             path={LoyaltySettingsPaths.Config}
-            name={t('configs')}
+            name={t('configs', 'Configs')}
           />
           <SettingsNavigationMenuLinkItem
             pathPrefix={LoyaltySettingsPaths.Loyalty}
             path={LoyaltySettingsPaths.Pricing}
-            name={t('pricing')}
+            name={t('pricing', 'Pricing')}
           />
         </Sidebar.Menu>
       </Sidebar.GroupContent>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentAddSheet.tsx
@@ -102,12 +102,12 @@ export const AgentAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-agent')}
+          {t('add-agent', 'Add agent')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-2xl">
         <Sheet.Header>
-          <Sheet.Title>{t('new-agent')}</Sheet.Title>
+          <Sheet.Title>{t('new-agent', 'New agent')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5 overflow-y-auto">
@@ -120,12 +120,12 @@ export const AgentAddSheet = () => {
                 <Form.Field
                   control={form.control}
                   name="number"
-                  rules={{ required: t('number-required') }}
+                  rules={{ required: t('number-required', 'Number is required') }}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('number-label')}</Form.Label>
+                      <Form.Label>{t('number-label', 'Number *')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('number')} {...field} />
+                        <Input placeholder={t('number', 'Number')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -135,10 +135,10 @@ export const AgentAddSheet = () => {
                 <Form.Field
                   control={form.control}
                   name="status"
-                  rules={{ required: t('status-required') }}
+                  rules={{ required: t('status-required', 'Status is required') }}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('status-label')}</Form.Label>
+                      <Form.Label>{t('status-label', 'Status *')}</Form.Label>
                       <SelectAgentStatus.FormItem
                         value={field.value}
                         onValueChange={field.onChange}
@@ -155,7 +155,7 @@ export const AgentAddSheet = () => {
                 name="customerIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('relevant-customers')}</Form.Label>
+                    <Form.Label>{t('relevant-customers', 'Relevant Customers')}</Form.Label>
                     <Form.Control>
                       <SelectCustomer
                         value={field.value}
@@ -173,7 +173,7 @@ export const AgentAddSheet = () => {
                 name="companyIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('relevant-companies')}</Form.Label>
+                    <Form.Label>{t('relevant-companies', 'Relevant Companies')}</Form.Label>
                     <Form.Control>
                       <SelectCompany
                         value={field.value}
@@ -197,7 +197,7 @@ export const AgentAddSheet = () => {
                         onCheckedChange={field.onChange}
                       />
                     </Form.Control>
-                    <Form.Label className="mb-2">{t('has-return')}</Form.Label>
+                    <Form.Label className="mb-2">{t('has-return', 'Has Return')}</Form.Label>
                   </Form.Item>
                 )}
               />
@@ -209,7 +209,7 @@ export const AgentAddSheet = () => {
                     name="returnAmount"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('return-amount')}</Form.Label>
+                        <Form.Label>{t('return-amount', 'Return Amount')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -227,7 +227,7 @@ export const AgentAddSheet = () => {
                     name="returnPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('return-percent')}</Form.Label>
+                        <Form.Label>{t('return-percent', 'Return Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -248,7 +248,7 @@ export const AgentAddSheet = () => {
                     name="prepaidPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('prepaid-percent')}</Form.Label>
+                        <Form.Label>{t('prepaid-percent', 'Prepaid Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -266,7 +266,7 @@ export const AgentAddSheet = () => {
                     name="discountPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('discount-percent')}</Form.Label>
+                        <Form.Label>{t('discount-percent', 'Discount Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -288,11 +288,11 @@ export const AgentAddSheet = () => {
                   name="startDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-date')}</Form.Label>
+                      <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-date')}
+                        placeholder={t('start-date', 'Start Date')}
                       />
                     </Form.Item>
                   )}
@@ -302,11 +302,11 @@ export const AgentAddSheet = () => {
                   name="endDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-date')}</Form.Label>
+                      <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-date')}
+                        placeholder={t('end-date', 'End Date')}
                       />
                     </Form.Item>
                   )}
@@ -319,11 +319,11 @@ export const AgentAddSheet = () => {
                   name="startMonth"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-month')}</Form.Label>
+                      <Form.Label>{t('start-month', 'Start Month')}</Form.Label>
                       <MonthPicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-month')}
+                        placeholder={t('start-month', 'Start Month')}
                       />
                     </Form.Item>
                   )}
@@ -333,11 +333,11 @@ export const AgentAddSheet = () => {
                   name="endMonth"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-month')}</Form.Label>
+                      <Form.Label>{t('end-month', 'End Month')}</Form.Label>
                       <MonthPicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-month')}
+                        placeholder={t('end-month', 'End Month')}
                       />
                     </Form.Item>
                   )}
@@ -350,11 +350,11 @@ export const AgentAddSheet = () => {
                   name="startDay"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-day')}</Form.Label>
+                      <Form.Label>{t('start-day', 'Start Day')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-day')}
+                        placeholder={t('start-day', 'Start Day')}
                       />
                     </Form.Item>
                   )}
@@ -364,11 +364,11 @@ export const AgentAddSheet = () => {
                   name="endDay"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-day')}</Form.Label>
+                      <Form.Label>{t('end-day', 'End Day')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-day')}
+                        placeholder={t('end-day', 'End Day')}
                       />
                     </Form.Item>
                   )}
@@ -380,11 +380,11 @@ export const AgentAddSheet = () => {
                 name="productRuleIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('choose-product-rules')}</Form.Label>
+                    <Form.Label>{t('choose-product-rules', 'Choose Product Rules')}</Form.Label>
                     <SelectProductRules
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('choose-product-rule')}
+                      placeholder={t('choose-product-rule', 'Choose product rule')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -397,10 +397,10 @@ export const AgentAddSheet = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentColumns.tsx
@@ -38,7 +38,7 @@ const ProductRulesCell = ({ agent }: { agent: IAgent }) => {
   return (
     <RecordTableInlineCell>
       <span className="text-xs text-muted-foreground">
-        {t('rules-count', { count: rules.length })}
+        {t('rules-count', '{{count}} rule(s)', { count: rules.length })}
       </span>
     </RecordTableInlineCell>
   );
@@ -53,7 +53,7 @@ export const agentColumns = (
     id: 'number',
     accessorKey: 'number',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('number')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('number', 'Number')} />
     ),
     size: 150,
     cell: ({ row }) => <NumberCell agent={row.original} />,
@@ -62,7 +62,7 @@ export const agentColumns = (
     id: 'status',
     accessorKey: 'status',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('status')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('status', 'Status')} />
     ),
     size: 100,
     cell: ({ cell }) => {
@@ -77,7 +77,7 @@ export const agentColumns = (
     id: 'hasReturn',
     accessorKey: 'hasReturn',
     header: () => (
-      <RecordTable.InlineHead icon={IconRefresh} label={t('has-return')} />
+      <RecordTable.InlineHead icon={IconRefresh} label={t('has-return', 'Has Return')} />
     ),
     size: 100,
     cell: ({ cell }) => (
@@ -99,7 +99,7 @@ export const agentColumns = (
     id: 'productRules',
     accessorKey: 'rulesOfProducts',
     header: () => (
-      <RecordTable.InlineHead icon={IconBox} label={t('product-rules')} />
+      <RecordTable.InlineHead icon={IconBox} label={t('product-rules', 'Product Rules')} />
     ),
     cell: ({ row }) => <ProductRulesCell agent={row.original} />,
   },

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentCommandBar.tsx
@@ -15,7 +15,7 @@ export const AgentCommandBar = () => {
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedRows.length })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedRows.length })}</CommandBar.Value>
         <Separator.Inline />
         <AgentRemove agentIds={agentIds} rows={selectedRows} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentEditSheet.tsx
@@ -119,7 +119,7 @@ export const AgentEditSheet = ({
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View className="sm:max-w-2xl">
         <Sheet.Header>
-          <Sheet.Title>{t('edit-agent')}</Sheet.Title>
+          <Sheet.Title>{t('edit-agent', 'Edit Agent')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5 overflow-y-auto">
@@ -132,12 +132,12 @@ export const AgentEditSheet = ({
                 <Form.Field
                   control={form.control}
                   name="number"
-                  rules={{ required: t('number-required') }}
+                  rules={{ required: t('number-required', 'Number is required') }}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('number-label')}</Form.Label>
+                      <Form.Label>{t('number-label', 'Number *')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('number')} {...field} />
+                        <Input placeholder={t('number', 'Number')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -147,10 +147,10 @@ export const AgentEditSheet = ({
                 <Form.Field
                   control={form.control}
                   name="status"
-                  rules={{ required: t('status-required') }}
+                  rules={{ required: t('status-required', 'Status is required') }}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('status-label')}</Form.Label>
+                      <Form.Label>{t('status-label', 'Status *')}</Form.Label>
                       <SelectAgentStatus.FormItem
                         value={field.value}
                         onValueChange={field.onChange}
@@ -166,7 +166,7 @@ export const AgentEditSheet = ({
                 name="customerIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('relevant-customers')}</Form.Label>
+                    <Form.Label>{t('relevant-customers', 'Relevant Customers')}</Form.Label>
                     <Form.Control>
                       <SelectCustomer
                         value={field.value}
@@ -184,7 +184,7 @@ export const AgentEditSheet = ({
                 name="companyIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('relevant-companies')}</Form.Label>
+                    <Form.Label>{t('relevant-companies', 'Relevant Companies')}</Form.Label>
                     <Form.Control>
                       <SelectCompany
                         value={field.value}
@@ -208,7 +208,7 @@ export const AgentEditSheet = ({
                         onCheckedChange={field.onChange}
                       />
                     </Form.Control>
-                    <Form.Label className="mb-2">{t('has-return')}</Form.Label>
+                    <Form.Label className="mb-2">{t('has-return', 'Has Return')}</Form.Label>
                   </Form.Item>
                 )}
               />
@@ -220,7 +220,7 @@ export const AgentEditSheet = ({
                     name="returnAmount"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('return-amount')}</Form.Label>
+                        <Form.Label>{t('return-amount', 'Return Amount')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -238,7 +238,7 @@ export const AgentEditSheet = ({
                     name="returnPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('return-percent')}</Form.Label>
+                        <Form.Label>{t('return-percent', 'Return Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -259,7 +259,7 @@ export const AgentEditSheet = ({
                     name="prepaidPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('prepaid-percent')}</Form.Label>
+                        <Form.Label>{t('prepaid-percent', 'Prepaid Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -277,7 +277,7 @@ export const AgentEditSheet = ({
                     name="discountPercent"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('discount-percent')}</Form.Label>
+                        <Form.Label>{t('discount-percent', 'Discount Percent')}</Form.Label>
                         <Input.Number
                           placeholder="0"
                           value={field.value ? Number(field.value) : undefined}
@@ -299,11 +299,11 @@ export const AgentEditSheet = ({
                   name="startDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-date')}</Form.Label>
+                      <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-date')}
+                        placeholder={t('start-date', 'Start Date')}
                       />
                     </Form.Item>
                   )}
@@ -313,11 +313,11 @@ export const AgentEditSheet = ({
                   name="endDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-date')}</Form.Label>
+                      <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-date')}
+                        placeholder={t('end-date', 'End Date')}
                       />
                     </Form.Item>
                   )}
@@ -330,11 +330,11 @@ export const AgentEditSheet = ({
                   name="startMonth"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-month')}</Form.Label>
+                      <Form.Label>{t('start-month', 'Start Month')}</Form.Label>
                       <MonthPicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-month')}
+                        placeholder={t('start-month', 'Start Month')}
                       />
                     </Form.Item>
                   )}
@@ -344,11 +344,11 @@ export const AgentEditSheet = ({
                   name="endMonth"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-month')}</Form.Label>
+                      <Form.Label>{t('end-month', 'End Month')}</Form.Label>
                       <MonthPicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-month')}
+                        placeholder={t('end-month', 'End Month')}
                       />
                     </Form.Item>
                   )}
@@ -361,11 +361,11 @@ export const AgentEditSheet = ({
                   name="startDay"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-day')}</Form.Label>
+                      <Form.Label>{t('start-day', 'Start Day')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('start-day')}
+                        placeholder={t('start-day', 'Start Day')}
                       />
                     </Form.Item>
                   )}
@@ -375,11 +375,11 @@ export const AgentEditSheet = ({
                   name="endDay"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-day')}</Form.Label>
+                      <Form.Label>{t('end-day', 'End Day')}</Form.Label>
                       <DatePicker
                         value={field.value}
                         onChange={field.onChange}
-                        placeholder={t('end-day')}
+                        placeholder={t('end-day', 'End Day')}
                       />
                     </Form.Item>
                   )}
@@ -391,11 +391,11 @@ export const AgentEditSheet = ({
                 name="productRuleIds"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('choose-product-rules')}</Form.Label>
+                    <Form.Label>{t('choose-product-rules', 'Choose Product Rules')}</Form.Label>
                     <SelectProductRules
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('choose-product-rule')}
+                      placeholder={t('choose-product-rule', 'Choose product rule')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -408,10 +408,10 @@ export const AgentEditSheet = ({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentFilter.tsx
@@ -26,7 +26,7 @@ const AgentFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />
@@ -34,11 +34,11 @@ const AgentFilterPopover = () => {
                 <SelectAgentStatus.FilterItem />
                 <SelectCustomer.FilterItem
                   value="agentCustomerId"
-                  label={t('customers')}
+                  label={t('customers', 'Customers')}
                 />
                 <SelectCompany.FilterItem
                   value="agentCompanyId"
-                  label={t('companies')}
+                  label={t('companies', 'Companies')}
                 />
               </Command.List>
             </Command>
@@ -80,22 +80,22 @@ export const AgentFilter = () => {
         <Filter.BarItem queryKey="agentCustomerId">
           <Filter.BarName>
             <IconUsers size={14} />
-            {t('customers')}
+            {t('customers', 'Customers')}
           </Filter.BarName>
           <SelectCustomer.FilterBar
             filterKey="agentCustomerId"
-            label={t('customers')}
+            label={t('customers', 'Customers')}
             mode="single"
           />
         </Filter.BarItem>
         <Filter.BarItem queryKey="agentCompanyId">
           <Filter.BarName>
             <IconBuilding size={14} />
-            {t('companies')}
+            {t('companies', 'Companies')}
           </Filter.BarName>
           <SelectCompany.FilterBar
             filterKey="agentCompanyId"
-            label={t('companies')}
+            label={t('companies', 'Companies')}
             mode="single"
           />
         </Filter.BarItem>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentMoreColumn.tsx
@@ -24,12 +24,16 @@ export const AgentMoreColumnCell = ({
 
     confirm({
       options: { confirmationValue },
-      message: t('delete-agent-confirm', { count: 1 }),
+      message: t(
+        'delete-agent-confirm',
+        'Are you sure you want to delete {{count}} agent(s)?',
+        { count: 1 },
+      ),
     }).then(() => {
       deleteAgent(agent._id).catch(() => {
         toast({
-          title: t('error'),
-          description: t('failed-to-delete-agent'),
+          title: t('error', 'Error'),
+          description: t('failed-to-delete-agent', 'Failed to delete agent'),
           variant: 'destructive',
         });
       });
@@ -38,8 +42,8 @@ export const AgentMoreColumnCell = ({
 
   return (
     <LoyaltyMoreActions
-      editLabel={t('edit')}
-      deleteLabel={t('delete')}
+      editLabel={t('edit', 'Edit')}
+      deleteLabel={t('delete', 'Delete')}
       deleteLoading={loading}
       onEdit={() => setEditOpen(true)}
       onDelete={handleDelete}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentRecordTable.tsx
@@ -48,10 +48,10 @@ export const AgentRecordTable = () => {
                 <IconUsers size={48} className="text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-agents-yet')}
+                {t('no-agents-yet', 'No agents yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                {t('get-started-agent')}
+                {t('get-started-agent', 'Get started by creating your first agent.')}
               </p>
             </div>
           </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/AgentTotalCount.tsx
@@ -11,7 +11,7 @@ export const AgentTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/delete/AgentRemove.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/delete/AgentRemove.tsx
@@ -17,7 +17,11 @@ export const AgentRemove = ({ agentIds, rows }: AgentRemoveProps) => {
 
   const handleDelete = () => {
     confirm({
-      message: t('delete-agent-confirm', { count: rows.length }),
+      message: t(
+        'delete-agent-confirm',
+        'Are you sure you want to delete {{count}} agent(s)?',
+        { count: rows.length },
+      ),
       options: {
         confirmationValue: 'delete',
       },
@@ -31,7 +35,7 @@ export const AgentRemove = ({ agentIds, rows }: AgentRemoveProps) => {
   return (
     <Button variant="ghost" size="sm" onClick={handleDelete} disabled={loading}>
       <IconTrash className="h-4 w-4" />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/MonthPicker.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/MonthPicker.tsx
@@ -41,7 +41,7 @@ export const MonthPicker = ({
     setOpen(false);
   };
 
-  const label = value ? dayjs(value).format('MMM YYYY') : (placeholder || t('pick-a-month'));
+  const label = value ? dayjs(value).format('MMM YYYY') : (placeholder || t('pick-a-month', 'Pick a month'));
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/SelectAgentStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/SelectAgentStatus.tsx
@@ -26,8 +26,8 @@ const StatusContent = ({
   const { t } = useTranslation('loyalty');
   return (
   <Command>
-    <Command.Input placeholder={t('search')} />
-    <Command.Empty>{t('no-statuses-found')}</Command.Empty>
+    <Command.Input placeholder={t('search', 'Search...')} />
+    <Command.Empty>{t('no-statuses-found', 'No statuses found')}</Command.Empty>
     <Command.List>
       {OPTIONS.map((o) => (
         <Command.Item
@@ -49,7 +49,7 @@ const FilterItem = () => {
   return (
     <Filter.Item value="agentStatus">
       <IconCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -80,12 +80,12 @@ const FilterBar = () => {
     <Filter.BarItem queryKey="agentStatus">
       <Filter.BarName>
         <IconCheck />
-        {t('status')}
+        {t('status', 'Status')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="agentStatus">
-            <span>{label ? t(label) : t('select-status')}</span>
+            <span>{label ? t(label) : t('select-status', 'Select status')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>
@@ -119,7 +119,7 @@ const FormItem = ({
       <Form.Control>
         <Combobox.Trigger className="w-full shadow-xs">
           <span className={label ? '' : 'text-accent-foreground/80'}>
-            {label ? t(label) : placeholder || t('select-status')}
+            {label ? t(label) : placeholder || t('select-status', 'Select status')}
           </span>
         </Combobox.Trigger>
       </Form.Control>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/SelectProductRules.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/components/selects/SelectProductRules.tsx
@@ -48,17 +48,17 @@ export const SelectProductRules = ({
         <Combobox.Trigger className="w-full shadow-xs">
           {selectedNames || (
             <span className="text-accent-foreground/80">
-              {placeholder || t('choose-product-rule')}
+              {placeholder || t('choose-product-rule', 'Choose product rule')}
             </span>
           )}
         </Combobox.Trigger>
       </Form.Control>
       <Combobox.Content>
         <Command>
-          <Command.Input placeholder={t('search-rules')} />
+          <Command.Input placeholder={t('search-rules', 'Search rules...')} />
           <Command.Empty>
             <span className="text-muted-foreground">
-              {loading ? t('loading') : t('no-rules-found')}
+              {loading ? t('loading', 'Loading...') : t('no-rules-found', 'No rules found')}
             </span>
           </Command.Empty>
           <Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useAddAgent.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useAddAgent.ts
@@ -31,14 +31,14 @@ export const useAddAgent = () => {
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('agent-created'),
+          title: t('success', 'Success'),
+          description: t('agent-created', 'Agent created successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useDeleteAgent.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useDeleteAgent.ts
@@ -38,14 +38,14 @@ export const useDeleteAgent = () => {
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('agent-deleted'),
+          title: t('success', 'Success'),
+          description: t('agent-deleted', 'Agent deleted successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useEditAgent.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/agents/hooks/useEditAgent.ts
@@ -17,14 +17,14 @@ export const useEditAgent = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('agent-updated'),
+          title: t('success', 'Success'),
+          description: t('agent-updated', 'Agent updated successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentAddModal.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentAddModal.tsx
@@ -37,15 +37,15 @@ export const AssignmentAddModal = () => {
         },
       });
       toast({
-        title: t('success'),
-        description: t('assignment-created'),
+        title: t('success', 'Success'),
+        description: t('assignment-created', 'Assignment created successfully'),
         variant: 'default',
       });
       setOpen(false);
       form.reset();
     } catch (e: unknown) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: e instanceof Error ? e.message : String(e),
         variant: 'destructive',
       });
@@ -57,12 +57,12 @@ export const AssignmentAddModal = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-assignment')}
+          {t('add-assignment', 'Add assignment')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md p-0">
         <Sheet.Header className="border-b gap-3 px-6 py-4">
-          <Sheet.Title>{t('new-assignment')}</Sheet.Title>
+          <Sheet.Title>{t('new-assignment', 'New Assignment')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-6">
@@ -74,14 +74,14 @@ export const AssignmentAddModal = () => {
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign')}</Form.Label>
+                    <Form.Label>{t('campaign', 'Campaign')}</Form.Label>
                     <SelectAssignmentCampaignFormItem
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('choose-assignment-campaign')}
+                      placeholder={t('choose-assignment-campaign', 'Choose assignment campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -91,10 +91,10 @@ export const AssignmentAddModal = () => {
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       <SelectCustomer
                         value={field.value ? [field.value] : []}
@@ -115,10 +115,10 @@ export const AssignmentAddModal = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentColumns.tsx
@@ -47,7 +47,7 @@ export const assignmentColumns = (
     id: 'campaign',
     accessorKey: 'campaign',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('campaign')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('campaign', 'Campaign')} />
     ),
     size: 180,
     cell: ({ row }) => (
@@ -60,7 +60,7 @@ export const assignmentColumns = (
     id: 'ownerId',
     accessorKey: 'ownerId',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-id')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-id', 'Owner Id')} />
     ),
     size: 180,
     cell: ({ row }) => (
@@ -73,7 +73,7 @@ export const assignmentColumns = (
     id: 'status',
     accessorKey: 'status',
     header: () => (
-      <RecordTable.InlineHead icon={IconToggleLeft} label={t('status')} />
+      <RecordTable.InlineHead icon={IconToggleLeft} label={t('status', 'Status')} />
     ),
     size: 100,
     cell: ({ cell }) => {
@@ -91,7 +91,7 @@ export const assignmentColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconCalendar} label={t('created-at')} />
+      <RecordTable.InlineHead icon={IconCalendar} label={t('created-at', 'Created At')} />
     ),
     size: 150,
     cell: ({ cell }) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentCommandBar.tsx
@@ -34,19 +34,19 @@ const AssignmentRemove = ({
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-assignment-confirm', { count: ids.length }),
+          message: t('delete-assignment-confirm', 'Are you sure you want to delete {{count}} selected assignment(s)?', { count: ids.length }),
         }).then(async () => {
           try {
             await removeAssignments({ variables: { _ids: ids } });
             rows.forEach((row) => row.toggleSelected(false));
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('assignments-deleted', { count: ids.length }),
+              description: t('assignments-deleted', '{{count}} assignment(s) deleted successfully', { count: ids.length }),
             });
           } catch (e: unknown) {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e instanceof Error ? e.message : String(e),
               variant: 'destructive',
             });
@@ -55,7 +55,7 @@ const AssignmentRemove = ({
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };
@@ -70,7 +70,7 @@ export const AssignmentCommandBar = () => {
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedRows.length })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedRows.length })}</CommandBar.Value>
         <Separator.Inline />
         <AssignmentRemove ids={ids} rows={selectedRows} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentFilter.tsx
@@ -39,7 +39,7 @@ const AssignmentFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentRecordTable.tsx
@@ -50,10 +50,10 @@ export const AssignmentRecordTable = () => {
             <div className="flex flex-col items-center text-center">
               <IconClipboardList size={48} className="text-gray-400 mb-4" />
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-assignments-yet')}
+                {t('no-assignments-yet', 'No assignments yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500 mb-4">
-                {t('get-started-assignment')}
+                {t('get-started-assignment', 'Get started by creating your first assignment.')}
               </p>
               <AssignmentAddModal />
             </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/AssignmentTotalCount.tsx
@@ -12,7 +12,7 @@ export const AssignmentTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/selects/SelectAssignmentCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/selects/SelectAssignmentCampaign.tsx
@@ -43,7 +43,7 @@ export const SelectAssignmentCampaignFilterItem = () => {
   return (
     <Filter.Item value="assignmentCampaignId">
       <IconTag />
-      {t('campaign')}
+      {t('campaign', 'Campaign')}
     </Filter.Item>
   );
 };
@@ -61,8 +61,8 @@ export const SelectAssignmentCampaignFilterView = ({
   return (
     <Filter.View filterKey={queryKey}>
       <Command>
-        <Command.Input placeholder={t('search-campaigns')} />
-        <Command.Empty>{t('no-campaigns-found')}</Command.Empty>
+        <Command.Input placeholder={t('search-campaigns', 'Search campaigns...')} />
+        <Command.Empty>{t('no-campaigns-found', 'No campaigns found')}</Command.Empty>
         <Command.List>
           {options.map((opt) => (
             <Command.Item
@@ -94,17 +94,17 @@ export const SelectAssignmentCampaignFilterBar = () => {
     <Filter.BarItem queryKey="assignmentCampaignId">
       <Filter.BarName>
         <IconTag />
-        {t('campaign')}
+        {t('campaign', 'Campaign')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="assignmentCampaignId">
-            <span>{selected?.label || t('campaign')}</span>
+            <span>{selected?.label || t('campaign', 'Campaign')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>
           <Command>
-            <Command.Input placeholder={t('search')} />
+            <Command.Input placeholder={t('search', 'Search...')} />
             <Command.List>
               {options.map((opt) => (
                 <Command.Item
@@ -151,14 +151,14 @@ export const SelectAssignmentCampaignFormItem = ({
           disabled={loading}
         >
           <span className={selected ? '' : 'text-muted-foreground'}>
-            {selected?.label || placeholder || t('choose-assignment-campaign')}
+            {selected?.label || placeholder || t('choose-assignment-campaign', 'Choose assignment campaign')}
           </span>
         </Combobox.Trigger>
       </Form.Control>
       <Combobox.Content>
         <Command>
-          <Command.Input placeholder={t('search-campaigns')} />
-          <Command.Empty>{t('no-campaigns-found')}</Command.Empty>
+          <Command.Input placeholder={t('search-campaigns', 'Search campaigns...')} />
+          <Command.Empty>{t('no-campaigns-found', 'No campaigns found')}</Command.Empty>
           <Command.List>
             {options.map((opt) => (
               <Command.Item

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/selects/SelectAssignmentStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/assignments/components/selects/SelectAssignmentStatus.tsx
@@ -21,7 +21,7 @@ export const SelectAssignmentStatusFilterItem = () => {
   return (
     <Filter.Item value="assignmentStatus">
       <IconToggleLeft />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -64,12 +64,12 @@ export const SelectAssignmentStatusFilterBar = () => {
     <Filter.BarItem queryKey="assignmentStatus">
       <Filter.BarName>
         <IconToggleLeft />
-        {t('status')}
+        {t('status', 'Status')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="assignmentStatus">
-            <span>{selected ? t(selected.label) : t('status')}</span>
+            <span>{selected ? t(selected.label) : t('status', 'Status')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/components/LoyaltyMainLayout.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/components/LoyaltyMainLayout.tsx
@@ -26,7 +26,7 @@ export const LoyaltyMainLayout = ({
         <PageHeader className="p-3 mx-0">
           <PageHeader.Start>
             <IconAward className="size-4" />
-            <span className="font-medium">{t('loyalty-title')}</span>
+            <span className="font-medium">{t('loyalty-title', 'Loyalty')}</span>
           </PageHeader.Start>
           <PageHeader.End>
             <LoyaltyHeaderEnd />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/components/LoyaltyMainSidebar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/components/LoyaltyMainSidebar.tsx
@@ -18,7 +18,7 @@ export const LoyaltyMainSidebar = () => {
   return (
     <Sidebar collapsible="none" className="flex-none border-r">
       <Sidebar.Group>
-        <Sidebar.GroupLabel>{t('loyalty-modules')}</Sidebar.GroupLabel>
+        <Sidebar.GroupLabel>{t('loyalty-modules', 'Loyalty modules')}</Sidebar.GroupLabel>
         <Sidebar.GroupContent>
           <Sidebar.Menu>
             {NAV_ITEMS.map(({ label, path }) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/components/SelectOwner.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/components/SelectOwner.tsx
@@ -29,8 +29,8 @@ const useOwnerParts = (ownerType?: string | null): OwnerParts => {
       Provider: SelectCompany.Provider,
       Content: SelectCompany.Content,
       Value: SelectCompany.Value,
-      label: t('company'),
-      placeholder: t('select-company'),
+      label: t('company', 'Company'),
+      placeholder: t('select-company', 'Select Company'),
     };
   }
   if (ownerType === 'user') {
@@ -38,16 +38,16 @@ const useOwnerParts = (ownerType?: string | null): OwnerParts => {
       Provider: SelectMember.Provider,
       Content: SelectMember.Content,
       Value: SelectMember.Value,
-      label: t('team-member'),
-      placeholder: t('select-team-member'),
+      label: t('team-member', 'Team Member'),
+      placeholder: t('select-team-member', 'Select Team Member'),
     };
   }
   return {
     Provider: SelectCustomer.Provider,
     Content: SelectCustomer.Content,
     Value: SelectCustomer.Value,
-    label: t('customer'),
-    placeholder: t('select-customer'),
+    label: t('customer', 'Customer'),
+    placeholder: t('select-customer', 'Select customer'),
   };
 };
 
@@ -73,7 +73,7 @@ const SelectOwnerFilterItem = ({ queryKey }: { queryKey: string }) => {
   return (
     <Filter.Item value={queryKey}>
       <IconUser />
-      {t('owner')}
+      {t('owner', 'Owner')}
     </Filter.Item>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponAddModal.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponAddModal.tsx
@@ -33,12 +33,12 @@ export const CouponAddModal = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-coupon')}
+          {t('add-coupon', 'Add coupon')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md p-0">
         <Sheet.Header className="border-b gap-3 px-6 py-4">
-          <Sheet.Title>{t('new-coupon')}</Sheet.Title>
+          <Sheet.Title>{t('new-coupon', 'New Coupon')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-6">
@@ -50,14 +50,14 @@ export const CouponAddModal = () => {
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign')}</Form.Label>
+                    <Form.Label>{t('campaign', 'Campaign')}</Form.Label>
                     <SelectCouponCampaignFormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val)}
-                      placeholder={t('choose-coupon-campaign')}
+                      placeholder={t('choose-coupon-campaign', 'Choose coupon campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -69,10 +69,10 @@ export const CouponAddModal = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponColumns.tsx
@@ -26,7 +26,7 @@ const CodeCell = ({ code }: { code?: string }) => {
   const handleCopy = () => {
     if (!code) return;
     navigator.clipboard.writeText(code);
-    toast({ title: t('copied'), description: code, variant: 'default' });
+    toast({ title: t('copied', 'Copied!'), description: code, variant: 'default' });
   };
 
   return (
@@ -72,7 +72,7 @@ export const couponColumns = (
     id: 'campaignId',
     accessorKey: 'campaign',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('campaign')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('campaign', 'Campaign')} />
     ),
     size: 160,
     cell: ({ row }) => (
@@ -84,7 +84,7 @@ export const couponColumns = (
   {
     id: 'code',
     accessorKey: 'code',
-    header: () => <RecordTable.InlineHead icon={IconHash} label={t('code')} />,
+    header: () => <RecordTable.InlineHead icon={IconHash} label={t('code', 'Code')} />,
     size: 140,
     cell: ({ row }) => <CodeCell code={row.original.code} />,
   },
@@ -92,7 +92,7 @@ export const couponColumns = (
     id: 'usageCount',
     accessorKey: 'usageCount',
     header: () => (
-      <RecordTable.InlineHead icon={IconChartBar} label={t('usage')} />
+      <RecordTable.InlineHead icon={IconChartBar} label={t('usage', 'Usage')} />
     ),
     size: 90,
     cell: ({ cell }) => (
@@ -104,7 +104,7 @@ export const couponColumns = (
   {
     id: 'usageLimit',
     accessorKey: 'usageLimit',
-    header: () => <RecordTable.InlineHead icon={IconLock} label={t('limit')} />,
+    header: () => <RecordTable.InlineHead icon={IconLock} label={t('limit', 'Limit')} />,
     size: 90,
     cell: ({ cell }) => (
       <RecordTableInlineCell>
@@ -116,7 +116,7 @@ export const couponColumns = (
     id: 'status',
     accessorKey: 'status',
     header: () => (
-      <RecordTable.InlineHead icon={IconToggleLeft} label={t('status')} />
+      <RecordTable.InlineHead icon={IconToggleLeft} label={t('status', 'Status')} />
     ),
     size: 100,
     cell: ({ cell }) => {
@@ -134,7 +134,7 @@ export const couponColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconCalendar} label={t('created-at')} />
+      <RecordTable.InlineHead icon={IconCalendar} label={t('created-at', 'Created At')} />
     ),
     size: 150,
     cell: ({ cell }) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponFilter.tsx
@@ -47,7 +47,7 @@ const CouponFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />
@@ -60,7 +60,7 @@ const CouponFilterPopover = () => {
                 <SelectCouponStatusFilterItem />
                 <Filter.Item value="couponDate">
                   <IconCalendar />
-                  {t('date')}
+                  {t('date', 'Date')}
                 </Filter.Item>
               </Command.List>
             </Command>
@@ -117,7 +117,7 @@ export const CouponFilter = () => {
         <Filter.BarItem queryKey="couponDate">
           <Filter.BarName>
             <IconCalendar />
-            {t('date')}
+            {t('date', 'Date')}
           </Filter.BarName>
           <Filter.Date filterKey="couponDate" />
         </Filter.BarItem>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponRecordTable.tsx
@@ -50,10 +50,10 @@ export const CouponRecordTable = () => {
             <div className="flex flex-col items-center text-center">
               <IconTicket size={48} className="text-gray-400 mb-4" />
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-coupons-yet')}
+                {t('no-coupons-yet', 'No coupons yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500 mb-4">
-                {t('get-started-coupon')}
+                {t('get-started-coupon', 'Get started by creating your first coupon.')}
               </p>
               <CouponAddModal />
             </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/CouponTotalCount.tsx
@@ -12,7 +12,7 @@ export const CouponTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponCampaign.tsx
@@ -43,7 +43,7 @@ export const SelectCouponCampaignFilterItem = () => {
   return (
     <Filter.Item value="couponCampaignId">
       <IconTag />
-      {t('campaign')}
+      {t('campaign', 'Campaign')}
     </Filter.Item>
   );
 };
@@ -61,8 +61,8 @@ export const SelectCouponCampaignFilterView = ({
   return (
     <Filter.View filterKey={queryKey}>
       <Command>
-        <Command.Input placeholder={t('search-campaigns')} />
-        <Command.Empty>{t('no-campaigns-found')}</Command.Empty>
+        <Command.Input placeholder={t('search-campaigns', 'Search campaigns...')} />
+        <Command.Empty>{t('no-campaigns-found', 'No campaigns found')}</Command.Empty>
         <Command.List>
           {options.map((opt) => (
             <Command.Item
@@ -94,17 +94,17 @@ export const SelectCouponCampaignFilterBar = () => {
     <Filter.BarItem queryKey="couponCampaignId">
       <Filter.BarName>
         <IconTag />
-        {t('campaign')}
+        {t('campaign', 'Campaign')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="couponCampaignId">
-            <span>{selected?.label || t('campaign')}</span>
+            <span>{selected?.label || t('campaign', 'Campaign')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>
           <Command>
-            <Command.Input placeholder={t('search')} />
+            <Command.Input placeholder={t('search', 'Search...')} />
             <Command.List>
               {options.map((opt) => (
                 <Command.Item
@@ -151,14 +151,14 @@ export const SelectCouponCampaignFormItem = ({
           disabled={loading}
         >
           <span className={selected ? '' : 'text-muted-foreground'}>
-            {selected?.label || placeholder || t('choose-coupon-campaign')}
+            {selected?.label || placeholder || t('choose-coupon-campaign', 'Choose coupon campaign')}
           </span>
         </Combobox.Trigger>
       </Form.Control>
       <Combobox.Content>
         <Command>
-          <Command.Input placeholder={t('search-campaigns')} />
-          <Command.Empty>{t('no-campaigns-found')}</Command.Empty>
+          <Command.Input placeholder={t('search-campaigns', 'Search campaigns...')} />
+          <Command.Empty>{t('no-campaigns-found', 'No campaigns found')}</Command.Empty>
           <Command.List>
             {options.map((opt) => (
               <Command.Item

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponOrderType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponOrderType.tsx
@@ -17,7 +17,7 @@ export const SelectCouponOrderTypeFilterItem = () => {
   return (
     <Filter.Item value="couponSortField">
       <IconSortAscending />
-      {t('order-type')}
+      {t('order-type', 'Order Type')}
     </Filter.Item>
   );
 };
@@ -59,12 +59,12 @@ export const SelectCouponOrderTypeFilterBar = () => {
     <Filter.BarItem queryKey="couponSortField">
       <Filter.BarName>
         <IconSortAscending />
-        {t('order-type')}
+        {t('order-type', 'Order Type')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="couponSortField">
-            <span>{selected?.label || t('order-type')}</span>
+            <span>{selected?.label || t('order-type', 'Order Type')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/components/selects/SelectCouponStatus.tsx
@@ -21,7 +21,7 @@ export const SelectCouponStatusFilterItem = () => {
   return (
     <Filter.Item value="couponStatus">
       <IconToggleLeft />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -64,12 +64,12 @@ export const SelectCouponStatusFilterBar = () => {
     <Filter.BarItem queryKey="couponStatus">
       <Filter.BarName>
         <IconToggleLeft />
-        {t('status')}
+        {t('status', 'Status')}
       </Filter.BarName>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <Filter.BarButton filterKey="couponStatus">
-            <span>{selected ? t(selected.label) : t('status')}</span>
+            <span>{selected ? t(selected.label) : t('status', 'Status')}</span>
           </Filter.BarButton>
         </Popover.Trigger>
         <Combobox.Content>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/hooks/useAddCoupon.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/coupons/hooks/useAddCoupon.ts
@@ -31,14 +31,14 @@ export const useAddCoupon = () => {
       onCompleted: (data) => {
         const count = data?.couponAdd?.length || 1;
         toast({
-          title: t('success'),
-          description: t('coupon-created', { count }),
+          title: t('success', 'Success'),
+          description: t('coupon-created', '{{count}} coupon(s) created successfully', { count }),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateAddSheet.tsx
@@ -89,12 +89,12 @@ export const DonateAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-donation')}
+          {t('add-donation', 'Add Donation')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('add-donation')}</Sheet.Title>
+          <Sheet.Title>{t('add-donation', 'Add Donation')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -106,14 +106,14 @@ export const DonateAddSheet = () => {
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectDonateCampaign.FormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -125,7 +125,7 @@ export const DonateAddSheet = () => {
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -138,9 +138,9 @@ export const DonateAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('user')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('user', 'User')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -152,10 +152,10 @@ export const DonateAddSheet = () => {
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       <DonateOwnerSelect
                         ownerType={ownerType}
@@ -173,12 +173,12 @@ export const DonateAddSheet = () => {
                 name="donateScore"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('donate-score')}</Form.Label>
+                    <Form.Label>{t('donate-score', 'Donate Score')}</Form.Label>
                     <Form.Control>
                       <Input
                         type="number"
                         min={0}
-                        placeholder={t('enter-donate-score')}
+                        placeholder={t('enter-donate-score', 'Enter donate score')}
                         {...field}
                       />
                     </Form.Control>
@@ -193,10 +193,10 @@ export const DonateAddSheet = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('creating') : t('save')}
+                  {loading ? t('creating', 'Creating...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateColumns.tsx
@@ -72,7 +72,7 @@ export const firstDonateColumns = (
     accessorKey: 'createdAt',
     header: () => {
       return (
-        <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />
+        <RecordTable.InlineHead icon={IconClock} label={t('created-at', 'Created At')} />
       );
     },
     size: 100,
@@ -82,7 +82,7 @@ export const firstDonateColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-type', 'Owner Type')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -101,7 +101,7 @@ export const secondDonateColumns = (
   {
     id: 'ownerId',
     accessorKey: 'ownerId',
-    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner')} />,
+    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner', 'Owner')} />,
     cell: ({ row }) => (
       <OwnerCell
         ownerId={row.original.ownerId}
@@ -112,7 +112,7 @@ export const secondDonateColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status')} />,
+    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status', 'Status')} />,
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateCommandBar.tsx
@@ -15,7 +15,7 @@ export const DonateCommandBar = () => {
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedRows.length })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedRows.length })}</CommandBar.Value>
         <Separator.Inline />
         <DonateRemove donateIds={donateIds} rows={selectedRows} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateEditSheet.tsx
@@ -111,7 +111,7 @@ export const DonateEditSheet = ({
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('edit-donation')}</Sheet.Title>
+          <Sheet.Title>{t('edit-donation', 'Edit Donation')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -123,14 +123,14 @@ export const DonateEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectDonateCampaign.FormItem
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -142,7 +142,7 @@ export const DonateEditSheet = ({
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -155,9 +155,9 @@ export const DonateEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('user')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('user', 'User')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -169,10 +169,10 @@ export const DonateEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       <DonateOwnerSelect
                         ownerType={ownerType}
@@ -190,12 +190,12 @@ export const DonateEditSheet = ({
                 name="donateScore"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('donate-score')}</Form.Label>
+                    <Form.Label>{t('donate-score', 'Donate Score')}</Form.Label>
                     <Form.Control>
                       <Input
                         type="number"
                         min={0}
-                        placeholder={t('enter-donate-score')}
+                        placeholder={t('enter-donate-score', 'Enter donate score')}
                         {...field}
                       />
                     </Form.Control>
@@ -210,10 +210,10 @@ export const DonateEditSheet = ({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateFilter.tsx
@@ -29,7 +29,7 @@ const DonateFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateRecordTable.tsx
@@ -54,10 +54,10 @@ export const DonateRecordTable = ({ posId }: { posId?: string }) => {
                 <IconShoppingCartX size={48} className="text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-donations-yet')}
+                {t('no-donations-yet', 'No donations yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                {t('get-started-donation')}
+                {t('get-started-donation', 'Get started by creating your first donation.')}
               </p>
             </div>
           </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/DonateTotalCount.tsx
@@ -11,7 +11,7 @@ export const DonateTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/delete/DonateRemove.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/delete/DonateRemove.tsx
@@ -19,8 +19,8 @@ export const DonateRemove = ({ donateIds, rows }: DonateRemoveProps) => {
     try {
       await deleteDonate({ _ids: donateIds });
       toast({
-        title: t('success'),
-        description: t('donations-deleted', { count: donateIds.length }),
+        title: t('success', 'Success'),
+        description: t('donations-deleted', '{{count}} donation(s) deleted successfully', { count: donateIds.length }),
         variant: 'default',
       });
     } catch {
@@ -31,7 +31,7 @@ export const DonateRemove = ({ donateIds, rows }: DonateRemoveProps) => {
   return (
     <Button variant="ghost" size="sm" onClick={handleDelete} disabled={loading}>
       <IconTrash className="h-4 w-4" />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectDonateCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectDonateCampaign.tsx
@@ -123,7 +123,7 @@ const SelectDonateCampaignValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-campaign')}
+        {placeholder || t('select-campaign', 'Select campaign')}
       </span>
     );
   }
@@ -165,9 +165,9 @@ const SelectDonateCampaignContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-campaigns')} />
+      <Command.Input placeholder={t('search-campaigns', 'Search campaigns...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-campaigns-found')}</span>
+        <span className="text-muted-foreground">{t('no-campaigns-found', 'No campaigns found')}</span>
       </Command.Empty>
       <Command.List>
         {options.map((option) => (
@@ -183,7 +183,7 @@ export const SelectDonateCampaignFilterItem = () => {
   return (
     <Filter.Item value="donateCampaign">
       <IconTag />
-      {t('campaign')}
+      {t('campaign', 'Campaign')}
     </Filter.Item>
   );
 };
@@ -238,7 +238,7 @@ export const SelectDonateCampaignFilterBar = ({
     <Filter.BarItem queryKey="donateCampaign">
       <Filter.BarName>
         <IconTag />
-        {!iconOnly && t('campaign')}
+        {!iconOnly && t('campaign', 'Campaign')}
       </Filter.BarName>
       <SelectDonateCampaignProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectOwnerType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectOwnerType.tsx
@@ -105,7 +105,7 @@ const SelectOwnerTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-owner-type')}
+        {placeholder || t('select-owner-type', 'Select owner type')}
       </span>
     );
   }
@@ -146,9 +146,9 @@ const SelectOwnerTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-owner-types')} />
+      <Command.Input placeholder={t('search-owner-types', 'Search owner types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-owner-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-owner-types-found', 'No owner types found')}</span>
       </Command.Empty>
       <Command.List>
         {OWNER_TYPE_OPTIONS.map((option) => (
@@ -164,7 +164,7 @@ export const SelectOwnerTypeFilterItem = () => {
   return (
     <Filter.Item value="ownerType">
       <IconUsers />
-      {t('owner-type')}
+      {t('owner-type', 'Owner Type')}
     </Filter.Item>
   );
 };
@@ -219,7 +219,7 @@ export const SelectOwnerTypeFilterBar = ({
     <Filter.BarItem queryKey="ownerType">
       <Filter.BarName>
         <IconUsers />
-        {!iconOnly && t('owner-type')}
+        {!iconOnly && t('owner-type', 'Owner Type')}
       </Filter.BarName>
       <SelectOwnerTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/components/selects/SelectStatus.tsx
@@ -102,7 +102,7 @@ const SelectStatusValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-status')}
+        {placeholder || t('select-status', 'Select status')}
       </span>
     );
   }
@@ -139,9 +139,9 @@ const SelectStatusContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-statuses')} />
+      <Command.Input placeholder={t('search-statuses', 'Search statuses...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-statuses-found')}</span>
+        <span className="text-muted-foreground">{t('no-statuses-found', 'No statuses found')}</span>
       </Command.Empty>
       <Command.List>
         {STATUS_OPTIONS.map((option) => (
@@ -157,7 +157,7 @@ export const SelectStatusFilterItem = () => {
   return (
     <Filter.Item value="status">
       <IconCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -210,7 +210,7 @@ export const SelectStatusFilterBar = ({
     <Filter.BarItem queryKey="status">
       <Filter.BarName>
         <IconCheck />
-        {!iconOnly && t('status')}
+        {!iconOnly && t('status', 'Status')}
       </Filter.BarName>
       <SelectStatusProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useAddDonate.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useAddDonate.ts
@@ -23,14 +23,14 @@ export const useAddDonate = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('donation-created'),
+          title: t('success', 'Success'),
+          description: t('donation-created', 'Donation created successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useDeleteDonate.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useDeleteDonate.ts
@@ -19,14 +19,14 @@ export const useDeleteDonate = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('donation-deleted'),
+          title: t('success', 'Success'),
+          description: t('donation-deleted', 'Donation(s) deleted successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useEditDonate.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/donates/hooks/useEditDonate.ts
@@ -24,14 +24,14 @@ export const useEditDonate = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('donation-updated'),
+          title: t('success', 'Success'),
+          description: t('donation-updated', 'Donation updated successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryAddSheet.tsx
@@ -57,12 +57,12 @@ export const LotteryAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-lottery')}
+          {t('add-lottery', 'Add Lottery')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('add-lottery')}</Sheet.Title>
+          <Sheet.Title>{t('add-lottery', 'Add Lottery')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -74,14 +74,14 @@ export const LotteryAddSheet = () => {
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectLotteryCampaign
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -93,7 +93,7 @@ export const LotteryAddSheet = () => {
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -106,9 +106,9 @@ export const LotteryAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('team-members')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('team-members', 'Team Members')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -120,10 +120,10 @@ export const LotteryAddSheet = () => {
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       {ownerType === 'company' ? (
                         <SelectCompany
@@ -149,7 +149,7 @@ export const LotteryAddSheet = () => {
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')}</Form.Label>
+                    <Form.Label>{t('status', 'Status')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -159,9 +159,9 @@ export const LotteryAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="new">{t('new')}</Select.Item>
-                          <Select.Item value="loss">{t('loss')}</Select.Item>
-                          <Select.Item value="won">{t('won')}</Select.Item>
+                          <Select.Item value="new">{t('new', 'New')}</Select.Item>
+                          <Select.Item value="loss">{t('loss', 'Loss')}</Select.Item>
+                          <Select.Item value="won">{t('won', 'Won')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -175,11 +175,11 @@ export const LotteryAddSheet = () => {
                 name="voucherCampaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                     <SelectVoucherCampaign.FormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('choose-voucher-campaign')}
+                      placeholder={t('choose-voucher-campaign', 'Choose voucher campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -192,10 +192,10 @@ export const LotteryAddSheet = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('creating') : t('save')}
+                  {loading ? t('creating', 'Creating...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryCampaignInline.tsx
@@ -45,7 +45,7 @@ const LotteryCampaignInlineProvider = ({
       loading: false,
       lotteryCampaignId: normalizedLotteryCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('select-lottery-campaigns')
+        ? t('select-lottery-campaigns', 'Select lottery campaigns')
         : placeholder,
       updateLotteryCampaigns:
         updateLotteryCampaigns || setCurrentLotteryCampaigns,
@@ -91,7 +91,7 @@ const LotteryCampaignInlineTitle = () => {
   if (!campaign) {
     return (
       <span className="text-muted-foreground">
-        {placeholder ?? t('no-campaign-selected')}
+        {placeholder ?? t('no-campaign-selected', 'No campaign selected')}
       </span>
     );
   }
@@ -99,7 +99,7 @@ const LotteryCampaignInlineTitle = () => {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <TextOverflowTooltip value={campaign.title || t('untitled-campaign')} />
+        <TextOverflowTooltip value={campaign.title || t('untitled-campaign', 'Untitled Campaign')} />
       </Tooltip.Trigger>
       <Tooltip.Content>
         <p>{campaign.title}</p>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryColumns.tsx
@@ -86,7 +86,7 @@ export const firstLotteryColumns = (
     id: 'number',
     accessorKey: 'number',
     header: () => (
-      <RecordTable.InlineHead icon={IconHash} label={t('number')} />
+      <RecordTable.InlineHead icon={IconHash} label={t('number', 'Number')} />
     ),
     cell: ({ row }) => <NumberCell lottery={row.original} />,
     size: 300,
@@ -95,7 +95,7 @@ export const firstLotteryColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />
+      <RecordTable.InlineHead icon={IconClock} label={t('created-at', 'Created At')} />
     ),
     size: 100,
     cell: ({ row }) => <CreatedAtCell lottery={row.original} />,
@@ -104,7 +104,7 @@ export const firstLotteryColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-type', 'Owner Type')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -123,7 +123,7 @@ export const secondLotteryColumns = (
   {
     id: 'ownerId',
     accessorKey: 'ownerId',
-    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner')} />,
+    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner', 'Owner')} />,
     cell: ({ row }) => (
       <OwnerCell
         ownerId={row.original.ownerId}
@@ -134,7 +134,7 @@ export const secondLotteryColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status')} />,
+    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status', 'Status')} />,
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryEditSheet.tsx
@@ -78,7 +78,7 @@ export const LotteryEditSheet = ({
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('edit-lottery')}</Sheet.Title>
+          <Sheet.Title>{t('edit-lottery', 'Edit Lottery')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -90,14 +90,14 @@ export const LotteryEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectLotteryCampaign
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -109,7 +109,7 @@ export const LotteryEditSheet = ({
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -122,11 +122,11 @@ export const LotteryEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('team-members')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('team-members', 'Team Members')}</Select.Item>
                           <Select.Item value="cpUser">
-                            {t('cp-user')}
+                            {t('cp-user', 'Client Portal User')}
                           </Select.Item>
                         </Select.Content>
                       </Select>
@@ -139,10 +139,10 @@ export const LotteryEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       {ownerType === 'company' ? (
                         <SelectCompany
@@ -168,7 +168,7 @@ export const LotteryEditSheet = ({
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')}</Form.Label>
+                    <Form.Label>{t('status', 'Status')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -178,10 +178,10 @@ export const LotteryEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="new">{t('new')}</Select.Item>
-                          <Select.Item value="active">{t('active')}</Select.Item>
-                          <Select.Item value="used">{t('used')}</Select.Item>
-                          <Select.Item value="expired">{t('expired')}</Select.Item>
+                          <Select.Item value="new">{t('new', 'New')}</Select.Item>
+                          <Select.Item value="active">{t('active', 'Active')}</Select.Item>
+                          <Select.Item value="used">{t('used', 'Used')}</Select.Item>
+                          <Select.Item value="expired">{t('expired', 'Expired')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -195,11 +195,11 @@ export const LotteryEditSheet = ({
                 name="voucherCampaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                     <SelectVoucherCampaign.FormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('choose-voucher-campaign')}
+                      placeholder={t('choose-voucher-campaign', 'Choose voucher campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -212,10 +212,10 @@ export const LotteryEditSheet = ({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryFilter.tsx
@@ -37,7 +37,7 @@ const LotteryFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryRecordTable.tsx
@@ -58,10 +58,10 @@ export const LotteryRecordTable = ({ posId }: { posId?: string }) => {
                 <IconShoppingCartX size={48} className="text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-lotteries-yet')}
+                {t('no-lotteries-yet', 'No lotteries yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                {t('get-started-lottery')}
+                {t('get-started-lottery', 'Get started by creating your first lottery.')}
               </p>
             </div>
           </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/LotteryTotalCount.tsx
@@ -11,7 +11,7 @@ export const LotteryTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/lottery-command-bar/LotteryCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/lottery-command-bar/LotteryCommandBar.tsx
@@ -16,7 +16,7 @@ export const LotteryCommandBar = () => {
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: selectedRows.length })}
+          {t('selected-count', '{{count}} selected', { count: selectedRows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <LotteryRemove lotteryIds={lotteryIds} rows={selectedRows} />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/lottery-command-bar/delete/LotteryRemove.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/lottery-command-bar/delete/LotteryRemove.tsx
@@ -27,19 +27,19 @@ export const LotteryRemove = ({
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-lottery-confirm', { count: lotteryIds.length }),
+          message: t('delete-lottery-confirm', 'Are you sure you want to delete {{count}} selected lottery(s)?', { count: lotteryIds.length }),
         }).then(async () => {
           try {
             await deleteLottery({ variables: { _ids: lotteryIds } });
             rows.forEach((row) => row.toggleSelected(false));
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('lotteries-deleted', { count: lotteryIds.length }),
+              description: t('lotteries-deleted', '{{count}} lottery(s) deleted successfully', { count: lotteryIds.length }),
             });
           } catch (e: unknown) {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e instanceof Error ? e.message : String(e),
               variant: 'destructive',
             });
@@ -48,7 +48,7 @@ export const LotteryRemove = ({
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectLotteryCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectLotteryCampaign.tsx
@@ -129,7 +129,7 @@ const SelectLotteryCampaignCommandItem = ({
       <LotteryCampaignInline
         lotteryCampaigns={[lotteryCampaign]}
         lotteryCampaignId={lotteryCampaign._id}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={lotteryCampaignId.includes(lotteryCampaign._id)}
@@ -161,7 +161,7 @@ const SelectLotteryCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-lottery-campaigns')}
+        placeholder={t('search-lottery-campaigns', 'Search lottery campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -204,7 +204,7 @@ export const SelectLotteryCampaignFilterItem = () => {
   return (
     <Filter.Item value="lotteryCampaign">
       <IconTicket />
-      {t('lottery-campaign')}
+      {t('lottery-campaign', 'Lottery Campaign')}
     </Filter.Item>
   );
 };
@@ -261,7 +261,7 @@ export const SelectLotteryCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'lotteryCampaign'}>
       <Filter.BarName>
         <IconTicket />
-        {!iconOnly && t('lottery-campaign')}
+        {!iconOnly && t('lottery-campaign', 'Lottery Campaign')}
       </Filter.BarName>
 
       <SelectLotteryCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectOrderType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectOrderType.tsx
@@ -103,7 +103,7 @@ const SelectOrderTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-order-type')}
+        {placeholder || t('select-order-type', 'Select order type')}
       </span>
     );
   }
@@ -144,9 +144,9 @@ const SelectOrderTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-order-types')} />
+      <Command.Input placeholder={t('search-order-types', 'Search order types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-order-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-order-types-found', 'No order types found')}</span>
       </Command.Empty>
       <Command.List>
         {ORDER_TYPE_OPTIONS.map((option) => (
@@ -162,7 +162,7 @@ export const SelectOrderTypeFilterItem = () => {
   return (
     <Filter.Item value="orderType">
       <IconArrowsSort />
-      {t('sort-order')}
+      {t('sort-order', 'Sort Order')}
     </Filter.Item>
   );
 };
@@ -217,7 +217,7 @@ export const SelectOrderTypeFilterBar = ({
     <Filter.BarItem queryKey="orderType">
       <Filter.BarName>
         <IconArrowsSort />
-        {!iconOnly && t('sort-order')}
+        {!iconOnly && t('sort-order', 'Sort Order')}
       </Filter.BarName>
       <SelectOrderTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectOwnerType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectOwnerType.tsx
@@ -105,7 +105,7 @@ const SelectOwnerTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-owner-type')}
+        {placeholder || t('select-owner-type', 'Select owner type')}
       </span>
     );
   }
@@ -146,9 +146,9 @@ const SelectOwnerTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-owner-types')} />
+      <Command.Input placeholder={t('search-owner-types', 'Search owner types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-owner-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-owner-types-found', 'No owner types found')}</span>
       </Command.Empty>
       <Command.List>
         {OWNER_TYPE_OPTIONS.map((option) => (
@@ -164,7 +164,7 @@ export const SelectOwnerTypeFilterItem = () => {
   return (
     <Filter.Item value="ownerType">
       <IconUsers />
-      {t('owner-type')}
+      {t('owner-type', 'Owner Type')}
     </Filter.Item>
   );
 };
@@ -219,7 +219,7 @@ export const SelectOwnerTypeFilterBar = ({
     <Filter.BarItem queryKey="ownerType">
       <Filter.BarName>
         <IconUsers />
-        {!iconOnly && t('owner-type')}
+        {!iconOnly && t('owner-type', 'Owner Type')}
       </Filter.BarName>
       <SelectOwnerTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectSortField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectSortField.tsx
@@ -104,7 +104,7 @@ const SelectSortFieldValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-sort-field')}
+        {placeholder || t('select-sort-field', 'Select sort field')}
       </span>
     );
   }
@@ -145,9 +145,9 @@ const SelectSortFieldContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-sort-fields')} />
+      <Command.Input placeholder={t('search-sort-fields', 'Search sort fields...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-sort-fields-found')}</span>
+        <span className="text-muted-foreground">{t('no-sort-fields-found', 'No sort fields found')}</span>
       </Command.Empty>
       <Command.List>
         {SORT_FIELD_OPTIONS.map((option) => (
@@ -163,7 +163,7 @@ export const SelectSortFieldFilterItem = () => {
   return (
     <Filter.Item value="sortField">
       <IconSortAscending />
-      {t('sort-field')}
+      {t('sort-field', 'Sort Field')}
     </Filter.Item>
   );
 };
@@ -218,7 +218,7 @@ export const SelectSortFieldFilterBar = ({
     <Filter.BarItem queryKey="sortField">
       <Filter.BarName>
         <IconSortAscending />
-        {!iconOnly && t('sort-field')}
+        {!iconOnly && t('sort-field', 'Sort Field')}
       </Filter.BarName>
       <SelectSortFieldProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/components/selects/SelectStatus.tsx
@@ -101,7 +101,7 @@ const SelectStatusValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-status')}
+        {placeholder || t('select-status', 'Select status')}
       </span>
     );
   }
@@ -138,9 +138,9 @@ const SelectStatusContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-statuses')} />
+      <Command.Input placeholder={t('search-statuses', 'Search statuses...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-statuses-found')}</span>
+        <span className="text-muted-foreground">{t('no-statuses-found', 'No statuses found')}</span>
       </Command.Empty>
       <Command.List>
         {STATUS_OPTIONS.map((option) => (
@@ -156,7 +156,7 @@ export const SelectStatusFilterItem = () => {
   return (
     <Filter.Item value="status">
       <IconCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -209,7 +209,7 @@ export const SelectStatusFilterBar = ({
     <Filter.BarItem queryKey="status">
       <Filter.BarName>
         <IconCheck />
-        {!iconOnly && t('status')}
+        {!iconOnly && t('status', 'Status')}
       </Filter.BarName>
       <SelectStatusProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/hooks/useAddLottery.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/hooks/useAddLottery.ts
@@ -22,14 +22,14 @@ export const useAddLottery = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('lottery-created'),
+          title: t('success', 'Success'),
+          description: t('lottery-created', 'Lottery created successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/hooks/useEditLottery.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/lotteries/hooks/useEditLottery.ts
@@ -26,14 +26,14 @@ export const useEditLottery = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('lottery-updated'),
+          title: t('success', 'Success'),
+          description: t('lottery-updated', 'Lottery updated successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ChooseDealSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ChooseDealSheet.tsx
@@ -73,22 +73,22 @@ const DealsList = ({
             htmlFor="deal-search"
             className="text-xs font-medium text-accent-foreground"
           >
-            {t('search-label')}
+            {t('search-label', 'Search')}
           </label>
           <Input
             id="deal-search"
-            placeholder={t('search-deals')}
+            placeholder={t('search-deals', 'Search deals...')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
 
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium text-accent-foreground">{t('board')}</p>
+          <p className="text-xs font-medium text-accent-foreground">{t('board', 'Board')}</p>
           <SelectBoard value={boardId} onValueChange={handleBoardChange} />
         </div>
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium text-accent-foreground">{t('pipeline')}</p>
+          <p className="text-xs font-medium text-accent-foreground">{t('pipeline', 'Pipeline')}</p>
           <SelectPipeline
             value={pipelineId}
             boardId={boardId}
@@ -97,7 +97,7 @@ const DealsList = ({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium text-accent-foreground">{t('stage')}</p>
+          <p className="text-xs font-medium text-accent-foreground">{t('stage', 'Stage')}</p>
           <SelectStage
             value={stageId}
             pipelineId={pipelineId}
@@ -107,8 +107,8 @@ const DealsList = ({
         </div>
         <div className="text-xs text-accent-foreground">
           {pipelineId || debouncedSearch
-            ? t('results-count', { count: deals.length })
-            : t('select-pipeline-to-see-deals')}
+            ? t('results-count', '{{count}} results', { count: deals.length })
+            : t('select-pipeline-to-see-deals', 'Select a pipeline to see deals')}
         </div>
       </div>
       <Separator />
@@ -118,7 +118,7 @@ const DealsList = ({
             <div className="flex gap-2 items-center px-2 h-8">
               <Spinner containerClassName="flex-none" />
               <span className="animate-pulse text-accent-foreground text-sm">
-                {t('loading-deals')}
+                {t('loading-deals', 'Loading deals...')}
               </span>
             </div>
           )}
@@ -171,7 +171,7 @@ const SelectedDeal = ({
   return (
   <ScrollArea className="h-full">
     <div className="flex flex-col gap-1 p-4">
-      <div className="px-3 mb-1 text-xs text-accent-foreground">{t('added')}</div>
+      <div className="px-3 mb-1 text-xs text-accent-foreground">{t('added', 'Added')}</div>
       {deal && (
         <Button
           variant="ghost"
@@ -217,7 +217,7 @@ export const ChooseDealSheet = ({
     <Sheet open={open} onOpenChange={handleOpenChange} modal>
       <Sheet.View className="sm:max-w-3xl p-0">
         <Sheet.Header className="px-6 py-4">
-          <Sheet.Title>{t('choose-deal')}</Sheet.Title>
+          <Sheet.Title>{t('choose-deal', 'Choose deal')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grid overflow-hidden grid-cols-2 p-0">
@@ -237,7 +237,7 @@ export const ChooseDealSheet = ({
             className="bg-border"
             onClick={() => handleOpenChange(false)}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
         </Sheet.Footer>
       </Sheet.View>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/GiveScoreModal.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/GiveScoreModal.tsx
@@ -89,14 +89,14 @@ export const GiveScoreModal = ({
         },
       });
       toast({
-        title: t('success'),
-        description: t('score-given'),
+        title: t('success', 'Success'),
+        description: t('score-given', 'Score given successfully'),
         variant: 'default',
       });
       handleOpenChange(false);
     } catch (e: unknown) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: e instanceof Error ? e.message : String(e),
         variant: 'destructive',
       });
@@ -108,12 +108,12 @@ export const GiveScoreModal = ({
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {triggerLabel ?? t('give-score')}
+          {triggerLabel ?? t('give-score', 'Give Score')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-2xl p-0">
         <Sheet.Header className="border-b gap-3 px-6 py-4">
-          <Sheet.Title>{t('give-score')}</Sheet.Title>
+          <Sheet.Title>{t('give-score', 'Give Score')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-6 w-full">
@@ -125,10 +125,10 @@ export const GiveScoreModal = ({
               <Form.Field
                 control={form.control}
                 name="ownerType"
-                rules={{ required: t('owner-type-required') }}
+                rules={{ required: t('owner-type-required', 'Owner type is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type-label')}</Form.Label>
+                    <Form.Label>{t('owner-type-label', 'Owner Type *')}</Form.Label>
                     <SelectOwnerTypeFormItem
                       value={field.value}
                       onValueChange={(val) => {
@@ -144,10 +144,10 @@ export const GiveScoreModal = ({
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <SelectOwnerByType
                       ownerType={ownerType}
                       value={field.value}
@@ -160,7 +160,7 @@ export const GiveScoreModal = ({
 
               {ownerId && (
                 <div className="flex flex-col gap-2 w-full">
-                  <span className="text-sm font-medium leading-none">{t('target')}</span>
+                  <span className="text-sm font-medium leading-none">{t('target', 'Target')}</span>
                   <Tabs
                     value={targetType || ''}
                     onValueChange={(val) => {
@@ -181,14 +181,14 @@ export const GiveScoreModal = ({
                         className="flex-1 cursor-pointer w-[50%] font-normal gap-1.5 data-[state=active]:bg-background bg-background data-[state=active]:shadow after:content-none after:border-none after:shadow-none after:bg-transparent"
                       >
                         <IconBriefcase size={15} />
-                        {t('sales-pipeline')}
+                        {t('sales-pipeline', 'Sales pipeline')}
                       </Tabs.Trigger>
                       <Tabs.Trigger
                         value="pos"
                         className="flex-1 cursor-pointer font-normal w-[50%] gap-1.5 data-[state=active]:bg-background bg-background data-[state=active]:shadow after:content-none after:border-none after:shadow-none after:bg-transparent"
                       >
                         <IconShoppingCart size={15} />
-                        {t('pos-order')}
+                        {t('pos-order', 'POS Order')}
                       </Tabs.Trigger>
                     </Tabs.List>
                   </Tabs>
@@ -209,7 +209,7 @@ export const GiveScoreModal = ({
                         onClick={() => setDealSheetOpen(true)}
                         className="text-xs text-primary hover:underline shrink-0 ml-2"
                       >
-                        {t('change')}
+                        {t('change', 'Change')}
                       </button>
                     </div>
                   )}
@@ -221,11 +221,11 @@ export const GiveScoreModal = ({
                 name="campaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('score-campaign')}</Form.Label>
+                    <Form.Label>{t('score-campaign', 'Score Campaign')}</Form.Label>
                     <SelectScoreCampaignFormItem
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('choose-score-campaign')}
+                      placeholder={t('choose-score-campaign', 'Choose score campaign (optional)')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -236,12 +236,12 @@ export const GiveScoreModal = ({
                 control={form.control}
                 name="change"
                 rules={{
-                  required: t('score-required'),
-                  validate: (v) => Number(v) !== 0 || t('score-cannot-be-zero'),
+                  required: t('score-required', 'Score is required'),
+                  validate: (v) => Number(v) !== 0 || t('score-cannot-be-zero', 'Score cannot be zero'),
                 }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('score-label')}</Form.Label>
+                    <Form.Label>{t('score-label', 'Score *')}</Form.Label>
                     <Form.Control>
                       <Input
                         type="number"
@@ -265,7 +265,7 @@ export const GiveScoreModal = ({
                 name="description"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('description')}</Form.Label>
+                    <Form.Label>{t('description', 'Description')}</Form.Label>
                     <Form.Control>
                       <Input {...field} placeholder="manual" />
                     </Form.Control>
@@ -280,10 +280,10 @@ export const GiveScoreModal = ({
                   variant="outline"
                   onClick={() => handleOpenChange(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('creating') : t('save')}
+                  {loading ? t('creating', 'Creating...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreColumns.tsx
@@ -81,7 +81,7 @@ export const scoreLogColumns = (
   {
     id: 'ownerName',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-name')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-name', 'Owner Name')} />
     ),
     size: 180,
     cell: ({ row }) => <ScoreOwnerNameCell row={row} />,
@@ -90,7 +90,7 @@ export const scoreLogColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconLabelFilled} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconLabelFilled} label={t('owner-type', 'Owner Type')} />
     ),
     size: 120,
     cell: ({ cell }) => (
@@ -103,7 +103,7 @@ export const scoreLogColumns = (
     id: 'totalScore',
     accessorKey: 'totalScore',
     header: () => (
-      <RecordTable.InlineHead icon={IconStar} label={t('total-score')} />
+      <RecordTable.InlineHead icon={IconStar} label={t('total-score', 'Total Score')} />
     ),
     size: 140,
     cell: ({ cell }) => (
@@ -116,7 +116,7 @@ export const scoreLogColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconCalendar} label={t('date')} />
+      <RecordTable.InlineHead icon={IconCalendar} label={t('date', 'Date')} />
     ),
     size: 120,
     cell: ({ cell }) => (
@@ -129,7 +129,7 @@ export const scoreLogColumns = (
     id: 'dealNumber',
     accessorFn: (row) => row.target?.number,
     header: () => (
-      <RecordTable.InlineHead icon={IconHash} label={t('deal-number')} />
+      <RecordTable.InlineHead icon={IconHash} label={t('deal-number', 'Deal Number')} />
     ),
     size: 200,
     cell: ({ cell }) => (
@@ -141,7 +141,7 @@ export const scoreLogColumns = (
   {
     id: 'action',
     accessorKey: 'action',
-    header: () => <RecordTable.InlineHead icon={IconTag} label={t('type')} />,
+    header: () => <RecordTable.InlineHead icon={IconTag} label={t('type', 'Type')} />,
     size: 90,
     cell: ({ cell }) => {
       const action = cell.getValue() as string | undefined;
@@ -165,7 +165,7 @@ export const scoreLogColumns = (
     id: 'pointsEarned',
     accessorFn: (row) => (row.action === 'add' ? row.change : undefined),
     header: () => (
-      <RecordTable.InlineHead icon={IconCoins} label={t('points-earned')} />
+      <RecordTable.InlineHead icon={IconCoins} label={t('points-earned', 'Points Earned')} />
     ),
     size: 130,
     cell: ({ cell }) => {
@@ -181,7 +181,7 @@ export const scoreLogColumns = (
     id: 'pointsSpent',
     accessorFn: (row) => (row.action === 'subtract' ? row.change : undefined),
     header: () => (
-      <RecordTable.InlineHead icon={IconChartBar} label={t('points-spent')} />
+      <RecordTable.InlineHead icon={IconChartBar} label={t('points-spent', 'Points Spent')} />
     ),
     size: 130,
     cell: ({ cell }) => {
@@ -197,7 +197,7 @@ export const scoreLogColumns = (
     id: 'pointsRefunded',
     accessorFn: (row) => (row.action === 'refund' ? row.change : undefined),
     header: () => (
-      <RecordTable.InlineHead icon={IconRefresh} label={t('points-refunded')} />
+      <RecordTable.InlineHead icon={IconRefresh} label={t('points-refunded', 'Points Refunded')} />
     ),
     size: 150,
     cell: ({ cell }) => {
@@ -213,7 +213,7 @@ export const scoreLogColumns = (
     id: 'pointsSet',
     accessorFn: (row) => (row.action === 'set' ? row.change : undefined),
     header: () => (
-      <RecordTable.InlineHead icon={IconCoins} label={t('score-set')} />
+      <RecordTable.InlineHead icon={IconCoins} label={t('score-set', 'Score Set')} />
     ),
     size: 120,
     cell: ({ cell }) => {
@@ -229,7 +229,7 @@ export const scoreLogColumns = (
     id: 'campaign',
     accessorFn: (row) => row.campaign?.title,
     header: () => (
-      <RecordTable.InlineHead icon={IconTrophy} label={t('campaign')} />
+      <RecordTable.InlineHead icon={IconTrophy} label={t('campaign', 'Campaign')} />
     ),
     size: 140,
     cell: ({ cell }) => (
@@ -242,7 +242,7 @@ export const scoreLogColumns = (
     id: 'description',
     accessorKey: 'description',
     header: () => (
-      <RecordTable.InlineHead icon={IconNote} label={t('description')} />
+      <RecordTable.InlineHead icon={IconNote} label={t('description', 'Description')} />
     ),
     size: 160,
     cell: ({ cell }) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreDetailSheet.tsx
@@ -47,7 +47,7 @@ export const ScoreDetailSheet = ({
     if (error) {
       return (
         <div className="flex items-center justify-center h-24 text-xs text-destructive">
-          {error.message || t('failed-to-load-score-logs')}
+          {error.message || t('failed-to-load-score-logs', 'Failed to load score logs')}
         </div>
       );
     }
@@ -55,7 +55,7 @@ export const ScoreDetailSheet = ({
     if (logs.length === 0) {
       return (
         <div className="flex items-center justify-center h-24 text-xs text-muted-foreground">
-          {t('no-log-records-found')}
+          {t('no-log-records-found', 'No log records found')}
         </div>
       );
     }
@@ -75,7 +75,7 @@ export const ScoreDetailSheet = ({
         </RecordTable.Provider>
         {isTruncated && (
           <p className="mt-2 text-center text-xs text-muted-foreground">
-            {t('showing-latest-entries', { count: SCORE_DETAIL_LIMIT })}
+            {t('showing-latest-entries', 'Showing the latest {{count}} entries.', { count: SCORE_DETAIL_LIMIT })}
           </p>
         )}
       </div>
@@ -89,7 +89,7 @@ export const ScoreDetailSheet = ({
           <div>
             <Sheet.Title>{ownerName || '—'}</Sheet.Title>
             <p className="text-xs text-muted-foreground mt-1 capitalize">
-              {record?.ownerType || ''} · {t('total-score-label')}{' '}
+              {record?.ownerType || ''} · {t('total-score-label', 'Total Score:')}{' '}
               <span className="font-semibold text-foreground">
                 {formatScore(record?.totalScore)}
               </span>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreFilter.tsx
@@ -74,7 +74,7 @@ const ScoreFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />
@@ -85,28 +85,28 @@ const ScoreFilterPopover = () => {
                 <SelectScoreAction.FilterItem />
                 <Filter.Item value="scoreBoardId">
                   <IconLabel />
-                  {t('board')}
+                  {t('board', 'Board')}
                 </Filter.Item>
                 <Filter.Item value="scorePipelineId">
                   <IconArrowsRight />
-                  {t('pipeline')}
+                  {t('pipeline', 'Pipeline')}
                 </Filter.Item>
                 <Filter.Item value="scoreStageId">
                   <IconListCheck />
-                  {t('stage')}
+                  {t('stage', 'Stage')}
                 </Filter.Item>
                 <Filter.Item value="number" inDialog>
                   <IconSearch />
-                  {t('number')}
+                  {t('number', 'Number')}
                 </Filter.Item>
                 <Filter.Item value="description" inDialog>
                   <IconFileDescription />
-                  {t('description')}
+                  {t('description', 'Description')}
                 </Filter.Item>
                 <SelectScoreActionTypeFilterItem />
                 <Filter.Item value="scoreDate">
                   <IconCalendar />
-                  {t('date')}
+                  {t('date', 'Date')}
                 </Filter.Item>
               </Command.List>
             </Command>
@@ -195,7 +195,7 @@ export const ScoreFilter = () => {
         <Filter.BarItem queryKey="number">
           <Filter.BarName>
             <IconSearch />
-            {t('number')}
+            {t('number', 'Number')}
           </Filter.BarName>
           <Filter.BarButton filterKey="number" inDialog>
             {number}
@@ -204,7 +204,7 @@ export const ScoreFilter = () => {
         <Filter.BarItem queryKey="description">
           <Filter.BarName>
             <IconFileDescription />
-            {t('description')}
+            {t('description', 'Description')}
           </Filter.BarName>
           <Filter.BarButton filterKey="description" inDialog>
             {description}
@@ -215,7 +215,7 @@ export const ScoreFilter = () => {
         <Filter.BarItem queryKey="scoreDate">
           <Filter.BarName>
             <IconCalendar />
-            {t('date')}
+            {t('date', 'Date')}
           </Filter.BarName>
           <Filter.Date filterKey="scoreDate" />
         </Filter.BarItem>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreMoreColumn.tsx
@@ -63,7 +63,7 @@ export const ScoreMoreColumnCell = ({
               disabled={!ownerId}
             >
               <IconListDetails size={14} />
-              {t('detail')}
+              {t('detail', 'Detail')}
             </Command.Item>
             <Command.Item
               value="see-profile"
@@ -71,7 +71,7 @@ export const ScoreMoreColumnCell = ({
               disabled={!ownerId}
             >
               <IconExternalLink size={14} />
-              {t('see-profile')}
+              {t('see-profile', 'See Profile')}
             </Command.Item>
           </Command.List>
         </Command>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreRecordTable.tsx
@@ -61,10 +61,10 @@ export const ScoreRecordTable = () => {
               <div className="flex flex-col items-center text-center">
                 <IconStar size={48} className="text-gray-400 mb-4" />
                 <h3 className="text-lg font-semibold text-gray-900">
-                  {t('no-scores-yet')}
+                  {t('no-scores-yet', 'No scores yet')}
                 </h3>
                 <p className="mt-1 text-sm text-gray-500 mb-4">
-                  {t('get-started-score')}
+                  {t('get-started-score', 'Get started by giving your first score.')}
                 </p>
                 <GiveScoreModal />
               </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreSummaryWidget.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreSummaryWidget.tsx
@@ -42,24 +42,24 @@ const ScoreStatCards = ({
       <div className="flex flex-col gap-2">
         <StatCard
           icon={<IconTrendingUp className="size-4 text-green-500" />}
-          label={t('total-point-earned')}
+          label={t('total-point-earned', 'Total Point Earned')}
           value={Number(earned).toLocaleString()}
         />
         <StatCard
           icon={<IconCoins className="size-4 text-blue-500" />}
-          label={t('points-balance')}
+          label={t('points-balance', 'Points Balance')}
           value={Number(balance).toLocaleString()}
         />
         <StatCard
           icon={<IconTrendingDown className="size-4 text-red-400" />}
-          label={t('total-point-redeemed')}
+          label={t('total-point-redeemed', 'Total Point Redeemed')}
           value={Number(redeemed).toLocaleString()}
         />
       </div>
       <Separator />
       <div className="flex flex-col gap-2">
         <SecondaryRow
-          label={t('redemption-rates')}
+          label={t('redemption-rates', 'Redemption Rates')}
           value={
             redemptionRate == null
               ? '—'
@@ -67,16 +67,16 @@ const ScoreStatCards = ({
           }
         />
         <SecondaryRow
-          label={t('active-loyalty-members')}
+          label={t('active-loyalty-members', 'Active Loyalty Members')}
           value={stats.activeLoyaltyMembers ?? '—'}
         />
         <SecondaryRow
-          label={t('monthly-active-users')}
+          label={t('monthly-active-users', 'Monthly Active Users')}
           value={stats.monthlyActiveUsers ?? '—'}
         />
         {stats.mostRedeemedProductCategory && (
           <SecondaryRow
-            label={t('top-redeemed-product-catalog')}
+            label={t('top-redeemed-product-catalog', 'Top Redeemed Product Catalog')}
             value={stats.mostRedeemedProductCategory}
           />
         )}
@@ -99,7 +99,7 @@ const ScoreSummaryPanelContent = () => {
             size="sm"
           >
             <IconCaretRightFilled className="transition-transform group-data-[state=open]/collapsible-menu:rotate-90" />
-            {t('summary')}
+            {t('summary', 'Summary')}
           </Button>
         </Collapsible.Trigger>
         <Collapsible.Content>
@@ -117,13 +117,13 @@ export const ScoreSummaryPanel = () => {
   return (
     <SideMenu value={open} onValueChange={setOpen}>
       <SideMenu.Content value="score-summary" className="data-[state=active]:w-96">
-        <SideMenu.Header Icon={IconChartHistogram} label={t('score-summary')} />
+        <SideMenu.Header Icon={IconChartHistogram} label={t('score-summary', 'Score Summary')} />
         {open === 'score-summary' && <ScoreSummaryPanelContent />}
       </SideMenu.Content>
       <SideMenu.Sidebar>
         <SideMenu.Trigger
           value="score-summary"
-          label={t('score-summary')}
+          label={t('score-summary', 'Score Summary')}
           Icon={IconChartHistogram}
         />
       </SideMenu.Sidebar>
@@ -157,7 +157,7 @@ export const ScoreSummaryWidget = ({
     <>
       <div className="h-11 px-4 flex items-center gap-2 flex-none bg-background">
         <IconChartHistogram className="size-4 text-muted-foreground" />
-        <span className="font-medium text-primary">{t('score-summary')}</span>
+        <span className="font-medium text-primary">{t('score-summary', 'Score Summary')}</span>
         <Button
           variant="secondary"
           size="sm"
@@ -170,7 +170,7 @@ export const ScoreSummaryWidget = ({
           ) : (
             <IconRefresh className="size-4" />
           )}
-          {t('repair')}
+          {t('repair', 'Repair')}
         </Button>
       </div>
       <Separator />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/ScoreTotalCount.tsx
@@ -12,7 +12,7 @@ export const ScoreTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerById.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerById.tsx
@@ -114,7 +114,7 @@ export const SelectClientPortalUserFormItem = ({
           [u.firstName, u.lastName].filter(Boolean).join(' ') ||
           u.email ||
           u.phone ||
-          t('unnamed'),
+          t('unnamed', 'Unnamed'),
       })),
     [data?.getClientPortalUsers?.list, t],
   );
@@ -126,7 +126,7 @@ export const SelectClientPortalUserFormItem = ({
       <Form.Control>
         <SelectTrigger
           selected={selected}
-          placeholder={placeholder ?? t('choose-client-portal-user')}
+          placeholder={placeholder ?? t('choose-client-portal-user', 'Choose client portal user')}
           className={className}
         />
       </Form.Control>
@@ -135,10 +135,10 @@ export const SelectClientPortalUserFormItem = ({
           <Command.Input
             value={search}
             onValueChange={setSearch}
-            placeholder={t('search-cp-users')}
+            placeholder={t('search-cp-users', 'Search client portal users...')}
           />
           <Command.Empty>
-            {loading ? t('loading') : t('no-cp-users-found')}
+            {loading ? t('loading', 'Loading...') : t('no-cp-users-found', 'No client portal users found')}
           </Command.Empty>
           <Command.List>
             <OptionList

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerByType.tsx
@@ -17,10 +17,10 @@ export const SelectOwnerByType = ({
 }: Props) => {
   const { t } = useTranslation('loyalty');
   const PLACEHOLDERS: Record<string, string> = {
-    customer: t('choose-customer'),
-    company: t('choose-company'),
-    user: t('choose-team-member'),
-    cpUser: t('choose-client-portal-user'),
+    customer: t('choose-customer', 'Choose customer'),
+    company: t('choose-company', 'Choose company'),
+    user: t('choose-team-member', 'Choose team member'),
+    cpUser: t('choose-client-portal-user', 'Choose client portal user'),
   };
   const resolvedPlaceholder = placeholder || PLACEHOLDERS[ownerType];
   const handleChange = (val: string | string[] | null) =>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectOwnerType.tsx
@@ -92,7 +92,7 @@ const SelectOwnerTypeValue = ({
   if (!selected) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-owner-type')}
+        {placeholder || t('select-owner-type', 'Select owner type')}
       </span>
     );
   }
@@ -110,9 +110,9 @@ const SelectOwnerTypeContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-owner-types')} />
+      <Command.Input placeholder={t('search-owner-types', 'Search owner types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-owner-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-owner-types-found', 'No owner types found')}</span>
       </Command.Empty>
       <Command.List>
         {OWNER_TYPE_OPTIONS.map((opt) => (
@@ -135,7 +135,7 @@ export const SelectOwnerTypeFilterItem = () => {
   return (
     <Filter.Item value="scoreOwnerType">
       <IconUsers />
-      {t('owner-type')}
+      {t('owner-type', 'Owner Type')}
     </Filter.Item>
   );
 };
@@ -176,7 +176,7 @@ export const SelectOwnerTypeFilterBar = ({
     <Filter.BarItem queryKey="scoreOwnerType">
       <Filter.BarName>
         <IconUsers />
-        {!iconOnly && t('owner-type')}
+        {!iconOnly && t('owner-type', 'Owner Type')}
       </Filter.BarName>
       <SelectOwnerTypeProvider
         value={value || ''}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreAction.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreAction.tsx
@@ -80,7 +80,7 @@ const SelectScoreActionValue = ({
   if (!selected) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-action')}
+        {placeholder || t('select-action', 'Select action')}
       </span>
     );
   }
@@ -98,9 +98,9 @@ const SelectScoreActionContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-action')} />
+      <Command.Input placeholder={t('search-action', 'Search action...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-action-found')}</span>
+        <span className="text-muted-foreground">{t('no-action-found', 'No action found')}</span>
       </Command.Empty>
       <Command.List>
         {ACTION_OPTIONS.map((opt) => (
@@ -123,7 +123,7 @@ export const SelectScoreActionFilterItem = () => {
   return (
     <Filter.Item value="scoreOrderType">
       <IconArrowsExchange />
-      {t('order-type')}
+      {t('order-type', 'Order Type')}
     </Filter.Item>
   );
 };
@@ -160,7 +160,7 @@ export const SelectScoreActionFilterBar = () => {
     <Filter.BarItem queryKey="scoreOrderType">
       <Filter.BarName>
         <IconArrowsExchange />
-        {t('order-type')}
+        {t('order-type', 'Order Type')}
       </Filter.BarName>
       <SelectScoreActionProvider
         value={value || ''}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreActionType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreActionType.tsx
@@ -84,7 +84,7 @@ const SelectScoreActionTypeValue = ({
   if (!selected) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-action')}
+        {placeholder || t('select-action', 'Select action')}
       </span>
     );
   }
@@ -102,9 +102,9 @@ const SelectScoreActionTypeContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-action')} />
+      <Command.Input placeholder={t('search-action', 'Search action...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-action-found')}</span>
+        <span className="text-muted-foreground">{t('no-action-found', 'No action found')}</span>
       </Command.Empty>
       <Command.List>
         {ACTION_OPTIONS.map((opt) => (
@@ -127,7 +127,7 @@ export const SelectScoreActionTypeFilterItem = () => {
   return (
     <Filter.Item value="scoreAction">
       <IconArrowsExchange />
-      {t('action')}
+      {t('action', 'Action')}
     </Filter.Item>
   );
 };
@@ -164,7 +164,7 @@ export const SelectScoreActionTypeFilterBar = () => {
     <Filter.BarItem queryKey="scoreAction">
       <Filter.BarName>
         <IconArrowsExchange />
-        {t('action')}
+        {t('action', 'Action')}
       </Filter.BarName>
       <SelectScoreActionTypeProvider
         value={value || ''}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/components/selects/SelectScoreCampaign.tsx
@@ -118,7 +118,7 @@ const SelectScoreCampaignValue = ({
   if (!selected) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-campaign')}
+        {placeholder || t('select-campaign', 'Select campaign')}
       </span>
     );
   }
@@ -140,10 +140,10 @@ const SelectScoreCampaignContent = () => {
       <Command.Input
         value={search}
         onValueChange={setSearch}
-        placeholder={t('search-campaigns')}
+        placeholder={t('search-campaigns', 'Search campaigns...')}
       />
       <Command.Empty>
-        {loading ? t('loading') : t('no-campaigns-found')}
+        {loading ? t('loading', 'Loading...') : t('no-campaigns-found', 'No campaigns found')}
       </Command.Empty>
       <Command.List>
         {options.map((opt) => (
@@ -166,7 +166,7 @@ export const SelectScoreCampaignFilterItem = () => {
   return (
     <Filter.Item value="scoreCampaignId">
       <IconTag />
-      {t('campaign')}
+      {t('campaign', 'Campaign')}
     </Filter.Item>
   );
 };
@@ -203,7 +203,7 @@ export const SelectScoreCampaignFilterBar = () => {
     <Filter.BarItem queryKey="scoreCampaignId">
       <Filter.BarName>
         <IconTag />
-        {t('campaign')}
+        {t('campaign', 'Campaign')}
       </Filter.BarName>
       <SelectScoreCampaignProvider
         value={value || ''}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useChangeScore.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useChangeScore.ts
@@ -30,14 +30,14 @@ export const useChangeScore = (
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('score-given'),
+          title: t('success', 'Success'),
+          description: t('score-given', 'Score given successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useRepairOwnerScore.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/scores/hooks/useRepairOwnerScore.ts
@@ -24,14 +24,14 @@ export const useRepairOwnerScore = (
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('score-repaired'),
+          title: t('success', 'Success'),
+          description: t('score-repaired', 'Score repaired successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/AssignmentTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/AssignmentTabs.tsx
@@ -40,7 +40,7 @@ export const AssignmentTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -60,7 +60,7 @@ export const AssignmentTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -68,7 +68,7 @@ export const AssignmentTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/assignment-campaign-field/AssignmentAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/assignment-campaign-field/AssignmentAddCampaignCoreFields.tsx
@@ -21,9 +21,9 @@ export const AssignmentAddCampaignCoreFields: React.FC<
         name="title"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('title')}</Form.Label>
+            <Form.Label>{t('title', 'Title')}</Form.Label>
             <Form.Control>
-              <Input placeholder={t('enter-assignment-title')} {...field} />
+              <Input placeholder={t('enter-assignment-title', 'Enter assignment title')} {...field} />
             </Form.Control>
             <Form.Message />
           </Form.Item>
@@ -35,7 +35,7 @@ export const AssignmentAddCampaignCoreFields: React.FC<
         name="segmentIds"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('segment')}</Form.Label>
+            <Form.Label>{t('segment', 'Segment')}</Form.Label>
             <SelectSegment
               value={field.value?.[0] || ''}
               onValueChange={(id) => field.onChange(id ? [id] : [])}
@@ -49,7 +49,7 @@ export const AssignmentAddCampaignCoreFields: React.FC<
         name="voucherCampaignId"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('voucher-campaign')}</Form.Label>
+            <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
             <Form.Control>
               <SelectVoucherCampaign
                 value={field.value || undefined}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/assignment-campaign-field/AssignmentAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/assignment-campaign-field/AssignmentAddCampaignMoreFields.tsx
@@ -58,7 +58,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -85,11 +85,11 @@ export const AssignmentAddCampaignMoreFields: React.FC<
           name="startDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('start-date')}</Form.Label>
+              <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-start-date')}
+                placeholder={t('select-start-date', 'Select start date')}
               />
               <Form.Message />
             </Form.Item>
@@ -103,11 +103,11 @@ export const AssignmentAddCampaignMoreFields: React.FC<
           name="endDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('end-date')}</Form.Label>
+              <Form.Label>{t('end-date', 'End Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-end-date')}
+                placeholder={t('select-end-date', 'Select end date')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/selects/SelectAssignmentDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/selects/SelectAssignmentDate.tsx
@@ -72,7 +72,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
       <>
         <IconCalendarPlus className="text-accent-foreground" />
         <span className="text-accent-foreground font-medium">
-          {placeholder || t('select-date')}
+          {placeholder || t('select-date', 'Select date...')}
         </span>
       </>
     );
@@ -168,7 +168,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/selects/SelectSegment.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/add-assignment-campaign/components/selects/SelectSegment.tsx
@@ -131,7 +131,7 @@ const SelectSegmentValue = ({
   if (!selectedSegment) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-segment')}
+        {placeholder || t('select-segment', 'Select segment')}
       </span>
     );
   }
@@ -187,10 +187,10 @@ const SelectSegmentContent = () => {
   if (loading) {
     return (
       <Command>
-        <Command.Input placeholder={t('search-segments')} />
+        <Command.Input placeholder={t('search-segments', 'Search segments')} />
         <Command.List>
           <div className="flex items-center justify-center py-4 h-32">
-            <span className="text-muted-foreground">{t('loading-segments')}</span>
+            <span className="text-muted-foreground">{t('loading-segments', 'Loading segments...')}</span>
           </div>
         </Command.List>
       </Command>
@@ -199,9 +199,9 @@ const SelectSegmentContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-segments')} />
+      <Command.Input placeholder={t('search-segments', 'Search segments')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-segments-found')}</span>
+        <span className="text-muted-foreground">{t('no-segments-found', 'No segments found')}</span>
       </Command.Empty>
       <Command.List>
         {segmentsArray.map((segment) => (
@@ -217,7 +217,7 @@ export const SelectSegmentFilterItem = () => {
   return (
     <Filter.Item value="segments">
       <IconTag />
-      {t('segments')}
+      {t('segments', 'Segments')}
     </Filter.Item>
   );
 };
@@ -275,7 +275,7 @@ export const SelectSegmentFilterBar = ({
     <Filter.BarItem queryKey={'segments'}>
       <Filter.BarName>
         <IconTag />
-        {t('segments')}
+        {t('segments', 'Segments')}
       </Filter.BarName>
       <SelectSegmentProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/components/EditAssignmentTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/components/EditAssignmentTabs.tsx
@@ -45,7 +45,7 @@ export const EditAssignmentTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -64,7 +64,7 @@ export const EditAssignmentTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -72,7 +72,7 @@ export const EditAssignmentTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('updating') : t('update')}
+        {editLoading ? t('updating', 'Updating...') : t('update', 'Update')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/components/LoyaltyAssignmentEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/components/LoyaltyAssignmentEditSheet.tsx
@@ -107,7 +107,7 @@ export const LoyaltyAssignmentEditSheet = ({ assignmentId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -119,7 +119,7 @@ export const LoyaltyAssignmentEditSheet = ({ assignmentId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-assignment-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-assignment-campaign', 'Edit assignment campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/hooks/useAssignmentEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/assignment-detail/hooks/useAssignmentEdit.tsx
@@ -29,14 +29,14 @@ export const useAssignmentEdit = () => {
     refetchQueries: [QUERY_ASSIGNMENT_CAMPAIGNS],
     onCompleted: () => {
       toast({
-        title: t('success'),
-        description: t('assignment-updated'),
+        title: t('success', 'Success'),
+        description: t('assignment-updated', 'Assignment campaign updated successfully'),
         variant: 'default',
       });
     },
     onError: (error) => {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentAddSheet.tsx
@@ -63,7 +63,7 @@ export const LoyaltyAssignmentAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-assignment-campaign')}
+          {t('add-assignment-campaign', 'Add assignment campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -74,7 +74,7 @@ export const LoyaltyAssignmentAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-assignment-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-assignment-campaign', 'Add assignment campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentColumns.tsx
@@ -21,7 +21,7 @@ export const assignmentColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentMoreColumn.tsx
@@ -40,20 +40,20 @@ export const AssignmentMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-assignment-confirm', { count: 1 }),
+      message: t('delete-assignment-confirm', 'Are you sure you want to delete {{count}} selected assignment(s)?', { count: 1 }),
     }).then(() => {
       removeAssignment({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('assignments-deleted', { count: 1 }),
+            title: t('assignments-deleted', '{{count}} assignment(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const AssignmentMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-assignments" onSelect={handleSeeAssignments}>
-              <IconTicket /> {t('see-assignments')}
+              <IconTicket /> {t('see-assignments', 'See assignments')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const AssignmentMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/AssignmentRecordTable.tsx
@@ -50,10 +50,10 @@ export const AssignmentRecordTable = () => {
                     className="text-muted-foreground mx-auto mb-4"
                   />
                   <h3 className="text-xl font-semibold mb-2">
-                    {t('no-assignments-yet')}
+                    {t('no-assignments-yet', 'No assignments yet')}
                   </h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-assignment')}
+                    {t('get-started-assignment', 'Get started by creating your first assignment.')}
                   </p>
                 </div>
                 <LoyaltyAssignmentAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/VoucherCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/VoucherCampaignInline.tsx
@@ -45,7 +45,7 @@ const VoucherCampaignInlineProvider = ({
       loading: false,
       voucherCampaignId: normalizedVoucherCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('choose-voucher-campaign')
+        ? t('choose-voucher-campaign', 'Choose voucher campaign')
         : placeholder,
       updateVoucherCampaigns: updateVoucherCampaigns || setCurrentVoucherCampaigns,
     };
@@ -119,7 +119,7 @@ const VoucherCampaignInlineTitle = () => {
     return (
       <TextOverflowTooltip
         value={voucherCampaigns
-          .map((c) => c.title || t('unnamed-campaign'))
+          .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
           .join(', ')}
       />
     );
@@ -129,10 +129,10 @@ const VoucherCampaignInlineTitle = () => {
     <Tooltip.Provider>
       <Tooltip>
         <Tooltip.Trigger asChild>
-          <span>{t('voucher-campaigns-count', { count: voucherCampaigns.length })}</span>
+          <span>{t('voucher-campaigns-count', '{{count}} voucher campaigns', { count: voucherCampaigns.length })}</span>
         </Tooltip.Trigger>
         <Tooltip.Content>
-          {voucherCampaigns.map((c) => c.title || t('unnamed-campaign')).join(', ')}
+          {voucherCampaigns.map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign')).join(', ')}
         </Tooltip.Content>
       </Tooltip>
     </Tooltip.Provider>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/assignment-command-bar/AssignmentCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/assignment-command-bar/AssignmentCommandBar.tsx
@@ -10,7 +10,7 @@ export const AssignmentCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteAssignment

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/assignment-command-bar/delete/DeleteAssignment.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/assignment-command-bar/delete/DeleteAssignment.tsx
@@ -19,20 +19,20 @@ export const DeleteAssignment = ({
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-assignment-confirm', { count: assignmentIds.length }),
+          message: t('delete-assignment-confirm', 'Are you sure you want to delete {{count}} selected assignment(s)?', { count: assignmentIds.length }),
         }).then(() => {
           removeAssignment({
             variables: { _ids: assignmentIds },
           })
             .then(() => {
               toast({
-                title: t('assignments-deleted', { count: assignmentIds.length }),
+                title: t('assignments-deleted', '{{count}} assignment(s) deleted successfully', { count: assignmentIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -41,7 +41,7 @@ export const DeleteAssignment = ({
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/selects/SelectVoucherCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/components/selects/SelectVoucherCampaign.tsx
@@ -135,7 +135,7 @@ const SelectVoucherCampaignCommandItem = ({
     >
       <VoucherCampaignInline
         voucherCampaigns={[voucherCampaign]}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={voucherCampaignId.includes(voucherCampaign._id)}
@@ -167,7 +167,7 @@ const SelectVoucherCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-voucher-campaigns')}
+        placeholder={t('search-voucher-campaigns', 'Search voucher campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -210,7 +210,7 @@ export const SelectVoucherCampaignFilterItem = () => {
   return (
     <Filter.Item value="voucherCampaign">
       <IconReceipt />
-      {t('voucher-campaign')}
+      {t('voucher-campaign', 'Voucher Campaign')}
     </Filter.Item>
   );
 };
@@ -265,7 +265,7 @@ export const SelectVoucherCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'voucherCampaign'}>
       <Filter.BarName>
         <IconReceipt />
-        {!iconOnly && t('voucher-campaign')}
+        {!iconOnly && t('voucher-campaign', 'Voucher Campaign')}
       </Filter.BarName>
 
       <SelectVoucherCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/hooks/useAddAssignment.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/hooks/useAddAssignment.tsx
@@ -85,15 +85,15 @@ export const useAddAssignment = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('assignment-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('assignment-campaign-created', 'Assignment campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/hooks/useAssignmentStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/assignment/hooks/useAssignmentStatusEdit.tsx
@@ -29,15 +29,15 @@ export function useAssignmentStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('assignment-status-updated'),
+          title: t('success', 'Success'),
+          description: t('assignment-status-updated', 'Assignment status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/components/LoyaltyBreadcrumb.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/components/LoyaltyBreadcrumb.tsx
@@ -15,7 +15,7 @@ export const LoyaltyBreadcrumb = () => {
       <div className="flex items-center gap-2">
         <Button variant="ghost" className="font-semibold">
           <IconCashBanknote className="w-4 h-4 text-accent-foreground" />
-          {t('settings')}
+          {t('settings', 'Settings')}
         </Button>
         <Separator.Inline />
         <Button variant="ghost" className="font-semibold">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/AddCouponCodeRuleForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/AddCouponCodeRuleForm.tsx
@@ -25,9 +25,9 @@ export function AddCouponCodeRuleForm({
           >
             <Tabs.List className="grid w-full grid-cols-2 border-0">
               <Tabs.Trigger className="" value="default">
-                {t('default')}
+                {t('default', 'Default')}
               </Tabs.Trigger>
-              <Tabs.Trigger value="static">{t('static')}</Tabs.Trigger>
+              <Tabs.Trigger value="static">{t('static', 'Static')}</Tabs.Trigger>
             </Tabs.List>
             <Tabs.Content value="default" className="mt-4">
               <CouponDefaultCodeRuleField form={form} />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/CouponTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/CouponTabs.tsx
@@ -92,7 +92,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -112,7 +112,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       {isLastTab() ? (
         <Button
@@ -121,7 +121,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
           onClick={handleSubmit}
           disabled={editLoading}
         >
-          {editLoading ? t('saving') : t('save')}
+          {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
         </Button>
       ) : (
         <Button
@@ -129,7 +129,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
           className="bg-primary text-primary-foreground hover:bg-primary/90"
           onClick={handleNext}
         >
-          {t('next')}
+          {t('next', 'Next')}
         </Button>
       )}
     </Sheet.Footer>
@@ -147,7 +147,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('campaign')}
+            {t('campaign', 'Campaign')}
           </Button>
         </Tabs.Trigger>
         <Tabs.Trigger asChild value="restriction">
@@ -155,7 +155,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('restriction')}
+            {t('restriction', 'Restriction')}
           </Button>
         </Tabs.Trigger>
         <Tabs.Trigger asChild value="codeRule">
@@ -163,7 +163,7 @@ export const CouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('code-rule')}
+            {t('code-rule', 'Code rule')}
           </Button>
         </Tabs.Trigger>
       </Tabs.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-campaign-field/CouponAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-campaign-field/CouponAddCampaignCoreFields.tsx
@@ -21,9 +21,9 @@ export const CouponAddCampaignCoreFields: React.FC<
           name="title"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('title')}</Form.Label>
+              <Form.Label>{t('title', 'Title')}</Form.Label>
               <Form.Control>
-                <Input placeholder={t('enter-coupon-title')} {...field} />
+                <Input placeholder={t('enter-coupon-title', 'Enter coupon title')} {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -34,7 +34,7 @@ export const CouponAddCampaignCoreFields: React.FC<
           name="count"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('count')}</Form.Label>
+              <Form.Label>{t('count', 'Count')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
@@ -56,11 +56,11 @@ export const CouponAddCampaignCoreFields: React.FC<
           name="buyScore"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('buy-score')}</Form.Label>
+              <Form.Label>{t('buy-score', 'Buy Score')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-coupon-buy-score')}
+                  placeholder={t('enter-coupon-buy-score', 'Enter coupon buy score')}
                   value={field.value ?? ''}
                   onChange={(e) =>
                     field.onChange(
@@ -81,7 +81,7 @@ export const CouponAddCampaignCoreFields: React.FC<
           name="kind"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('kind')}</Form.Label>
+              <Form.Label>{t('kind', 'Kind')}</Form.Label>
               <Form.Control>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <Select.Trigger
@@ -89,7 +89,7 @@ export const CouponAddCampaignCoreFields: React.FC<
                   >
                     {COUPON_KIND_TYPES.find(
                       (type) => type.value === field.value,
-                    )?.label || t('select-kind')}
+                    )?.label || t('select-kind', 'Select kind')}
                   </Select.Trigger>
                   <Select.Content>
                     {COUPON_KIND_TYPES.map((option) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-campaign-field/CouponAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-campaign-field/CouponAddCampaignMoreFields.tsx
@@ -58,7 +58,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -85,11 +85,11 @@ export const CouponAddCampaignMoreFields: React.FC<
           name="startDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('start-date')}</Form.Label>
+              <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-start-date')}
+                placeholder={t('select-start-date', 'Select start date')}
               />
               <Form.Message />
             </Form.Item>
@@ -103,11 +103,11 @@ export const CouponAddCampaignMoreFields: React.FC<
           name="endDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('end-date')}</Form.Label>
+              <Form.Label>{t('end-date', 'End Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-end-date')}
+                placeholder={t('select-end-date', 'Select end date')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-code-rule-field/CouponDefaultCodeRuleField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-code-rule-field/CouponDefaultCodeRuleField.tsx
@@ -21,11 +21,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="codeLength"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('code-length')}</Form.Label>
+              <Form.Label>{t('code-length', 'Code Length')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-code-length')}
+                  placeholder={t('enter-code-length', 'Enter code length')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -39,11 +39,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="prefixUppercase"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('prefix-uppercase')}</Form.Label>
+              <Form.Label>{t('prefix-uppercase', 'Prefix Uppercase')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-prefix-uppercase')}
+                  placeholder={t('enter-prefix-uppercase', 'Enter prefix uppercase')}
                   {...field}
                   onChange={(e) => field.onChange(e.target.value)}
                 />
@@ -59,11 +59,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="numberOfCodes"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('number-of-codes')}</Form.Label>
+              <Form.Label>{t('number-of-codes', 'Number of Codes')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-number-of-codes')}
+                  placeholder={t('enter-number-of-codes', 'Enter number of codes')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -77,11 +77,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="postfixUppercase"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('postfix-uppercase')}</Form.Label>
+              <Form.Label>{t('postfix-uppercase', 'Postfix Uppercase')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-postfix-uppercase')}
+                  placeholder={t('enter-postfix-uppercase', 'Enter postfix uppercase')}
                   {...field}
                   onChange={(e) => field.onChange(e.target.value)}
                 />
@@ -97,11 +97,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="characterSet"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('character-set')}</Form.Label>
+              <Form.Label>{t('character-set', 'Character Set')}</Form.Label>
               <Form.Control>
                 <Select value={field.value} onValueChange={field.onChange}>
                   <Select.Trigger className="w-full">
-                    <Select.Value placeholder={t('select-character-set')} />
+                    <Select.Value placeholder={t('select-character-set', 'Select character set')} />
                   </Select.Trigger>
 
                   <Select.Content>
@@ -122,11 +122,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="usageLimit"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('usage-limit')}</Form.Label>
+              <Form.Label>{t('usage-limit', 'Usage Limit')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-usage-limit')}
+                  placeholder={t('enter-usage-limit', 'Enter usage limit')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -143,11 +143,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="pattern"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('pattern')}</Form.Label>
+              <Form.Label>{t('pattern', 'Pattern')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-pattern')}
+                  placeholder={t('enter-pattern', 'Enter pattern')}
                   {...field}
                   onChange={(e) => field.onChange(e.target.value)}
                 />
@@ -161,11 +161,11 @@ export const CouponDefaultCodeRuleField: React.FC<
           name="redemptionLimitPerUser"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('redemption-limit-per-user')}</Form.Label>
+              <Form.Label>{t('redemption-limit-per-user', 'Redemption Limit Per User')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-redemption-limit-per-user')}
+                  placeholder={t('enter-redemption-limit-per-user', 'Enter redemption limit per user')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-code-rule-field/CouponStaticCodeRuleField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-code-rule-field/CouponStaticCodeRuleField.tsx
@@ -20,10 +20,10 @@ export const CouponStaticCodeRuleField: React.FC<
           name="staticCode"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('code')}</Form.Label>
+              <Form.Label>{t('code', 'Code')}</Form.Label>
               <Form.Control>
                 <Input
-                  placeholder={t('enter-coupon-code')}
+                  placeholder={t('enter-coupon-code', 'Enter the coupon code here')}
                   value={field.value ?? ''}
                   onChange={(e) => field.onChange(e.target.value)}
                 />
@@ -39,11 +39,11 @@ export const CouponStaticCodeRuleField: React.FC<
           name="usageLimit"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('usage-limit')}</Form.Label>
+              <Form.Label>{t('usage-limit', 'Usage Limit')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-usage-limit')}
+                  placeholder={t('enter-usage-limit', 'Enter usage limit')}
                   {...field}
                   value={field.value ?? ''}
                   onChange={(e) =>
@@ -66,11 +66,11 @@ export const CouponStaticCodeRuleField: React.FC<
           name="redemptionLimitPerUser"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('redemption-limit-per-user')}</Form.Label>
+              <Form.Label>{t('redemption-limit-per-user', 'Redemption Limit Per User')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-redemption-limit-per-user')}
+                  placeholder={t('enter-redemption-limit-per-user', 'Enter redemption limit per user')}
                   value={field.value ?? ''}
                   onChange={(e) =>
                     field.onChange(

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-restriction-field/CouponAddRestrictionCoreField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-restriction-field/CouponAddRestrictionCoreField.tsx
@@ -21,11 +21,11 @@ export const CouponAddRestrictionCoreField: React.FC<
           name="minimumSpend"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('minimum-spend')}</Form.Label>
+              <Form.Label>{t('minimum-spend', 'Minimum Spend')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-minimum-spend')}
+                  placeholder={t('enter-minimum-spend', 'Enter minimum spend')}
                   {...field}
                 />
               </Form.Control>
@@ -38,7 +38,7 @@ export const CouponAddRestrictionCoreField: React.FC<
           name="categoryIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('product-category')}</Form.Label>
+              <Form.Label>{t('product-category', 'Product Category')}</Form.Label>
               <Form.Control>
                 <SelectCategory
                   mode="multiple"
@@ -59,11 +59,11 @@ export const CouponAddRestrictionCoreField: React.FC<
           name="maximumSpend"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('maximum-spend')}</Form.Label>
+              <Form.Label>{t('maximum-spend', 'Maximum Spend')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-maximum-spend')}
+                  placeholder={t('enter-maximum-spend', 'Enter maximum spend')}
                   {...field}
                 />
               </Form.Control>
@@ -76,7 +76,7 @@ export const CouponAddRestrictionCoreField: React.FC<
           name="excludeCategoryIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-product-category')}</Form.Label>
+              <Form.Label>{t('or-exclude-product-category', 'Or Exclude Product Category')}</Form.Label>
               <Form.Control>
                 <SelectCategory
                   mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-restriction-field/CouponAddRestrictionMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/coupon-restriction-field/CouponAddRestrictionMoreFields.tsx
@@ -21,7 +21,7 @@ export const CouponAddRestrictionMoreFields: React.FC<
           name="productIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('product')}</Form.Label>
+              <Form.Label>{t('product', 'Product')}</Form.Label>
               <Form.Control>
                 <SelectProduct
                   mode="multiple"
@@ -40,7 +40,7 @@ export const CouponAddRestrictionMoreFields: React.FC<
           name="tag"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('tag')}</Form.Label>
+              <Form.Label>{t('tag', 'Tag')}</Form.Label>
               <Form.Control>
                 <SelectTags
                   mode="multiple"
@@ -61,7 +61,7 @@ export const CouponAddRestrictionMoreFields: React.FC<
           name="excludeProductIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-product')}</Form.Label>
+              <Form.Label>{t('or-exclude-product', 'Or Exclude Product')}</Form.Label>
               <Form.Control>
                 <SelectProduct
                   mode="multiple"
@@ -80,7 +80,7 @@ export const CouponAddRestrictionMoreFields: React.FC<
           name="orExcludeTag"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-tag')}</Form.Label>
+              <Form.Label>{t('or-exclude-tag', 'Or Exclude Tag')}</Form.Label>
               <Form.Control>
                 <SelectTags
                   mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/selects/SelectCouponDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/add-coupon-campaign/components/selects/SelectCouponDate.tsx
@@ -80,7 +80,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
     <>
       <IconCalendarPlus className="text-accent-foreground" />
       <span className="text-accent-foreground font-medium">
-        {placeholder || t('select-date')}
+        {placeholder || t('select-date', 'Select date...')}
       </span>
     </>
   );
@@ -163,7 +163,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponAddSheet.tsx
@@ -67,7 +67,7 @@ export const LoyaltyCouponAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-coupon-campaign')}
+          {t('add-coupon-campaign', 'Add coupon campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -78,7 +78,7 @@ export const LoyaltyCouponAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-coupon-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-coupon-campaign', 'Add coupon campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponColumns.tsx
@@ -33,7 +33,7 @@ export const couponColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -51,7 +51,7 @@ export const couponColumns = (
     id: 'kind',
     accessorKey: 'kind',
     header: () => (
-      <RecordTable.InlineHead icon={IconTicket} label={t('type')} />
+      <RecordTable.InlineHead icon={IconTicket} label={t('type', 'Type')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponMoreColumn.tsx
@@ -40,20 +40,20 @@ export const CouponMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-coupon-confirm', { count: 1 }),
+      message: t('delete-coupon-confirm', 'Are you sure you want to delete {{count}} selected coupon(s)?', { count: 1 }),
     }).then(() => {
       removeCoupon({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('coupons-deleted', { count: 1 }),
+            title: t('coupons-deleted', '{{count}} coupon(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const CouponMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-coupons" onSelect={handleSeeCoupons}>
-              <IconTicket /> {t('see-coupons')}
+              <IconTicket /> {t('see-coupons', 'See coupons')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const CouponMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/CouponRecordTable.tsx
@@ -53,10 +53,10 @@ export const CouponRecordTable = () => {
                     className="text-muted-foreground mx-auto mb-4"
                   />
                   <h3 className="text-xl font-semibold mb-2">
-                    {t('no-coupons-yet')}
+                    {t('no-coupons-yet', 'No coupons yet')}
                   </h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-coupon')}
+                    {t('get-started-coupon', 'Get started by creating your first coupon.')}
                   </p>
                 </div>
                 <LoyaltyCouponAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/coupon-command-bar/CouponCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/coupon-command-bar/CouponCommandBar.tsx
@@ -10,7 +10,7 @@ export const CouponCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteCoupon

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/coupon-command-bar/delete/DeleteCoupon.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/components/coupon-command-bar/delete/DeleteCoupon.tsx
@@ -15,20 +15,20 @@ export const DeleteCoupon = ({ couponIds }: { couponIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-coupon-confirm', { count: couponIds.length }),
+          message: t('delete-coupon-confirm', 'Are you sure you want to delete {{count}} selected coupon(s)?', { count: couponIds.length }),
         }).then(() => {
           removeCoupon({
             variables: { _ids: couponIds },
           })
             .then(() => {
               toast({
-                title: t('coupons-deleted', { count: couponIds.length }),
+                title: t('coupons-deleted', '{{count}} coupon(s) deleted successfully', { count: couponIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const DeleteCoupon = ({ couponIds }: { couponIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/components/EditCouponTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/components/EditCouponTabs.tsx
@@ -100,7 +100,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -116,7 +116,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       {isLastTab() ? (
         <Button
@@ -125,7 +125,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
           onClick={handleSubmit}
           disabled={editLoading}
         >
-          {editLoading ? t('updating') : t('update')}
+          {editLoading ? t('updating', 'Updating...') : t('update', 'Update')}
         </Button>
       ) : (
         <Button
@@ -133,7 +133,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
           className="bg-primary text-primary-foreground hover:bg-primary/90"
           onClick={handleNext}
         >
-          {t('next')}
+          {t('next', 'Next')}
         </Button>
       )}
     </Sheet.Footer>
@@ -151,7 +151,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('campaign')}
+            {t('campaign', 'Campaign')}
           </Button>
         </Tabs.Trigger>
         <Tabs.Trigger asChild value="restriction">
@@ -159,7 +159,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('restriction')}
+            {t('restriction', 'Restriction')}
           </Button>
         </Tabs.Trigger>
         <Tabs.Trigger asChild value="codeRule">
@@ -167,7 +167,7 @@ export const EditCouponTabs = ({ onOpenChange, form }: Props) => {
             variant={'outline'}
             className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
           >
-            {t('code-rule')}
+            {t('code-rule', 'Code rule')}
           </Button>
         </Tabs.Trigger>
       </Tabs.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/components/LoyaltyCouponEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/components/LoyaltyCouponEditSheet.tsx
@@ -139,7 +139,7 @@ export const LoyaltyCouponEditSheet = ({ couponId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -151,7 +151,7 @@ export const LoyaltyCouponEditSheet = ({ couponId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-coupon-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-coupon-campaign', 'Edit coupon campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/hooks/useCouponEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/coupon-detail/hooks/useCouponEdit.tsx
@@ -24,15 +24,15 @@ export const useCouponEdit = (
     refetchQueries,
     onCompleted: () => {
       toast({
-        title: t('success'),
-        description: t('coupon-updated'),
+        title: t('success', 'Success'),
+        description: t('coupon-updated', 'Coupon updated successfully'),
         variant: 'default',
       });
       onCompleted?.();
     },
     onError: (error) => {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/hooks/useAddCoupon.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/hooks/useAddCoupon.tsx
@@ -98,15 +98,15 @@ export const useAddCoupon = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('coupon-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('coupon-campaign-created', 'Coupon campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/hooks/useCouponStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/coupon/hooks/useCouponStatusEdit.tsx
@@ -26,15 +26,15 @@ export function useCouponStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('coupon-status-updated'),
+          title: t('success', 'Success'),
+          description: t('coupon-status-updated', 'Coupon status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/DonationTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/DonationTabs.tsx
@@ -44,7 +44,7 @@ export const DonationTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -64,7 +64,7 @@ export const DonationTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -72,7 +72,7 @@ export const DonationTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/donation-field/DonationAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/donation-field/DonationAddCampaignCoreFields.tsx
@@ -28,9 +28,9 @@ export const DonationAddCampaignCoreFields: React.FC<
           name="title"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('title')}</Form.Label>
+              <Form.Label>{t('title', 'Title')}</Form.Label>
               <Form.Control>
-                <Input placeholder={t('enter-donation-title')} {...field} />
+                <Input placeholder={t('enter-donation-title', 'Enter donation title')} {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -41,11 +41,11 @@ export const DonationAddCampaignCoreFields: React.FC<
           name="maxScore"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('max-score')}</Form.Label>
+              <Form.Label>{t('max-score', 'Max Score')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-max-score')}
+                  placeholder={t('enter-max-score', 'Enter max score')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -66,7 +66,7 @@ export const DonationAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.voucherCampaignId`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('voucher-campaign')}</Form.Label>
+                      <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                       <Form.Control>
                         <SelectVoucherCampaign
                           value={field.value || undefined}
@@ -84,11 +84,11 @@ export const DonationAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.minScore`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('min-score')}</Form.Label>
+                      <Form.Label>{t('min-score', 'Min Score')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
-                          placeholder={t('score')}
+                          placeholder={t('score', 'Score')}
                           {...field}
                           onChange={(e) =>
                             field.onChange(Number(e.target.value))
@@ -118,7 +118,7 @@ export const DonationAddCampaignCoreFields: React.FC<
           variant="secondary"
         >
           <IconPlus />
-          {t('add-level')}
+          {t('add-level', 'Add level')}
         </Button>
       </div>
     </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/donation-field/DonationAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/donation-field/DonationAddCampaignMoreFields.tsx
@@ -58,7 +58,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -85,11 +85,11 @@ export const DonationAddCampaignMoreFields: React.FC<
           name="startDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('start-date')}</Form.Label>
+              <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-start-date')}
+                placeholder={t('select-start-date', 'Select start date')}
               />
               <Form.Message />
             </Form.Item>
@@ -103,11 +103,11 @@ export const DonationAddCampaignMoreFields: React.FC<
           name="endDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('end-date')}</Form.Label>
+              <Form.Label>{t('end-date', 'End Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-end-date')}
+                placeholder={t('select-end-date', 'Select end date')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/selects/SelectDonationDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/add-donation-campaign/components/selects/SelectDonationDate.tsx
@@ -72,7 +72,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
       <>
         <IconCalendarPlus className="text-accent-foreground" />
         <span className="text-accent-foreground font-medium">
-          {placeholder || t('select-date')}
+          {placeholder || t('select-date', 'Select date...')}
         </span>
       </>
     );
@@ -168,7 +168,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonateMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonateMoreColumn.tsx
@@ -40,20 +40,20 @@ export const DonationMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-donation-confirm', { count: 1 }),
+      message: t('delete-donation-confirm', 'Are you sure you want to delete {{count}} selected donation(s)?', { count: 1 }),
     }).then(() => {
       removeDonation({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('donations-deleted', { count: 1 }),
+            title: t('donations-deleted', '{{count}} donation(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const DonationMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-donates" onSelect={handleSeeDonates}>
-              <IconTicket /> {t('see-donates')}
+              <IconTicket /> {t('see-donates', 'See donates')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const DonationMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationAddSheet.tsx
@@ -68,7 +68,7 @@ export const LoyaltyDonationAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-donation-campaign')}
+          {t('add-donation-campaign', 'Add donation campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -79,7 +79,7 @@ export const LoyaltyDonationAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-donation-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-donation-campaign', 'Add donation campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationColumns.tsx
@@ -21,7 +21,7 @@ export const donationColumns = (
     id: 'name',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('name')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('name', 'Name')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/DonationRecordTable.tsx
@@ -50,10 +50,10 @@ export const DonationRecordTable = () => {
                     className="text-muted-foreground mx-auto mb-4"
                   />
                   <h3 className="text-xl font-semibold mb-2">
-                    {t('no-donations-yet')}
+                    {t('no-donations-yet', 'No donations yet')}
                   </h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-donation')}
+                    {t('get-started-donation', 'Get started by creating your first donation.')}
                   </p>
                 </div>
                 <LoyaltyDonationAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/VoucherCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/VoucherCampaignInline.tsx
@@ -46,7 +46,7 @@ const VoucherCampaignInlineProvider = ({
       loading: false,
       voucherCampaignId: normalizedVoucherCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('choose-voucher-campaign')
+        ? t('choose-voucher-campaign', 'Choose voucher campaign')
         : placeholder,
       updateVoucherCampaigns:
         updateVoucherCampaigns || setSelectedVoucherCampaigns,
@@ -121,7 +121,7 @@ const VoucherCampaignInlineTitle = () => {
     return (
       <TextOverflowTooltip
         value={voucherCampaigns
-          .map((c) => c.title || t('unnamed-campaign'))
+          .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
           .join(', ')}
       />
     );
@@ -131,11 +131,11 @@ const VoucherCampaignInlineTitle = () => {
     <Tooltip.Provider>
       <Tooltip>
         <Tooltip.Trigger asChild>
-          <span>{t('voucher-campaigns-count', { count: voucherCampaigns.length })}</span>
+          <span>{t('voucher-campaigns-count', '{{count}} voucher campaigns', { count: voucherCampaigns.length })}</span>
         </Tooltip.Trigger>
         <Tooltip.Content>
           {voucherCampaigns
-            .map((c) => c.title || t('unnamed-campaign'))
+            .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
             .join(', ')}
         </Tooltip.Content>
       </Tooltip>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/donation-command-bar/DonationCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/donation-command-bar/DonationCommandBar.tsx
@@ -10,7 +10,7 @@ export const DonationCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteDonation

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/donation-command-bar/delete/DeleteDonation.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/donation-command-bar/delete/DeleteDonation.tsx
@@ -15,20 +15,20 @@ export const DeleteDonation = ({ donationIds }: { donationIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-donation-confirm', { count: donationIds.length }),
+          message: t('delete-donation-confirm', 'Are you sure you want to delete {{count}} selected donation(s)?', { count: donationIds.length }),
         }).then(() => {
           removeDonation({
             variables: { _ids: donationIds },
           })
             .then(() => {
               toast({
-                title: t('donations-deleted', { count: donationIds.length }),
+                title: t('donations-deleted', '{{count}} donation(s) deleted successfully', { count: donationIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const DeleteDonation = ({ donationIds }: { donationIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/selects/SelectVoucherCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/components/selects/SelectVoucherCampaign.tsx
@@ -137,7 +137,7 @@ const SelectVoucherCampaignCommandItem = ({
     >
       <VoucherCampaignInline
         voucherCampaigns={[voucherCampaign]}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={voucherCampaignId.includes(voucherCampaign._id)}
@@ -169,7 +169,7 @@ const SelectVoucherCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-voucher-campaigns')}
+        placeholder={t('search-voucher-campaigns', 'Search voucher campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -212,7 +212,7 @@ export const SelectVoucherCampaignFilterItem = () => {
   return (
     <Filter.Item value="voucherCampaign">
       <IconReceipt />
-      {t('voucher-campaign')}
+      {t('voucher-campaign', 'Voucher Campaign')}
     </Filter.Item>
   );
 };
@@ -267,7 +267,7 @@ export const SelectVoucherCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'voucherCampaign'}>
       <Filter.BarName>
         <IconReceipt />
-        {!iconOnly && t('voucher-campaign')}
+        {!iconOnly && t('voucher-campaign', 'Voucher Campaign')}
       </Filter.BarName>
 
       <SelectVoucherCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/components/EditDonationTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/components/EditDonationTabs.tsx
@@ -49,7 +49,7 @@ export const EditDonationTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -68,7 +68,7 @@ export const EditDonationTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -76,7 +76,7 @@ export const EditDonationTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('updating') : t('update')}
+        {editLoading ? t('updating', 'Updating...') : t('update', 'Update')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/components/LoyaltyDonationEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/components/LoyaltyDonationEditSheet.tsx
@@ -119,7 +119,7 @@ export const LoyaltyDonationEditSheet = ({ donationId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -131,7 +131,7 @@ export const LoyaltyDonationEditSheet = ({ donationId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-donation-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-donation-campaign', 'Edit donation campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/hooks/useDonationEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/donation-detail/hooks/useDonationEdit.tsx
@@ -29,14 +29,14 @@ export const useDonationEdit = () => {
       refetchQueries: ['getCampaigns'],
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('donation-updated'),
+          title: t('success', 'Success'),
+          description: t('donation-updated', 'Donation updated successfully'),
           variant: 'default',
         });
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/hooks/useAddDonation.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/hooks/useAddDonation.tsx
@@ -84,15 +84,15 @@ export const useAddDonation = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('donation-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('donation-campaign-created', 'Donation campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/hooks/useDonationStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/donate/hooks/useDonationStatusEdit.tsx
@@ -29,15 +29,15 @@ export function useDonationStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('donation-status-updated'),
+          title: t('success', 'Success'),
+          description: t('donation-status-updated', 'Donation status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/general-config/components/LoyaltyConfigFormFIelds.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/general-config/components/LoyaltyConfigFormFIelds.tsx
@@ -24,7 +24,7 @@ export const LoyaltyConfigFormFields = () => {
         className="h-full w-full mx-auto max-w-2xl px-9 py-5 flex flex-col gap-8"
         onSubmit={form.handleSubmit(onSubmit)}
       >
-        <h1 className="text-lg font-semibold">{t('general-settings')}</h1>
+        <h1 className="text-lg font-semibold">{t('general-settings', 'General settings')}</h1>
 
         <Form.Field
           name="loyaltyRatioCurrency"
@@ -32,13 +32,13 @@ export const LoyaltyConfigFormFields = () => {
           render={({ field }) => (
             <Form.Item>
               <Form.Label className="font-sans normal-case text-foreground text-sm font-medium leading-none">
-                {t('loyalty-ratio-currency')}
+                {t('loyalty-ratio-currency', 'Loyalty ratio currency')}
               </Form.Label>
               <Form.Message />
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-loyalty-ratio-currency')}
+                  placeholder={t('enter-loyalty-ratio-currency', 'Enter loyalty ratio currency')}
                   className="h-8"
                   {...field}
                 />
@@ -46,20 +46,20 @@ export const LoyaltyConfigFormFields = () => {
             </Form.Item>
           )}
         />
-        <h1 className="text-lg font-semibold">{t('share-settings')}</h1>
+        <h1 className="text-lg font-semibold">{t('share-settings', 'Share settings')}</h1>
         <Form.Field
           name="feeForScoreSharing"
           control={form.control}
           render={({ field }) => (
             <Form.Item>
               <Form.Label className="font-sans normal-case text-foreground text-sm font-medium leading-none">
-                {t('fee-for-score-sharing')}
+                {t('fee-for-score-sharing', 'Fee for score sharing')}
               </Form.Label>
               <Form.Message />
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-fee-for-score-sharing')}
+                  placeholder={t('enter-fee-for-score-sharing', 'Enter fee for score sharing')}
                   className="h-8"
                   {...field}
                 />
@@ -74,7 +74,7 @@ export const LoyaltyConfigFormFields = () => {
             type="submit"
             disabled={isUpdating}
           >
-            {isUpdating ? t('saving') : t('save')}
+            {isUpdating ? t('saving', 'Saving...') : t('save', 'Save')}
           </Button>
         </div>
       </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/general-config/hooks/useLoyaltyConfig.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/general-config/hooks/useLoyaltyConfig.tsx
@@ -23,14 +23,14 @@ export const useLoyaltyConfig = () => {
     refetchQueries: [{ query: LOYALTY_CONFIGS_QUERY }],
     onCompleted: () => {
       toast({
-        title: t('success'),
-        description: t('loyalty-config-updated'),
+        title: t('success', 'Success'),
+        description: t('loyalty-config-updated', 'Loyalty config updated successfully'),
         variant: 'default',
       });
     },
     onError: (err) => {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: err.message,
         variant: 'destructive',
       });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/LotteryTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/LotteryTabs.tsx
@@ -45,7 +45,7 @@ export const LotteryTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -65,7 +65,7 @@ export const LotteryTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -73,7 +73,7 @@ export const LotteryTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/lottery-field/LotteryAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/lottery-field/LotteryAddCampaignCoreFields.tsx
@@ -38,9 +38,9 @@ export const LotteryAddCampaignCoreFields: React.FC<
         name="title"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('title')}</Form.Label>
+            <Form.Label>{t('title', 'Title')}</Form.Label>
             <Form.Control>
-              <Input placeholder={t('enter-lottery-title')} {...field} />
+              <Input placeholder={t('enter-lottery-title', 'Enter lottery title')} {...field} />
             </Form.Control>
             <Form.Message />
           </Form.Item>
@@ -51,11 +51,11 @@ export const LotteryAddCampaignCoreFields: React.FC<
         name={`buyScore`}
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('buy-score')}</Form.Label>
+            <Form.Label>{t('buy-score', 'Buy Score')}</Form.Label>
             <Form.Control>
               <Input
                 type="number"
-                placeholder={t('enter-buy-score')}
+                placeholder={t('enter-buy-score', 'Enter buy score')}
                 {...field}
                 onChange={(e) => field.onChange(Number(e.target.value))}
               />
@@ -66,11 +66,11 @@ export const LotteryAddCampaignCoreFields: React.FC<
       />
 
       <div className="space-y-4">
-        <Form.Label>{t('number-format')}</Form.Label>
+        <Form.Label>{t('number-format', 'Number Format')}</Form.Label>
         <div className="flex gap-2 items-center">
           <SelectFormatNumber.FormItem
             value={formatType}
-            placeholder={t('choose-allow-chars')}
+            placeholder={t('choose-allow-chars', 'Choose allow chars')}
             onValueChange={(value) => setFormatType(value)}
             className="w-62"
           />
@@ -96,7 +96,7 @@ export const LotteryAddCampaignCoreFields: React.FC<
             disabled={!formatType}
           >
             <IconPlus />
-            {t('add-format')}
+            {t('add-format', 'Add format')}
           </Button>
         </div>
         <Form.Field
@@ -107,7 +107,7 @@ export const LotteryAddCampaignCoreFields: React.FC<
               <Form.Control>
                 <Input
                   readOnly
-                  placeholder={t('format-preview')}
+                  placeholder={t('format-preview', 'Format preview')}
                   {...field}
                   value={field.value || ''}
                 />
@@ -127,9 +127,9 @@ export const LotteryAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.name`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('name')}</Form.Label>
+                      <Form.Label>{t('name', 'Name')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-name')} {...field} />
+                        <Input placeholder={t('enter-name', 'Enter name')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -140,7 +140,7 @@ export const LotteryAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.voucherCampaignId`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('voucher-campaign')}</Form.Label>
+                      <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                       <Form.Control>
                         <SelectVoucherCampaign
                           value={field.value || undefined}
@@ -156,11 +156,11 @@ export const LotteryAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.count`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('count')}</Form.Label>
+                      <Form.Label>{t('count', 'Count')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
-                          placeholder={t('count')}
+                          placeholder={t('count', 'Count')}
                           {...field}
                           onChange={(e) =>
                             field.onChange(Number(e.target.value))
@@ -197,7 +197,7 @@ export const LotteryAddCampaignCoreFields: React.FC<
           variant="secondary"
         >
           <IconPlus />
-          {t('add-level')}
+          {t('add-level', 'Add level')}
         </Button>
       </div>
     </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/lottery-field/LotteryAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/lottery-field/LotteryAddCampaignMoreFields.tsx
@@ -66,7 +66,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -93,11 +93,11 @@ export const LotteryAddCampaignMoreFields: React.FC<
         name="startDate"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('start-date')}</Form.Label>
+            <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
             <DateSelectFormField
               value={field.value}
               onValueChange={field.onChange}
-              placeholder={t('select-start-date')}
+              placeholder={t('select-start-date', 'Select start date')}
             />
             <Form.Message />
           </Form.Item>
@@ -109,11 +109,11 @@ export const LotteryAddCampaignMoreFields: React.FC<
         name="endDate"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('end-date')}</Form.Label>
+            <Form.Label>{t('end-date', 'End Date')}</Form.Label>
             <DateSelectFormField
               value={field.value}
               onValueChange={field.onChange}
-              placeholder={t('select-end-date')}
+              placeholder={t('select-end-date', 'Select end date')}
             />
             <Form.Message />
           </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/selects/SelectLotteryDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/add-lottery-campaign/components/selects/SelectLotteryDate.tsx
@@ -67,7 +67,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
       <>
         <IconCalendarPlus className="text-accent-foreground" />
         <span className="text-accent-foreground font-medium">
-          {placeholder || t('select-date')}
+          {placeholder || t('select-date', 'Select date...')}
         </span>
       </>
     );
@@ -163,7 +163,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryAddSheet.tsx
@@ -64,7 +64,7 @@ export const LotteryAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-lottery-campaign')}
+          {t('add-lottery-campaign', 'Add lottery campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -75,7 +75,7 @@ export const LotteryAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-lottery-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-lottery-campaign', 'Add lottery campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryColumns.tsx
@@ -21,7 +21,7 @@ export const lotteryColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryMoreColumn.tsx
@@ -40,20 +40,20 @@ export const LotteryMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-lottery-confirm', { count: 1 }),
+      message: t('delete-lottery-confirm', 'Are you sure you want to delete {{count}} selected lottery(s)?', { count: 1 }),
     }).then(() => {
       removeLottery({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('lotteries-deleted', { count: 1 }),
+            title: t('lotteries-deleted', '{{count}} lottery(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const LotteryMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-lotteries" onSelect={handleSeeLotteries}>
-              <IconTicket /> {t('see-lotteries')}
+              <IconTicket /> {t('see-lotteries', 'See lotteries')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const LotteryMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/LotteryRecordTable.tsx
@@ -48,9 +48,9 @@ export const LotteryRecordTable = () => {
                     size={64}
                     className="text-muted-foreground mx-auto mb-4"
                   />
-                  <h3 className="text-xl font-semibold mb-2">{t('no-lotteries-yet')}</h3>
+                  <h3 className="text-xl font-semibold mb-2">{t('no-lotteries-yet', 'No lotteries yet')}</h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-lottery')}
+                    {t('get-started-lottery', 'Get started by creating your first lottery.')}
                   </p>
                 </div>
                 <LotteryAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/VoucherCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/VoucherCampaignInline.tsx
@@ -45,7 +45,7 @@ const VoucherCampaignInlineProvider = ({
       loading: false,
       voucherCampaignId: normalizedVoucherCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('choose-voucher-campaign')
+        ? t('choose-voucher-campaign', 'Choose voucher campaign')
         : placeholder,
       updateVoucherCampaigns:
         updateVoucherCampaigns || setCurrentVoucherCampaigns,
@@ -120,7 +120,7 @@ const VoucherCampaignInlineTitle = () => {
     return (
       <TextOverflowTooltip
         value={voucherCampaigns
-          .map((c) => c.title || t('unnamed-campaign'))
+          .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
           .join(', ')}
       />
     );
@@ -130,11 +130,11 @@ const VoucherCampaignInlineTitle = () => {
     <Tooltip.Provider>
       <Tooltip>
         <Tooltip.Trigger asChild>
-          <span>{t('voucher-campaigns-count', { count: voucherCampaigns.length })}</span>
+          <span>{t('voucher-campaigns-count', '{{count}} voucher campaigns', { count: voucherCampaigns.length })}</span>
         </Tooltip.Trigger>
         <Tooltip.Content>
           {voucherCampaigns
-            .map((c) => c.title || t('unnamed-campaign'))
+            .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
             .join(', ')}
         </Tooltip.Content>
       </Tooltip>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/lottery-command-bar/LotteryCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/lottery-command-bar/LotteryCommandBar.tsx
@@ -10,7 +10,7 @@ export const LotteryCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteLottery

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/lottery-command-bar/delete/DeleteLottery.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/lottery-command-bar/delete/DeleteLottery.tsx
@@ -15,20 +15,20 @@ export const DeleteLottery = ({ lotteryIds }: { lotteryIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-lottery-confirm', { count: lotteryIds.length }),
+          message: t('delete-lottery-confirm', 'Are you sure you want to delete {{count}} selected lottery(s)?', { count: lotteryIds.length }),
         }).then(() => {
           removeLottery({
             variables: { _ids: lotteryIds },
           })
             .then(() => {
               toast({
-                title: t('lotteries-deleted', { count: lotteryIds.length }),
+                title: t('lotteries-deleted', '{{count}} lottery(s) deleted successfully', { count: lotteryIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const DeleteLottery = ({ lotteryIds }: { lotteryIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/selects/SelectFormatNumber.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/selects/SelectFormatNumber.tsx
@@ -136,7 +136,7 @@ const SelectFormatNumberValue = ({
   if (!selectedFormatOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-format-option')}
+        {placeholder || t('select-format-option', 'Select format option')}
       </span>
     );
   }
@@ -177,9 +177,9 @@ const SelectFormatNumberContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-format-option')} />
+      <Command.Input placeholder={t('search-format-option', 'Search format option')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-format-options-found')}</span>
+        <span className="text-muted-foreground">{t('no-format-options-found', 'No format options found')}</span>
       </Command.Empty>
       <Command.List>
         {formatOptions?.map((formatOption) => (
@@ -198,7 +198,7 @@ export const SelectFormatNumberFilterItem = () => {
   return (
     <Filter.Item value="formatNumber">
       <IconFilter />
-      {t('format-number')}
+      {t('format-number', 'Format Number')}
     </Filter.Item>
   );
 };
@@ -253,7 +253,7 @@ export const SelectFormatNumberFilterBar = ({
     <Filter.BarItem queryKey={'formatNumber'}>
       <Filter.BarName>
         <IconFilter />
-        {t('format-number')}
+        {t('format-number', 'Format Number')}
       </Filter.BarName>
       <SelectFormatNumberProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/selects/SelectVoucherCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/components/selects/SelectVoucherCampaign.tsx
@@ -135,7 +135,7 @@ const SelectVoucherCampaignCommandItem = ({
     >
       <VoucherCampaignInline
         voucherCampaigns={[voucherCampaign]}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={voucherCampaignId.includes(voucherCampaign._id)}
@@ -167,7 +167,7 @@ const SelectVoucherCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-voucher-campaigns')}
+        placeholder={t('search-voucher-campaigns', 'Search voucher campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -210,7 +210,7 @@ export const SelectVoucherCampaignFilterItem = () => {
   return (
     <Filter.Item value="voucherCampaign">
       <IconReceipt />
-      {t('voucher-campaign')}
+      {t('voucher-campaign', 'Voucher Campaign')}
     </Filter.Item>
   );
 };
@@ -265,7 +265,7 @@ export const SelectVoucherCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'voucherCampaign'}>
       <Filter.BarName>
         <IconReceipt />
-        {!iconOnly && t('voucher-campaign')}
+        {!iconOnly && t('voucher-campaign', 'Voucher Campaign')}
       </Filter.BarName>
 
       <SelectVoucherCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useAddLottery.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useAddLottery.tsx
@@ -91,15 +91,15 @@ export const useAddLottery = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('lottery-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('lottery-campaign-created', 'Lottery campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useEditLottery.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useEditLottery.tsx
@@ -36,15 +36,15 @@ export function useEditLottery() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('lottery-updated'),
+          title: t('success', 'Success'),
+          description: t('lottery-updated', 'Lottery updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useLotteryStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/hooks/useLotteryStatusEdit.tsx
@@ -29,15 +29,15 @@ export function useLotteryStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('lottery-status-updated'),
+          title: t('success', 'Success'),
+          description: t('lottery-status-updated', 'Lottery status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/lottery-detail/components/EditLotteryTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/lottery-detail/components/EditLotteryTabs.tsx
@@ -20,8 +20,8 @@ export const EditLotteryTabs = ({ onOpenChange, form, lotteryId }: Props) => {
   const handleSubmit = async () => {
     if (!lotteryId) {
       toast({
-        title: t('error'),
-        description: t('no-lottery-id-provided'),
+        title: t('error', 'Error'),
+        description: t('no-lottery-id-provided', 'No lottery ID provided'),
         variant: 'destructive',
       });
       return;
@@ -58,7 +58,7 @@ export const EditLotteryTabs = ({ onOpenChange, form, lotteryId }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -78,7 +78,7 @@ export const EditLotteryTabs = ({ onOpenChange, form, lotteryId }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -86,7 +86,7 @@ export const EditLotteryTabs = ({ onOpenChange, form, lotteryId }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/lottery-detail/components/LoyaltyLotteryEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/lottery/lottery-detail/components/LoyaltyLotteryEditSheet.tsx
@@ -115,7 +115,7 @@ export const LoyaltyLotteryEditSheet = ({ lotteryId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -127,7 +127,7 @@ export const LoyaltyLotteryEditSheet = ({ lotteryId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-lottery-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-lottery-campaign', 'Edit Lottery campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/AddLoyaltyScore.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/AddLoyaltyScore.tsx
@@ -126,14 +126,14 @@ export function AddLoyaltyScoreForm({
             className="bg-background hover:bg-background/90"
             onClick={handleCancel}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
           <Button
             type="submit"
             className="bg-primary text-primary-foreground hover:bg-primary/90"
             disabled={editLoading}
           >
-            {editLoading ? t('saving') : t('save')}
+            {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
           </Button>
         </Sheet.Footer>
       </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddCoreFields.tsx
@@ -21,9 +21,9 @@ export const LoyaltyScoreAddCoreFields: React.FC<
           name="title"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('title')}</Form.Label>
+              <Form.Label>{t('title', 'Title')}</Form.Label>
               <Form.Control>
-                <Input {...field} placeholder={t('enter-title')} />
+                <Input {...field} placeholder={t('enter-title', 'Enter title')} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -34,7 +34,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
           name="order"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('order')}</Form.Label>
+              <Form.Label>{t('order', 'Order')}</Form.Label>
               <Form.Control>
                 <Input
                   {...field}
@@ -53,11 +53,11 @@ export const LoyaltyScoreAddCoreFields: React.FC<
         name="description"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('description')}</Form.Label>
+            <Form.Label>{t('description', 'Description')}</Form.Label>
             <Form.Control>
               <Textarea
                 {...field}
-                placeholder={t('enter-description')}
+                placeholder={t('enter-description', 'Enter description')}
                 className="min-h-[80px]"
               />
             </Form.Control>
@@ -72,7 +72,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.productCategoryIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('product-category')}</Form.Label>
+                <Form.Label>{t('product-category', 'Product Category')}</Form.Label>
                 <Form.Control>
                   <SelectCategory
                     mode="multiple"
@@ -92,7 +92,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.productIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('product')}</Form.Label>
+                <Form.Label>{t('product', 'Product')}</Form.Label>
                 <Form.Control>
                   <SelectProduct
                     mode="multiple"
@@ -111,7 +111,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.tagIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('tag')}</Form.Label>
+                <Form.Label>{t('tag', 'Tag')}</Form.Label>
                 <Form.Control>
                   <SelectTags
                     mode="multiple"
@@ -133,7 +133,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.excludeProductCategoryIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('or-exclude-product-category')}</Form.Label>
+                <Form.Label>{t('or-exclude-product-category', 'Or Exclude Product Category')}</Form.Label>
                 <Form.Control>
                   <SelectCategory
                     mode="multiple"
@@ -153,7 +153,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.excludeProductIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('or-exclude-product')}</Form.Label>
+                <Form.Label>{t('or-exclude-product', 'Or Exclude Product')}</Form.Label>
                 <Form.Control>
                   <SelectProduct
                     mode="multiple"
@@ -172,7 +172,7 @@ export const LoyaltyScoreAddCoreFields: React.FC<
             name="conditions.excludeTagIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('or-exclude-tag')}</Form.Label>
+                <Form.Label>{t('or-exclude-tag', 'Or Exclude Tag')}</Form.Label>
                 <Form.Control>
                   <SelectTags
                     mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/LoyaltyScoreAddMoreFields.tsx
@@ -46,14 +46,14 @@ const AttributionSelect = ({
           variant="link"
           className="h-auto p-0 text-primary text-sm font-normal"
         >
-          {t('attribution')} ▾
+          {t('attribution', 'Attribution')} ▾
         </Button>
       </Popover.Trigger>
       <Combobox.Content className="w-64">
         <Command>
-          <Command.Input placeholder={t('type-to-search')} />
+          <Command.Input placeholder={t('type-to-search', 'Type to search')} />
           <Command.List>
-            <Command.Group heading={t('attributions')}>
+            <Command.Group heading={t('attributions', 'Attributions')}>
               {attributes.map((attr) => (
                 <Command.Item
                   key={attr.value}
@@ -141,7 +141,7 @@ const FieldNameSection = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <Form.Label>{t('field-name')}</Form.Label>
+      <Form.Label>{t('field-name', 'Field Name')}</Form.Label>
       <div className="flex gap-2">
         <button
           type="button"
@@ -151,7 +151,7 @@ const FieldNameSection = ({
             }`}
           onClick={() => setFieldTab('new')}
         >
-          {t('new')}
+          {t('new', 'New')}
         </button>
         <button
           type="button"
@@ -161,7 +161,7 @@ const FieldNameSection = ({
             }`}
           onClick={() => setFieldTab('exists')}
         >
-          {t('exists')}
+          {t('exists', 'Exists')}
         </button>
       </div>
 
@@ -178,7 +178,7 @@ const FieldNameSection = ({
                     lastNewFieldName.current = event.target.value;
                     field.onChange(event);
                   }}
-                  placeholder={t('enter-field-name')}
+                  placeholder={t('enter-field-name', 'Enter field name')}
                 />
               </Form.Control>
               <Form.Message />
@@ -199,7 +199,7 @@ const FieldNameSection = ({
                 }}
                 contentTypes={[`core:${ownerType}`]}
                 groupId={fieldGroupId}
-                placeholder={t('select-field')}
+                placeholder={t('select-field', 'Select field')}
               />
               <Form.Message />
             </Form.Item>
@@ -235,7 +235,7 @@ export const LoyaltyScoreAddMoreFields = ({
           }
           className="justify-between"
         >
-          <span>{t('sales-pipeline')}</span>
+          <span>{t('sales-pipeline', 'Sales pipeline')}</span>
           {selectedService === 'sales' && (
             <span
               role="button"
@@ -268,7 +268,7 @@ export const LoyaltyScoreAddMoreFields = ({
             })
           }
         >
-          {t('pos-order')}
+          {t('pos-order', 'POS Order')}
         </Button>
       </div>
 
@@ -281,9 +281,9 @@ export const LoyaltyScoreAddMoreFields = ({
       {selectedService && (
         <Tabs defaultValue="add" className="w-full">
           <Tabs.List>
-            <Tabs.Trigger value="add">{t('add')}</Tabs.Trigger>
-            <Tabs.Trigger value="subtract">{t('subtract')}</Tabs.Trigger>
-            <Tabs.Trigger value="set">{t('set')}</Tabs.Trigger>
+            <Tabs.Trigger value="add">{t('add', 'Add')}</Tabs.Trigger>
+            <Tabs.Trigger value="subtract">{t('subtract', 'Subtract')}</Tabs.Trigger>
+            <Tabs.Trigger value="set">{t('set', 'Set')}</Tabs.Trigger>
           </Tabs.List>
 
           <Tabs.Content value="add" className="pt-4">
@@ -294,7 +294,7 @@ export const LoyaltyScoreAddMoreFields = ({
                 render={({ field }) => (
                   <Form.Item>
                     <div className="flex items-center gap-2">
-                      <Form.Label>{t('score-value')}</Form.Label>
+                      <Form.Label>{t('score-value', 'Score Value')}</Form.Label>
                       <AttributionSelect
                         serviceName={selectedService}
                         onSelect={(val) =>
@@ -305,7 +305,7 @@ export const LoyaltyScoreAddMoreFields = ({
                     <Form.Control>
                       <Textarea
                         {...field}
-                        placeholder={t('enter-score-placeholder-add')}
+                        placeholder={t('enter-score-placeholder-add', 'Type a placeholder for add score')}
                       />
                     </Form.Control>
                     <Form.Message />
@@ -317,9 +317,9 @@ export const LoyaltyScoreAddMoreFields = ({
                 name="add.currencyRatio"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('currency-ratio')}</Form.Label>
+                    <Form.Label>{t('currency-ratio', 'Currency Ratio')}</Form.Label>
                     <Form.Control>
-                      <Input {...field} placeholder={t('enter-currency-ratio')} />
+                      <Input {...field} placeholder={t('enter-currency-ratio', 'Type a currency ratio')} />
                     </Form.Control>
                     <Form.Message />
                   </Form.Item>
@@ -336,7 +336,7 @@ export const LoyaltyScoreAddMoreFields = ({
                 render={({ field }) => (
                   <Form.Item>
                     <div className="flex items-center gap-2">
-                      <Form.Label>{t('score-value')}</Form.Label>
+                      <Form.Label>{t('score-value', 'Score Value')}</Form.Label>
                       <AttributionSelect
                         serviceName={selectedService}
                         onSelect={(val) =>
@@ -347,7 +347,7 @@ export const LoyaltyScoreAddMoreFields = ({
                     <Form.Control>
                       <Textarea
                         {...field}
-                        placeholder={t('enter-score-placeholder-subtract')}
+                        placeholder={t('enter-score-placeholder-subtract', 'Type a placeholder for subtract score')}
                       />
                     </Form.Control>
                     <Form.Message />
@@ -359,9 +359,9 @@ export const LoyaltyScoreAddMoreFields = ({
                 name="subtract.currencyRatio"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('currency-ratio')}</Form.Label>
+                    <Form.Label>{t('currency-ratio', 'Currency Ratio')}</Form.Label>
                     <Form.Control>
-                      <Input {...field} placeholder={t('enter-currency-ratio')} />
+                      <Input {...field} placeholder={t('enter-currency-ratio', 'Type a currency ratio')} />
                     </Form.Control>
                     <Form.Message />
                   </Form.Item>
@@ -380,7 +380,7 @@ export const LoyaltyScoreAddMoreFields = ({
                       />
                     </Form.Control>
                     <Form.Label className="mb-2">
-                      {t('only-client-portal-optional')}
+                      {t('only-client-portal-optional', 'Only Client Portal (optional)')}
                     </Form.Label>
                   </Form.Item>
                 )}
@@ -396,7 +396,7 @@ export const LoyaltyScoreAddMoreFields = ({
                 render={({ field }) => (
                   <Form.Item>
                     <div className="flex items-center gap-2">
-                      <Form.Label>{t('score-value')}</Form.Label>
+                      <Form.Label>{t('score-value', 'Score Value')}</Form.Label>
                       <AttributionSelect
                         serviceName={selectedService}
                         onSelect={(val) =>
@@ -407,7 +407,7 @@ export const LoyaltyScoreAddMoreFields = ({
                     <Form.Control>
                       <Textarea
                         {...field}
-                        placeholder={t('enter-score-placeholder-set')}
+                        placeholder={t('enter-score-placeholder-set', 'Type a placeholder for set score')}
                       />
                     </Form.Control>
                     <Form.Message />
@@ -419,9 +419,9 @@ export const LoyaltyScoreAddMoreFields = ({
                 name="set.currencyRatio"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('currency-ratio')}</Form.Label>
+                    <Form.Label>{t('currency-ratio', 'Currency Ratio')}</Form.Label>
                     <Form.Control>
-                      <Input {...field} placeholder={t('enter-currency-ratio')} />
+                      <Input {...field} placeholder={t('enter-currency-ratio', 'Type a currency ratio')} />
                     </Form.Control>
                     <Form.Message />
                   </Form.Item>
@@ -436,7 +436,7 @@ export const LoyaltyScoreAddMoreFields = ({
       {
         selectedService && (
           <div className="flex flex-col gap-2">
-            <Form.Label>{t('apply-score-to')}</Form.Label>
+            <Form.Label>{t('apply-score-to', 'Apply Score To')}</Form.Label>
             <div className="grid grid-cols-3 gap-4">
               {OWNER_TYPES.map(({ label, value }) => (
                 <Button
@@ -466,7 +466,7 @@ export const LoyaltyScoreAddMoreFields = ({
               name="fieldGroupId"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('field-group')}</Form.Label>
+                  <Form.Label>{t('field-group', 'Field Group')}</Form.Label>
                   <SelectFieldGroup
                     value={field.value || ''}
                     onValueChange={field.onChange}
@@ -488,7 +488,7 @@ export const LoyaltyScoreAddMoreFields = ({
                     />
                   </Form.Control>
                   <Form.Label className="mb-2">
-                    {t('only-client-portal-optional')}
+                    {t('only-client-portal-optional', 'Only Client Portal (optional)')}
                   </Form.Label>
                 </Form.Item>
               )}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/ServiceConfigSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/ServiceConfigSheet.tsx
@@ -74,7 +74,7 @@ const MultiStageSelect = ({
           {selectedLabel ? (
             <p className="font-medium text-sm truncate">{selectedLabel}</p>
           ) : (
-            <span className="text-accent-foreground/80">{placeholder ?? t('select-stages')}</span>
+            <span className="text-accent-foreground/80">{placeholder ?? t('select-stages', 'Select stages...')}</span>
           )}
         </Combobox.Trigger>
       </Form.Control>
@@ -83,10 +83,10 @@ const MultiStageSelect = ({
           <Command.Input
             value={search}
             onValueChange={setSearch}
-            placeholder={t('search-stage')}
+            placeholder={t('search-stage', 'Search stage...')}
           />
           <Command.Empty>
-            {loading ? t('loading') : t('no-stages-found')}
+            {loading ? t('loading', 'Loading...') : t('no-stages-found', 'No stages found')}
           </Command.Empty>
           <Command.List>
             {searchStages.map((stage) => (
@@ -129,7 +129,7 @@ const CardBasedRuleRow = ({
           name={`additionalConfig.cardBasedRule.${index}.boardId`}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('board')}</Form.Label>
+              <Form.Label>{t('board', 'Board')}</Form.Label>
               <SelectBoard.FormItem
                 mode="single"
                 value={field.value || ''}
@@ -148,7 +148,7 @@ const CardBasedRuleRow = ({
                     [],
                   );
                 }}
-                placeholder={t('select-placeholder')}
+                placeholder={t('select-placeholder', 'Select...')}
               />
               <Form.Message />
             </Form.Item>
@@ -160,7 +160,7 @@ const CardBasedRuleRow = ({
           name={`additionalConfig.cardBasedRule.${index}.pipelineId`}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('pipeline')}</Form.Label>
+              <Form.Label>{t('pipeline', 'Pipeline')}</Form.Label>
               <SelectPipeline.FormItem
                 mode="single"
                 value={field.value || ''}
@@ -176,7 +176,7 @@ const CardBasedRuleRow = ({
                     [],
                   );
                 }}
-                placeholder={t('select-placeholder')}
+                placeholder={t('select-placeholder', 'Select...')}
               />
               <Form.Message />
             </Form.Item>
@@ -188,12 +188,12 @@ const CardBasedRuleRow = ({
           name={`additionalConfig.cardBasedRule.${index}.stageIds`}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('stages')}</Form.Label>
+              <Form.Label>{t('stages', 'Stages')}</Form.Label>
               <MultiStageSelect
                 value={field.value || []}
                 pipelineId={pipelineId}
                 onValueChange={field.onChange}
-                placeholder={t('select-placeholder')}
+                placeholder={t('select-placeholder', 'Select...')}
               />
               <Form.Message />
             </Form.Item>
@@ -205,12 +205,12 @@ const CardBasedRuleRow = ({
           name={`additionalConfig.cardBasedRule.${index}.refundStageIds`}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('refund-stages')}</Form.Label>
+              <Form.Label>{t('refund-stages', 'Refund Stages')}</Form.Label>
               <MultiStageSelect
                 value={field.value || []}
                 pipelineId={pipelineId}
                 onValueChange={field.onChange}
-                placeholder={t('select-placeholder')}
+                placeholder={t('select-placeholder', 'Select...')}
               />
               <Form.Message />
             </Form.Item>
@@ -250,7 +250,7 @@ export const ServiceConfigSheet = ({
     <Dialog open={open} onOpenChange={onOpenChange} modal>
       <Dialog.Content className="max-w-5xl h-[70vh] p-0 gap-0 flex flex-col">
         <Dialog.Header className="border-b py-4 px-8 flex flex-row items-center justify-between shrink-0">
-          <Dialog.Title>{t('service-configurations')}</Dialog.Title>
+          <Dialog.Title>{t('service-configurations', 'Service Configurations')}</Dialog.Title>
           <Dialog.Close asChild>
             <Button type="button" variant="ghost" size="icon">
               <IconX className="size-4" />
@@ -262,7 +262,7 @@ export const ServiceConfigSheet = ({
           <div className="p-5 flex flex-col gap-6">
             <div>
               <h3 className="text-base font-semibold text-primary mb-3">
-                {t('product-based-rule')}
+                {t('product-based-rule', 'Product based rule')}
               </h3>
               <Form.Field
                 control={form.control}
@@ -270,7 +270,7 @@ export const ServiceConfigSheet = ({
                 render={({ field }) => (
                   <Form.Item className="flex flex-row items-center gap-3">
                     <Form.Label className="mb-0 uppercase text-xs tracking-wide">
-                      {t('discount-check-optional')}
+                      {t('discount-check-optional', 'Discount Check (optional)')}
                     </Form.Label>
                     <Form.Control>
                       <Checkbox
@@ -285,7 +285,7 @@ export const ServiceConfigSheet = ({
 
             <div>
               <h3 className="text-base font-semibold text-primary mb-3">
-                {t('deal-based-rule')}
+                {t('deal-based-rule', 'Deal based rule')}
               </h3>
               <div className="flex flex-col gap-4">
                 {fields.map((fieldItem, index) => (
@@ -311,7 +311,7 @@ export const ServiceConfigSheet = ({
                   }
                 >
                   <IconPlus className="size-4" />
-                  {t('add')}
+                  {t('add', 'Add')}
                 </Button>
               </div>
             </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectAttribution.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectAttribution.tsx
@@ -112,7 +112,7 @@ const SelectAttributionValue = ({
   if (attributionIds.length === 0) {
     return (
       <div className="text-muted-foreground">
-        {placeholder || t('select-attribution')}
+        {placeholder || t('select-attribution', 'Select attribution...')}
       </div>
     );
   }
@@ -128,7 +128,7 @@ const SelectAttributionValue = ({
           {attribution.details?.fullName ||
             attribution.username ||
             attribution.email ||
-            t('unknown')}
+            t('unknown', 'Unknown')}
         </div>
       ))}
     </div>
@@ -153,7 +153,7 @@ const SelectAttributionCommandItem = ({
       <Combobox.Check checked={attributionIds.includes(attribution._id)} />
       <div className="ml-2">
         <div className="font-medium">
-          {attribution.details?.fullName || attribution.username || t('unknown')}
+          {attribution.details?.fullName || attribution.username || t('unknown', 'Unknown')}
         </div>
         {attribution.email && (
           <div className="text-sm text-muted-foreground">
@@ -247,7 +247,7 @@ export const SelectAttributionFilterItem = ({
   return (
     <Filter.Item value={value || 'assignedTo'}>
       <IconUser />
-      {label || t('assigned-to')}
+      {label || t('assigned-to', 'Assigned To')}
     </Filter.Item>
   );
 };
@@ -310,7 +310,7 @@ export const SelectAttributionFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'assignedTo'}>
       <Filter.BarName>
         <IconUser />
-        {label ? label : !iconOnly && t('assigned-to') || ''}
+        {label ? label : !iconOnly && t('assigned-to', 'Assigned To') || ''}
       </Filter.BarName>
       <SelectAttributionProvider
         mode={mode}
@@ -458,7 +458,7 @@ export const SelectAttributionDetail = ({
             </Button>
           ) : (
             <Combobox.TriggerBase className="font-medium">
-              {t('add-owner')} <IconPlus />
+              {t('add-owner', 'Add Owner')} <IconPlus />
             </Combobox.TriggerBase>
           )}
         </Popover.Trigger>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectField.tsx
@@ -132,7 +132,7 @@ const SelectFieldValue = ({
   if (!selectedField) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-field')}
+        {placeholder || t('select-field', 'Select field')}
       </span>
     );
   }
@@ -176,10 +176,10 @@ const SelectFieldContent = () => {
   if (loading) {
     return (
       <Command>
-        <Command.Input placeholder={t('search-fields')} />
+        <Command.Input placeholder={t('search-fields', 'Search fields')} />
         <Command.List>
           <div className="flex items-center justify-center py-4 h-32">
-            <span className="text-muted-foreground">{t('loading-fields')}</span>
+            <span className="text-muted-foreground">{t('loading-fields', 'Loading fields...')}</span>
           </div>
         </Command.List>
       </Command>
@@ -188,9 +188,9 @@ const SelectFieldContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-fields')} />
+      <Command.Input placeholder={t('search-fields', 'Search fields')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-fields-found')}</span>
+        <span className="text-muted-foreground">{t('no-fields-found', 'No fields found')}</span>
       </Command.Empty>
       <Command.List>
         {fieldsArray.map((field) => (
@@ -206,7 +206,7 @@ export const SelectFieldFilterItem = () => {
   return (
     <Filter.Item value="fields">
       <IconTextSize />
-      {t('fields')}
+      {t('fields', 'Fields')}
     </Filter.Item>
   );
 };
@@ -268,7 +268,7 @@ export const SelectFieldFilterBar = ({
     <Filter.BarItem queryKey={'fields'}>
       <Filter.BarName>
         <IconTextSize />
-        {t('fields')}
+        {t('fields', 'Fields')}
       </Filter.BarName>
       <SelectFieldProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectFieldGroup.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/components/selects/SelectFieldGroup.tsx
@@ -133,7 +133,7 @@ const SelectFieldGroupValue = ({
   if (!selectedFieldGroup) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-field-group')}
+        {placeholder || t('select-field-group', 'Select field group')}
       </span>
     );
   }
@@ -181,11 +181,11 @@ const SelectFieldGroupContent = () => {
   if (loading) {
     return (
       <Command>
-        <Command.Input placeholder={t('search-field-groups')} />
+        <Command.Input placeholder={t('search-field-groups', 'Search field groups')} />
         <Command.List>
           <div className="flex items-center justify-center py-4 h-32">
             <span className="text-muted-foreground">
-              {t('loading-field-groups')}
+              {t('loading-field-groups', 'Loading field groups...')}
             </span>
           </div>
         </Command.List>
@@ -195,9 +195,9 @@ const SelectFieldGroupContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-field-groups')} />
+      <Command.Input placeholder={t('search-field-groups', 'Search field groups')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-field-groups-found')}</span>
+        <span className="text-muted-foreground">{t('no-field-groups-found', 'No field groups found')}</span>
       </Command.Empty>
       <Command.List>
         {fieldGroupsArray.map((fieldGroup) => (
@@ -216,7 +216,7 @@ export const SelectFieldGroupFilterItem = () => {
   return (
     <Filter.Item value="fieldGroups">
       <IconComponents />
-      {t('field-groups')}
+      {t('field-groups', 'Field Groups')}
     </Filter.Item>
   );
 };
@@ -276,7 +276,7 @@ export const SelectFieldGroupFilterBar = ({
     <Filter.BarItem queryKey={'fieldGroups'}>
       <Filter.BarName>
         <IconComponents />
-        {t('field-groups')}
+        {t('field-groups', 'Field Groups')}
       </Filter.BarName>
       <SelectFieldGroupProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/hooks/useAddLoyaltyScore.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/add-score-campaign/hooks/useAddLoyaltyScore.tsx
@@ -106,15 +106,15 @@ export const useAddScoreCampaign = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('score-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('score-campaign-created', 'Score campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreAddSheet.tsx
@@ -41,7 +41,7 @@ export const LoyaltyScoreAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-score-campaign')}
+          {t('add-score-campaign', 'Add score campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -61,7 +61,7 @@ export const LoyaltyScoreAddSheetHeader = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Sheet.Header className="border-b gap-3">
-      <Sheet.Title>{t('create-loyalty-score')}</Sheet.Title> <Sheet.Close />
+      <Sheet.Title>{t('create-loyalty-score', 'Create Loyalty Score')}</Sheet.Title> <Sheet.Close />
     </Sheet.Header>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreMoreColumn.tsx
@@ -44,20 +44,20 @@ export const ScoreMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-score-confirm', { count: 1 }),
+      message: t('delete-score-confirm', 'Are you sure you want to delete {{count}} selected score campaign(s)?', { count: 1 }),
     }).then(() => {
       deleteScore({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('scores-deleted', { count: 1 }),
+            title: t('scores-deleted', '{{count}} score campaign(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -78,10 +78,10 @@ export const ScoreMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-scores" onSelect={handleSeeScores}>
-              <IconChartHistogram /> {t('see-scores')}
+              <IconChartHistogram /> {t('see-scores', 'See scores')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -92,7 +92,7 @@ export const ScoreMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreRecordTable.tsx
@@ -54,10 +54,10 @@ export const ScoreRecordTable = () => {
                     className="text-muted-foreground mx-auto mb-4"
                   />
                   <h3 className="text-xl font-semibold mb-2">
-                    {t('no-score-campaigns-yet')}
+                    {t('no-score-campaigns-yet', 'No score campaign yet')}
                   </h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-score-campaign')}
+                    {t('get-started-score-campaign', 'Get started by creating your first score campaign.')}
                   </p>
                 </div>
                 <LoyaltyScoreAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreRowsCommandbar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/LoyaltyScoreRowsCommandbar.tsx
@@ -16,7 +16,7 @@ export const LoyaltyScoreRowsCommandbar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value onClose={() => table.setRowSelection({})}>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <LoyaltyScoreRowsDelete />
@@ -33,10 +33,10 @@ export const LoyaltyScoreRowsDelete = () => {
 
   const handleDelete = () => {
     confirm({
-      message: t('delete-score-rows-confirm'),
+      message: t('delete-score-rows-confirm', 'Are you sure you want to delete these loyalty score rows?'),
       options: {
-        okLabel: t('delete'),
-        cancelLabel: t('cancel'),
+        okLabel: t('delete', 'Delete'),
+        cancelLabel: t('cancel', 'Cancel'),
       },
     }).then(() => {
       const loyaltyScoreRowIds = table
@@ -47,7 +47,7 @@ export const LoyaltyScoreRowsDelete = () => {
         variables: { _ids: loyaltyScoreRowIds },
         onError: (error: Error) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: error.message,
             variant: 'destructive',
           });
@@ -55,8 +55,8 @@ export const LoyaltyScoreRowsDelete = () => {
         onCompleted: () => {
           table.setRowSelection({});
           toast({
-            title: t('success'),
-            description: t('score-rows-deleted'),
+            title: t('success', 'Success'),
+            description: t('score-rows-deleted', 'Loyalty score rows deleted successfully'),
           });
         },
       });
@@ -66,7 +66,7 @@ export const LoyaltyScoreRowsDelete = () => {
   return (
     <Button variant="secondary" disabled={loading} onClick={handleDelete}>
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/ScoreColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/ScoreColumns.tsx
@@ -34,7 +34,7 @@ export const scoreColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -50,7 +50,7 @@ export const scoreColumns = (
     id: 'order',
     accessorKey: 'order',
     header: () => (
-      <RecordTable.InlineHead icon={IconListNumbers} label={t('order')} />
+      <RecordTable.InlineHead icon={IconListNumbers} label={t('order', 'Order')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -65,7 +65,7 @@ export const scoreColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconLabelFilled} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconLabelFilled} label={t('owner-type', 'Owner Type')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/loyalty-score-command-bar/LoyaltyScoreCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/loyalty-score-command-bar/LoyaltyScoreCommandBar.tsx
@@ -10,7 +10,7 @@ export const LoyaltyScoreCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <LoyaltyScoreDelete

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/loyalty-score-command-bar/delete/LoyaltyScoreDelete.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/components/loyalty-score-command-bar/delete/LoyaltyScoreDelete.tsx
@@ -15,20 +15,20 @@ export const LoyaltyScoreDelete = ({ scoreIds }: { scoreIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-score-confirm', { count: scoreIds.length }),
+          message: t('delete-score-confirm', 'Are you sure you want to delete {{count}} selected score campaign(s)?', { count: scoreIds.length }),
         }).then(() => {
           removeScore({
             variables: { _ids: scoreIds },
           })
             .then(() => {
               toast({
-                title: t('scores-deleted', { count: scoreIds.length }),
+                title: t('scores-deleted', '{{count}} score campaign(s) deleted successfully', { count: scoreIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const LoyaltyScoreDelete = ({ scoreIds }: { scoreIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/hooks/useLoyaltyScoreEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/hooks/useLoyaltyScoreEdit.tsx
@@ -12,10 +12,10 @@ export const useLoyaltyScoreEdit = () => {
     editStatus({
       ...options,
       variables,
-      onCompleted: () => toast({ title: t('score-campaign-updated'), variant: 'success' }),
+      onCompleted: () => toast({ title: t('score-campaign-updated', 'Score campaign updated successfully'), variant: 'success' }),
       onError(error) {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/EditScoreForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/EditScoreForm.tsx
@@ -34,8 +34,8 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
     (data) => {
       if (!scoreDetail?._id) {
         toast({
-          title: t('error'),
-          description: t('score-campaign-id-not-found'),
+          title: t('error', 'Error'),
+          description: t('score-campaign-id-not-found', 'Score campaign ID not found'),
           variant: 'destructive',
         });
         return;
@@ -87,8 +87,8 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
         },
         onCompleted: () => {
           toast({
-            title: t('success'),
-            description: t('score-campaign-updated'),
+            title: t('success', 'Success'),
+            description: t('score-campaign-updated', 'Score campaign updated successfully'),
             variant: 'default',
           });
           setEditScoreId(null);
@@ -96,7 +96,7 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
         },
         onError: (e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -105,8 +105,8 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
     },
     () => {
       toast({
-        title: t('validation-error'),
-        description: t('fill-required-fields'),
+        title: t('validation-error', 'Validation Error'),
+        description: t('fill-required-fields', 'Please fill in all required fields'),
         variant: 'destructive',
       });
     },
@@ -137,14 +137,14 @@ export const EditScoreForm = ({ onOpenChange, form }: Props) => {
               onOpenChange(false);
             }}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
           <Button
             type="submit"
             className="bg-primary text-primary-foreground hover:bg-primary/90"
             disabled={loading}
           >
-            {loading ? t('updating') : t('update')}
+            {loading ? t('updating', 'Updating...') : t('update', 'Update')}
           </Button>
         </Sheet.Footer>
       </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/LoyaltyScoreEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/score/score-detail/components/LoyaltyScoreEditSheet.tsx
@@ -154,7 +154,7 @@ export const LoyaltyScoreEditSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-score-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-score-campaign', 'Edit score campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <EditScoreForm

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/SpinTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/SpinTabs.tsx
@@ -45,7 +45,7 @@ export const SpinTabs = ({ onOpenChange, form }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -65,7 +65,7 @@ export const SpinTabs = ({ onOpenChange, form }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -73,7 +73,7 @@ export const SpinTabs = ({ onOpenChange, form }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/selects/SelectSpinDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/selects/SelectSpinDate.tsx
@@ -67,7 +67,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
       <>
         <IconCalendarPlus className="text-accent-foreground" />
         <span className="text-accent-foreground font-medium">
-          {placeholder || t('select-date')}
+          {placeholder || t('select-date', 'Select date...')}
         </span>
       </>
     );
@@ -163,7 +163,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/spin-field/SpinAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/spin-field/SpinAddCampaignCoreFields.tsx
@@ -28,9 +28,9 @@ export const SpinAddCampaignCoreFields: React.FC<
           name="title"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('title')}</Form.Label>
+              <Form.Label>{t('title', 'Title')}</Form.Label>
               <Form.Control>
-                <Input placeholder={t('enter-spin-title')} {...field} />
+                <Input placeholder={t('enter-spin-title', 'Enter spin title')} {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -41,11 +41,11 @@ export const SpinAddCampaignCoreFields: React.FC<
           name={`buyScore`}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('buy-score')}</Form.Label>
+              <Form.Label>{t('buy-score', 'Buy Score')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-buy-score')}
+                  placeholder={t('enter-buy-score', 'Enter buy score')}
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -66,9 +66,9 @@ export const SpinAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.name`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('name')}</Form.Label>
+                      <Form.Label>{t('name', 'Name')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-name')} {...field} />
+                        <Input placeholder={t('enter-name', 'Enter name')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -79,7 +79,7 @@ export const SpinAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.voucherCampaignId`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('voucher-campaign')}</Form.Label>
+                      <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                       <Form.Control>
                         <SelectVoucherCampaign
                           value={field.value || undefined}
@@ -95,11 +95,11 @@ export const SpinAddCampaignCoreFields: React.FC<
                   name={`awards.${index}.probability`}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('probability')}</Form.Label>
+                      <Form.Label>{t('probability', 'Probability')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
-                          placeholder={t('probability')}
+                          placeholder={t('probability', 'Probability')}
                           {...field}
                           onChange={(e) =>
                             field.onChange(Number(e.target.value))
@@ -135,7 +135,7 @@ export const SpinAddCampaignCoreFields: React.FC<
           variant="secondary"
         >
           <IconPlus />
-          {t('add-level')}
+          {t('add-level', 'Add level')}
         </Button>
       </div>
     </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/spin-field/SpinAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/add-spin-campaign/components/spin-field/SpinAddCampaignMoreFields.tsx
@@ -58,7 +58,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -85,11 +85,11 @@ export const SpinAddCampaignMoreFields: React.FC<
           name="startDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('start-date')}</Form.Label>
+              <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-start-date')}
+                placeholder={t('select-start-date', 'Select start date')}
               />
               <Form.Message />
             </Form.Item>
@@ -103,11 +103,11 @@ export const SpinAddCampaignMoreFields: React.FC<
           name="endDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('end-date')}</Form.Label>
+              <Form.Label>{t('end-date', 'End Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-end-date')}
+                placeholder={t('select-end-date', 'Select end date')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinAddSheet.tsx
@@ -61,7 +61,7 @@ export const LoyaltySpinAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-spin-campaign')}
+          {t('add-spin-campaign', 'Add spin campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -72,7 +72,7 @@ export const LoyaltySpinAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-spin-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-spin-campaign', 'Add spin campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinColumns.tsx
@@ -21,7 +21,7 @@ export const spinColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinMoreColumn.tsx
@@ -40,20 +40,20 @@ export const SpinMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-spin-campaign-confirm'),
+      message: t('delete-spin-campaign-confirm', 'Are you sure you want to delete this spin campaign?'),
     }).then(() => {
       removeSpin({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('spins-deleted', { count: 1 }),
+            title: t('spins-deleted', '{{count}} spin(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const SpinMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-spins" onSelect={handleSeeSpins}>
-              <IconTicket /> {t('see-spins')}
+              <IconTicket /> {t('see-spins', 'See spins')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const SpinMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/SpinRecordTable.tsx
@@ -49,9 +49,9 @@ export const SpinRecordTable = () => {
                     size={64}
                     className="text-muted-foreground mx-auto mb-4"
                   />
-                  <h3 className="text-xl font-semibold mb-2">{t('no-spins-yet')}</h3>
+                  <h3 className="text-xl font-semibold mb-2">{t('no-spins-yet', 'No spin yet')}</h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-spin')}
+                    {t('get-started-spin', 'Get started by creating your first spin.')}
                   </p>
                 </div>
                 <LoyaltySpinAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/VoucherCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/VoucherCampaignInline.tsx
@@ -46,7 +46,7 @@ const VoucherCampaignInlineProvider = ({
         && [voucherCampaignId]
         || [],
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('select-voucher-campaigns')
+        ? t('select-voucher-campaigns', 'Select voucher campaigns')
         : placeholder,
       updateVoucherCampaigns: updateVoucherCampaigns || setCurrentVoucherCampaigns,
     };
@@ -120,7 +120,7 @@ const VoucherCampaignInlineTitle = () => {
     return (
       <TextOverflowTooltip
         value={voucherCampaigns
-          .map((c) => c.title || t('unnamed-campaign'))
+          .map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
           .join(', ')}
       />
     );
@@ -130,10 +130,10 @@ const VoucherCampaignInlineTitle = () => {
     <Tooltip.Provider>
       <Tooltip>
         <Tooltip.Trigger asChild>
-          <span>{t('voucher-campaigns-count', { count: voucherCampaigns.length })}</span>
+          <span>{t('voucher-campaigns-count', '{{count}} voucher campaigns', { count: voucherCampaigns.length })}</span>
         </Tooltip.Trigger>
         <Tooltip.Content>
-          {voucherCampaigns.map((c) => c.title || t('unnamed-campaign')).join(', ')}
+          {voucherCampaigns.map((c) => c.title || t('unnamed-campaign', 'Unnamed campaign')).join(', ')}
         </Tooltip.Content>
       </Tooltip>
     </Tooltip.Provider>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/selects/SelectVoucherCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/selects/SelectVoucherCampaign.tsx
@@ -120,7 +120,7 @@ const SelectVoucherCampaignCommandItem = ({
     >
       <VoucherCampaignInline
         voucherCampaigns={[voucherCampaign]}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={voucherCampaignId.includes(voucherCampaign._id)}
@@ -152,7 +152,7 @@ const SelectVoucherCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-voucher-campaigns')}
+        placeholder={t('search-voucher-campaigns', 'Search voucher campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -195,7 +195,7 @@ export const SelectVoucherCampaignFilterItem = () => {
   return (
     <Filter.Item value="voucherCampaign">
       <IconReceipt />
-      {t('voucher-campaign')}
+      {t('voucher-campaign', 'Voucher Campaign')}
     </Filter.Item>
   );
 };
@@ -252,7 +252,7 @@ export const SelectVoucherCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'voucherCampaign'}>
       <Filter.BarName>
         <IconReceipt />
-        {!iconOnly && t('voucher-campaign')}
+        {!iconOnly && t('voucher-campaign', 'Voucher Campaign')}
       </Filter.BarName>
 
       <SelectVoucherCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/spin-command-bar/SpinCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/spin-command-bar/SpinCommandBar.tsx
@@ -10,7 +10,7 @@ export const SpinCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteSpin

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/spin-command-bar/delete/DeleteSpin.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/components/spin-command-bar/delete/DeleteSpin.tsx
@@ -15,20 +15,20 @@ export const DeleteSpin = ({ spinIds }: { spinIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-spin-confirm', { count: spinIds.length }),
+          message: t('delete-spin-confirm', 'Are you sure you want to delete {{count}} selected spin(s)?', { count: spinIds.length }),
         }).then(() => {
           removeSpin({
             variables: { _ids: spinIds },
           })
             .then(() => {
               toast({
-                title: t('spins-deleted', { count: spinIds.length }),
+                title: t('spins-deleted', '{{count}} spin(s) deleted successfully', { count: spinIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const DeleteSpin = ({ spinIds }: { spinIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useAddSpin.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useAddSpin.tsx
@@ -93,15 +93,15 @@ export const useAddSpin = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('spin-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('spin-campaign-created', 'Spin campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useEditSpin.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useEditSpin.tsx
@@ -32,15 +32,15 @@ export function useEditSpin() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('spin-campaign-updated'),
+          title: t('success', 'Success'),
+          description: t('spin-campaign-updated', 'Spin campaign updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useSpinStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/hooks/useSpinStatusEdit.tsx
@@ -26,15 +26,15 @@ export function useSpinStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('spin-status-updated'),
+          title: t('success', 'Success'),
+          description: t('spin-status-updated', 'Spin status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/spin-detail/components/EditSpinTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/spin-detail/components/EditSpinTabs.tsx
@@ -20,8 +20,8 @@ export const EditSpinTabs = ({ onOpenChange, form, spinId }: Props) => {
   const handleSubmit = async () => {
     if (!spinId) {
       toast({
-        title: t('error'),
-        description: t('no-spin-id-provided'),
+        title: t('error', 'Error'),
+        description: t('no-spin-id-provided', 'No spin ID provided'),
         variant: 'destructive',
       });
       return;
@@ -56,7 +56,7 @@ export const EditSpinTabs = ({ onOpenChange, form, spinId }: Props) => {
       variables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -76,7 +76,7 @@ export const EditSpinTabs = ({ onOpenChange, form, spinId }: Props) => {
         className="bg-background hover:bg-background/90"
         onClick={() => onOpenChange(false)}
       >
-        {t('cancel')}
+        {t('cancel', 'Cancel')}
       </Button>
       <Button
         type="button"
@@ -84,7 +84,7 @@ export const EditSpinTabs = ({ onOpenChange, form, spinId }: Props) => {
         onClick={handleSubmit}
         disabled={editLoading}
       >
-        {editLoading ? t('saving') : t('save')}
+        {editLoading ? t('saving', 'Saving...') : t('save', 'Save')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/spin-detail/components/LoyaltySpinEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/spin/spin-detail/components/LoyaltySpinEditSheet.tsx
@@ -111,7 +111,7 @@ export const LoyaltySpinEditSheet = ({ spinId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -123,7 +123,7 @@ export const LoyaltySpinEditSheet = ({ spinId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-spin-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-spin-campaign', 'Edit spin campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherLotteryForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherLotteryForm.tsx
@@ -25,7 +25,7 @@ export const AddVoucherLotteryForm: React.FC<AddVoucherLotteryFormProps> = ({
         name="lottery"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('lottery')}</Form.Label>
+            <Form.Label>{t('lottery', 'Lottery')}</Form.Label>
             <Form.Control>
               <Select onValueChange={field.onChange} value={field.value}>
                 <Select.Trigger
@@ -33,7 +33,7 @@ export const AddVoucherLotteryForm: React.FC<AddVoucherLotteryFormProps> = ({
                 >
                   {lotteryCampaigns.find(
                     (campaign: any) => campaign._id === field.value,
-                  )?.title || t('select-lottery')}
+                  )?.title || t('select-lottery', 'Select lottery')}
                 </Select.Trigger>
                 <Select.Content>
                   {lotteryCampaigns.map((campaign: any) => (
@@ -53,11 +53,11 @@ export const AddVoucherLotteryForm: React.FC<AddVoucherLotteryFormProps> = ({
         name="lotteryCount"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('lottery-count')}</Form.Label>
+            <Form.Label>{t('lottery-count', 'Lottery Count')}</Form.Label>
             <Form.Control>
               <Input
                 type="number"
-                placeholder={t('enter-lottery-count')}
+                placeholder={t('enter-lottery-count', 'Enter Lottery Count')}
                 value={field.value ?? ''}
                 onChange={(e) =>
                   field.onChange(

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherProductBonusForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherProductBonusForm.tsx
@@ -20,7 +20,7 @@ export const AddVoucherProductBonusForm: React.FC<
         name="bonusProduct"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('bonus-product')}</Form.Label>
+            <Form.Label>{t('bonus-product', 'Bonus Product')}</Form.Label>
             <Form.Control>
               <SelectProduct
                 value={field.value}
@@ -38,11 +38,11 @@ export const AddVoucherProductBonusForm: React.FC<
         name="bonusCount"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('bonus-count')}</Form.Label>
+            <Form.Label>{t('bonus-count', 'Bonus Count')}</Form.Label>
             <Form.Control>
               <Input
                 type="number"
-                placeholder={t('enter-bonus-count')}
+                placeholder={t('enter-bonus-count', 'Enter bonus count')}
                 value={field.value ?? ''}
                 onChange={(e) =>
                   field.onChange(

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherSpinForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/AddVoucherSpinForm.tsx
@@ -24,7 +24,7 @@ export const AddVoucherSpinForm: React.FC<AddVoucherSpinFormProps> = ({
         name="spinCampaignId"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('spin-campaign')}</Form.Label>
+            <Form.Label>{t('spin-campaign', 'Spin Campaign')}</Form.Label>
             <Form.Control>
               <Select onValueChange={field.onChange} value={field.value}>
                 <Select.Trigger
@@ -32,7 +32,7 @@ export const AddVoucherSpinForm: React.FC<AddVoucherSpinFormProps> = ({
                 >
                   {spinCampaigns.find(
                     (campaign: any) => campaign._id === field.value,
-                  )?.title || t('select-spin-campaign')}
+                  )?.title || t('select-spin-campaign', 'Select spin campaign')}
                 </Select.Trigger>
                 <Select.Content>
                   {spinCampaigns.map((campaign: any) => (
@@ -52,11 +52,11 @@ export const AddVoucherSpinForm: React.FC<AddVoucherSpinFormProps> = ({
         name="spinCount"
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('spin-count')}</Form.Label>
+            <Form.Label>{t('spin-count', 'Spin Count')}</Form.Label>
             <Form.Control>
               <Input
                 type="number"
-                placeholder={t('enter-spin-count')}
+                placeholder={t('enter-spin-count', 'Enter spin count')}
                 value={field.value ?? ''}
                 onChange={(e) =>
                   field.onChange(

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/VoucherTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/VoucherTabs.tsx
@@ -101,7 +101,7 @@ export const VoucherTabs = ({ onOpenChange, form }: Props) => {
         variables,
         onError: (e: ApolloError) =>
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           }),
@@ -114,8 +114,8 @@ export const VoucherTabs = ({ onOpenChange, form }: Props) => {
     () => {
       setActiveTab('campaign');
       toast({
-        title: t('validation-error'),
-        description: t('fill-required-fields'),
+        title: t('validation-error', 'Validation Error'),
+        description: t('fill-required-fields', 'Please fill in all required fields'),
         variant: 'destructive',
       });
     },
@@ -136,28 +136,28 @@ export const VoucherTabs = ({ onOpenChange, form }: Props) => {
     >
       <Tabs.List className="flex justify-center">
         <Tabs.Trigger asChild value="campaign">
-          <Button variant="outline">{t('campaign')}</Button>
+          <Button variant="outline">{t('campaign', 'Campaign')}</Button>
         </Tabs.Trigger>
 
         <Tabs.Trigger asChild value="restriction">
-          <Button variant="outline">{t('restriction')}</Button>
+          <Button variant="outline">{t('restriction', 'Restriction')}</Button>
         </Tabs.Trigger>
 
         {showProductBonusTab && (
           <Tabs.Trigger asChild value="productBonus">
-            <Button variant="outline">{t('product-bonus')}</Button>
+            <Button variant="outline">{t('product-bonus', 'Product Bonus')}</Button>
           </Tabs.Trigger>
         )}
 
         {showLotteryTab && (
           <Tabs.Trigger asChild value="lottery">
-            <Button variant="outline">{t('lottery-campaign')}</Button>
+            <Button variant="outline">{t('lottery-campaign', 'Lottery Campaign')}</Button>
           </Tabs.Trigger>
         )}
 
         {showSpinTab && (
           <Tabs.Trigger asChild value="spin">
-            <Button variant="outline">{t('spin-campaign')}</Button>
+            <Button variant="outline">{t('spin-campaign', 'Spin Campaign')}</Button>
           </Tabs.Trigger>
         )}
       </Tabs.List>
@@ -209,15 +209,15 @@ export const VoucherTabs = ({ onOpenChange, form }: Props) => {
 
       <Sheet.Footer className="flex justify-end gap-2 p-2">
         <Button variant="ghost" onClick={() => onOpenChange(false)}>
-          {t('cancel')}
+          {t('cancel', 'Cancel')}
         </Button>
 
         {isLast ? (
           <Button onClick={handleSubmit} disabled={loading}>
-            {loading ? t('saving') : t('save')}
+            {loading ? t('saving', 'Saving...') : t('save', 'Save')}
           </Button>
         ) : (
-          <Button onClick={handleNext}>{t('next')}</Button>
+          <Button onClick={handleNext}>{t('next', 'Next')}</Button>
         )}
       </Sheet.Footer>
     </Tabs>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/selects/SelectVoucherDate.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/selects/SelectVoucherDate.tsx
@@ -67,7 +67,7 @@ const DateSelectValue = ({ placeholder }: { placeholder?: string }) => {
       <>
         <IconCalendarPlus className="text-accent-foreground" />
         <span className="text-accent-foreground font-medium">
-          {placeholder || t('select-date')}
+          {placeholder || t('select-date', 'Select date...')}
         </span>
       </>
     );
@@ -163,7 +163,7 @@ export const DateSelectTaskRoot = ({
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <DateSelectTrigger>
-          <DateSelectValue placeholder={t('not-specified')} />
+          <DateSelectValue placeholder={t('not-specified', 'Not specified')} />
         </DateSelectTrigger>
         <Content className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
           <DateSelectContent />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-campaign-field/VoucherAddCampaignCoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-campaign-field/VoucherAddCampaignCoreFields.tsx
@@ -22,9 +22,9 @@ export const VoucherAddCampaignCoreFields: React.FC<
           name="title"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('title')}</Form.Label>
+              <Form.Label>{t('title', 'Title')}</Form.Label>
               <Form.Control>
-                <Input placeholder={t('enter-voucher-title')} {...field} />
+                <Input placeholder={t('enter-voucher-title', 'Enter voucher title')} {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -35,14 +35,14 @@ export const VoucherAddCampaignCoreFields: React.FC<
           name="type"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('type')}</Form.Label>
+              <Form.Label>{t('type', 'Type')}</Form.Label>
               <Form.Control>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <Select.Trigger
                     className={field.value ? '' : 'text-muted-foreground'}
                   >
                     {VOUCHER_TYPES.find((type) => type.value === field.value)
-                      ?.label || t('select-voucher-type')}
+                      ?.label || t('select-voucher-type', 'Select voucher type')}
                   </Select.Trigger>
                   <Select.Content>
                     {VOUCHER_TYPES.map((option) => (
@@ -62,11 +62,11 @@ export const VoucherAddCampaignCoreFields: React.FC<
           name="value"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('count')}</Form.Label>
+              <Form.Label>{t('count', 'Count')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-count')}
+                  placeholder={t('enter-count', 'Enter count')}
                   value={field.value ?? ''}
                   onChange={(e) =>
                     field.onChange(
@@ -88,11 +88,11 @@ export const VoucherAddCampaignCoreFields: React.FC<
           name="buyScore"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('buy-score')}</Form.Label>
+              <Form.Label>{t('buy-score', 'Buy Score')}</Form.Label>
               <Form.Control>
                 <Input
                   type="text"
-                  placeholder={t('enter-voucher-buy-score')}
+                  placeholder={t('enter-voucher-buy-score', 'Enter voucher buy score')}
                   {...field}
                 />
               </Form.Control>
@@ -105,7 +105,7 @@ export const VoucherAddCampaignCoreFields: React.FC<
           name="kind"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('kind')}</Form.Label>
+              <Form.Label>{t('kind', 'Kind')}</Form.Label>
               <Form.Control>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <Select.Trigger
@@ -113,7 +113,7 @@ export const VoucherAddCampaignCoreFields: React.FC<
                   >
                     {VOUCHER_KIND_TYPES.find(
                       (type) => type.value === field.value,
-                    )?.label || t('select-kind')}
+                    )?.label || t('select-kind', 'Select kind')}
                   </Select.Trigger>
                   <Select.Content>
                     {VOUCHER_KIND_TYPES.map((option) => (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-campaign-field/VoucherAddCampaignMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-campaign-field/VoucherAddCampaignMoreFields.tsx
@@ -58,7 +58,7 @@ const DateSelectFormField = ({
                 <>
                   <IconCalendarPlus className="text-accent-foreground" />
                   <span className="text-accent-foreground font-medium">
-                    {placeholder || t('select-date')}
+                    {placeholder || t('select-date', 'Select date...')}
                   </span>
                 </>
               )}
@@ -85,11 +85,11 @@ export const VoucherAddCampaignMoreFields: React.FC<
           name="startDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('start-date')}</Form.Label>
+              <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-start-date')}
+                placeholder={t('select-start-date', 'Select start date')}
               />
               <Form.Message />
             </Form.Item>
@@ -103,11 +103,11 @@ export const VoucherAddCampaignMoreFields: React.FC<
           name="endDate"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('end-date')}</Form.Label>
+              <Form.Label>{t('end-date', 'End Date')}</Form.Label>
               <DateSelectFormField
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-end-date')}
+                placeholder={t('select-end-date', 'Select end date')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-restriction-field/VoucherAddRestrictionCoreField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-restriction-field/VoucherAddRestrictionCoreField.tsx
@@ -21,11 +21,11 @@ export const VoucherAddRestrictionCoreField: React.FC<
           name="minimumSpend"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('minimum-spend')}</Form.Label>
+              <Form.Label>{t('minimum-spend', 'Minimum Spend')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-minimum-spend')}
+                  placeholder={t('enter-minimum-spend', 'Enter minimum spend')}
                   value={field.value ?? ''}
                   onChange={(e) =>
                     field.onChange(
@@ -45,7 +45,7 @@ export const VoucherAddRestrictionCoreField: React.FC<
           name="categoryIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('product-category')}</Form.Label>
+              <Form.Label>{t('product-category', 'Product Category')}</Form.Label>
               <Form.Control>
                 <SelectCategory
                   mode="multiple"
@@ -66,11 +66,11 @@ export const VoucherAddRestrictionCoreField: React.FC<
           name="maximumSpend"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('maximum-spend')}</Form.Label>
+              <Form.Label>{t('maximum-spend', 'Maximum Spend')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
-                  placeholder={t('enter-maximum-spend')}
+                  placeholder={t('enter-maximum-spend', 'Enter maximum spend')}
                   value={field.value ?? ''}
                   onChange={(e) =>
                     field.onChange(
@@ -90,7 +90,7 @@ export const VoucherAddRestrictionCoreField: React.FC<
           name="excludeCategoryIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-product-category')}</Form.Label>
+              <Form.Label>{t('or-exclude-product-category', 'Or Exclude Product Category')}</Form.Label>
               <Form.Control>
                 <SelectCategory
                   mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-restriction-field/VoucherAddRestrictionMoreFields.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/add-voucher-campaign/components/voucher-restriction-field/VoucherAddRestrictionMoreFields.tsx
@@ -21,7 +21,7 @@ export const VoucherAddRestrictionMoreFields: React.FC<
           name="productIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('product')}</Form.Label>
+              <Form.Label>{t('product', 'Product')}</Form.Label>
               <Form.Control>
                 <SelectProduct
                   mode="multiple"
@@ -40,7 +40,7 @@ export const VoucherAddRestrictionMoreFields: React.FC<
           name="tag"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('tag')}</Form.Label>
+              <Form.Label>{t('tag', 'Tag')}</Form.Label>
               <Form.Control>
                 <SelectTags
                   mode="multiple"
@@ -61,7 +61,7 @@ export const VoucherAddRestrictionMoreFields: React.FC<
           name="excludeProductIds"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-product')}</Form.Label>
+              <Form.Label>{t('or-exclude-product', 'Or Exclude Product')}</Form.Label>
               <Form.Control>
                 <SelectProduct
                   mode="multiple"
@@ -80,7 +80,7 @@ export const VoucherAddRestrictionMoreFields: React.FC<
           name="orExcludeTag"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('or-exclude-tag')}</Form.Label>
+              <Form.Label>{t('or-exclude-tag', 'Or Exclude Tag')}</Form.Label>
               <Form.Control>
                 <SelectTags
                   mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/GenerateVoucherSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/GenerateVoucherSheet.tsx
@@ -101,7 +101,7 @@ export const GenerateVoucherSheet = () => {
       <Sheet.Trigger asChild>
         <Button variant="outline">
           <IconSparkles />
-          {t('generate-voucher')}
+          {t('generate-voucher', 'Generate voucher')}
           <Kbd>G</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -112,7 +112,7 @@ export const GenerateVoucherSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('generate-voucher')}</Sheet.Title>
+          <Sheet.Title>{t('generate-voucher', 'Generate voucher')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">
@@ -123,7 +123,7 @@ export const GenerateVoucherSheet = () => {
                 name="campaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                     <Form.Control>
                       <Select
                         onValueChange={field.onChange}
@@ -133,7 +133,7 @@ export const GenerateVoucherSheet = () => {
                           className={field.value ? '' : 'text-muted-foreground'}
                         >
                           {campaignList.find((c) => c._id === field.value)
-                            ?.title || t('select-voucher-campaign')}
+                            ?.title || t('select-voucher-campaign', 'Select voucher campaign')}
                         </Select.Trigger>
                         <Select.Content>
                           {campaignList.map((campaign) => (
@@ -141,7 +141,7 @@ export const GenerateVoucherSheet = () => {
                               key={campaign._id}
                               value={campaign._id}
                             >
-                              {campaign.title || t('unnamed-campaign')}
+                              {campaign.title || t('unnamed-campaign', 'Unnamed campaign')}
                             </Select.Item>
                           ))}
                         </Select.Content>
@@ -157,7 +157,7 @@ export const GenerateVoucherSheet = () => {
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         onValueChange={field.onChange}
@@ -186,9 +186,9 @@ export const GenerateVoucherSheet = () => {
                 name="ownerId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-id')}</Form.Label>
+                    <Form.Label>{t('owner-id', 'Owner Id')}</Form.Label>
                     <Form.Control>
-                      <Input placeholder={t('enter-owner-id')} {...field} />
+                      <Input placeholder={t('enter-owner-id', 'Enter owner ID')} {...field} />
                     </Form.Control>
                     <Form.Message />
                   </Form.Item>
@@ -200,7 +200,7 @@ export const GenerateVoucherSheet = () => {
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')}</Form.Label>
+                    <Form.Label>{t('status', 'Status')}</Form.Label>
                     <Form.Control>
                       <Select
                         onValueChange={field.onChange}
@@ -228,10 +228,10 @@ export const GenerateVoucherSheet = () => {
         </Sheet.Content>
         <Sheet.Footer className="flex justify-end gap-2 p-4 border-t">
           <Button variant="ghost" onClick={onClose}>
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
           <Button onClick={handleSubmit} disabled={loading}>
-            {loading ? t('generating') : t('generate')}
+            {loading ? t('generating', 'Generating...') : t('generate', 'Generate')}
           </Button>
         </Sheet.Footer>
       </Sheet.View>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherAddSheet.tsx
@@ -59,7 +59,7 @@ export const LoyaltyVoucherAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-voucher-campaign')}
+          {t('add-voucher-campaign', 'Add voucher campaign')}
           <Kbd>C</Kbd>
         </Button>
       </Sheet.Trigger>
@@ -70,7 +70,7 @@ export const LoyaltyVoucherAddSheet = () => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('add-voucher-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('add-voucher-campaign', 'Add voucher campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherColumns.tsx
@@ -33,7 +33,7 @@ export const voucherColumns = (
     id: 'title',
     accessorKey: 'title',
     header: () => (
-      <RecordTable.InlineHead icon={IconTag} label={t('title')} />
+      <RecordTable.InlineHead icon={IconTag} label={t('title', 'Title')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -51,7 +51,7 @@ export const voucherColumns = (
     id: 'voucherType',
     accessorKey: 'voucherType',
     header: () => (
-      <RecordTable.InlineHead icon={IconTicket} label={t('type')} />
+      <RecordTable.InlineHead icon={IconTicket} label={t('type', 'Type')} />
     ),
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherMoreColumn.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherMoreColumn.tsx
@@ -40,20 +40,20 @@ export const VoucherMoreColumnCell = ({
     if (!_id) return;
 
     confirm({
-      message: t('delete-voucher-single-confirm'),
+      message: t('delete-voucher-single-confirm', 'Are you sure you want to delete this voucher?'),
     }).then(() => {
       removeVoucher({
         variables: { _ids: [_id] },
       })
         .then(() => {
           toast({
-            title: t('vouchers-deleted', { count: 1 }),
+            title: t('vouchers-deleted', '{{count}} voucher(s) deleted successfully', { count: 1 }),
             variant: 'success',
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -74,10 +74,10 @@ export const VoucherMoreColumnCell = ({
         <Command>
           <Command.List>
             <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
+              <IconEdit /> {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="see-vouchers" onSelect={handleSeeVouchers}>
-              <IconTicket /> {t('see-vouchers')}
+              <IconTicket /> {t('see-vouchers', 'See vouchers')}
             </Command.Item>
             <Command.Item asChild>
               <Button
@@ -88,7 +88,7 @@ export const VoucherMoreColumnCell = ({
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VoucherRecordTable.tsx
@@ -53,10 +53,10 @@ export const VoucherRecordTable = () => {
                     className="text-muted-foreground mx-auto mb-4"
                   />
                   <h3 className="text-xl font-semibold mb-2">
-                    {t('no-voucher-yet')}
+                    {t('no-voucher-yet', 'No voucher yet')}
                   </h3>
                   <p className="text-muted-foreground max-w-md">
-                    {t('get-started-voucher')}
+                    {t('get-started-voucher', 'Get started by creating your first voucher.')}
                   </p>
                 </div>
                 <LoyaltyVoucherAddSheet />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VouchersNavigation.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/VouchersNavigation.tsx
@@ -15,7 +15,7 @@ export const VouchersNavigation = () => {
             <Button variant="ghost" asChild name="vouchers">
               <Link to="/loyalty/vouchers">
                 <IconTicket />
-                {t('vouchers')}
+                {t('vouchers', 'Vouchers')}
               </Link>
             </Button>
           </Breadcrumb.Item>
@@ -29,7 +29,7 @@ export const VouchersNavigation = () => {
             >
               <Link to="/loyalty/vouchers/categories">
                 <IconCategory />
-                {t('categories')}
+                {t('categories', 'Categories')}
               </Link>
             </Toggle>
           </Breadcrumb.Page>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/voucher-command-bar/VoucherCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/voucher-command-bar/VoucherCommandBar.tsx
@@ -10,7 +10,7 @@ export const VoucherCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected-count', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected-count', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <DeleteVoucher

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/voucher-command-bar/delete/DeleteVoucher.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/components/voucher-command-bar/delete/DeleteVoucher.tsx
@@ -15,20 +15,20 @@ export const DeleteVoucher = ({ voucherIds }: { voucherIds: string[] }) => {
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-voucher-confirm', { count: voucherIds.length }),
+          message: t('delete-voucher-confirm', 'Are you sure you want to delete {{count}} selected voucher(s)?', { count: voucherIds.length }),
         }).then(() => {
           removeVoucher({
             variables: { _ids: voucherIds },
           })
             .then(() => {
               toast({
-                title: t('vouchers-deleted', { count: voucherIds.length }),
+                title: t('vouchers-deleted', '{{count}} voucher(s) deleted successfully', { count: voucherIds.length }),
                 variant: 'success',
               });
             })
             .catch((e: ApolloError) => {
               toast({
-                title: t('error'),
+                title: t('error', 'Error'),
                 description: e.message,
                 variant: 'destructive',
               });
@@ -37,7 +37,7 @@ export const DeleteVoucher = ({ voucherIds }: { voucherIds: string[] }) => {
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useAddVoucher.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useAddVoucher.tsx
@@ -102,15 +102,15 @@ export const useAddVoucher = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('voucher-campaign-created'),
+          title: t('success', 'Success'),
+          description: t('voucher-campaign-created', 'Voucher campaign created successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useGenerateVoucher.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useGenerateVoucher.tsx
@@ -40,15 +40,15 @@ export const useGenerateVoucher = () => {
       ...options,
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('voucher-generated'),
+          title: t('success', 'Success'),
+          description: t('voucher-generated', 'Voucher generated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (error) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: error.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useVoucherStatusEdit.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/hooks/useVoucherStatusEdit.tsx
@@ -29,15 +29,15 @@ export function useVoucherStatusEdit() {
       },
       onCompleted: (data) => {
         toast({
-          title: t('success'),
-          description: t('voucher-status-updated'),
+          title: t('success', 'Success'),
+          description: t('voucher-status-updated', 'Voucher status updated successfully'),
           variant: 'default',
         });
         options?.onCompleted?.(data);
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/EditVoucherTabs.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/EditVoucherTabs.tsx
@@ -67,8 +67,8 @@ export const EditVoucherTabs = ({ onOpenChange, form }: Props) => {
     (data) => {
       if (!voucherDetail?._id) {
         toast({
-          title: t('error'),
-          description: t('no-voucher-id-provided'),
+          title: t('error', 'Error'),
+          description: t('no-voucher-id-provided', 'No voucher ID provided'),
           variant: 'destructive',
         });
         return;
@@ -126,14 +126,14 @@ export const EditVoucherTabs = ({ onOpenChange, form }: Props) => {
         variables,
         onError: (e: ApolloError) =>
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           }),
         onCompleted: () => {
           toast({
-            title: t('success'),
-            description: t('voucher-campaign-updated'),
+            title: t('success', 'Success'),
+            description: t('voucher-campaign-updated', 'Voucher campaign updated successfully'),
             variant: 'default',
           });
           onOpenChange(false);
@@ -143,8 +143,8 @@ export const EditVoucherTabs = ({ onOpenChange, form }: Props) => {
     () => {
       setActiveTab('campaign');
       toast({
-        title: t('validation-error'),
-        description: t('fill-required-fields'),
+        title: t('validation-error', 'Validation Error'),
+        description: t('fill-required-fields', 'Please fill in all required fields'),
         variant: 'destructive',
       });
     },
@@ -158,28 +158,28 @@ export const EditVoucherTabs = ({ onOpenChange, form }: Props) => {
     >
       <Tabs.List className="flex justify-center">
         <Tabs.Trigger asChild value="campaign">
-          <Button variant="outline">{t('campaign')}</Button>
+          <Button variant="outline">{t('campaign', 'Campaign')}</Button>
         </Tabs.Trigger>
 
         <Tabs.Trigger asChild value="restriction">
-          <Button variant="outline">{t('restriction')}</Button>
+          <Button variant="outline">{t('restriction', 'Restriction')}</Button>
         </Tabs.Trigger>
 
         {showProductBonusTab && (
           <Tabs.Trigger asChild value="productBonus">
-            <Button variant="outline">{t('product-bonus')}</Button>
+            <Button variant="outline">{t('product-bonus', 'Product Bonus')}</Button>
           </Tabs.Trigger>
         )}
 
         {showLotteryTab && (
           <Tabs.Trigger asChild value="lottery">
-            <Button variant="outline">{t('lottery-campaign')}</Button>
+            <Button variant="outline">{t('lottery-campaign', 'Lottery Campaign')}</Button>
           </Tabs.Trigger>
         )}
 
         {showSpinTab && (
           <Tabs.Trigger asChild value="spin">
-            <Button variant="outline">{t('spin-campaign')}</Button>
+            <Button variant="outline">{t('spin-campaign', 'Spin Campaign')}</Button>
           </Tabs.Trigger>
         )}
       </Tabs.List>
@@ -231,15 +231,15 @@ export const EditVoucherTabs = ({ onOpenChange, form }: Props) => {
 
       <Sheet.Footer className="flex justify-end gap-2 p-2">
         <Button variant="ghost" onClick={() => onOpenChange(false)}>
-          {t('cancel')}
+          {t('cancel', 'Cancel')}
         </Button>
 
         {isLast ? (
           <Button onClick={handleSubmit} disabled={loading}>
-            {loading ? t('updating') : t('update')}
+            {loading ? t('updating', 'Updating...') : t('update', 'Update')}
           </Button>
         ) : (
-          <Button onClick={handleNext}>{t('next')}</Button>
+          <Button onClick={handleNext}>{t('next', 'Next')}</Button>
         )}
       </Sheet.Footer>
     </Tabs>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/LoyaltyVoucherEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/LoyaltyVoucherEditSheet.tsx
@@ -121,7 +121,7 @@ export const LoyaltyVoucherEditSheet = ({ voucherId }: Props) => {
         <Sheet.Trigger asChild>
           <Button variant="ghost" size="sm">
             <IconEdit className="h-4 w-4" />
-            {t('edit')}
+            {t('edit', 'Edit')}
             <Kbd>E</Kbd>
           </Button>
         </Sheet.Trigger>
@@ -133,7 +133,7 @@ export const LoyaltyVoucherEditSheet = ({ voucherId }: Props) => {
         }}
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-voucher-campaign')}</Sheet.Title>
+          <Sheet.Title>{t('edit-voucher-campaign', 'Edit voucher campaign')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="grow size-full h-auto flex flex-col overflow-hidden">

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/VoucherDetailSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/settings/voucher/voucher-detail/components/VoucherDetailSheet.tsx
@@ -80,14 +80,14 @@ const NotFound = ({ title }: { title: string }) => {
         />
         <div className="flex flex-col gap-2">
           <h2 className="text-xl font-semibold w-full text-center">
-            {t('details-not-found', { title })}
+            {t('details-not-found', '{{title}} details not found', { title })}
           </h2>
           <p className="text-accent-foreground w-full text-center">
-            {t('no-data-on-title', { title })}
+            {t('no-data-on-title', 'There seems to be no data on this {{title}}', { title })}
           </p>
         </div>
         <Sheet.Close asChild>
-          <Button variant="outline">{t('close')}</Button>
+          <Button variant="outline">{t('close', 'Close')}</Button>
         </Sheet.Close>
       </div>
     </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinAddSheet.tsx
@@ -56,12 +56,12 @@ export const SpinAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-spin')}
+          {t('add-spin', 'Add Spin')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('add-spin')}</Sheet.Title>
+          <Sheet.Title>{t('add-spin', 'Add Spin')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -76,11 +76,11 @@ export const SpinAddSheet = () => {
                 rules={{ required: 'Campaign is required' }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectSpinCampaign
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -92,7 +92,7 @@ export const SpinAddSheet = () => {
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -105,10 +105,10 @@ export const SpinAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('user')}</Select.Item>
-                          <Select.Item value="cpUser">{t('cp-user')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('user', 'User')}</Select.Item>
+                          <Select.Item value="cpUser">{t('cp-user', 'Client Portal User')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -123,7 +123,7 @@ export const SpinAddSheet = () => {
                 rules={{ required: 'Owner is required' }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       <SelectOwnerByType
                         ownerType={ownerType}
@@ -141,7 +141,7 @@ export const SpinAddSheet = () => {
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')}</Form.Label>
+                    <Form.Label>{t('status', 'Status')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -151,9 +151,9 @@ export const SpinAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="new">{t('new')}</Select.Item>
-                          <Select.Item value="loss">{t('loss')}</Select.Item>
-                          <Select.Item value="won">{t('won')}</Select.Item>
+                          <Select.Item value="new">{t('new', 'New')}</Select.Item>
+                          <Select.Item value="loss">{t('loss', 'Loss')}</Select.Item>
+                          <Select.Item value="won">{t('won', 'Won')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -167,11 +167,11 @@ export const SpinAddSheet = () => {
                 name="voucherCampaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                     <SelectVoucherCampaign.FormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('choose-voucher-campaign')}
+                      placeholder={t('choose-voucher-campaign', 'Choose voucher campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -184,10 +184,10 @@ export const SpinAddSheet = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('creating') : t('save')}
+                  {loading ? t('creating', 'Creating...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinCampaignInline.tsx
@@ -45,7 +45,7 @@ const SpinCampaignInlineProvider = ({
       loading: false,
       spinCampaignId: normalizedSpinCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('select-spin-campaigns')
+        ? t('select-spin-campaigns', 'Select spin campaigns')
         : placeholder,
       updateSpinCampaigns: updateSpinCampaigns || setCurrentSpinCampaigns,
     };
@@ -88,7 +88,7 @@ const SpinCampaignInlineTitle = () => {
   if (!campaign) {
     return (
       <span className="text-muted-foreground">
-        {placeholder ?? t('no-campaign-selected')}
+        {placeholder ?? t('no-campaign-selected', 'No campaign selected')}
       </span>
     );
   }
@@ -96,7 +96,7 @@ const SpinCampaignInlineTitle = () => {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <TextOverflowTooltip value={campaign.title || t('untitled-campaign')} />
+        <TextOverflowTooltip value={campaign.title || t('untitled-campaign', 'Untitled Campaign')} />
       </Tooltip.Trigger>
       <Tooltip.Content>
         <p>{campaign.title}</p>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinColumns.tsx
@@ -70,7 +70,7 @@ export const firstSpinColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />
+      <RecordTable.InlineHead icon={IconClock} label={t('created-at', 'Created At')} />
     ),
     size: 100,
     cell: ({ row }) => <CreatedAtCell spin={row.original} />,
@@ -79,7 +79,7 @@ export const firstSpinColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-type', 'Owner Type')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -98,7 +98,7 @@ export const secondSpinColumns = (
   {
     id: 'ownerId',
     accessorKey: 'ownerId',
-    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner')} />,
+    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner', 'Owner')} />,
     cell: ({ row }) => (
       <OwnerCell
         ownerId={row.original.ownerId}
@@ -109,7 +109,7 @@ export const secondSpinColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status')} />,
+    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status', 'Status')} />,
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinCommandBar.tsx
@@ -14,7 +14,7 @@ export const SpinCommandBar = () => {
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedRows.length })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedRows.length })}</CommandBar.Value>
         <Separator.Inline />
         <SpinRemove spinIds={spinIds} rows={selectedRows} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinEditSheet.tsx
@@ -77,7 +77,7 @@ export const SpinEditSheet = ({
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('edit-spin')}</Sheet.Title>
+          <Sheet.Title>{t('edit-spin', 'Edit Spin')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -89,14 +89,14 @@ export const SpinEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign-label')}</Form.Label>
+                    <Form.Label>{t('campaign-label', 'Campaign *')}</Form.Label>
                     <SelectSpinCampaign
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -108,7 +108,7 @@ export const SpinEditSheet = ({
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -121,11 +121,11 @@ export const SpinEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('user')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('user', 'User')}</Select.Item>
                           <Select.Item value="cpUser">
-                            {t('cp-user')}
+                            {t('cp-user', 'Client Portal User')}
                           </Select.Item>
                         </Select.Content>
                       </Select>
@@ -138,10 +138,10 @@ export const SpinEditSheet = ({
               <Form.Field
                 control={form.control}
                 name="ownerId"
-                rules={{ required: t('owner-required') }}
+                rules={{ required: t('owner-required', 'Owner is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       <SelectOwnerByType
                         ownerType={ownerType}
@@ -159,7 +159,7 @@ export const SpinEditSheet = ({
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')}</Form.Label>
+                    <Form.Label>{t('status', 'Status')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -169,9 +169,9 @@ export const SpinEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="new">{t('new')}</Select.Item>
-                          <Select.Item value="loss">{t('loss')}</Select.Item>
-                          <Select.Item value="won">{t('won')}</Select.Item>
+                          <Select.Item value="new">{t('new', 'New')}</Select.Item>
+                          <Select.Item value="loss">{t('loss', 'Loss')}</Select.Item>
+                          <Select.Item value="won">{t('won', 'Won')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -185,11 +185,11 @@ export const SpinEditSheet = ({
                 name="voucherCampaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
                     <SelectVoucherCampaign.FormItem
                       value={field.value}
                       onValueChange={(val) => field.onChange(val as string)}
-                      placeholder={t('choose-voucher-campaign')}
+                      placeholder={t('choose-voucher-campaign', 'Choose voucher campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -202,10 +202,10 @@ export const SpinEditSheet = ({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinFilter.tsx
@@ -37,7 +37,7 @@ const SpinFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinRecordTable.tsx
@@ -57,10 +57,10 @@ export const SpinRecordTable = ({ posId }: { posId?: string }) => {
                 <IconShoppingCartX size={48} className="text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-spins-yet')}
+                {t('no-spins-yet', 'No spin yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                {t('get-started-spin')}
+                {t('get-started-spin', 'Get started by creating your first spin.')}
               </p>
             </div>
           </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/SpinTotalCount.tsx
@@ -11,7 +11,7 @@ export const SpinTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/delete/SpinRemove.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/delete/SpinRemove.tsx
@@ -27,19 +27,19 @@ export const SpinRemove = ({
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-spin-confirm', { count: spinIds.length }),
+          message: t('delete-spin-confirm', 'Are you sure you want to delete {{count}} selected spin(s)?', { count: spinIds.length }),
         }).then(async () => {
           try {
             await deleteSpin({ variables: { _ids: spinIds } });
             rows.forEach((row) => row.toggleSelected(false));
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('spins-deleted', { count: spinIds.length }),
+              description: t('spins-deleted', '{{count}} spin(s) deleted successfully', { count: spinIds.length }),
             });
           } catch (e: unknown) {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e instanceof Error ? e.message : String(e),
               variant: 'destructive',
             });
@@ -48,7 +48,7 @@ export const SpinRemove = ({
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectOwnerType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectOwnerType.tsx
@@ -105,7 +105,7 @@ const SelectOwnerTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-owner-type')}
+        {placeholder || t('select-owner-type', 'Select owner type')}
       </span>
     );
   }
@@ -146,9 +146,9 @@ const SelectOwnerTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-owner-types')} />
+      <Command.Input placeholder={t('search-owner-types', 'Search owner types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-owner-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-owner-types-found', 'No owner types found')}</span>
       </Command.Empty>
       <Command.List>
         {OWNER_TYPE_OPTIONS.map((option) => (
@@ -164,7 +164,7 @@ export const SelectOwnerTypeFilterItem = () => {
   return (
     <Filter.Item value="ownerType">
       <IconUsers />
-      {t('owner-type')}
+      {t('owner-type', 'Owner Type')}
     </Filter.Item>
   );
 };
@@ -219,7 +219,7 @@ export const SelectOwnerTypeFilterBar = ({
     <Filter.BarItem queryKey="ownerType">
       <Filter.BarName>
         <IconUsers />
-        {!iconOnly && t('owner-type')}
+        {!iconOnly && t('owner-type', 'Owner Type')}
       </Filter.BarName>
       <SelectOwnerTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectSpinCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectSpinCampaign.tsx
@@ -118,7 +118,7 @@ const SelectSpinCampaignCommandItem = ({
       <SpinCampaignInline
         spinCampaigns={[spinCampaign]}
         spinCampaignId={spinCampaign._id}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check checked={spinCampaignId.includes(spinCampaign._id)} />
     </Command.Item>
@@ -148,7 +148,7 @@ const SelectSpinCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-spin-campaigns')}
+        placeholder={t('search-spin-campaigns', 'Search spin campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -189,7 +189,7 @@ export const SelectSpinCampaignFilterItem = () => {
   return (
     <Filter.Item value="spinCampaign">
       <IconTicket />
-      {t('spin-campaign')}
+      {t('spin-campaign', 'Spin Campaign')}
     </Filter.Item>
   );
 };
@@ -246,7 +246,7 @@ export const SelectSpinCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'spinCampaign'}>
       <Filter.BarName>
         <IconTicket />
-        {!iconOnly && t('spin-campaign')}
+        {!iconOnly && t('spin-campaign', 'Spin Campaign')}
       </Filter.BarName>
 
       <SelectSpinCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/components/selects/SelectStatus.tsx
@@ -102,7 +102,7 @@ const SelectStatusValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-status')}
+        {placeholder || t('select-status', 'Select status')}
       </span>
     );
   }
@@ -139,9 +139,9 @@ const SelectStatusContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-statuses')} />
+      <Command.Input placeholder={t('search-statuses', 'Search statuses...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-statuses-found')}</span>
+        <span className="text-muted-foreground">{t('no-statuses-found', 'No statuses found')}</span>
       </Command.Empty>
       <Command.List>
         {STATUS_OPTIONS.map((option) => (
@@ -157,7 +157,7 @@ export const SelectStatusFilterItem = () => {
   return (
     <Filter.Item value="status">
       <IconCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -210,7 +210,7 @@ export const SelectStatusFilterBar = ({
     <Filter.BarItem queryKey="status">
       <Filter.BarName>
         <IconCheck />
-        {!iconOnly && t('status')}
+        {!iconOnly && t('status', 'Status')}
       </Filter.BarName>
       <SelectStatusProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/hooks/useAddSpin.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/hooks/useAddSpin.ts
@@ -22,14 +22,14 @@ export const useAddSpin = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('spin-created'),
+          title: t('success', 'Success'),
+          description: t('spin-created', 'Spin created successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/hooks/useEditSpin.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/spin/hooks/useEditSpin.ts
@@ -23,14 +23,14 @@ export const useEditSpin = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('spin-updated'),
+          title: t('success', 'Success'),
+          description: t('spin-updated', 'Spin updated successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherAddSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherAddSheet.tsx
@@ -64,12 +64,12 @@ export const VoucherAddSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('add-voucher')}
+          {t('add-voucher', 'Add Voucher')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('add-voucher')}</Sheet.Title>
+          <Sheet.Title>{t('add-voucher', 'Add Voucher')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -81,14 +81,14 @@ export const VoucherAddSheet = () => {
               <Form.Field
                 control={form.control}
                 name="campaignId"
-                rules={{ required: t('campaign-required') }}
+                rules={{ required: t('campaign-required', 'Campaign is required') }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('voucher-campaign-label')}</Form.Label>
+                    <Form.Label>{t('voucher-campaign-label', 'Voucher Campaign *')}</Form.Label>
                     <SelectVoucherCampaign
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('select-campaign')}
+                      placeholder={t('select-campaign', 'Select campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -100,7 +100,7 @@ export const VoucherAddSheet = () => {
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -114,11 +114,11 @@ export const VoucherAddSheet = () => {
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('team-members')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('team-members', 'Team Members')}</Select.Item>
                           <Select.Item value="cpUser">
-                            {t('cp-user')}
+                            {t('cp-user', 'Client Portal User')}
                           </Select.Item>
                         </Select.Content>
                       </Select>
@@ -134,7 +134,7 @@ export const VoucherAddSheet = () => {
                   name="tagIds"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('tag')}</Form.Label>
+                      <Form.Label>{t('tag', 'Tag')}</Form.Label>
                       <Form.Control>
                         <SelectTags
                           tagType="core:customer"
@@ -157,11 +157,11 @@ export const VoucherAddSheet = () => {
                 name="ownerIds"
                 rules={{
                   validate: (v) =>
-                    v.length > 0 || t('owner-required-one'),
+                    v.length > 0 || t('owner-required-one', 'At least one owner is required'),
                 }}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       {ownerType === 'company' ? (
                         <SelectCompany
@@ -192,10 +192,10 @@ export const VoucherAddSheet = () => {
                   variant="outline"
                   onClick={() => setOpen(false)}
                 >
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('creating') : t('save')}
+                  {loading ? t('creating', 'Creating...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherCampaignInline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherCampaignInline.tsx
@@ -45,7 +45,7 @@ const VoucherCampaignInlineProvider = ({
       loading: false,
       voucherCampaignId: normalizedVoucherCampaignId,
       placeholder: isUndefinedOrNull(placeholder)
-        ? t('select-voucher-campaigns')
+        ? t('select-voucher-campaigns', 'Select voucher campaigns')
         : placeholder,
       updateVoucherCampaigns:
         updateVoucherCampaigns || setCurrentVoucherCampaigns,
@@ -120,7 +120,7 @@ const VoucherCampaignInlineTitle = () => {
     return (
       <TextOverflowTooltip
         value={voucherCampaigns
-          .map((c: IVoucherCampaign) => c.title || t('unnamed-campaign'))
+          .map((c: IVoucherCampaign) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
           .join(', ')}
       />
     );
@@ -130,11 +130,11 @@ const VoucherCampaignInlineTitle = () => {
     <Tooltip.Provider>
       <Tooltip>
         <Tooltip.Trigger asChild>
-          <span>{t('voucher-campaigns-count', { count: voucherCampaigns.length })}</span>
+          <span>{t('voucher-campaigns-count', '{{count}} voucher campaigns', { count: voucherCampaigns.length })}</span>
         </Tooltip.Trigger>
         <Tooltip.Content>
           {voucherCampaigns
-            .map((c: IVoucherCampaign) => c.title || t('unnamed-campaign'))
+            .map((c: IVoucherCampaign) => c.title || t('unnamed-campaign', 'Unnamed campaign'))
             .join(', ')}
         </Tooltip.Content>
       </Tooltip>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherColumns.tsx
@@ -102,7 +102,7 @@ export const firstVoucherColumns = (
     id: 'createdAt',
     accessorKey: 'createdAt',
     header: () => (
-      <RecordTable.InlineHead icon={IconClock} label={t('created-at')} />
+      <RecordTable.InlineHead icon={IconClock} label={t('created-at', 'Created At')} />
     ),
     cell: ({ row }) => <CreatedAtCell voucher={row.original} />,
   },
@@ -110,7 +110,7 @@ export const firstVoucherColumns = (
     id: 'ownerType',
     accessorKey: 'ownerType',
     header: () => (
-      <RecordTable.InlineHead icon={IconUser} label={t('owner-type')} />
+      <RecordTable.InlineHead icon={IconUser} label={t('owner-type', 'Owner Type')} />
     ),
     cell: ({ cell }) => {
       return (
@@ -129,7 +129,7 @@ export const secondVoucherColumns = (
   {
     id: 'ownerId',
     accessorKey: 'ownerId',
-    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner')} />,
+    header: () => <RecordTable.InlineHead icon={IconUser} label={t('owner', 'Owner')} />,
     cell: ({ row }) => (
       <OwnerCell
         ownerId={row.original.ownerId}
@@ -140,7 +140,7 @@ export const secondVoucherColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status')} />,
+    header: () => <RecordTable.InlineHead icon={IconTag} label={t('status', 'Status')} />,
     cell: ({ cell }) => {
       return (
         <RecordTableInlineCell>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherEditSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherEditSheet.tsx
@@ -82,7 +82,7 @@ export const VoucherEditSheet = ({
     <Sheet open={open} onOpenChange={onOpenChange} modal>
       <Sheet.View className="sm:max-w-md">
         <Sheet.Header>
-          <Sheet.Title>{t('edit-voucher')}</Sheet.Title>
+          <Sheet.Title>{t('edit-voucher', 'Edit Voucher')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Sheet.Content className="p-5">
@@ -96,11 +96,11 @@ export const VoucherEditSheet = ({
                 name="campaignId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('campaign')}</Form.Label>
+                    <Form.Label>{t('campaign', 'Campaign')}</Form.Label>
                     <SelectVoucherCampaign
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder={t('choose-voucher-campaign')}
+                      placeholder={t('choose-voucher-campaign', 'Choose voucher campaign')}
                     />
                     <Form.Message />
                   </Form.Item>
@@ -112,7 +112,7 @@ export const VoucherEditSheet = ({
                 name="ownerType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-type')}</Form.Label>
+                    <Form.Label>{t('owner-type', 'Owner Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -125,11 +125,11 @@ export const VoucherEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="customer">{t('customer')}</Select.Item>
-                          <Select.Item value="company">{t('company')}</Select.Item>
-                          <Select.Item value="user">{t('team-members')}</Select.Item>
+                          <Select.Item value="customer">{t('customer', 'Customer')}</Select.Item>
+                          <Select.Item value="company">{t('company', 'Company')}</Select.Item>
+                          <Select.Item value="user">{t('team-members', 'Team Members')}</Select.Item>
                           <Select.Item value="cpUser">
-                            {t('cp-user')}
+                            {t('cp-user', 'Client Portal User')}
                           </Select.Item>
                         </Select.Content>
                       </Select>
@@ -144,7 +144,7 @@ export const VoucherEditSheet = ({
                 name="ownerId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('owner-label')}</Form.Label>
+                    <Form.Label>{t('owner-label', 'Owner *')}</Form.Label>
                     <Form.Control>
                       {ownerType === 'company' ? (
                         <SelectCompany
@@ -178,7 +178,7 @@ export const VoucherEditSheet = ({
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status-label')}</Form.Label>
+                    <Form.Label>{t('status-label', 'Status *')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -188,8 +188,8 @@ export const VoucherEditSheet = ({
                           <Select.Value />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="new">{t('new')}</Select.Item>
-                          <Select.Item value="used">{t('used')}</Select.Item>
+                          <Select.Item value="new">{t('new', 'New')}</Select.Item>
+                          <Select.Item value="used">{t('used', 'Used')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -204,10 +204,10 @@ export const VoucherEditSheet = ({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                 >
-                  {t('close')}
+                  {t('close', 'Close')}
                 </Button>
                 <Button type="submit" disabled={loading}>
-                  {loading ? t('saving') : t('save')}
+                  {loading ? t('saving', 'Saving...') : t('save', 'Save')}
                 </Button>
               </div>
             </form>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherFilter.tsx
@@ -43,7 +43,7 @@ const VoucherFilterPopover = () => {
           <Filter.View>
             <Command>
               <Filter.CommandInput
-                placeholder={t('filter')}
+                placeholder={t('filter', 'Filter')}
                 variant="secondary"
                 className="bg-background"
               />
@@ -56,7 +56,7 @@ const VoucherFilterPopover = () => {
                 <SelectStatus.FilterItem />
                 <Filter.Item value="date">
                   <IconCalendar />
-                  {t('date')}
+                  {t('date', 'Date')}
                 </Filter.Item>
               </Command.List>
             </Command>
@@ -115,7 +115,7 @@ export const VoucherFilter = () => {
         <Filter.BarItem queryKey="date">
           <Filter.BarName>
             <IconCalendar />
-            {t('date')}
+            {t('date', 'Date')}
           </Filter.BarName>
           <Filter.Date filterKey="date" />
         </Filter.BarItem>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherRecordTable.tsx
@@ -59,10 +59,10 @@ export const VoucherRecordTable = ({ posId }: { posId?: string }) => {
                 <IconShoppingCartX size={48} className="text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900">
-                {t('no-vouchers-yet')}
+                {t('no-vouchers-yet', 'No vouchers yet')}
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                {t('get-started-voucher')}
+                {t('get-started-voucher', 'Get started by creating your first voucher.')}
               </p>
             </div>
           </div>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherTotalCount.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/VoucherTotalCount.tsx
@@ -11,7 +11,7 @@ export const VoucherTotalCount = () => {
       {isUndefinedOrNull(totalCount) ? (
         <Skeleton className="w-20 h-4 inline-block mt-1.5" />
       ) : (
-        `${totalCount} ${t('records-found')}`
+        `${totalCount} ${t('records-found', 'records found')}`
       )}
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectOrderType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectOrderType.tsx
@@ -103,7 +103,7 @@ const SelectOrderTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-order-type')}
+        {placeholder || t('select-order-type', 'Select order type')}
       </span>
     );
   }
@@ -146,9 +146,9 @@ const SelectOrderTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-order-types')} />
+      <Command.Input placeholder={t('search-order-types', 'Search order types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-order-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-order-types-found', 'No order types found')}</span>
       </Command.Empty>
       <Command.List>
         {ORDER_TYPE_OPTIONS.map((option) => (
@@ -164,7 +164,7 @@ export const SelectOrderTypeFilterItem = () => {
   return (
     <Filter.Item value="orderType">
       <IconArrowsSort />
-      {t('sort-order')}
+      {t('sort-order', 'Sort Order')}
     </Filter.Item>
   );
 };
@@ -219,7 +219,7 @@ export const SelectOrderTypeFilterBar = ({
     <Filter.BarItem queryKey={'orderType'}>
       <Filter.BarName>
         <IconArrowsSort />
-        {!iconOnly && t('sort-order')}
+        {!iconOnly && t('sort-order', 'Sort Order')}
       </Filter.BarName>
       <SelectOrderTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectOwnerType.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectOwnerType.tsx
@@ -105,7 +105,7 @@ const SelectOwnerTypeValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-owner-type')}
+        {placeholder || t('select-owner-type', 'Select owner type')}
       </span>
     );
   }
@@ -148,9 +148,9 @@ const SelectOwnerTypeContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-owner-types')} />
+      <Command.Input placeholder={t('search-owner-types', 'Search owner types...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-owner-types-found')}</span>
+        <span className="text-muted-foreground">{t('no-owner-types-found', 'No owner types found')}</span>
       </Command.Empty>
       <Command.List>
         {OWNER_TYPE_OPTIONS.map((option) => (
@@ -170,7 +170,7 @@ export const SelectOwnerTypeFilterItem = ({
   return (
     <Filter.Item value={queryKey}>
       <IconUsers />
-      {t('owner-type')}
+      {t('owner-type', 'Owner Type')}
     </Filter.Item>
   );
 };
@@ -225,7 +225,7 @@ export const SelectOwnerTypeFilterBar = ({
     <Filter.BarItem queryKey={queryKey}>
       <Filter.BarName>
         <IconUsers />
-        {!iconOnly && t('owner-type')}
+        {!iconOnly && t('owner-type', 'Owner Type')}
       </Filter.BarName>
       <SelectOwnerTypeProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectSortField.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectSortField.tsx
@@ -103,7 +103,7 @@ const SelectSortFieldValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-sort-field')}
+        {placeholder || t('select-sort-field', 'Select sort field')}
       </span>
     );
   }
@@ -146,9 +146,9 @@ const SelectSortFieldContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-sort-fields')} />
+      <Command.Input placeholder={t('search-sort-fields', 'Search sort fields...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-sort-fields-found')}</span>
+        <span className="text-muted-foreground">{t('no-sort-fields-found', 'No sort fields found')}</span>
       </Command.Empty>
       <Command.List>
         {SORT_FIELD_OPTIONS.map((option) => (
@@ -164,7 +164,7 @@ export const SelectSortFieldFilterItem = () => {
   return (
     <Filter.Item value="sortField">
       <IconSortAscending />
-      {t('sort-field')}
+      {t('sort-field', 'Sort Field')}
     </Filter.Item>
   );
 };
@@ -219,7 +219,7 @@ export const SelectSortFieldFilterBar = ({
     <Filter.BarItem queryKey={'sortField'}>
       <Filter.BarName>
         <IconSortAscending />
-        {!iconOnly && t('sort-field')}
+        {!iconOnly && t('sort-field', 'Sort Field')}
       </Filter.BarName>
       <SelectSortFieldProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectStatus.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectStatus.tsx
@@ -101,7 +101,7 @@ const SelectStatusValue = ({
   if (!selectedOption) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-status')}
+        {placeholder || t('select-status', 'Select status')}
       </span>
     );
   }
@@ -140,9 +140,9 @@ const SelectStatusContent = () => {
   const { t } = useTranslation('loyalty');
   return (
     <Command>
-      <Command.Input placeholder={t('search-statuses')} />
+      <Command.Input placeholder={t('search-statuses', 'Search statuses...')} />
       <Command.Empty>
-        <span className="text-muted-foreground">{t('no-statuses-found')}</span>
+        <span className="text-muted-foreground">{t('no-statuses-found', 'No statuses found')}</span>
       </Command.Empty>
       <Command.List>
         {STATUS_OPTIONS.map((option) => (
@@ -158,7 +158,7 @@ export const SelectStatusFilterItem = () => {
   return (
     <Filter.Item value="status">
       <IconCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 };
@@ -211,7 +211,7 @@ export const SelectStatusFilterBar = ({
     <Filter.BarItem queryKey={'status'}>
       <Filter.BarName>
         <IconCheck />
-        {!iconOnly && t('status')}
+        {!iconOnly && t('status', 'Status')}
       </Filter.BarName>
       <SelectStatusProvider
         mode={mode}

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectVoucherCampaign.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/selects/SelectVoucherCampaign.tsx
@@ -144,7 +144,7 @@ const SelectVoucherCampaignCommandItem = ({
     >
       <VoucherCampaignInline
         voucherCampaigns={[voucherCampaign]}
-        placeholder={t('unnamed-campaign')}
+        placeholder={t('unnamed-campaign', 'Unnamed campaign')}
       />
       <Combobox.Check
         checked={voucherCampaignId.includes(voucherCampaign._id)}
@@ -176,7 +176,7 @@ const SelectVoucherCampaignContent = () => {
         onValueChange={setSearch}
         variant="secondary"
         wrapperClassName="flex-auto"
-        placeholder={t('search-voucher-campaigns')}
+        placeholder={t('search-voucher-campaigns', 'Search voucher campaigns...')}
         className="h-9"
       />
       <Command.List>
@@ -219,7 +219,7 @@ export const SelectVoucherCampaignFilterItem = () => {
   return (
     <Filter.Item value="voucherCampaignId">
       <IconReceipt />
-      {t('voucher-campaign')}
+      {t('voucher-campaign', 'Voucher Campaign')}
     </Filter.Item>
   );
 };
@@ -274,7 +274,7 @@ export const SelectVoucherCampaignFilterBar = ({
     <Filter.BarItem queryKey={queryKey || 'voucherCampaignId'}>
       <Filter.BarName>
         <IconReceipt />
-        {!iconOnly && t('voucher-campaign')}
+        {!iconOnly && t('voucher-campaign', 'Voucher Campaign')}
       </Filter.BarName>
 
       <SelectVoucherCampaignProvider

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/VoucherCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/VoucherCommandBar.tsx
@@ -15,7 +15,7 @@ export const VoucherCommandBar = () => {
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedRows.length })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedRows.length })}</CommandBar.Value>
         <Separator.Inline />
         <VoucherRemove voucherIds={voucherIds} rows={selectedRows} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/delete/VoucherDeleteAll.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/delete/VoucherDeleteAll.tsx
@@ -18,19 +18,19 @@ export const VoucherDeleteAll = ({ totalCount }: { totalCount: number }) => {
 
   const handleDeleteAll = () => {
     confirm({
-      message: t('delete-all-vouchers-confirm', { count: totalCount }),
+      message: t('delete-all-vouchers-confirm', 'Are you sure you want to delete all {{count}} vouchers?', { count: totalCount }),
     }).then(async () => {
       try {
         const result = await removeByFilter({ variables });
         const deleted = result.data?.vouchersRemoveByFilter ?? 0;
         toast({
-          title: t('success'),
+          title: t('success', 'Success'),
           variant: 'success',
-          description: t('vouchers-deleted', { count: deleted }),
+          description: t('vouchers-deleted', '{{count}} voucher(s) deleted successfully', { count: deleted }),
         });
       } catch (e: any) {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -46,7 +46,7 @@ export const VoucherDeleteAll = ({ totalCount }: { totalCount: number }) => {
       disabled={loading}
     >
       <IconTrash />
-      {t('delete-all-count', { count: totalCount })}
+      {t('delete-all-count', 'Delete All ({{count}})', { count: totalCount })}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/delete/VoucherRemove.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/components/voucher-command-bar/delete/VoucherRemove.tsx
@@ -27,19 +27,19 @@ export const VoucherRemove = ({
       className="text-destructive"
       onClick={() =>
         confirm({
-          message: t('delete-voucher-confirm', { count: voucherIds.length }),
+          message: t('delete-voucher-confirm', 'Are you sure you want to delete {{count}} selected voucher(s)?', { count: voucherIds.length }),
         }).then(async () => {
           try {
             await deleteVoucher({ variables: { _ids: voucherIds } });
             rows.forEach((row) => row.toggleSelected(false));
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('vouchers-deleted', { count: voucherIds.length }),
+              description: t('vouchers-deleted', '{{count}} voucher(s) deleted successfully', { count: voucherIds.length }),
             });
           } catch (e: unknown) {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e instanceof Error ? e.message : String(e),
               variant: 'destructive',
             });
@@ -48,7 +48,7 @@ export const VoucherRemove = ({
       }
     >
       <IconTrash />
-      {t('delete')}
+      {t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/hooks/useAddVoucher.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/hooks/useAddVoucher.ts
@@ -26,21 +26,21 @@ export const useAddVoucher = () => {
       onCompleted: (data) => {
         if (data?.vouchersAddMany === 'error') {
           toast({
-            title: t('error'),
-            description: t('voucher-create-failed'),
+            title: t('error', 'Error'),
+            description: t('voucher-create-failed', 'Failed to create vouchers. Please check the campaign configuration.'),
             variant: 'destructive',
           });
           return;
         }
         toast({
-          title: t('success'),
-          description: t('voucher-created'),
+          title: t('success', 'Success'),
+          description: t('voucher-created', 'Voucher created successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/hooks/useEditVoucher.ts
+++ b/frontend/plugins/loyalty_ui/src/modules/loyalties/vouchers/hooks/useEditVoucher.ts
@@ -25,14 +25,14 @@ export const useEditVoucher = () => {
       variables,
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('voucher-updated'),
+          title: t('success', 'Success'),
+          description: t('voucher-updated', 'Voucher updated successfully'),
           variant: 'default',
         });
       },
       onError: (err) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: err.message,
           variant: 'destructive',
         });

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
@@ -38,7 +38,7 @@ export const pricingColumns = (
     id: 'name',
     accessorKey: 'name',
     header: () => (
-      <RecordTable.InlineHead label={t('name')} icon={IconAlignLeft} />
+      <RecordTable.InlineHead label={t('name', 'Name')} icon={IconAlignLeft} />
     ),
     cell: ({ cell, row }) => {
       const pricingId = row.original._id;
@@ -58,7 +58,7 @@ export const pricingColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead label={t('status')} icon={IconHash} />,
+    header: () => <RecordTable.InlineHead label={t('status', 'Status')} icon={IconHash} />,
     cell: ({ cell }) => {
       const status = cell.getValue() as string;
       return (
@@ -78,7 +78,7 @@ export const pricingColumns = (
     id: 'priority',
     accessorKey: 'priority',
     header: () => (
-      <RecordTable.InlineHead label={t('priority')} icon={IconTag} />
+      <RecordTable.InlineHead label={t('priority', 'Priority')} icon={IconTag} />
     ),
     cell: ({ cell }) => {
       const value = cell.getValue() as IPricing['priority'];
@@ -89,7 +89,7 @@ export const pricingColumns = (
     id: 'applyType',
     accessorKey: 'applyType',
     header: () => (
-      <RecordTable.InlineHead label={t('apply-type')} icon={IconTag} />
+      <RecordTable.InlineHead label={t('apply-type', 'Apply Type')} icon={IconTag} />
     ),
     cell: ({ cell }) => {
       return (
@@ -105,7 +105,7 @@ export const pricingColumns = (
     id: 'createdBy',
     accessorKey: 'createdBy',
     header: () => (
-      <RecordTable.InlineHead label={t('created-by')} icon={IconUser} />
+      <RecordTable.InlineHead label={t('created-by', 'Created By')} icon={IconUser} />
     ),
     cell: ({ cell }) => {
       const createdById = cell.getValue() as string;
@@ -125,7 +125,7 @@ export const pricingColumns = (
     accessorKey: 'createdAt',
     header: () => (
       <RecordTable.InlineHead
-        label={t('date-created')}
+        label={t('date-created', 'Date Created')}
         icon={IconCalendarPlus}
       />
     ),
@@ -144,7 +144,7 @@ export const pricingColumns = (
     accessorKey: 'updatedAt',
     header: () => (
       <RecordTable.InlineHead
-        label={t('last-updated-at')}
+        label={t('last-updated-at', 'Last Updated At')}
         icon={IconCalendarPlus}
       />
     ),

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingCommandBar.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingCommandBar.tsx
@@ -15,7 +15,7 @@ export function PricingCommandBar() {
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('selected-count', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('selected-count', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         <PricingDelete pricingIds={selectedIds} />
       </CommandBar.Bar>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingDateSelect.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingDateSelect.tsx
@@ -62,7 +62,7 @@ const PricingDateSelectValue = ({
   if (!value) {
     return (
       <span className="text-sm text-accent-foreground/80">
-        {placeholder || t('select-date')}
+        {placeholder || t('select-date', 'Select date...')}
       </span>
     );
   }
@@ -93,7 +93,7 @@ const PricingDateSelectFormItemValue = ({
         ) : (
           <IconCalendarQuestion className="size-4" />
         )}
-        {placeholder || t('select-date')}
+        {placeholder || t('select-date', 'Select date...')}
       </span>
     );
   }

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingDelete.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingDelete.tsx
@@ -35,7 +35,7 @@ export const PricingDelete = ({
     }
 
     confirm({
-      message: t('delete-pricing-confirm', { count: pricingCount }),
+      message: t('delete-pricing-confirm', 'Are you sure you want to delete the {{count}} selected pricing item(s)?', { count: pricingCount }),
       options: confirmOptions,
     }).then(async () => {
       try {
@@ -46,17 +46,17 @@ export const PricingDelete = ({
         }
 
         toast({
-          title: t('success'),
-          description: t('pricing-deleted', { count: pricingCount }),
+          title: t('success', 'Success'),
+          description: t('pricing-deleted', '{{count}} pricing item(s) deleted successfully.', { count: pricingCount }),
           variant: 'success',
         });
 
         navigate('/settings/loyalty/pricing');
       } catch (error: unknown) {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            error instanceof Error ? error.message : t('pricing-delete-failed'),
+            error instanceof Error ? error.message : t('pricing-delete-failed', 'Failed to delete pricing. Please try again.'),
           variant: 'destructive',
         });
       }
@@ -71,7 +71,7 @@ export const PricingDelete = ({
       disabled={loading}
     >
       <IconTrash className="w-4 h-4 mr-2" />
-      {loading ? t('deleting') : t('delete')}
+      {loading ? t('deleting', 'Deleting...') : t('delete', 'Delete')}
     </Button>
   );
 };

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingFilter.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingFilter.tsx
@@ -73,7 +73,7 @@ export const PricingFilterBar = ({
   return (
     <>
       <Filter.BarItem queryKey="status">
-        <Filter.BarName>{t('status')}</Filter.BarName>
+        <Filter.BarName>{t('status', 'Status')}</Filter.BarName>
         <Filter.BarButton filterKey="status">{displayStatus}</Filter.BarButton>
       </Filter.BarItem>
 
@@ -81,7 +81,7 @@ export const PricingFilterBar = ({
         <SelectBranches.FilterBar
           mode="single"
           filterKey="branchId"
-          label={t('branch')}
+          label={t('branch', 'Branch')}
         />
       )}
 
@@ -89,17 +89,17 @@ export const PricingFilterBar = ({
         <SelectDepartments.FilterBar
           mode="single"
           filterKey="departmentId"
-          label={t('department')}
+          label={t('department', 'Department')}
         />
       )}
 
       {productId && (
-        <SelectProduct.FilterBar filterKey="productId" label={t('product')} />
+        <SelectProduct.FilterBar filterKey="productId" label={t('product', 'Product')} />
       )}
 
       {priority !== undefined && priority !== null && (
         <Filter.BarItem queryKey="priority">
-          <Filter.BarName>{t('priority')}</Filter.BarName>
+          <Filter.BarName>{t('priority', 'Priority')}</Filter.BarName>
           <Filter.BarButton filterKey="priority">
             {t(priorityLabelKey(priorityOption?.value))}
           </Filter.BarButton>
@@ -110,7 +110,7 @@ export const PricingFilterBar = ({
         <Filter.BarItem queryKey="date">
           <Filter.BarName>
             <IconCalendar size={16} />
-            {t('date')}
+            {t('date', 'Date')}
           </Filter.BarName>
           <Filter.BarButton filterKey="date">
             {formatDateTime(date as string)}
@@ -120,36 +120,36 @@ export const PricingFilterBar = ({
 
       {isQuantityEnabled === true && (
         <Filter.BarItem queryKey="isQuantityEnabled">
-          <Filter.BarName>{t('quantity-enabled')}</Filter.BarName>
+          <Filter.BarName>{t('quantity-enabled', 'Quantity Enabled')}</Filter.BarName>
           <Filter.BarButton filterKey="isQuantityEnabled">
-            {t('yes')}
+            {t('yes', 'Yes')}
           </Filter.BarButton>
         </Filter.BarItem>
       )}
 
       {isPriceEnabled === true && (
         <Filter.BarItem queryKey="isPriceEnabled">
-          <Filter.BarName>{t('price-enabled')}</Filter.BarName>
+          <Filter.BarName>{t('price-enabled', 'Price Enabled')}</Filter.BarName>
           <Filter.BarButton filterKey="isPriceEnabled">
-            {t('yes')}
+            {t('yes', 'Yes')}
           </Filter.BarButton>
         </Filter.BarItem>
       )}
 
       {isExpiryEnabled === true && (
         <Filter.BarItem queryKey="isExpiryEnabled">
-          <Filter.BarName>{t('expiry-enabled')}</Filter.BarName>
+          <Filter.BarName>{t('expiry-enabled', 'Expiry Enabled')}</Filter.BarName>
           <Filter.BarButton filterKey="isExpiryEnabled">
-            {t('yes')}
+            {t('yes', 'Yes')}
           </Filter.BarButton>
         </Filter.BarItem>
       )}
 
       {isRepeatEnabled === true && (
         <Filter.BarItem queryKey="isRepeatEnabled">
-          <Filter.BarName>{t('repeat-enabled')}</Filter.BarName>
+          <Filter.BarName>{t('repeat-enabled', 'Repeat Enabled')}</Filter.BarName>
           <Filter.BarButton filterKey="isRepeatEnabled">
-            {t('yes')}
+            {t('yes', 'Yes')}
           </Filter.BarButton>
         </Filter.BarItem>
       )}
@@ -191,49 +191,49 @@ export const PricingFilterView = () => {
       <Filter.View>
         <Command>
           <Filter.CommandInput
-            placeholder={t('filter')}
+            placeholder={t('filter', 'Filter')}
             variant="secondary"
             className="bg-background"
           />
           <Command.List className="p-1">
             <Filter.Item value="status">
               <IconHierarchy size={16} />
-              {t('status')}
+              {t('status', 'Status')}
             </Filter.Item>
-            <SelectBranches.FilterItem value="branchId" label={t('branch')} />
+            <SelectBranches.FilterItem value="branchId" label={t('branch', 'Branch')} />
             <SelectDepartments.FilterItem
               value="departmentId"
-              label={t('department')}
+              label={t('department', 'Department')}
             />
             <Filter.Item value="productId">
               <IconShoppingCart size={16} />
-              {t('product')}
+              {t('product', 'Product')}
             </Filter.Item>
             <Command.Separator className="my-1" />
             <Filter.Item value="priority">
               <IconFilter size={16} />
-              {t('priority')}
+              {t('priority', 'Priority')}
             </Filter.Item>
             <Filter.Item value="date">
               <IconCalendar size={16} />
-              {t('date')}
+              {t('date', 'Date')}
             </Filter.Item>
             <Command.Separator className="my-1" />
             <BooleanFilterCheckbox
               filterKey="isQuantityEnabled"
-              label={t('quantity-enabled')}
+              label={t('quantity-enabled', 'Quantity Enabled')}
             />
             <BooleanFilterCheckbox
               filterKey="isPriceEnabled"
-              label={t('price-enabled')}
+              label={t('price-enabled', 'Price Enabled')}
             />
             <BooleanFilterCheckbox
               filterKey="isExpiryEnabled"
-              label={t('expiry-enabled')}
+              label={t('expiry-enabled', 'Expiry Enabled')}
             />
             <BooleanFilterCheckbox
               filterKey="isRepeatEnabled"
-              label={t('repeat-enabled')}
+              label={t('repeat-enabled', 'Repeat Enabled')}
             />
           </Command.List>
         </Command>
@@ -266,7 +266,7 @@ const StatusFilterContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-status')} />
+      <Command.Input placeholder={t('search-status', 'Search status')} />
       <Command.List>
         {STATUS_OPTIONS.map((option) => (
           <Command.Item
@@ -335,7 +335,7 @@ const DateFilterContent = () => {
             <TimeField
               value={selectedTime}
               onChange={onTimeChange}
-              aria-label={t('time')}
+              aria-label={t('time', 'Time')}
               className="flex-1"
             >
               <DateInput />
@@ -345,11 +345,11 @@ const DateFilterContent = () => {
       </div>
       <div className="flex gap-2 justify-end px-2 py-2 border-t">
         <Button variant="outline" size="sm" onClick={onCancel}>
-          {t('cancel')}
+          {t('cancel', 'Cancel')}
         </Button>
 
         <Button size="sm" onClick={onApply}>
-          {t('apply')}
+          {t('apply', 'Apply')}
         </Button>
       </div>
     </>
@@ -416,7 +416,7 @@ const PriorityFilterContent = () => {
 
   return (
     <Command>
-      <Command.Input placeholder={t('search-priority')} />
+      <Command.Input placeholder={t('search-priority', 'Search priority')} />
       <Command.List>
         {PRICING_PRIORITY_OPTIONS.map((option) => (
           <Command.Item

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingHeader.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingHeader.tsx
@@ -37,7 +37,7 @@ export function PricingHeader() {
               <Button variant="ghost" asChild>
                 <Link to="/settings/loyalty/pricing">
                   <IconCoins />
-                  {t('pricing')}
+                  {t('pricing', 'Pricing')}
                 </Link>
               </Button>
             </Breadcrumb.Item>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingMoreCell.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingMoreCell.tsx
@@ -31,7 +31,7 @@ export const PricingMoreCell = ({ row }: CellContext<IPricing, unknown>) => {
 
   const handleDelete = () => {
     confirm({
-      message: t('delete-pricing-by-name', { name: pricing.name }),
+      message: t('delete-pricing-by-name', 'Are you sure you want to delete "{{name}}"?', { name: pricing.name }),
       options: {
         confirmationValue: 'delete',
       },
@@ -40,16 +40,16 @@ export const PricingMoreCell = ({ row }: CellContext<IPricing, unknown>) => {
         await deletePricing(pricing._id);
 
         toast({
-          title: t('success'),
-          description: t('pricing-deleted', { count: 1 }),
+          title: t('success', 'Success'),
+          description: t('pricing-deleted', '{{count}} pricing item(s) deleted successfully.', { count: 1 }),
           variant: 'success',
         });
       } catch (error: unknown) {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: getErrorMessage(
             error,
-            t('pricing-delete-failed'),
+            t('pricing-delete-failed', 'Failed to delete pricing. Please try again.'),
           ),
           variant: 'destructive',
         });
@@ -79,7 +79,7 @@ export const PricingMoreCell = ({ row }: CellContext<IPricing, unknown>) => {
                 onClick={handleEdit}
               >
                 <IconEdit className="size-4" />
-                {t('edit')}
+                {t('edit', 'Edit')}
               </Button>
             </Command.Item>
             <Command.Item asChild>
@@ -91,7 +91,7 @@ export const PricingMoreCell = ({ row }: CellContext<IPricing, unknown>) => {
                 disabled={loading}
               >
                 <IconTrash className="size-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Button>
             </Command.Item>
           </Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
@@ -15,16 +15,16 @@ export function PricingRecordTable() {
       <div className="flex flex-col gap-2 justify-center items-center p-6 w-full h-full text-center">
         <IconCoins size={64} stroke={1.5} className="text-muted-foreground" />
         <h2 className="text-lg font-semibold text-muted-foreground">
-          {t('no-pricing-yet')}
+          {t('no-pricing-yet', 'No pricing yet')}
         </h2>
         <p className="mb-4 text-md text-muted-foreground">
-          {t('get-started-pricing')}
+          {t('get-started-pricing', 'Add your first pricing to get started.')}
         </p>
         <PricingCreateSheet
           trigger={
             <Button variant="outline">
               <IconPlus />
-              {t('create-pricing')}
+              {t('create-pricing', 'Create Pricing')}
             </Button>
           }
         />

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingSubHeader.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingSubHeader.tsx
@@ -66,7 +66,7 @@ export function PricingSubHeader() {
 
           <div className="h-7 text-sm font-medium leading-7 whitespace-nowrap text-muted-foreground">
             {totalCount
-              ? `${totalCount} ${t('records-found')}`
+              ? `${totalCount} ${t('records-found', 'records found')}`
               : loading && (
                   <Skeleton className="w-20 h-4 inline-block mt-1.5" />
                 )}

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/create-pricing/PricingCreateSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/create-pricing/PricingCreateSheet.tsx
@@ -76,36 +76,36 @@ const getTargetValidationError = (
         ? null
         : {
             field: 'productCategoryIds',
-            message: t('select-at-least-one-category'),
+            message: t('select-at-least-one-category', 'Select at least one category.'),
           };
     case 'product':
       return values.appliesProductIds.length
         ? null
         : {
             field: 'appliesProductIds',
-            message: t('select-at-least-one-product'),
+            message: t('select-at-least-one-product', 'Select at least one product.'),
           };
     case 'segment':
       return values.segmentId
         ? null
-        : { field: 'segmentId', message: t('select-a-segment') };
+        : { field: 'segmentId', message: t('select-a-segment', 'Select a segment.') };
     case 'vendor':
       return values.vendorCompanyIds.length
         ? null
         : {
             field: 'vendorCompanyIds',
-            message: t('select-at-least-one-vendor'),
+            message: t('select-at-least-one-vendor', 'Select at least one vendor.'),
           };
     case 'tag':
       return values.productTagIds.length
         ? null
-        : { field: 'productTagIds', message: t('select-at-least-one-tag') };
+        : { field: 'productTagIds', message: t('select-at-least-one-tag', 'Select at least one tag.') };
     case 'bundle':
       return values.bundleProductIds.length
         ? null
         : {
             field: 'bundleProductIds',
-            message: t('select-at-least-one-bundle-product'),
+            message: t('select-at-least-one-bundle-product', 'Select at least one bundle product.'),
           };
     default:
       return null;
@@ -172,11 +172,11 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
     if (!isDateRangeValid(values.startDate, values.endDate)) {
       form.setError('endDate', {
         type: 'validate',
-        message: t('end-date-after-start'),
+        message: t('end-date-after-start', 'End date must be after start date.'),
       });
       toast({
-        title: t('invalid-date-range'),
-        description: t('end-date-after-start'),
+        title: t('invalid-date-range', 'Invalid date range'),
+        description: t('end-date-after-start', 'End date must be after start date.'),
         variant: 'destructive',
       });
       return;
@@ -190,7 +190,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
         message: targetError.message,
       });
       toast({
-        title: t('missing-pricing-target'),
+        title: t('missing-pricing-target', 'Missing pricing target'),
         description: targetError.message,
         variant: 'destructive',
       });
@@ -254,15 +254,15 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
       await createPricing(doc);
 
       toast({
-        title: t('pricing-created'),
-        description: t('pricing-created-desc'),
+        title: t('pricing-created', 'Pricing created'),
+        description: t('pricing-created-desc', 'New pricing has been created successfully.'),
       });
 
       handleOpenChange(false);
     } catch {
       toast({
-        title: t('failed-to-create-pricing'),
-        description: t('unexpected-error'),
+        title: t('failed-to-create-pricing', 'Failed to create pricing'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -271,7 +271,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
   const defaultTrigger = (
     <Button>
       <IconPlus />
-      {t('create-pricing')}
+      {t('create-pricing', 'Create Pricing')}
     </Button>
   );
 
@@ -281,7 +281,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
       <Sheet.View className="flex-col h-full max-h-screen p-0 sm:max-w-md">
         <Sheet.Header className="px-5 shrink-0">
           <Sheet.Title className="text-lg font-bold">
-            {t('create-pricing')}
+            {t('create-pricing', 'Create Pricing')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -298,10 +298,10 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                 render={({ field }) => (
                   <Form.Item>
                     <Form.Label>
-                      {t('name')} <span className="text-destructive">*</span>
+                      {t('name', 'Name')} <span className="text-destructive">*</span>
                     </Form.Label>
                     <Form.Control>
-                      <Input placeholder={t('enter-pricing-name')} {...field} />
+                      <Input placeholder={t('enter-pricing-name', 'Enter pricing name')} {...field} />
                     </Form.Control>
                   </Form.Item>
                 )}
@@ -312,7 +312,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                 name="priority"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('priority')}</Form.Label>
+                    <Form.Label>{t('priority', 'Priority')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -343,11 +343,11 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   name="startDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('start-date')}</Form.Label>
+                      <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
                       <Form.Control>
                         <DatePicker
                           value={parseDateValue(field.value)}
-                          placeholder={t('select-start-date')}
+                          placeholder={t('select-start-date', 'Select start date')}
                           onChange={(value) =>
                             field.onChange(
                               formatDateValue(
@@ -367,11 +367,11 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   name="endDate"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('end-date')}</Form.Label>
+                      <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                       <Form.Control>
                         <DatePicker
                           value={parseDateValue(field.value)}
-                          placeholder={t('select-end-date')}
+                          placeholder={t('select-end-date', 'Select end date')}
                           onChange={(value) =>
                             field.onChange(
                               formatDateValue(
@@ -389,7 +389,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
 
               <div className="flex items-center my-4">
                 <div className="flex-1 border-t" />
-                <Form.Label className="mx-2">{t('more-info')}</Form.Label>
+                <Form.Label className="mx-2">{t('more-info', 'More Info')}</Form.Label>
                 <div className="flex-1 border-t" />
               </div>
 
@@ -398,33 +398,33 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                 name="appliesTo"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('applies-to')}</Form.Label>
+                    <Form.Label>{t('applies-to', 'APPLIES TO')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="bg-background">
-                          <Select.Value placeholder={t('select-target')} />
+                          <Select.Value placeholder={t('select-target', 'Select target')} />
                         </Select.Trigger>
                         <Select.Content>
                           <Select.Item value="category">
-                            {t('specific-category')}
+                            {t('specific-category', 'Specific Category')}
                           </Select.Item>
                           <Select.Item value="product">
-                            {t('specific-product')}
+                            {t('specific-product', 'Specific Product')}
                           </Select.Item>
                           <Select.Item value="segment">
-                            {t('specific-segment')}
+                            {t('specific-segment', 'Specific Segment')}
                           </Select.Item>
                           <Select.Item value="vendor">
-                            {t('specific-vendor')}
+                            {t('specific-vendor', 'Specific Vendor')}
                           </Select.Item>
                           <Select.Item value="tag">
-                            {t('specific-tag')}
+                            {t('specific-tag', 'Specific Tag')}
                           </Select.Item>
                           <Select.Item value="bundle">
-                            {t('specific-bundle')}
+                            {t('specific-bundle', 'Specific Bundle')}
                           </Select.Item>
                         </Select.Content>
                       </Select>
@@ -441,7 +441,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     render={({ field }) => (
                       <Form.Item>
                         <Form.Label>
-                          {t('product-categories-label')}{' '}
+                          {t('product-categories-label', 'PRODUCT CATEGORIES')}{' '}
                           <span className="text-destructive">*</span>
                         </Form.Label>
                         <Form.Control>
@@ -465,7 +465,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     name="excludeCategoryIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('exclude-categories')}</Form.Label>
+                        <Form.Label>{t('exclude-categories', 'EXCLUDE CATEGORIES')}</Form.Label>
                         <Form.Control>
                           <SelectCategory
                             mode="multiple"
@@ -487,7 +487,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     name="excludeProductIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('exclude-products')}</Form.Label>
+                        <Form.Label>{t('exclude-products', 'EXCLUDE PRODUCTS')}</Form.Label>
                         <Form.Control>
                           <SelectProduct
                             mode="multiple"
@@ -513,7 +513,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   render={({ field }) => (
                     <Form.Item>
                       <Form.Label>
-                        {t('products-label')}{' '}
+                        {t('products-label', 'PRODUCTS')}{' '}
                         <span className="text-destructive">*</span>
                       </Form.Label>
                       <Form.Control>
@@ -540,7 +540,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   render={({ field }) => (
                     <Form.Item>
                       <Form.Label>
-                        {t('segment-label')}{' '}
+                        {t('segment-label', 'SEGMENT')}{' '}
                         <span className="text-destructive">*</span>
                       </Form.Label>
                       <Form.Control>
@@ -562,7 +562,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   render={({ field }) => (
                     <Form.Item>
                       <Form.Label>
-                        {t('vendors')}{' '}
+                        {t('vendors', 'VENDORS')}{' '}
                         <span className="text-destructive">*</span>
                       </Form.Label>
                       <Form.Control>
@@ -590,7 +590,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     render={({ field }) => (
                       <Form.Item>
                         <Form.Label>
-                          {t('product-tags')}{' '}
+                          {t('product-tags', 'PRODUCT TAGS')}{' '}
                           <span className="text-destructive">*</span>
                         </Form.Label>
                         <Form.Control>
@@ -613,7 +613,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     name="excludeTagIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('exclude-tags')}</Form.Label>
+                        <Form.Label>{t('exclude-tags', 'EXCLUDE TAGS')}</Form.Label>
                         <Form.Control>
                           <SelectTags
                             tagType="sales:product"
@@ -634,7 +634,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                     name="excludeProductIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('exclude-products')}</Form.Label>
+                        <Form.Label>{t('exclude-products', 'EXCLUDE PRODUCTS')}</Form.Label>
                         <Form.Control>
                           <SelectProduct
                             mode="multiple"
@@ -659,7 +659,7 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                   render={({ field }) => (
                     <Form.Item>
                       <Form.Label>
-                        {t('products-to-bundle')}{' '}
+                        {t('products-to-bundle', 'PRODUCTS TO BUNDLE')}{' '}
                         <span className="text-destructive">*</span>
                       </Form.Label>
                       <Form.Control>
@@ -689,10 +689,10 @@ export function PricingCreateSheet({ trigger }: PricingCreateSheetProps) {
                 variant="outline"
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading || !isFormValid}>
-                {loading ? t('creating') : t('create')}
+                {loading ? t('creating', 'Creating...') : t('create', 'Create')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/MainContent.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/MainContent.tsx
@@ -97,7 +97,7 @@ export const PricingMainContent: React.FC<MainContentProps> = ({
     return (
       <div className="p-6 text-center">
         <p className="text-destructive">
-          {t('failed-to-load-pricing-details', { message: error.message })}
+          {t('failed-to-load-pricing-details', 'Failed to load Pricing details: {{message}}', { message: error.message })}
         </p>
       </div>
     );
@@ -108,11 +108,11 @@ export const PricingMainContent: React.FC<MainContentProps> = ({
       <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-background shrink-0">
         <div className="flex items-center flex-1 min-w-0 gap-4">
           <h1 className="max-w-[300px] text-xl font-semibold truncate text-foreground">
-            {pricingDetail?.name || t('new-pricing')}
+            {pricingDetail?.name || t('new-pricing', 'New Pricing')}
           </h1>
 
           <Badge variant="secondary" className="text-xs shrink-0">
-            {pricingDetail?.applyType || t('na')}
+            {pricingDetail?.applyType || t('na', 'N/A')}
           </Badge>
         </div>
 

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/expiry/ExpiryInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/expiry/ExpiryInfo.tsx
@@ -20,12 +20,12 @@ export const ExpiryInfo = (props: ExpiryInfoProps) => {
   return (
     <PricingRuleInfo<ExpiryRuleConfig>
       {...props}
-      title={t('expiry')}
+      title={t('expiry', 'Expiry')}
       rulesKey="expiryRules"
       enabledKey="isExpiryEnabled"
-      successTitle={t('expiry-rules-updated')}
-      errorTitle={t('failed-to-update-expiry-rules')}
-      emptyMessage={<>{t('no-expiry-rules')}</>}
+      successTitle={t('expiry-rules-updated', 'Expiry rules updated')}
+      errorTitle={t('failed-to-update-expiry-rules', 'Failed to update expiry rules')}
+      emptyMessage={<>{t('no-expiry-rules', 'No expiry rules configured yet. Click "Add rule" to set up expiry conditions for this product.')}</>}
       RuleSheet={ExpiryRuleSheet}
     />
   );

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/expiry/ExpiryRuleSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/expiry/ExpiryRuleSheet.tsx
@@ -102,7 +102,7 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
         <Sheet.Trigger asChild>
           <Button variant="outline">
             {' '}
-            <IconPlus size={16} className="mr-2" /> {t('add-rule')}
+            <IconPlus size={16} className="mr-2" /> {t('add-rule', 'Add rule')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -110,7 +110,7 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
           <Sheet.Title>
-            {isEditing ? t('edit-expiry-rule') : t('add-new-expiry-rule')}
+            {isEditing ? t('edit-expiry-rule', 'Edit Expiry Rule') : t('add-new-expiry-rule', 'Add New Expiry Rule')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -127,21 +127,21 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                 name="ruleType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-type')}</Form.Label>
+                    <Form.Label>{t('rule-type', 'Rule type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-rule-type')} />
+                          <Select.Value placeholder={t('choose-rule-type', 'Choose rule type')} />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="hour">{t('hour')}</Select.Item>
-                          <Select.Item value="day">{t('day')}</Select.Item>
-                          <Select.Item value="week">{t('week')}</Select.Item>
-                          <Select.Item value="month">{t('month')}</Select.Item>
-                          <Select.Item value="year">{t('year')}</Select.Item>
+                          <Select.Item value="hour">{t('hour', 'Hour')}</Select.Item>
+                          <Select.Item value="day">{t('day', 'Day')}</Select.Item>
+                          <Select.Item value="week">{t('week', 'Week')}</Select.Item>
+                          <Select.Item value="month">{t('month', 'Month')}</Select.Item>
+                          <Select.Item value="year">{t('year', 'Year')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -154,10 +154,10 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                 name="ruleValue"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-value')}</Form.Label>
+                    <Form.Label>{t('rule-value', 'Rule value')}</Form.Label>
                     <Form.Control>
                       <Input
-                        placeholder={t('enter-number')}
+                        placeholder={t('enter-number', 'Enter number')}
                         type="number"
                         {...field}
                       />
@@ -171,14 +171,14 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                 name="discountType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('discount-type')}</Form.Label>
+                    <Form.Label>{t('discount-type', 'Discount type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-discount-type')} />
+                          <Select.Value placeholder={t('choose-discount-type', 'Choose discount type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {DISCOUNT_TYPES.map((option) => (
@@ -202,7 +202,7 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                   name="discountValue"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
@@ -223,7 +223,7 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                   name="bonusProductId"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <SelectProduct
                           mode="single"
@@ -243,14 +243,14 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                 name="priceAdjustType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-type')}</Form.Label>
+                    <Form.Label>{t('price-adjust-type', 'Price adjust type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-type')} />
+                          <Select.Value placeholder={t('choose-type', 'Choose type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {PRICE_ADJUST_TYPES.map((option) => (
@@ -273,7 +273,7 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
                 name="priceAdjustFactor"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-factor')}</Form.Label>
+                    <Form.Label>{t('price-adjust-factor', 'Price adjust factor')}</Form.Label>
                     <Form.Control>
                       <Input placeholder="0" type="number" {...field} />
                     </Form.Control>
@@ -283,9 +283,9 @@ export const ExpiryRuleSheet: React.FC<ExpiryRuleSheetProps> = ({
 
               <div className="flex gap-2 justify-end pt-4">
                 <Button type="button" variant="outline" onClick={handleClose}>
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
-                <Button type="submit">{t('save')}</Button>
+                <Button type="submit">{t('save', 'Save')}</Button>
               </div>
             </form>
           </Form>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/general/GeneralInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/general/GeneralInfo.tsx
@@ -189,11 +189,11 @@ export const GeneralInfo = ({
     if (!isDateRangeValid(values.startDate, values.endDate)) {
       form.setError('endDate', {
         type: 'validate',
-        message: t('end-date-after-start'),
+        message: t('end-date-after-start', 'End date must be after start date.'),
       });
       toast({
-        title: t('invalid-date-range'),
-        description: t('end-date-after-start'),
+        title: t('invalid-date-range', 'Invalid date range'),
+        description: t('end-date-after-start', 'End date must be after start date.'),
         variant: 'destructive',
       });
       return;
@@ -255,13 +255,13 @@ export const GeneralInfo = ({
       await editPricing(baseDoc);
       form.reset(values);
       toast({
-        title: t('pricing-updated'),
-        description: t('changes-saved'),
+        title: t('pricing-updated', 'Pricing updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-pricing'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-pricing', 'Failed to update pricing'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -280,7 +280,7 @@ export const GeneralInfo = ({
           size="sm"
           disabled={loading || !pricingId}
         >
-          {loading ? t('saving') : t('save-changes')}
+          {loading ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
         </Button>
       ) : null,
     );
@@ -296,7 +296,7 @@ export const GeneralInfo = ({
           onSubmit={form.handleSubmit(handleSubmit)}
           noValidate
         >
-          <InfoCard title={t('general')}>
+          <InfoCard title={t('general', 'General')}>
             <InfoCard.Content className="grid w-full grid-cols-2 gap-6">
               <div className="flex flex-col w-full space-y-4">
                 <div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-2">
@@ -305,10 +305,10 @@ export const GeneralInfo = ({
                     name="name"
                     render={({ field }) => (
                       <Form.Item className="min-w-0">
-                        <Form.Label>{t('name')}</Form.Label>
+                        <Form.Label>{t('name', 'Name')}</Form.Label>
                         <Form.Control>
                           <Input
-                            placeholder={t('enter-pricing-name')}
+                            placeholder={t('enter-pricing-name', 'Enter pricing name')}
                             {...field}
                           />
                         </Form.Control>
@@ -321,27 +321,27 @@ export const GeneralInfo = ({
                     name="status"
                     render={({ field }) => (
                       <Form.Item className="min-w-0">
-                        <Form.Label>{t('status')}</Form.Label>
+                        <Form.Label>{t('status', 'Status')}</Form.Label>
                         <Form.Control>
                           <Select
                             value={field.value}
                             onValueChange={field.onChange}
                           >
                             <Select.Trigger>
-                              <Select.Value placeholder={t('select-status')} />
+                              <Select.Value placeholder={t('select-status', 'Select status')} />
                             </Select.Trigger>
                             <Select.Content>
                               <Select.Item value="active">
-                                {t('active')}
+                                {t('active', 'Active')}
                               </Select.Item>
                               <Select.Item value="archived">
-                                {t('archived')}
+                                {t('archived', 'Archived')}
                               </Select.Item>
                               <Select.Item value="draft">
-                                {t('draft')}
+                                {t('draft', 'Draft')}
                               </Select.Item>
                               <Select.Item value="completed">
-                                {t('completed')}
+                                {t('completed', 'Completed')}
                               </Select.Item>
                             </Select.Content>
                           </Select>
@@ -356,7 +356,7 @@ export const GeneralInfo = ({
                   name="priority"
                   render={({ field }) => (
                     <Form.Item className="min-w-0">
-                      <Form.Label>{t('priority')}</Form.Label>
+                      <Form.Label>{t('priority', 'Priority')}</Form.Label>
                       <Form.Control>
                         <Select
                           value={field.value}
@@ -385,15 +385,15 @@ export const GeneralInfo = ({
                   <GeneralDateField
                     control={form.control}
                     name="startDate"
-                    label={t('start-date')}
-                    placeholder={t('select-start-date')}
+                    label={t('start-date', 'Start Date')}
+                    placeholder={t('select-start-date', 'Select start date')}
                   />
 
                   <GeneralDateField
                     control={form.control}
                     name="endDate"
-                    label={t('end-date')}
-                    placeholder={t('select-end-date')}
+                    label={t('end-date', 'End Date')}
+                    placeholder={t('select-end-date', 'Select end date')}
                   />
                 </div>
               </div>
@@ -405,33 +405,33 @@ export const GeneralInfo = ({
                     name="appliesTo"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('applies-to')}</Form.Label>
+                        <Form.Label>{t('applies-to', 'APPLIES TO')}</Form.Label>
                         <Form.Control>
                           <Select
                             value={field.value}
                             onValueChange={field.onChange}
                           >
                             <Select.Trigger>
-                              <Select.Value placeholder={t('select-target')} />
+                              <Select.Value placeholder={t('select-target', 'Select target')} />
                             </Select.Trigger>
                             <Select.Content>
                               <Select.Item value="category">
-                                {t('specific-category')}
+                                {t('specific-category', 'Specific Category')}
                               </Select.Item>
                               <Select.Item value="product">
-                                {t('specific-product')}
+                                {t('specific-product', 'Specific Product')}
                               </Select.Item>
                               <Select.Item value="segment">
-                                {t('specific-segment')}
+                                {t('specific-segment', 'Specific Segment')}
                               </Select.Item>
                               <Select.Item value="vendor">
-                                {t('specific-vendor')}
+                                {t('specific-vendor', 'Specific Vendor')}
                               </Select.Item>
                               <Select.Item value="tag">
-                                {t('specific-tag')}
+                                {t('specific-tag', 'Specific Tag')}
                               </Select.Item>
                               <Select.Item value="bundle">
-                                {t('specific-bundle')}
+                                {t('specific-bundle', 'Specific Bundle')}
                               </Select.Item>
                             </Select.Content>
                           </Select>
@@ -449,7 +449,7 @@ export const GeneralInfo = ({
                       render={({ field }) => (
                         <Form.Item>
                           <Form.Label>
-                            {t('product-categories-label')}
+                            {t('product-categories-label', 'PRODUCT CATEGORIES')}
                           </Form.Label>
                           <Form.Control>
                             <SelectCategory
@@ -469,7 +469,7 @@ export const GeneralInfo = ({
                       name="excludeCategoryIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('exclude-categories')}</Form.Label>
+                          <Form.Label>{t('exclude-categories', 'EXCLUDE CATEGORIES')}</Form.Label>
                           <Form.Control>
                             <SelectCategory
                               mode="multiple"
@@ -488,7 +488,7 @@ export const GeneralInfo = ({
                       name="excludeProductIds"
                       render={({ field }) => (
                         <Form.Item className="lg:col-span-2">
-                          <Form.Label>{t('exclude-products')}</Form.Label>
+                          <Form.Label>{t('exclude-products', 'EXCLUDE PRODUCTS')}</Form.Label>
                           <Form.Control>
                             <SelectProduct
                               mode="multiple"
@@ -511,7 +511,7 @@ export const GeneralInfo = ({
                       name="appliesProductIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('products-label')}</Form.Label>
+                          <Form.Label>{t('products-label', 'PRODUCTS')}</Form.Label>
                           <Form.Control>
                             <SelectProduct
                               mode="multiple"
@@ -534,7 +534,7 @@ export const GeneralInfo = ({
                       name="segmentId"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('segment-label')}</Form.Label>
+                          <Form.Label>{t('segment-label', 'SEGMENT')}</Form.Label>
                           <Form.Control>
                             <SelectSegment
                               selected={field.value || undefined}
@@ -554,7 +554,7 @@ export const GeneralInfo = ({
                       name="vendorCompanyIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('vendors')}</Form.Label>
+                          <Form.Label>{t('vendors', 'VENDORS')}</Form.Label>
                           <Form.Control>
                             <SelectCompany
                               mode="multiple"
@@ -577,7 +577,7 @@ export const GeneralInfo = ({
                       name="productTagIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('product-tags')}</Form.Label>
+                          <Form.Label>{t('product-tags', 'PRODUCT TAGS')}</Form.Label>
                           <Form.Control>
                             <SelectTags
                               tagType="sales:product"
@@ -597,7 +597,7 @@ export const GeneralInfo = ({
                       name="excludeTagIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('exclude-tags')}</Form.Label>
+                          <Form.Label>{t('exclude-tags', 'EXCLUDE TAGS')}</Form.Label>
                           <Form.Control>
                             <SelectTags
                               tagType="sales:product"
@@ -617,7 +617,7 @@ export const GeneralInfo = ({
                       name="excludeProductIds"
                       render={({ field }) => (
                         <Form.Item className="lg:col-span-2">
-                          <Form.Label>{t('exclude-products')}</Form.Label>
+                          <Form.Label>{t('exclude-products', 'EXCLUDE PRODUCTS')}</Form.Label>
                           <Form.Control>
                             <SelectProduct
                               mode="multiple"
@@ -640,7 +640,7 @@ export const GeneralInfo = ({
                       name="bundleProductIds"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('products-to-bundle')}</Form.Label>
+                          <Form.Label>{t('products-to-bundle', 'PRODUCTS TO BUNDLE')}</Form.Label>
                           <Form.Control>
                             <SelectProduct
                               mode="multiple"

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/Location.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/Location.tsx
@@ -54,13 +54,13 @@ export const Location = ({ pricingId, pricingDetail }: LocationProps) => {
         branchIds: values.branchIds,
       });
       toast({
-        title: t('location-updated'),
-        description: t('changes-saved'),
+        title: t('location-updated', 'Location updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-location'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-location', 'Failed to update location'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -79,7 +79,7 @@ export const Location = ({ pricingId, pricingDetail }: LocationProps) => {
             name="branchIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('branches')}</Form.Label>
+                <Form.Label>{t('branches', 'Branches')}</Form.Label>
                 <Form.Control>
                   <SelectBranches.FormItem
                     mode="multiple"
@@ -95,7 +95,7 @@ export const Location = ({ pricingId, pricingDetail }: LocationProps) => {
             name="departmentIds"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('departments')}</Form.Label>
+                <Form.Label>{t('departments', 'Departments')}</Form.Label>
                 <Form.Control>
                   <SelectDepartments.FormItem
                     mode="multiple"
@@ -111,7 +111,7 @@ export const Location = ({ pricingId, pricingDetail }: LocationProps) => {
         {hasChanges && (
           <div className="flex justify-end pt-4 border-t">
             <Button type="submit" disabled={loading}>
-              {t('save-changes')}
+              {t('save-changes', 'Save Changes')}
             </Button>
           </div>
         )}

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/OptionsInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/OptionsInfo.tsx
@@ -244,7 +244,7 @@ export const OptionsInfo = ({
           size="sm"
           disabled={loading}
         >
-          {loading ? t('saving') : t('save-changes')}
+          {loading ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
         </Button>
       ) : null,
     );
@@ -337,13 +337,13 @@ export const OptionsInfo = ({
       );
 
       toast({
-        title: t('options-updated'),
-        description: t('changes-saved'),
+        title: t('options-updated', 'Options updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-options'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-options', 'Failed to update options'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -351,7 +351,7 @@ export const OptionsInfo = ({
 
   return (
     <div className="p-6">
-      <InfoCard title={t('options')}>
+      <InfoCard title={t('options', 'Options')}>
         <InfoCard.Content>
           <Form {...form}>
             <form
@@ -362,7 +362,7 @@ export const OptionsInfo = ({
             >
               <div className="flex items-center my-4">
                 <div className="flex-1 border-t" />
-                <Label className="mx-2">{t('location')}</Label>
+                <Label className="mx-2">{t('location', 'Location')}</Label>
                 <div className="flex-1 border-t" />
               </div>
 
@@ -373,7 +373,7 @@ export const OptionsInfo = ({
                     name="branchIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('branches-caps')}</Form.Label>
+                        <Form.Label>{t('branches-caps', 'BRANCHES')}</Form.Label>
                         <Form.Control>
                           <SelectBranches.FormItem
                             mode="multiple"
@@ -389,7 +389,7 @@ export const OptionsInfo = ({
                     name="departmentIds"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('departments-caps')}</Form.Label>
+                        <Form.Label>{t('departments-caps', 'DEPARTMENTS')}</Form.Label>
                         <Form.Control>
                           <SelectDepartments.FormItem
                             mode="multiple"
@@ -405,7 +405,7 @@ export const OptionsInfo = ({
 
               <div className="flex items-center my-4">
                 <div className="flex-1 border-t" />
-                <Label className="mx-2">{t('pipeline')}</Label>
+                <Label className="mx-2">{t('pipeline', 'Pipeline')}</Label>
                 <div className="flex-1 border-t" />
               </div>
 
@@ -416,12 +416,12 @@ export const OptionsInfo = ({
                     name="boardId"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('board-caps')}</Form.Label>
+                        <Form.Label>{t('board-caps', 'BOARD')}</Form.Label>
                         <Form.Control>
                           <SelectBoardFormItem
                             value={field.value}
                             onValueChange={handleBoardChange}
-                            placeholder={t('choose-a-board')}
+                            placeholder={t('choose-a-board', 'Choose a board')}
                           />
                         </Form.Control>
                       </Form.Item>
@@ -433,13 +433,13 @@ export const OptionsInfo = ({
                     name="pipelineId"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('pipeline-caps')}</Form.Label>
+                        <Form.Label>{t('pipeline-caps', 'PIPELINE')}</Form.Label>
                         <Form.Control>
                           <SelectPipelineFormItem
                             value={field.value}
                             onValueChange={field.onChange}
                             boardId={form.watch('boardId')}
-                            placeholder={t('choose-a-pipeline')}
+                            placeholder={t('choose-a-pipeline', 'Choose a pipeline')}
                           />
                         </Form.Control>
                       </Form.Item>
@@ -450,7 +450,7 @@ export const OptionsInfo = ({
 
               <div className="flex items-center my-4">
                 <div className="flex-1 border-t" />
-                <Label className="mx-2">{t('repeat')}</Label>
+                <Label className="mx-2">{t('repeat', 'Repeat')}</Label>
                 <div className="flex-1 border-t" />
               </div>
 
@@ -467,7 +467,7 @@ export const OptionsInfo = ({
 
                   {repeatRules.length === 0 ? (
                     <div className="py-6 text-sm text-center text-muted-foreground">
-                      {t('no-repeat-rules')}
+                      {t('no-repeat-rules', 'No repeat rules yet. Click "Add rule" to add one.')}
                     </div>
                   ) : (
                     <div className="space-y-2">
@@ -483,7 +483,7 @@ export const OptionsInfo = ({
                               variant="outline"
                               size="icon"
                               type="button"
-                              aria-label={t('edit-repeat-rule')}
+                              aria-label={t('edit-repeat-rule', 'Edit repeat rule')}
                               onClick={() => setEditingRule(rule)}
                             >
                               <IconEdit size={14} />
@@ -493,7 +493,7 @@ export const OptionsInfo = ({
                               size="icon"
                               type="button"
                               className="text-destructive"
-                              aria-label={t('delete-repeat-rule')}
+                              aria-label={t('delete-repeat-rule', 'Delete repeat rule')}
                               onClick={() => handleRuleDelete(rule)}
                             >
                               <IconTrash size={14} />

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/Stage.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/options/Stage.tsx
@@ -62,13 +62,13 @@ export const Stage = ({ pricingId, pricingDetail }: StageProps) => {
         stageId: stageId || undefined,
       });
       toast({
-        title: t('stage-updated'),
-        description: t('changes-saved'),
+        title: t('stage-updated', 'Stage updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-stage'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-stage', 'Failed to update stage'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -78,31 +78,31 @@ export const Stage = ({ pricingId, pricingDetail }: StageProps) => {
     <div className="space-y-6">
       <div className="grid grid-cols-3 gap-4">
         <div className="space-y-2">
-          <Label>{t('board-caps')}</Label>
+          <Label>{t('board-caps', 'BOARD')}</Label>
           <SelectBoardFormItem
             value={boardId}
             onValueChange={handleBoardChange}
-            placeholder={t('choose-a-board')}
+            placeholder={t('choose-a-board', 'Choose a board')}
           />
         </div>
 
         <div className="space-y-2">
-          <Label>{t('pipeline-caps')}</Label>
+          <Label>{t('pipeline-caps', 'PIPELINE')}</Label>
           <SelectPipelineFormItem
             value={pipelineId}
             onValueChange={handlePipelineChange}
             boardId={boardId}
-            placeholder={t('choose-a-pipeline')}
+            placeholder={t('choose-a-pipeline', 'Choose a pipeline')}
           />
         </div>
 
         <div className="space-y-2">
-          <Label>{t('stage-caps')}</Label>
+          <Label>{t('stage-caps', 'STAGE')}</Label>
           <SelectStageFormItem
             value={stageId}
             onValueChange={handleStageChange}
             pipelineId={pipelineId}
-            placeholder={t('choose-a-stage')}
+            placeholder={t('choose-a-stage', 'Choose a stage')}
           />
         </div>
       </div>
@@ -110,7 +110,7 @@ export const Stage = ({ pricingId, pricingDetail }: StageProps) => {
       {hasChanges && (
         <div className="flex justify-end pt-4 border-t">
           <Button onClick={handleSave} disabled={loading}>
-            {t('save-changes')}
+            {t('save-changes', 'Save Changes')}
           </Button>
         </div>
       )}

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/participants/ParticipantsInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/participants/ParticipantsInfo.tsx
@@ -65,7 +65,7 @@ export const ParticipantsInfo = ({
           size="sm"
           disabled={loading}
         >
-          {loading ? t('saving') : t('save-changes')}
+          {loading ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
         </Button>
       ) : null,
     );
@@ -90,13 +90,13 @@ export const ParticipantsInfo = ({
       setInitialSnapshot(participantDoc);
 
       toast({
-        title: t('participants-updated'),
-        description: t('changes-saved'),
+        title: t('participants-updated', 'Participants updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-participants'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-participants', 'Failed to update participants'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -104,7 +104,7 @@ export const ParticipantsInfo = ({
 
   return (
     <div className="p-6">
-      <InfoCard title={t('participants')}>
+      <InfoCard title={t('participants', 'Participants')}>
         <InfoCard.Content>
           <Form {...form}>
             <form

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/price/PriceInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/price/PriceInfo.tsx
@@ -20,12 +20,12 @@ export function PriceInfo(props: PriceInfoProps) {
   return (
     <PricingRuleInfo<PriceRuleConfig>
       {...props}
-      title={t('price')}
+      title={t('price', 'Price')}
       rulesKey="priceRules"
       enabledKey="isPriceEnabled"
-      successTitle={t('price-rules-updated')}
-      errorTitle={t('failed-to-update-price-rules')}
-      emptyMessage={<>{t('no-price-rules')}</>}
+      successTitle={t('price-rules-updated', 'Price rules updated')}
+      errorTitle={t('failed-to-update-price-rules', 'Failed to update price rules')}
+      emptyMessage={<>{t('no-price-rules', 'No price rules yet. Click "Add rule" to add one.')}</>}
       RuleSheet={PriceRuleSheet}
     />
   );

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/price/PriceRuleSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/price/PriceRuleSheet.tsx
@@ -102,7 +102,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
         <Sheet.Trigger asChild>
           <Button variant="outline">
             {' '}
-            <IconPlus size={16} className="mr-2" /> {t('add-rule')}
+            <IconPlus size={16} className="mr-2" /> {t('add-rule', 'Add rule')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -110,7 +110,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
           <Sheet.Title>
-            {isEditing ? t('edit-price-rule') : t('add-price-rule')}
+            {isEditing ? t('edit-price-rule', 'Edit price rule') : t('add-price-rule', 'Add price rule')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -127,19 +127,19 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                 name="ruleType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-type')}</Form.Label>
+                    <Form.Label>{t('rule-type', 'Rule type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-rule-type')} />
+                          <Select.Value placeholder={t('choose-rule-type', 'Choose rule type')} />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="exact">{t('exact')}</Select.Item>
-                          <Select.Item value="every">{t('every')}</Select.Item>
-                          <Select.Item value="minimum">{t('minimum')}</Select.Item>
+                          <Select.Item value="exact">{t('exact', 'Exact')}</Select.Item>
+                          <Select.Item value="every">{t('every', 'Every')}</Select.Item>
+                          <Select.Item value="minimum">{t('minimum', 'Minimum')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -152,7 +152,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                 name="ruleValue"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-value')}</Form.Label>
+                    <Form.Label>{t('rule-value', 'Rule value')}</Form.Label>
                     <Form.Control>
                       <Input placeholder="0.00$" type="number" {...field} />
                     </Form.Control>
@@ -165,14 +165,14 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                 name="discountType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('discount-type')}</Form.Label>
+                    <Form.Label>{t('discount-type', 'Discount type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-discount-type')} />
+                          <Select.Value placeholder={t('choose-discount-type', 'Choose discount type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {DISCOUNT_TYPES.map((option) => (
@@ -196,7 +196,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                   name="discountValue"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
@@ -217,7 +217,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                   name="bonusProductId"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <SelectProduct
                           mode="single"
@@ -237,14 +237,14 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                 name="priceAdjustType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-type')}</Form.Label>
+                    <Form.Label>{t('price-adjust-type', 'Price adjust type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-type')} />
+                          <Select.Value placeholder={t('choose-type', 'Choose type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {PRICE_ADJUST_TYPES.map((option) => (
@@ -267,7 +267,7 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
                 name="priceAdjustFactor"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-factor')}</Form.Label>
+                    <Form.Label>{t('price-adjust-factor', 'Price adjust factor')}</Form.Label>
                     <Form.Control>
                       <Input placeholder="0" type="number" {...field} />
                     </Form.Control>
@@ -277,9 +277,9 @@ export const PriceRuleSheet: React.FC<PriceRuleSheetProps> = ({
 
               <div className="flex gap-2 justify-end pt-4">
                 <Button type="button" variant="outline" onClick={handleClose}>
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
-                <Button type="submit">{t('save')}</Button>
+                <Button type="submit">{t('save', 'Save')}</Button>
               </div>
             </form>
           </Form>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/quantity/QuantityInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/quantity/QuantityInfo.tsx
@@ -20,12 +20,12 @@ export function QuantityInfo(props: QuantityInfoProps) {
   return (
     <PricingRuleInfo<QuantityRuleConfig>
       {...props}
-      title={t('quantity')}
+      title={t('quantity', 'Quantity')}
       rulesKey="quantityRules"
       enabledKey="isQuantityEnabled"
-      successTitle={t('quantity-rules-updated')}
-      errorTitle={t('failed-to-update-quantity-rules')}
-      emptyMessage={<>{t('no-quantity-rules')}</>}
+      successTitle={t('quantity-rules-updated', 'Quantity rules updated')}
+      errorTitle={t('failed-to-update-quantity-rules', 'Failed to update quantity rules')}
+      emptyMessage={<>{t('no-quantity-rules', 'No quantity rules yet. Click "Add rule" to add one.')}</>}
       RuleSheet={QuantityRuleSheet}
     />
   );

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/quantity/QuantityRuleSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/quantity/QuantityRuleSheet.tsx
@@ -102,7 +102,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
         <Sheet.Trigger asChild>
           <Button variant="outline">
             {' '}
-            <IconPlus size={16} className="mr-2" /> {t('add-rule')}
+            <IconPlus size={16} className="mr-2" /> {t('add-rule', 'Add rule')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -110,7 +110,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
           <Sheet.Title>
-            {isEditing ? t('edit-quantity-rule') : t('add-quantity-rule')}
+            {isEditing ? t('edit-quantity-rule', 'Edit quantity rule') : t('add-quantity-rule', 'Add quantity rule')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -127,19 +127,19 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                 name="ruleType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-type')}</Form.Label>
+                    <Form.Label>{t('rule-type', 'Rule type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-rule-type')} />
+                          <Select.Value placeholder={t('choose-rule-type', 'Choose rule type')} />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="exact">{t('exact')}</Select.Item>
-                          <Select.Item value="every">{t('every')}</Select.Item>
-                          <Select.Item value="minimum">{t('minimum')}</Select.Item>
+                          <Select.Item value="exact">{t('exact', 'Exact')}</Select.Item>
+                          <Select.Item value="every">{t('every', 'Every')}</Select.Item>
+                          <Select.Item value="minimum">{t('minimum', 'Minimum')}</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -152,7 +152,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                 name="ruleValue"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('rule-value')}</Form.Label>
+                    <Form.Label>{t('rule-value', 'Rule value')}</Form.Label>
                     <Form.Control>
                       <Input placeholder="0" type="number" {...field} />
                     </Form.Control>
@@ -165,14 +165,14 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                 name="discountType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('discount-type')}</Form.Label>
+                    <Form.Label>{t('discount-type', 'Discount type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-discount-type')} />
+                          <Select.Value placeholder={t('choose-discount-type', 'Choose discount type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {DISCOUNT_TYPES.map((option) => (
@@ -196,7 +196,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                   name="discountValue"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <Input
                           type="number"
@@ -217,7 +217,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                   name="bonusProductId"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('discount-value')}</Form.Label>
+                      <Form.Label>{t('discount-value', 'Discount value')}</Form.Label>
                       <Form.Control>
                         <SelectProduct
                           mode="single"
@@ -237,14 +237,14 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                 name="priceAdjustType"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-type')}</Form.Label>
+                    <Form.Label>{t('price-adjust-type', 'Price adjust type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger className="w-full">
-                          <Select.Value placeholder={t('choose-type')} />
+                          <Select.Value placeholder={t('choose-type', 'Choose type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {PRICE_ADJUST_TYPES.map((option) => (
@@ -267,7 +267,7 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
                 name="priceAdjustFactor"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('price-adjust-factor')}</Form.Label>
+                    <Form.Label>{t('price-adjust-factor', 'Price adjust factor')}</Form.Label>
                     <Form.Control>
                       <Input placeholder="0" type="number" {...field} />
                     </Form.Control>
@@ -277,9 +277,9 @@ export const QuantityRuleSheet: React.FC<QuantityRuleSheetProps> = ({
 
               <div className="flex gap-2 justify-end pt-4">
                 <Button type="button" variant="outline" onClick={handleClose}>
-                  {t('cancel')}
+                  {t('cancel', 'Cancel')}
                 </Button>
-                <Button type="submit">{t('save')}</Button>
+                <Button type="submit">{t('save', 'Save')}</Button>
               </div>
             </form>
           </Form>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/repeat/RepeatInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/repeat/RepeatInfo.tsx
@@ -80,7 +80,7 @@ export const RepeatInfo: React.FC<RepeatInfoProps> = ({ pricingDetail }) => {
 
   return (
     <div className="p-6 space-y-4">
-      <InfoCard title={t('repeat')}>
+      <InfoCard title={t('repeat', 'Repeat')}>
         <InfoCard.Content className="space-y-4">
           <div className="flex justify-end">
             <RepeatRuleSheet
@@ -93,7 +93,7 @@ export const RepeatInfo: React.FC<RepeatInfoProps> = ({ pricingDetail }) => {
 
           {rules.length === 0 ? (
             <div className="py-6 text-sm text-center text-muted-foreground">
-              {t('no-repeat-rules')}
+              {t('no-repeat-rules', 'No repeat rules yet. Click "Add rule" to add one.')}
             </div>
           ) : (
             <div className="space-y-2">
@@ -108,7 +108,7 @@ export const RepeatInfo: React.FC<RepeatInfoProps> = ({ pricingDetail }) => {
                     <Button
                       variant="outline"
                       size="icon"
-                      aria-label={t('edit-repeat-rule')}
+                      aria-label={t('edit-repeat-rule', 'Edit repeat rule')}
                       onClick={() => setEditingRule(rule)}
                     >
                       <IconEdit size={14} />
@@ -117,7 +117,7 @@ export const RepeatInfo: React.FC<RepeatInfoProps> = ({ pricingDetail }) => {
                       variant="outline"
                       size="icon"
                       className="text-destructive"
-                      aria-label={t('delete-repeat-rule')}
+                      aria-label={t('delete-repeat-rule', 'Delete repeat rule')}
                       onClick={() => handleRuleDelete(rule)}
                     >
                       <IconTrash size={14} />

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/repeat/RepeatRuleSheet.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/repeat/RepeatRuleSheet.tsx
@@ -161,7 +161,7 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
       {!isEditing && (
         <Sheet.Trigger asChild>
           <Button type="button" variant="outline">
-            <IconPlus size={16} className="mr-2" /> {t('add-rule')}
+            <IconPlus size={16} className="mr-2" /> {t('add-rule', 'Add rule')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -169,7 +169,7 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
       <Sheet.View className="flex-col h-full p-0 sm:max-w-xl">
         <Sheet.Header>
           <Sheet.Title>
-            {isEditing ? t('edit-repeat-rule') : t('add-repeat-rule')}
+            {isEditing ? t('edit-repeat-rule', 'Edit repeat rule') : t('add-repeat-rule', 'Add repeat rule')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -190,27 +190,27 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                   name="ruleType"
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('rule-type')}</Form.Label>
+                      <Form.Label>{t('rule-type', 'Rule type')}</Form.Label>
                       <Form.Control>
                         <Select
                           value={field.value}
                           onValueChange={field.onChange}
                         >
                           <Select.Trigger className="w-full">
-                            <Select.Value placeholder={t('choose-rule-type')} />
+                            <Select.Value placeholder={t('choose-rule-type', 'Choose rule type')} />
                           </Select.Trigger>
                           <Select.Content>
                             <Select.Item value="everyDay">
-                              {t('every-day')}
+                              {t('every-day', 'Every Day')}
                             </Select.Item>
                             <Select.Item value="everyWeek">
-                              {t('every-week')}
+                              {t('every-week', 'Every Week')}
                             </Select.Item>
                             <Select.Item value="everyMonth">
-                              {t('every-month')}
+                              {t('every-month', 'Every Month')}
                             </Select.Item>
                             <Select.Item value="everyYear">
-                              {t('every-year')}
+                              {t('every-year', 'Every Year')}
                             </Select.Item>
                           </Select.Content>
                         </Select>
@@ -227,11 +227,11 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                       name="startDate"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('start-date')}</Form.Label>
+                          <Form.Label>{t('start-date', 'Start Date')}</Form.Label>
                           <Form.Control>
                             <DatePicker
                               value={parseDateValue(field.value)}
-                              placeholder={t('select-start-date')}
+                              placeholder={t('select-start-date', 'Select start date')}
                               onChange={(value) =>
                                 field.onChange(
                                   formatDateValue(
@@ -250,11 +250,11 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                       name="endDate"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('end-date')}</Form.Label>
+                          <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                           <Form.Control>
                             <DatePicker
                               value={parseDateValue(field.value)}
-                              placeholder={t('select-end-date')}
+                              placeholder={t('select-end-date', 'Select end date')}
                               onChange={(value) =>
                                 field.onChange(
                                   formatDateValue(
@@ -277,7 +277,7 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                       name="startTime"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('start-time')}</Form.Label>
+                          <Form.Label>{t('start-time', 'Start Time')}</Form.Label>
                           <Form.Control>
                             <PricingTimeSelect
                               value={field.value || null}
@@ -295,7 +295,7 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                       name="endTime"
                       render={({ field }) => (
                         <Form.Item>
-                          <Form.Label>{t('end-time')}</Form.Label>
+                          <Form.Label>{t('end-time', 'End Time')}</Form.Label>
                           <Form.Control>
                             <PricingTimeSelect
                               value={field.value || null}
@@ -316,14 +316,14 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                     name="weekDay"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('rule-value')}</Form.Label>
+                        <Form.Label>{t('rule-value', 'Rule value')}</Form.Label>
                         <Form.Control>
                           <Select
                             value={field.value || ''}
                             onValueChange={field.onChange}
                           >
                             <Select.Trigger className="w-full">
-                              <Select.Value placeholder={t('select-a-weekday')} />
+                              <Select.Value placeholder={t('select-a-weekday', 'Select a weekday')} />
                             </Select.Trigger>
                             <Select.Content>
                               {WEEK_DAYS.map((day) => (
@@ -345,14 +345,14 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
                     name="monthDay"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('rule-value')}</Form.Label>
+                        <Form.Label>{t('rule-value', 'Rule value')}</Form.Label>
                         <Form.Control>
                           <Select
                             value={field.value || ''}
                             onValueChange={field.onChange}
                           >
                             <Select.Trigger className="w-full">
-                              <Select.Value placeholder={t('select-a-day')} />
+                              <Select.Value placeholder={t('select-a-day', 'Select a day')} />
                             </Select.Trigger>
                             <Select.Content>
                               {MONTH_DAYS.map((day) => (
@@ -372,9 +372,9 @@ export const RepeatRuleSheet: React.FC<RepeatRuleSheetProps> = ({
 
             <Sheet.Footer className="px-6 py-4 bg-background">
               <Button type="button" variant="outline" onClick={handleClose}>
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
-              <Button type="submit">{t('save')}</Button>
+              <Button type="submit">{t('save', 'Save')}</Button>
             </Sheet.Footer>
           </form>
         </Form>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/CommonRuleInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/CommonRuleInfo.tsx
@@ -122,13 +122,13 @@ export const CommonRuleInfo = ({
       form.reset(values);
 
       toast({
-        title: t('common-rule-updated'),
-        description: t('changes-saved'),
+        title: t('common-rule-updated', 'Common rule updated'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
-        title: t('failed-to-update-common-rule'),
-        description: t('unexpected-error'),
+        title: t('failed-to-update-common-rule', 'Failed to update common rule'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -147,7 +147,7 @@ export const CommonRuleInfo = ({
           size="sm"
           disabled={loading}
         >
-          {loading ? t('saving') : t('save-changes')}
+          {loading ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
         </Button>
       ) : null,
     );
@@ -168,11 +168,11 @@ export const CommonRuleInfo = ({
           name="discountType"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('discount-type')}</Form.Label>
+              <Form.Label>{t('discount-type', 'Discount type')}</Form.Label>
               <Form.Control>
                 <Select value={field.value} onValueChange={field.onChange}>
                   <Select.Trigger>
-                    <Select.Value placeholder={t('select-discount-type')} />
+                    <Select.Value placeholder={t('select-discount-type', 'Select discount type')} />
                   </Select.Trigger>
                   <Select.Content>
                     {DISCOUNT_TYPES.map((option) => (
@@ -195,7 +195,7 @@ export const CommonRuleInfo = ({
               render={({ field }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t('discount-value')}{' '}
+                    {t('discount-value', 'Discount value')}{' '}
                     <span className="text-destructive">*</span>
                   </Form.Label>
                   <Form.Control>
@@ -216,11 +216,11 @@ export const CommonRuleInfo = ({
               name="priceAdjustType"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('price-adjust-type')}</Form.Label>
+                  <Form.Label>{t('price-adjust-type', 'Price adjust type')}</Form.Label>
                   <Form.Control>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <Select.Trigger>
-                        <Select.Value placeholder={t('none')} />
+                        <Select.Value placeholder={t('none', 'None')} />
                       </Select.Trigger>
                       <Select.Content>
                         {PRICE_ADJUST_TYPES.map((option) => (
@@ -240,7 +240,7 @@ export const CommonRuleInfo = ({
               name="priceAdjustFactor"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('price-adjust-factor')}</Form.Label>
+                  <Form.Label>{t('price-adjust-factor', 'Price adjust factor')}</Form.Label>
                   <Form.Control>
                     <Input
                       type="number"
@@ -260,7 +260,7 @@ export const CommonRuleInfo = ({
                 name="bonusProductId"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('bonus-product')}</Form.Label>
+                    <Form.Label>{t('bonus-product', 'Bonus Product')}</Form.Label>
                     <Form.Control>
                       <SelectProduct
                         value={field.value || ''}
@@ -293,7 +293,7 @@ export const CommonRuleInfo = ({
   }
 
   return (
-    <InfoCard title={t('common')}>
+    <InfoCard title={t('common', 'Common')}>
       <InfoCard.Content>{content}</InfoCard.Content>
     </InfoCard>
   );

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/PricingRuleInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/PricingRuleInfo.tsx
@@ -197,12 +197,12 @@ export const PricingRuleInfo = <T extends PricingRuleConfig>({
       setHasChanges(false);
       toast({
         title: successTitle,
-        description: t('changes-saved'),
+        description: t('changes-saved', 'Changes have been saved successfully.'),
       });
     } catch {
       toast({
         title: errorTitle,
-        description: t('unexpected-error'),
+        description: t('unexpected-error', 'An unexpected error occurred.'),
         variant: 'destructive',
       });
     }
@@ -231,7 +231,7 @@ export const PricingRuleInfo = <T extends PricingRuleConfig>({
           onClick={handleSaveAll}
           disabled={loading}
         >
-          {loading ? t('saving') : t('save-changes')}
+          {loading ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
         </Button>
       ) : null,
     );
@@ -261,13 +261,13 @@ export const PricingRuleInfo = <T extends PricingRuleConfig>({
       ) : (
         <div className="space-y-2">
           <div className="flex flex-1 px-3 text-sm font-medium text-muted-foreground">
-            <div className="flex-1">{t('rule-type')}</div>
-            <div className="flex-1">{t('rule-value')}</div>
-            <div className="flex-1">{t('discount-type')}</div>
-            <div className="flex-1">{t('discount-value')}</div>
-            <div className="flex-1">{t('price-adjust-type')}</div>
-            <div className="flex-1">{t('price-adjust-factor')}</div>
-            <div className="w-20 text-center">{t('actions')}</div>
+            <div className="flex-1">{t('rule-type', 'Rule type')}</div>
+            <div className="flex-1">{t('rule-value', 'Rule value')}</div>
+            <div className="flex-1">{t('discount-type', 'Discount type')}</div>
+            <div className="flex-1">{t('discount-value', 'Discount value')}</div>
+            <div className="flex-1">{t('price-adjust-type', 'Price adjust type')}</div>
+            <div className="flex-1">{t('price-adjust-factor', 'Price adjust factor')}</div>
+            <div className="w-20 text-center">{t('actions', 'Actions')}</div>
           </div>
 
           {rules.map((rule) => (

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/RulesInfo.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/edit-pricing/components/rules/RulesInfo.tsx
@@ -142,7 +142,7 @@ export const RulesInfo = ({
 
   return (
     <div className="p-6">
-      <InfoCard title={t('rules')}>
+      <InfoCard title={t('rules', 'Rules')}>
         <InfoCard.Content className="space-y-4">
           <Tabs value={currentRule} onValueChange={handleTabChange}>
             <Tabs.List className="w-fit">

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectBoard.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectBoard.tsx
@@ -76,13 +76,13 @@ const SelectBoardValue = ({ placeholder }: { placeholder?: string }) => {
   const { value, boards, loading } = useSelectBoardContext();
 
   if (loading) {
-    return <span className="text-accent-foreground/80">{t('loading-boards')}</span>;
+    return <span className="text-accent-foreground/80">{t('loading-boards', 'Loading boards...')}</span>;
   }
 
   if (!boards || boards.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-board')}
+        {placeholder || t('select-board', 'Select board')}
       </span>
     );
   }
@@ -92,7 +92,7 @@ const SelectBoardValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedBoard) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-board')}
+        {placeholder || t('select-board', 'Select board')}
       </span>
     );
   }
@@ -132,7 +132,7 @@ const SelectBoardContent = () => {
       <Command.List>
         <Command.Empty>
           <div className="text-muted-foreground">
-            {loading ? t('loading-boards') : t('no-boards-found')}
+            {loading ? t('loading-boards', 'Loading boards...') : t('no-boards-found', 'No boards found')}
           </div>
         </Command.Empty>
         {boards?.map((board) => (

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectPipeline.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectPipeline.tsx
@@ -83,14 +83,14 @@ const SelectPipelineValue = ({ placeholder }: { placeholder?: string }) => {
 
   if (loading) {
     return (
-      <span className="text-accent-foreground/80">{t('loading-pipelines')}</span>
+      <span className="text-accent-foreground/80">{t('loading-pipelines', 'Loading pipelines...')}</span>
     );
   }
 
   if (!pipelines || pipelines.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-pipeline')}
+        {placeholder || t('select-pipeline', 'Select pipeline')}
       </span>
     );
   }
@@ -102,7 +102,7 @@ const SelectPipelineValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedPipeline) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-pipeline')}
+        {placeholder || t('select-pipeline', 'Select pipeline')}
       </span>
     );
   }
@@ -138,10 +138,10 @@ const SelectPipelineContent = () => {
   const { t } = useTranslation('loyalty');
   const { pipelines, boardId, loading } = useSelectPipelineContext();
   const emptyMessage = loading
-    ? t('loading-pipelines')
+    ? t('loading-pipelines', 'Loading pipelines...')
     : boardId
-    ? t('no-pipelines-found')
-    : t('board-not-selected');
+    ? t('no-pipelines-found', 'No pipelines found')
+    : t('board-not-selected', 'Board not selected');
   return (
     <Command>
       <Command.List>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectStage.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/hooks/useSelectStage.tsx
@@ -80,13 +80,13 @@ const SelectStageValue = ({ placeholder }: { placeholder?: string }) => {
   const { value, stages, loading } = useSelectStageContext();
 
   if (loading) {
-    return <span className="text-accent-foreground/80">{t('loading-stages')}</span>;
+    return <span className="text-accent-foreground/80">{t('loading-stages', 'Loading stages...')}</span>;
   }
 
   if (!stages || stages.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-stage')}
+        {placeholder || t('select-stage', 'Select stage')}
       </span>
     );
   }
@@ -96,7 +96,7 @@ const SelectStageValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedStage) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-stage')}
+        {placeholder || t('select-stage', 'Select stage')}
       </span>
     );
   }
@@ -132,10 +132,10 @@ const SelectStageContent = () => {
   const { t } = useTranslation('loyalty');
   const { stages, pipelineId, loading } = useSelectStageContext();
   const emptyMessage = loading
-    ? t('loading-stages')
+    ? t('loading-stages', 'Loading stages...')
     : pipelineId
-    ? t('no-stages-found')
-    : t('pipeline-not-selected');
+    ? t('no-stages-found', 'No stages found')
+    : t('pipeline-not-selected', 'Pipeline not selected');
   return (
     <Command>
       <Command.List>

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/AssignmentPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/AssignmentPage.tsx
@@ -15,7 +15,7 @@ const AssignmentHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/assignment">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <AssignmentAddModal />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/CouponPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/CouponPage.tsx
@@ -16,7 +16,7 @@ const CouponHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/coupon">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <Export pluginName="loyalty" moduleName="coupon" collectionName="coupon" />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/DonatePage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/DonatePage.tsx
@@ -15,7 +15,7 @@ const DonateHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/donate">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <DonateAddSheet />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/LotteryPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/LotteryPage.tsx
@@ -15,7 +15,7 @@ const LotteryHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/lottery">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <LotteryAddSheet />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/ScorePage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/ScorePage.tsx
@@ -16,7 +16,7 @@ const ScoreHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/score">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <GiveScoreModal />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/SpinPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/SpinPage.tsx
@@ -15,7 +15,7 @@ const SpinHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/spin">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <SpinAddSheet />

--- a/frontend/plugins/loyalty_ui/src/pages/loyalties/VoucherPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/loyalties/VoucherPage.tsx
@@ -15,7 +15,7 @@ const VoucherHeaderActions = () => {
       <Button variant="outline" size="sm" asChild>
         <Link to="/settings/loyalty/config/voucher">
           <IconSettings className="size-4" />
-          {t('go-to-settings')}
+          {t('go-to-settings', 'Go to settings')}
         </Link>
       </Button>
       <VoucherAddSheet />

--- a/frontend/plugins/loyalty_ui/src/pages/pricing/PricingEditPage.tsx
+++ b/frontend/plugins/loyalty_ui/src/pages/pricing/PricingEditPage.tsx
@@ -34,7 +34,7 @@ export const PricingEditPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/settings/loyalty/pricing">
                     <IconCoins />
-                    {t('pricing')}
+                    {t('pricing', 'Pricing')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>
@@ -45,8 +45,8 @@ export const PricingEditPage = () => {
                     <Select.Value
                       placeholder={
                         loading
-                          ? t('loading')
-                          : currentPricing?.name || t('select-pricing')
+                          ? t('loading', 'Loading...')
+                          : currentPricing?.name || t('select-pricing', 'Select Pricing')
                       }
                     />
                   </Select.Trigger>

--- a/frontend/plugins/loyalty_ui/src/widgets/automations/components/AutomationRemoteEntry.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/automations/components/AutomationRemoteEntry.tsx
@@ -25,10 +25,10 @@ const AutomationRemoteErrorFallback = ({
   const { t } = useTranslation('loyalty');
   return (
     <div className="flex size-full flex-col items-center justify-center gap-3 p-4 text-center">
-      <p className="text-sm font-medium">{t('unable-to-load-loyalty-automation')}</p>
+      <p className="text-sm font-medium">{t('unable-to-load-loyalty-automation', 'Unable to load loyalty automation')}</p>
       <p className="text-xs text-accent-foreground">{error?.message}</p>
       <Button size="sm" variant="secondary" onClick={resetErrorBoundary}>
-        {t('try-again')}
+        {t('try-again', 'Try again')}
       </Button>
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/LoyaltyActionNodeContent.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/LoyaltyActionNodeContent.tsx
@@ -42,8 +42,8 @@ export const LoyaltyActionNodeContent = ({
           <IconReceipt className="size-3.5" />
         </span>
         <span>
-          {t('issue-voucher-using')}{' '}
-          {voucherCampaignId ? t('voucher-campaign') : t('no-campaign-selected')}
+          {t('issue-voucher-using', 'Issue voucher using')}{' '}
+          {voucherCampaignId ? t('voucher-campaign', 'Voucher Campaign') : t('no-campaign-selected', 'No campaign selected')}
         </span>
       </div>
     );
@@ -59,8 +59,8 @@ export const LoyaltyActionNodeContent = ({
           <IconTicket className="size-3.5" />
         </span>
         <span>
-          {t('award-spin-using')}{' '}
-          {spinCampaignId ? t('spin-campaign') : t('no-campaign-selected')}
+          {t('award-spin-using', 'Award spin using')}{' '}
+          {spinCampaignId ? t('spin-campaign', 'Spin Campaign') : t('no-campaign-selected', 'No campaign selected')}
         </span>
       </div>
     );
@@ -87,8 +87,8 @@ export const LoyaltyActionNodeContent = ({
         <Icon className="size-3.5" />
       </span>
       <span>
-        {SCORE_ACTION_LABELS[action]} {t('using')}{' '}
-        {campaignId ? t('score-campaign') : t('no-campaign-selected')}
+        {SCORE_ACTION_LABELS[action]} {t('using', 'using')}{' '}
+        {campaignId ? t('score-campaign', 'Score Campaign') : t('no-campaign-selected', 'No campaign selected')}
       </span>
     </div>
   );

--- a/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/adjust-score/AdjustScoreCampaignActionConfigForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/adjust-score/AdjustScoreCampaignActionConfigForm.tsx
@@ -51,7 +51,7 @@ export const AdjustScoreCampaignActionConfigForm = ({
           name="attribution"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('recipient')}</Form.Label>
+              <Form.Label>{t('recipient', 'Recipient')}</Form.Label>
               <PlaceholderInput
                 propertyType={targetType}
                 value={field.value}
@@ -76,11 +76,11 @@ export const AdjustScoreCampaignActionConfigForm = ({
           name="campaignId"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('score-campaign')}</Form.Label>
+              <Form.Label>{t('score-campaign', 'Score Campaign')}</Form.Label>
               <SelectScoreCampaign.FormItem
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-score-campaign')}
+                placeholder={t('select-score-campaign', 'Select score campaign')}
               />
               <Form.Message />
             </Form.Item>
@@ -92,7 +92,7 @@ export const AdjustScoreCampaignActionConfigForm = ({
           name="action"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('score-change')}</Form.Label>
+              <Form.Label>{t('score-change', 'Score change')}</Form.Label>
               <Form.Control>
                 <ToggleGroup
                   type="single"

--- a/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/spin/AwardSpinActionConfigForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/spin/AwardSpinActionConfigForm.tsx
@@ -48,7 +48,7 @@ export const AwardSpinActionConfigForm = ({
           name="attribution"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('recipient')}</Form.Label>
+              <Form.Label>{t('recipient', 'Recipient')}</Form.Label>
               <PlaceholderInput
                 propertyType={targetType}
                 value={field.value}
@@ -73,11 +73,11 @@ export const AwardSpinActionConfigForm = ({
           name="spinCampaignId"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('spin-campaign')}</Form.Label>
+              <Form.Label>{t('spin-campaign', 'Spin Campaign')}</Form.Label>
               <SelectSpinCampaign.FormItem
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-spin-campaign')}
+                placeholder={t('select-spin-campaign', 'Select spin campaign')}
               />
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/voucher/IssueVoucherActionConfigForm.tsx
+++ b/frontend/plugins/loyalty_ui/src/widgets/automations/modules/loyalty/components/action/voucher/IssueVoucherActionConfigForm.tsx
@@ -48,7 +48,7 @@ export const IssueVoucherActionConfigForm = ({
           name="attribution"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('recipient')}</Form.Label>
+              <Form.Label>{t('recipient', 'Recipient')}</Form.Label>
               <PlaceholderInput
                 propertyType={targetType}
                 value={field.value}
@@ -73,11 +73,11 @@ export const IssueVoucherActionConfigForm = ({
           name="voucherCampaignId"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('voucher-campaign')}</Form.Label>
+              <Form.Label>{t('voucher-campaign', 'Voucher Campaign')}</Form.Label>
               <SelectVoucherCampaign.FormItem
                 value={field.value}
                 onValueChange={field.onChange}
-                placeholder={t('select-voucher-campaign')}
+                placeholder={t('select-voucher-campaign', 'Select voucher campaign')}
               />
               <Form.Message />
             </Form.Item>


### PR DESCRIPTION
Adds fallback text to translation calls across the loyalties (agents, assignments, components, coupons, donates, lotteries, scores, settings, spin, vouchers), pricing, widgets, and pages modules so missing keys degrade to readable English instead of the raw key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added reliable English fallback text across loyalty and pricing screens, including labels, placeholders, empty states, buttons, filters, dialogs, and notifications.
  * Improved selected-item count and deletion messages with clearer count interpolation.
* **Form Improvements**
  * Added required-field validation and clearer required indicators in several loyalty forms.
* **Usability**
  * Improved date, campaign, status, owner, and product selection prompts when translations are unavailable.
  * Improved handling of invalid or missing dates in pricing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->