### PR TITLE
fix(payment): persist TDB order details for callback processing

### DIFF
--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -60,9 +60,20 @@ export const loadInvoiceClass = (models: IModels) => {
         try {
           const response = await api.createInvoice(transaction.toObject());
           transaction.response = response;
-          transaction.details = {
-            ...transaction.details,
-          };
+          if (payment.kind === 'tdb') {
+            const tdbResponse = response as {
+              order: {
+                id: number;
+                password: string;
+              };
+            };
+
+            transaction.details = {
+              ...transaction.details,
+              tdbOrderId: tdbResponse.order.id,
+              tdbPassword: tdbResponse.order.password,
+            };
+          }
           await transaction.save();
 
           return invoice;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Store TDB order ID and password in transaction details when creating invoices for TDB payments to ensure callbacks have required data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment transactions now store TDB order details when a TDB payment is created, helping preserve the information needed to complete or reference the payment later.
  * Improved handling for this payment type so transaction data is saved with the correct payment-specific values instead of remaining empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->