### PR TITLE
feat(core-ui): render labeled favorites with a robot icon

### DIFF
--- a/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { IconStar } from '@tabler/icons-react';
+import { IconRobot } from '@tabler/icons-react';
 import { GET_FAVORITES } from '@/navigation/graphql/queries/getFavorites';
 import { usePluginsModules } from '@/navigation/hooks/usePluginsModules';
 import { useAtomValue } from 'jotai';
@@ -38,7 +38,7 @@ export function useFavorites(): FavoriteModule[] {
       acc.push({
         _id: favorite._id,
         name: favorite.label,
-        icon: IconStar,
+        icon: IconRobot,
         path: favorite.path,
       });
       return acc;


### PR DESCRIPTION
Labeled favorites (records that carry an explicit `label`) now render a robot icon in the sidebar instead of a star, distinguishing entity favorites from plain module favorites.

Single-file change: swaps the icon used in the labeled-favorite branch of `useFavorites`. Module favorites are unaffected.

- No API/schema changes
- No lockfile changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated the icon shown for labeled favorites in the navigation area to a robot-style icon.
  * Favorite items and overall behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->