### PR TITLE
fix(erxes-ui): resolve gallery image urls through blocknote file resolver

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -138,19 +138,15 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
     updateBlock({ columns: String(n) });
   };
 
-  const uploadButtonLabel = uploading
-    ? 'Uploading...'
-    : images.length === 0
-      ? 'Add images to gallery'
-      : 'Add more';
-
-  const uploadButtonIcon = uploading ? (
-    <IconLoader2 size={15} className="animate-spin" />
-  ) : images.length === 0 ? (
-    <IconPhoto size={15} />
-  ) : (
-    <IconPlus size={15} />
-  );
+  let uploadButtonLabel = 'Add more';
+  let uploadButtonIcon = <IconPlus size={15} />;
+  if (uploading) {
+    uploadButtonLabel = 'Uploading...';
+    uploadButtonIcon = <IconLoader2 size={15} className="animate-spin" />;
+  } else if (images.length === 0) {
+    uploadButtonLabel = 'Add images to gallery';
+    uploadButtonIcon = <IconPhoto size={15} />;
+  }
 
   if (readonly && images.length === 0) return null;
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -6,6 +6,7 @@ import {
 import {
   createReactBlockSpec,
   ReactCustomBlockRenderProps,
+  useResolveUrl,
 } from '@blocknote/react';
 import { IconLayoutGrid, IconPhoto, IconPlus, IconX, IconLoader2 } from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
@@ -45,6 +46,43 @@ const parseImages = (raw: string): GalleryImage[] => {
   } catch {
     return [];
   }
+};
+
+const GalleryImage: FC<{
+  image: GalleryImage;
+  readonly: boolean;
+  onRemove: () => void;
+}> = ({ image, readonly, onRemove }) => {
+  const { downloadUrl } = useResolveUrl(image.url);
+  const src = downloadUrl ?? image.url;
+
+  return (
+    <div className="relative group aspect-square overflow-hidden rounded-md bg-muted">
+      <img
+        src={src}
+        alt={image.caption ?? ''}
+        className="w-full h-full object-cover"
+        draggable={false}
+      />
+      {!readonly && (
+        <button
+          type="button"
+          className="absolute top-1 right-1 flex items-center justify-center w-5 h-5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onRemove();
+          }}
+        >
+          <IconX size={12} />
+        </button>
+      )}
+      {image.caption && (
+        <div className="absolute bottom-0 inset-x-0 bg-black/50 text-white text-xs px-1.5 py-0.5 truncate">
+          {image.caption}
+        </div>
+      )}
+    </div>
+  );
 };
 
 const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
@@ -94,34 +132,12 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
           style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
         >
           {images.map((img, i) => (
-            <div
+            <GalleryImage
               key={i}
-              className="relative group aspect-square overflow-hidden rounded-md bg-muted"
-            >
-              <img
-                src={img.url}
-                alt={img.caption ?? ''}
-                className="w-full h-full object-cover"
-                draggable={false}
-              />
-              {!readonly && (
-                <button
-                  type="button"
-                  className="absolute top-1 right-1 flex items-center justify-center w-5 h-5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    removeImage(i);
-                  }}
-                >
-                  <IconX size={12} />
-                </button>
-              )}
-              {img.caption && (
-                <div className="absolute bottom-0 inset-x-0 bg-black/50 text-white text-xs px-1.5 py-0.5 truncate">
-                  {img.caption}
-                </div>
-              )}
-            </div>
+              image={img}
+              readonly={readonly}
+              onRemove={() => removeImage(i)}
+            />
           ))}
         </div>
       )}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -17,6 +17,7 @@ import {
 } from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
+import { Spinner } from 'erxes-ui/components';
 
 export interface GalleryImage {
   url: string;
@@ -59,17 +60,24 @@ const GalleryImage: FC<{
   readonly: boolean;
   onRemove: () => void;
 }> = ({ image, readonly, onRemove }) => {
-  const { downloadUrl } = useResolveUrl(image.url);
+  const { loadingState, downloadUrl } = useResolveUrl(image.url);
+  const isResolving = loadingState === 'loading';
   const src = downloadUrl ?? image.url;
 
   return (
     <div className="relative group aspect-square overflow-hidden rounded-md bg-muted">
-      <img
-        src={src}
-        alt={image.caption ?? ''}
-        className="w-full h-full object-cover"
-        draggable={false}
-      />
+      {isResolving ? (
+        <div className="flex h-full w-full items-center justify-center">
+          <Spinner size="sm" />
+        </div>
+      ) : (
+        <img
+          src={src}
+          alt={image.caption ?? ''}
+          className="w-full h-full object-cover"
+          draggable={false}
+        />
+      )}
       {!readonly && (
         <button
           type="button"

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -144,6 +144,14 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
       ? 'Add images to gallery'
       : 'Add more';
 
+  const uploadButtonIcon = uploading ? (
+    <IconLoader2 size={15} className="animate-spin" />
+  ) : images.length === 0 ? (
+    <IconPhoto size={15} />
+  ) : (
+    <IconPlus size={15} />
+  );
+
   if (readonly && images.length === 0) return null;
 
   return (
@@ -188,13 +196,7 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
                 if (!uploading) inputRef.current?.click();
               }}
             >
-              {uploading ? (
-                <IconLoader2 size={15} className="animate-spin" />
-              ) : images.length === 0 ? (
-                <IconPhoto size={15} />
-              ) : (
-                <IconPlus size={15} />
-              )}
+              {uploadButtonIcon}
               <span>{uploadButtonLabel}</span>
             </button>
           ) : (

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -138,6 +138,12 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
     updateBlock({ columns: String(n) });
   };
 
+  const uploadButtonLabel = uploading
+    ? 'Uploading...'
+    : images.length === 0
+      ? 'Add images to gallery'
+      : 'Add more';
+
   if (readonly && images.length === 0) return null;
 
   return (
@@ -149,7 +155,7 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
         >
           {images.map((img, i) => (
             <GalleryImage
-              key={i}
+              key={img.url}
               image={img}
               readonly={readonly}
               onRemove={() => removeImage(i)}
@@ -189,13 +195,7 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
               ) : (
                 <IconPlus size={15} />
               )}
-              <span>
-                {uploading
-                  ? 'Uploading...'
-                  : images.length === 0
-                    ? 'Add images to gallery'
-                    : 'Add more'}
-              </span>
+              <span>{uploadButtonLabel}</span>
             </button>
           ) : (
             images.length === 0 && (
@@ -253,9 +253,9 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
           : { display: 'none' }
       }
     >
-      {images.map((img, i) =>
+      {images.map((img) =>
         img.caption ? (
-          <figure key={i} style={{ margin: 0 }}>
+          <figure key={img.url} style={{ margin: 0 }}>
             <img
               src={img.url}
               alt={img.caption}
@@ -265,7 +265,7 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
           </figure>
         ) : (
           <img
-            key={i}
+            key={img.url}
             src={img.url}
             alt=""
             style={{ width: '100%', height: 'auto', display: 'block' }}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -8,7 +8,13 @@ import {
   ReactCustomBlockRenderProps,
   useResolveUrl,
 } from '@blocknote/react';
-import { IconLayoutGrid, IconPhoto, IconPlus, IconX, IconLoader2 } from '@tabler/icons-react';
+import {
+  IconLayoutGrid,
+  IconPhoto,
+  IconPlus,
+  IconX,
+  IconLoader2,
+} from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
 
@@ -115,7 +121,9 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
   };
 
   const removeImage = (index: number) => {
-    updateBlock({ images: JSON.stringify(images.filter((_, i) => i !== index)) });
+    updateBlock({
+      images: JSON.stringify(images.filter((_, i) => i !== index)),
+    });
   };
 
   const setColumns = (n: number) => {
@@ -173,7 +181,13 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
               ) : (
                 <IconPlus size={15} />
               )}
-              <span>{uploading ? 'Uploading...' : images.length === 0 ? 'Add images to gallery' : 'Add more'}</span>
+              <span>
+                {uploading
+                  ? 'Uploading...'
+                  : images.length === 0
+                    ? 'Add images to gallery'
+                    : 'Add more'}
+              </span>
             </button>
           ) : (
             images.length === 0 && (
@@ -234,11 +248,20 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
       {images.map((img, i) =>
         img.caption ? (
           <figure key={i} style={{ margin: 0 }}>
-            <img src={img.url} alt={img.caption} style={{ width: '100%', height: 'auto', display: 'block' }} />
+            <img
+              src={img.url}
+              alt={img.caption}
+              style={{ width: '100%', height: 'auto', display: 'block' }}
+            />
             <figcaption>{img.caption}</figcaption>
           </figure>
         ) : (
-          <img key={i} src={img.url} alt="" style={{ width: '100%', height: 'auto', display: 'block' }} />
+          <img
+            key={i}
+            src={img.url}
+            alt=""
+            style={{ width: '100%', height: 'auto', display: 'block' }}
+          />
         ),
       )}
     </div>


### PR DESCRIPTION
Summary
Gallery block images рендэрлэхэд broken/greyed зурагтай харагдаж байсныг зассан — local disk storage бүтэн URL биш зөвхөн key буцаадаг тул <img src> ажиллахгүй байв.
CustomImageBlock-д ашигладаг useResolveUrl шийдлийг Gallery block-д мөн адил хэрэглэсэн (per-image subcomponent-оор, учир нь .map() дотор hook шууд дуудаж болохгүй).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved gallery image handling by resolving each image’s download URL before display, with a loading spinner while resolving.
  * Enhanced caption rendering for gallery images, including clearer presentation in externally provided HTML content.

* **Bug Fixes**
  * Removed image controls now reliably remain hidden in read-only mode.
  * Gallery rendering is updated for more consistent behavior across standard and external HTML views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->