### PR TITLE
call report

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/queries.ts
@@ -56,6 +56,24 @@ const callQueries = {
     return res;
   },
 
+  // Integrations list for the call reports page. Reports are read-only
+  // analytics over CDRs, so this is NOT restricted to operators — any
+  // logged-in user can view them. Only report-relevant fields are exposed;
+  // credentials and infrastructure details (token, operators, trunks,
+  // wsServer) never leave the API.
+  async callReportIntegrations(_root, _args, { models, user }: IContext) {
+    if (!user?._id) {
+      throw new Error('Login required');
+    }
+
+    return models.CallIntegrations.find(
+      {},
+      { inboxId: 1, phone: 1, queues: 1, queueNames: 1 },
+    )
+      .sort({ phone: 1 })
+      .lean<any[]>();
+  },
+
   async callsCustomerDetail(_root, { customerPhone }, { subdomain }: IContext) {
     const customer = await sendTRPCMessage({
       subdomain,
@@ -544,21 +562,14 @@ const callQueries = {
   async callGetQueueStats(
     _args,
     { startDate, endDate, queueId, direction },
-    { models, user }: IContext,
+    { models }: IContext,
   ) {
-    // const isAdmin =
-    //   user.isOwner || user.permissionGroupIds?.includes('frontline:admin');
-    const queues = await models.CallIntegrations.getIntegrationQueuesByUser(
-      user._id,
-    );
-
-    const isContainsQueue = true;
     const matchStage: any = {
       start: { $gte: new Date(startDate) },
       end: { $lte: new Date(endDate) },
     };
 
-    if (direction) {
+    if (direction && direction !== 'all') {
       matchStage.userfield = direction;
     }
 
@@ -601,7 +612,7 @@ const callQueries = {
 
       {
         $match: {
-          queue: isContainsQueue ? queueId : { $in: queues },
+          queue: queueId && queueId !== 'all' ? queueId : { $ne: null },
         },
       },
 
@@ -736,19 +747,9 @@ const callQueries = {
   async callGetAgentStats(
     _args,
     { startDate, endDate, queueId, agentId = null, direction },
-    { models, user }: IContext,
+    { models }: IContext,
   ) {
     if (!queueId) {
-      return [];
-    }
-    // const isAdmin =
-    //   user.isOwner || user.permissionGroupIds?.includes('frontline:admin');
-    const queues = await models.CallIntegrations.getIntegrationQueuesByUser(
-      user._id,
-    );
-
-    const isContainsQueue = queueId && queues.includes(queueId);
-    if (!isContainsQueue && queueId) {
       return [];
     }
 
@@ -758,7 +759,7 @@ const callQueries = {
       lastapp: 'Queue',
     };
 
-    if (direction) {
+    if (direction && direction !== 'all') {
       matchStage.userfield = direction;
     }
 
@@ -802,7 +803,7 @@ const callQueries = {
 
       {
         $match: {
-          queue: queueId ? queueId : { $ne: null },
+          queue: queueId && queueId !== 'all' ? queueId : { $ne: null },
           agent: agentId ? agentId : { $nin: [null, ''] },
           $expr: {
             $and: [
@@ -1001,7 +1002,7 @@ const callQueries = {
 
       {
         $match: {
-          queue: queueId ? queueId : { $ne: null },
+          queue: queueId && queueId !== 'all' ? queueId : { $ne: null },
         },
       },
 

--- a/backend/plugins/frontline_api/src/modules/integrations/call/graphql/schema/call.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/graphql/schema/call.ts
@@ -5,6 +5,7 @@ const integrationCommonFields = `
     wsServer: String
     operators: JSON
     queues: [String]
+    queueNames: [String]
     srcTrunk: String
     dstTrunk: String
 `;
@@ -328,6 +329,7 @@ export const queries = `
   callActiveSessions(inboxIntegrationId: String!, extension: String): [CallSession]
   callsIntegrationDetail(integrationId: String!): CallsIntegrationDetailResponse
   callUserIntegrations: [CallsIntegrationDetailResponse]
+  callReportIntegrations: [CallsIntegrationDetailResponse]
   callsCustomerDetail(customerPhone: String): Customer
   callsActiveSession: CallActiveSession
   callHistories(${filterParams}, skip: Int): [CallHistory]

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/graphql/queries/callConfigQueries.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/graphql/queries/callConfigQueries.ts
@@ -56,6 +56,18 @@ export const CALL_CUSTOMER_DETAIL = gql`
   }
 `;
 
+export const CALL_REPORT_INTEGRATIONS = gql`
+  query callReportIntegrations {
+    callReportIntegrations {
+      _id
+      inboxId
+      phone
+      queues
+      queueNames
+    }
+  }
+`;
+
 export const CALL_ACTIVE_SESSION = gql`
   query callsActiveSession {
     callsActiveSession {

--- a/frontend/plugins/frontline_ui/src/modules/report/call/CallReportsPage.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/call/CallReportsPage.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { format, endOfDay, startOfMonth, subMonths } from 'date-fns';
 import { ScrollArea, Spinner, Tabs } from 'erxes-ui';
-import { useQuery } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 
-import { useCallUserIntegration } from '@/integrations/call/hooks/useCallUserIntegration';
-import { CALL_QUEUE_LIST } from '@/integrations/call/graphql/queries/callQueueList';
 import { getDateRange } from '@/report/utils/dateFilters';
 
 import { CallFiltersContext } from './hooks/useCallFilters';
+import { useReportIntegrations } from './hooks/useReportIntegrations';
 import { SubHeader } from './components/SubHeader';
 import { KpiSection } from './components/KpiSection/KpiSection';
 import { OverviewSection } from './components/OverviewSection/OverviewSection';
@@ -17,10 +15,10 @@ import { AgentsSection } from './components/AgentsSection/AgentsSection';
 import { CallbacksSection } from './components/CallbacksSection/CallbacksSection';
 import { TopNumbersSection } from './components/TopNumbersSection/TopNumbersSection';
 
-import { deduplicateIntegrations, normalizeQueue } from './utils';
+import { deduplicateIntegrations } from './utils';
 import type { CallFilters, SelectOption } from './types';
 
-type QueueRecord = { _id?: string; name?: string; queue?: string };
+const ALL_QUEUES_OPTION: SelectOption = { label: 'All queues', value: 'all' };
 
 const TABS = [
   { value: 'overview', label: 'overview' },
@@ -43,18 +41,19 @@ export function CallReportsPage() {
   const { t } = useTranslation('frontline');
   const [tab, setTab] = useState<TabValue>('overview');
   const [integrationId, setIntegrationId] = useState('');
-  const [queueId, setQueueId] = useState('');
+  const [queueId, setQueueId] = useState('all');
   const [direction, setDirection] = useState('all');
   const [dateFilter, setDateFilter] = useState('last-3-months');
 
   // ── Integrations ─────────────────────────────────────────────────────────
-  const { callUserIntegrations = [], loading: integrationsLoading } =
-    useCallUserIntegration();
+  // All call integrations — not limited to ones the current user operates.
+  const { integrations, loading: integrationsLoading } =
+    useReportIntegrations();
 
   const integrationOptions = useMemo<SelectOption[]>(() => {
-    const deduped = deduplicateIntegrations(callUserIntegrations as any);
+    const deduped = deduplicateIntegrations(integrations);
     return deduped.map((i) => ({ label: i.phone, value: i.inboxId }));
-  }, [callUserIntegrations]);
+  }, [integrations]);
 
   // Auto-select first integration
   useEffect(() => {
@@ -63,27 +62,35 @@ export function CallReportsPage() {
   }, [integrationOptions, integrationId]);
 
   // ── Queues ───────────────────────────────────────────────────────────────
-  const { data: queuesData, loading: queuesLoading } = useQuery<
-    { callQueueList: Array<string | QueueRecord> },
-    { inboxId: string }
-  >(CALL_QUEUE_LIST, {
-    variables: { inboxId: integrationId },
-    skip: !integrationId,
-  });
+  // Queue options come from the selected integration's own queue list
+  // (union across duplicate docs sharing the same inboxId), plus "All queues".
+  // `queueNames` is index-parallel to `queues`, so use it for friendly labels.
+  const queueOptions = useMemo<SelectOption[]>(() => {
+    const labels = new Map<string, string>();
+    for (const integration of integrations) {
+      if (integration.inboxId !== integrationId) continue;
+      (integration.queues ?? []).forEach((queue, index) => {
+        if (!queue) return;
+        const value = String(queue);
+        const name = integration.queueNames?.[index];
+        if (name && name !== value) {
+          labels.set(value, `${name} (${value})`);
+        } else if (!labels.has(value)) {
+          labels.set(value, value);
+        }
+      });
+    }
+    return [
+      ALL_QUEUES_OPTION,
+      ...Array.from(labels, ([value, label]) => ({ label, value })),
+    ];
+  }, [integrations, integrationId]);
 
-  const queueOptions = useMemo<SelectOption[]>(
-    () =>
-      (queuesData?.callQueueList ?? [])
-        .map(normalizeQueue)
-        .filter((q): q is SelectOption => Boolean(q)),
-    [queuesData],
-  );
-
-  // Auto-select first queue (or reset when integration changes)
+  // Reset to "All queues" when the selected queue disappears
+  // (e.g. after switching integration)
   useEffect(() => {
-    if (!queueOptions.length) return;
     if (!queueOptions.some(({ value }) => value === queueId)) {
-      setQueueId(queueOptions[0].value);
+      setQueueId(ALL_QUEUES_OPTION.value);
     }
   }, [queueOptions, queueId]);
 
@@ -128,7 +135,7 @@ export function CallReportsPage() {
     ],
   );
 
-  const hasQueue = Boolean(queueId);
+  const hasIntegration = Boolean(integrationId);
 
   return (
     <CallFiltersContext.Provider value={filtersCtx}>
@@ -138,7 +145,6 @@ export function CallReportsPage() {
           integrationOptions={integrationOptions}
           queueOptions={queueOptions}
           integrationsLoading={integrationsLoading}
-          queuesLoading={queuesLoading}
         />
 
         {/* ── Empty / error states ──────────────────────────────────────── */}
@@ -147,23 +153,15 @@ export function CallReportsPage() {
             {t('no-call-integration-found')}
           </div>
         )}
-        {!queuesLoading &&
-          integrationId &&
-          integrationOptions.length > 0 &&
-          !queueOptions.length && (
-            <div className="m-6 rounded-xl border-2 border-dashed p-12 text-center text-sm text-muted-foreground">
-              {t('no-queues-assigned')}
-            </div>
-          )}
 
-        {(integrationsLoading || queuesLoading) && !hasQueue && (
+        {integrationsLoading && !hasIntegration && (
           <div className="flex flex-1 items-center justify-center">
             <Spinner />
           </div>
         )}
 
         {/* ── Main content ─────────────────────────────────────────────── */}
-        {hasQueue && (
+        {hasIntegration && (
           <Tabs
             value={tab}
             onValueChange={(v) => setTab(v as TabValue)}

--- a/frontend/plugins/frontline_ui/src/modules/report/call/hooks/useReportIntegrations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/call/hooks/useReportIntegrations.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@apollo/client';
+import { toast } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+import { CALL_REPORT_INTEGRATIONS } from '@/integrations/call/graphql/queries/callConfigQueries';
+
+export interface ReportIntegration {
+  _id: string;
+  inboxId: string;
+  phone: string;
+  queues?: string[];
+  /** Human-readable names parallel to `queues` (same index). */
+  queueNames?: string[];
+}
+
+/**
+ * Integrations for the call reports page.
+ *
+ * Unlike `useCallUserIntegration` (softphone widget), this is NOT limited to
+ * integrations where the current user is an operator — reports are read-only
+ * analytics, so every integration is listed.
+ */
+export const useReportIntegrations = () => {
+  const { t } = useTranslation('frontline');
+  const { data, loading } = useQuery<{
+    callReportIntegrations: ReportIntegration[];
+  }>(CALL_REPORT_INTEGRATIONS, {
+    onError: (e) => {
+      toast({
+        title: t('something-went-wrong-getting-user-integrations'),
+        description: e.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  return { integrations: data?.callReportIntegrations ?? [], loading };
+};

--- a/frontend/plugins/frontline_ui/src/modules/report/call/utils.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/call/utils.ts
@@ -1,5 +1,4 @@
 import { formatSeconds } from '@/integrations/call/utils/callUtils';
-import type { SelectOption } from './types';
 
 /** Format a number to fixed decimals (defaults 1). */
 export const fmt = (n: number | null | undefined, decimals = 1): string =>
@@ -75,33 +74,16 @@ export const CARRIER_COLOR_VAR: Record<string, string> = {
 };
 
 /**
- * Normalise a raw queue value (string | object) to a SelectOption.
- * Returns null if the value is empty.
- */
-export function normalizeQueue(
-  queue: string | { _id?: string; name?: string; queue?: string },
-): SelectOption | null {
-  if (typeof queue === 'string') return { label: queue, value: queue };
-  const value = queue.name || queue._id || queue.queue;
-  if (!value) return null;
-  return { label: queue.name || String(value), value: String(value) };
-}
-
-/**
  * Collapse duplicate integrations by inboxId, joining phone numbers.
  */
-export function deduplicateIntegrations(
-  integrations: Array<{
-    inboxId: string;
-    phone: string;
-    [key: string]: unknown;
-  }>,
-): Array<{ inboxId: string; phone: string }> {
-  const map = new Map<string, { inboxId: string; phone: string }>();
+export function deduplicateIntegrations<
+  T extends { inboxId: string; phone: string },
+>(integrations: T[]): T[] {
+  const map = new Map<string, T>();
   for (const integration of integrations) {
     const phone = formatPhoneStr(integration.phone);
-    if (map.has(integration.inboxId)) {
-      const existing = map.get(integration.inboxId)!;
+    const existing = map.get(integration.inboxId);
+    if (existing) {
       if (!existing.phone.includes(phone)) {
         existing.phone += `, ${phone}`;
       }


### PR DESCRIPTION
## Summary by Sourcery

Expose report-focused call integrations and simplify queue-based filtering for the call reports analytics page.

New Features:
- Add GraphQL query and frontend hook to fetch all call integrations for the reports page, including queues and human-readable queue names.
- Introduce an "All queues" option and support a neutral "all" direction in call report filters.

Enhancements:
- Update call reports frontend to derive queues directly from integration data and remove the separate queues query and loading state.
- Relax backend queue and direction filtering in call stats queries so reports can cover all queues or all directions without operator-based restrictions.
- Make integration deduplication utility generic while preserving support for multiple phone numbers per inbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added call report integration data to power report filtering and display more queue details.
  * Introduced an “All queues” option and improved queue names shown in call reports.

* **Bug Fixes**
  * Call report filters now reset correctly when a selected queue is no longer available.
  * Improved loading behavior so the page waits for integration data before rendering report controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->