### PR TITLE
feat(core): store optional label on favorites and render labeled favorites in the sidebar

### DIFF
--- a/backend/core-api/src/modules/organization/settings/db/definitions/favorites.ts
+++ b/backend/core-api/src/modules/organization/settings/db/definitions/favorites.ts
@@ -5,6 +5,7 @@ export interface IFavorites {
   type: string;
   path: string;
   userId: string;
+  label?: string;
 }
 
 export interface IFavoritesDocument extends IFavorites, Document {
@@ -28,6 +29,9 @@ export const favoritesSchema = new Schema(
     userId: {
       type: String,
       required: true,
+    },
+    label: {
+      type: String,
     },
   },
   { timestamps: true },

--- a/backend/core-api/src/modules/organization/settings/db/models/Favorites.ts
+++ b/backend/core-api/src/modules/organization/settings/db/models/Favorites.ts
@@ -12,6 +12,7 @@ export interface IFavoritesModel extends Model<IFavoritesDocument> {
     type,
     path,
     userId,
+    label,
   }: IFavorites): Promise<IFavoritesDocument>;
   getFavorites({
     type,

--- a/backend/core-api/src/modules/organization/settings/graphql/favorites/mutations.ts
+++ b/backend/core-api/src/modules/organization/settings/graphql/favorites/mutations.ts
@@ -4,7 +4,7 @@ import { IFavorites } from '@/organization/settings/db/definitions/favorites';
 export const favoriteMutations = {
   toggleFavorite: async (
     _parent: undefined,
-    { type, path }: IFavorites,
+    { type, path, label }: IFavorites,
     { models, user }: IContext,
   ) => {
     const favorite = await models.Favorites.getFavorites({
@@ -24,6 +24,7 @@ export const favoriteMutations = {
         type,
         path,
         userId: user._id,
+        label,
       });
     }
   },

--- a/backend/core-api/src/modules/organization/settings/graphql/favorites/schemas.ts
+++ b/backend/core-api/src/modules/organization/settings/graphql/favorites/schemas.ts
@@ -3,6 +3,7 @@ export const types = `
     _id: String!
     type: String!
     path: String!
+    label: String
   }
 `;
 
@@ -12,5 +13,5 @@ export const queries = `
 `;
 
 export const mutations = `
-  toggleFavorite(type: String!, path: String!, ): Favorite
+  toggleFavorite(type: String!, path: String!, label: String, ): Favorite
 `;

--- a/frontend/core-ui/src/modules/navigation/components/SidebarNavigationFavorites.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/SidebarNavigationFavorites.tsx
@@ -10,8 +10,8 @@ export function SidebarNavigationFavorites() {
   return (
     <NavigationMenuGroup name={t('favorites')} separate={false}>
       <MyInboxNavigationItem />
-      {favorites.map((item) => {
-        return <SidebarNavigationFavoritesItem key={item.name} {...item} />;
+      {favorites.map(({ _id, ...item }) => {
+        return <SidebarNavigationFavoritesItem key={_id} {...item} />;
       })}
     </NavigationMenuGroup>
   );

--- a/frontend/core-ui/src/modules/navigation/graphql/queries/getFavorites.tsx
+++ b/frontend/core-ui/src/modules/navigation/graphql/queries/getFavorites.tsx
@@ -6,6 +6,7 @@ export const GET_FAVORITES = gql`
       _id
       type
       path
+      label
     }
   }
 `;

--- a/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { IconStar } from '@tabler/icons-react';
 import { GET_FAVORITES } from '@/navigation/graphql/queries/getFavorites';
 import { usePluginsModules } from '@/navigation/hooks/usePluginsModules';
 import { useAtomValue } from 'jotai';
@@ -8,9 +9,11 @@ interface Favorite {
   _id: string;
   type: 'module' | 'submenu';
   path: string;
+  label?: string | null;
 }
 
 interface FavoriteModule {
+  _id: string;
   name: string;
   icon?: React.ElementType;
   path: string;
@@ -31,6 +34,16 @@ export function useFavorites(): FavoriteModule[] {
   const favorites = data?.getFavoritesByCurrentUser ?? [];
 
   return favorites.reduce<FavoriteModule[]>((acc, favorite) => {
+    if (favorite.label) {
+      acc.push({
+        _id: favorite._id,
+        name: favorite.label,
+        icon: IconStar,
+        path: favorite.path,
+      });
+      return acc;
+    }
+
     if (favorite.type === 'module') {
       const module = modules?.find(
         (m) => m.path === favorite.path.replace('/', ''),
@@ -38,6 +51,7 @@ export function useFavorites(): FavoriteModule[] {
 
       if (module) {
         acc.push({
+          _id: favorite._id,
           name: module.name,
           icon: module.icon,
           path: module.path,


### PR DESCRIPTION
## What

Favorites records gain an optional stored `label`, and favorites that carry a label render directly in the sidebar Favorites section.

## Details

- **Data model**: `IFavorites` and the Mongoose `favoritesSchema` gain an optional `label` string. The `label` is threaded through `Favorites.create`, the `toggleFavorite` mutation, and the GraphQL `Favorite` type / `toggleFavorite` args (nullable — existing callers are unaffected).
- **Sidebar rendering**: `useFavorites` now short-circuits for labeled favorites, returning `{ name: label, icon: IconStar, path }` directly instead of doing a module-registry lookup. Label-less favorites keep their existing module-lookup behavior unchanged.
- **Keying**: `SidebarNavigationFavorites` now keys each item by `_id` instead of `name`, so two favorites can share a display name without a React key collision. `_id` is surfaced on the returned item type for this.

## Motivation

Today a favorite can only point at a whole module, whose name/icon are resolved from the module registry. Storing an optional label lets plugins favorite a *specific entity* (e.g. a single record's page) and give it a human-readable name in the sidebar, not just whole modules.

## Notes

- Backward compatible: `label` is optional everywhere; favorites created without it behave exactly as before.
- Scope: `backend/core-api` and `frontend/core-ui` only.

## Summary by Sourcery

Add optional labels to favorites and render labeled favorites directly in the sidebar, while improving favorites identification.

New Features:
- Persist an optional label on favorites in the backend data model and GraphQL API.
- Render labeled favorites in the sidebar using their stored label and a star icon without module lookups.

Enhancements:
- Key sidebar favorite items by backend `_id` rather than display name to avoid key collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorites can now include an optional label, which is shown in navigation and returned by the app.
  * Labeled favorites are displayed with a star icon and use the label as their visible name.

* **Bug Fixes**
  * Improved favorites handling so items render consistently with stable keys.
  * Favorites data is now passed through consistently across the app and API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->