### PR TITLE
fix: channels response create, similarities

### DIFF
--- a/frontend/core-ui/src/modules/products/bulk-similarity/components/SimilarityList.tsx
+++ b/frontend/core-ui/src/modules/products/bulk-similarity/components/SimilarityList.tsx
@@ -35,7 +35,9 @@ export const SimilarityList = ({ onNew }: SimilarityListProps) => {
         </Empty.Header>
         {onNew && (
           <Empty.Content>
-            <Button onClick={onNew}>{t('new-similarity', 'New similarity')}</Button>
+            <Button onClick={onNew}>
+              {t('new-similarity', 'New similarity')}
+            </Button>
           </Empty.Content>
         )}
       </Empty>
@@ -56,7 +58,10 @@ export const SimilarityList = ({ onNew }: SimilarityListProps) => {
             {loading && <RecordTable.RowSkeleton rows={10} />}
             {!loading && similarities.length > 0 && <RecordTable.RowList />}
             {!loading && hasMore && (
-              <RecordTable.RowSkeleton rows={1} handleInView={handleFetchMore} />
+              <RecordTable.RowSkeleton
+                rows={1}
+                handleInView={handleFetchMore}
+              />
             )}
           </RecordTable.Body>
         </RecordTable>

--- a/frontend/core-ui/src/modules/products/bulk-similarity/components/SimilarityList.tsx
+++ b/frontend/core-ui/src/modules/products/bulk-similarity/components/SimilarityList.tsx
@@ -12,7 +12,8 @@ interface SimilarityListProps {
 
 export const SimilarityList = ({ onNew }: SimilarityListProps) => {
   const { t } = useTranslation('product', { keyPrefix: 'bulk-similarity' });
-  const { similarities, loading } = useProductSimilarities();
+  const { similarities, loading, hasMore, handleFetchMore } =
+    useProductSimilarities();
   const similarityColumns = useMemo(() => createSimilarityColumns(t), [t]);
 
   if (!loading && !similarities.length) {
@@ -54,6 +55,9 @@ export const SimilarityList = ({ onNew }: SimilarityListProps) => {
           <RecordTable.Body>
             {loading && <RecordTable.RowSkeleton rows={10} />}
             {!loading && similarities.length > 0 && <RecordTable.RowList />}
+            {!loading && hasMore && (
+              <RecordTable.RowSkeleton rows={1} handleInView={handleFetchMore} />
+            )}
           </RecordTable.Body>
         </RecordTable>
       </RecordTable.Scroll>

--- a/frontend/core-ui/src/modules/products/bulk-similarity/hooks/useProductSimilarities.ts
+++ b/frontend/core-ui/src/modules/products/bulk-similarity/hooks/useProductSimilarities.ts
@@ -1,19 +1,68 @@
 import { useQuery } from '@apollo/client';
-import { PRODUCT_SIMILARITIES } from '../graphql/queries';
+import { useRef } from 'react';
+import {
+  PRODUCT_SIMILARITIES,
+  PRODUCT_SIMILARITIES_TOTAL_COUNT,
+} from '../graphql/queries';
 import { IProductSimilarity } from '../types';
 
+const DEFAULT_PER_PAGE = 30;
+
 export const useProductSimilarities = (variables?: {
-  page?: number;
   perPage?: number;
   searchValue?: string;
 }) => {
-  const { data, loading, refetch } = useQuery<{
+  const perPage = variables?.perPage || DEFAULT_PER_PAGE;
+  const searchValue = variables?.searchValue;
+
+  const pageRef = useRef(1);
+  const fetchingMoreRef = useRef(false);
+
+  const { data, loading, refetch, fetchMore } = useQuery<{
     productBulkSimilarities: IProductSimilarity[];
-  }>(PRODUCT_SIMILARITIES, { variables });
+  }>(PRODUCT_SIMILARITIES, {
+    variables: { page: 1, perPage, searchValue },
+  });
+
+  const { data: totalCountData } = useQuery<{
+    productBulkSimilaritiesTotalCount: number;
+  }>(PRODUCT_SIMILARITIES_TOTAL_COUNT, {
+    variables: { searchValue },
+  });
+
+  const similarities = data?.productBulkSimilarities || [];
+  const totalCount = totalCountData?.productBulkSimilaritiesTotalCount || 0;
+  const hasMore = similarities.length < totalCount;
+
+  const handleFetchMore = () => {
+    if (fetchingMoreRef.current || loading || !hasMore) return;
+
+    fetchingMoreRef.current = true;
+    const nextPage = pageRef.current + 1;
+
+    fetchMore({
+      variables: { page: nextPage, perPage, searchValue },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        pageRef.current = nextPage;
+        return {
+          productBulkSimilarities: [
+            ...prev.productBulkSimilarities,
+            ...fetchMoreResult.productBulkSimilarities,
+          ],
+        };
+      },
+    }).finally(() => {
+      fetchingMoreRef.current = false;
+    });
+  };
 
   return {
-    similarities: data?.productBulkSimilarities || [],
+    similarities,
     loading,
+    totalCount,
+    handleFetchMore,
+    hasMore,
     refetch,
   };
 };

--- a/frontend/plugins/frontline_ui/src/modules/channels/components/settings/breadcrumbs/ChannelSettingsBreadcrumb.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/components/settings/breadcrumbs/ChannelSettingsBreadcrumb.tsx
@@ -6,6 +6,7 @@ import { PipelineDetailBreadcrumb } from '@/pipelines/components/PipelineDetailB
 import { PipelineConfigBreadcrumb } from '@/pipelines/components/configs/components/PipelineConfigBreadcrumb';
 import { PipelinePermissionsBreadcrumb } from '@/pipelines/components/permissions/components/PipelinePermissionsBreadcrumb';
 import { ResponseDetailBreadcrumb } from '@/responseTemplate/components/ResponseDetailBreadcrumb';
+import { CreateResponse } from '@/responseTemplate/components/CreateResponse';
 import { TicketStatusesBreadcrumb } from '@/status/components/TicketStatusesBreadcrumb';
 import { FrontlinePaths } from '@/types/FrontlinePaths';
 import { IconCircles } from '@tabler/icons-react';
@@ -94,6 +95,11 @@ export const ChannelSettingsBreadcrumb = () => {
               {t('response-templates')}
             </Button>
           </Link>
+          {!isMatchingLocation(FrontlinePaths.ResponseDetail) && (
+            <span className="ml-auto">
+              <CreateResponse />
+            </span>
+          )}
         </>
       )}
       {isMatchingLocation(FrontlinePaths.ResponseDetail) && (


### PR DESCRIPTION
## Summary by Sourcery

Add infinite scrolling for product bulk similarities and expose quick creation of response templates from channel settings.

New Features:
- Support incremental loading of product bulk similarities with total count and fetch-more handling.
- Expose a Create Response action in channel response template settings when not viewing a specific response.

Enhancements:
- Update similarity list UI to render additional skeleton rows and trigger loading of more similarities as they come into view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “load more” pagination to product similarity lists, including automatic loading as more results come into view.
  * Displayed the total number of similarity results and a clearer end-of-list experience.
  * Added a quick action to create a response template from the channel settings breadcrumb path.

* **Bug Fixes**
  * Improved similarity list fetching so additional results append smoothly without disrupting the current list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->