### PR TITLE
feat(automations): add recurring schedule trigger

### DIFF
--- a/backend/core-api/src/meta/automations/constants.ts
+++ b/backend/core-api/src/meta/automations/constants.ts
@@ -44,6 +44,21 @@ export const CORE_AUTOMATION_CONSTANTS: AutomationConstants = {
   },
   triggers: [
     {
+      type: AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+      moduleName: 'schedules',
+      collectionName: 'recurring',
+      icon: 'IconCalendarClock',
+      label: 'Recurring schedule',
+      description: 'Run an automation on a recurring cron schedule',
+      isCustom: true,
+      output: {
+        variables: [
+          { key: 'scheduledAt', label: 'Scheduled at' },
+          { key: 'timezone', label: 'Timezone' },
+        ],
+      },
+    },
+    {
       type: AUTOMATION_CORE_TRIGGER_TYPES.INCOMING_WEBHOOK,
       moduleName: 'webhooks',
       collectionName: 'incoming',

--- a/backend/core-api/src/modules/automations/graphql/resolvers/mutations.ts
+++ b/backend/core-api/src/modules/automations/graphql/resolvers/mutations.ts
@@ -14,12 +14,17 @@ import {
 export interface IAutomationsEdit extends IAutomation {
   _id: string;
 }
-const requestScheduleReconcile = (subdomain: string) =>
-  sendWorkerQueue('automations', 'schedule').add(
-    'reconcile-recurring-automations',
-    { kind: 'reconcile', subdomain },
-    { removeOnComplete: 10, removeOnFail: 10 },
-  );
+const requestScheduleReconcile = async (subdomain: string) => {
+  try {
+    await sendWorkerQueue('automations', 'schedule').add(
+      'reconcile-recurring-automations',
+      { kind: 'reconcile', subdomain },
+      { removeOnComplete: 10, removeOnFail: 10 },
+    );
+  } catch {
+    // The recurring scheduler retries reconciliation every 60 seconds.
+  }
+};
 
 export const automationMutations = {
   /**

--- a/backend/core-api/src/modules/automations/graphql/resolvers/mutations.ts
+++ b/backend/core-api/src/modules/automations/graphql/resolvers/mutations.ts
@@ -14,6 +14,12 @@ import {
 export interface IAutomationsEdit extends IAutomation {
   _id: string;
 }
+const requestScheduleReconcile = (subdomain: string) =>
+  sendWorkerQueue('automations', 'schedule').add(
+    'reconcile-recurring-automations',
+    { kind: 'reconcile', subdomain },
+    { removeOnComplete: 10, removeOnFail: 10 },
+  );
 
 export const automationMutations = {
   /**
@@ -22,7 +28,7 @@ export const automationMutations = {
   async automationsAdd(
     _root,
     doc: IAutomation,
-    { user, models, checkPermission }: IContext,
+    { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('automationsCreate');
 
@@ -32,6 +38,7 @@ export const automationMutations = {
       createdBy: user._id,
       updatedBy: user._id,
     });
+    await requestScheduleReconcile(subdomain);
 
     return models.Automations.getAutomation(automation._id);
   },
@@ -42,7 +49,7 @@ export const automationMutations = {
   async automationsEdit(
     _root,
     { _id, ...doc }: IAutomationsEdit,
-    { user, models, checkPermission }: IContext,
+    { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('automationsUpdate');
 
@@ -63,6 +70,7 @@ export const automationMutations = {
       { _id },
       { $set: { ...doc, updatedAt: new Date(), updatedBy: user._id } },
     );
+    await requestScheduleReconcile(subdomain);
 
     return models.Automations.getAutomation(_id);
   },
@@ -74,7 +82,7 @@ export const automationMutations = {
   async archiveAutomations(
     _root,
     { automationIds, isRestore },
-    { models, user, checkPermission }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('automationsUpdate');
 
@@ -102,6 +110,7 @@ export const automationMutations = {
         },
       },
     );
+    await requestScheduleReconcile(subdomain);
     return automationIds;
   },
   /**
@@ -110,7 +119,7 @@ export const automationMutations = {
   async automationsRemove(
     _root,
     { automationIds }: { automationIds: string[] },
-    { models, user, checkPermission }: IContext,
+    { models, user, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('automationsDelete');
 
@@ -148,6 +157,7 @@ export const automationMutations = {
     await models.AutomationExecutions.removeExecutions(automationIds);
 
     await models.Segments.deleteMany({ _id: { $in: segmentIds } });
+    await requestScheduleReconcile(subdomain);
 
     return automationIds;
   },

--- a/backend/erxes-api-shared/src/core-modules/automations/constants.ts
+++ b/backend/erxes-api-shared/src/core-modules/automations/constants.ts
@@ -60,6 +60,7 @@ export const AUTOMATION_CORE_ACTIONS = {
 
 export const AUTOMATION_CORE_TRIGGER_TYPES = {
   INCOMING_WEBHOOK: 'core:webhooks.incoming',
+  SCHEDULE: 'core:schedules.recurring',
   USER: 'core:organization.users',
   CUSTOMER: 'core:contacts.customers',
   LEAD: 'core:contacts.leads',

--- a/backend/gateway/src/locales/en/automations.json
+++ b/backend/gateway/src/locales/en/automations.json
@@ -244,6 +244,16 @@
       }
     }
   },
+  "schedule-cron-required": "Cron expression is required",
+  "schedule-cron-format-error": "Use a 5, 6, or 7 field cron expression",
+  "schedule-timezone-required": "Timezone is required",
+  "schedule-validation-title": "Check the schedule configuration",
+  "schedule-validation-description": "A valid cron expression and timezone are required.",
+  "schedule-cron-label": "Cron expression",
+  "schedule-cron-description": "Five to seven fields. For example, 0 9 * * 1 runs every Monday at 09:00.",
+  "schedule-timezone-label": "Timezone",
+  "schedule-timezone-description": "Use an IANA timezone such as UTC, Asia/Ulaanbaatar, or America/New_York.",
+  "schedule-not-configured": "Schedule not configured",
   "error": "Error",
   "success": "Success"
 }

--- a/backend/gateway/src/locales/mn/automations.json
+++ b/backend/gateway/src/locales/mn/automations.json
@@ -244,6 +244,16 @@
       }
     }
   },
+  "schedule-cron-required": "Cron илэрхийлэл шаардлагатай",
+  "schedule-cron-format-error": "5, 6 эсвэл 7 талбартай cron илэрхийлэл ашиглана уу",
+  "schedule-timezone-required": "Цагийн бүс шаардлагатай",
+  "schedule-validation-title": "Хуваарийн тохиргоог шалгана уу",
+  "schedule-validation-description": "Зөв cron илэрхийлэл болон цагийн бүс шаардлагатай.",
+  "schedule-cron-label": "Cron илэрхийлэл",
+  "schedule-cron-description": "Таваас долоон талбар ашиглана. Жишээлбэл, 0 9 * * 1 нь Даваа гараг бүрийн 09:00 цагт ажиллана.",
+  "schedule-timezone-label": "Цагийн бүс",
+  "schedule-timezone-description": "UTC, Asia/Ulaanbaatar эсвэл America/New_York зэрэг IANA цагийн бүс ашиглана уу.",
+  "schedule-not-configured": "Хуваарь тохируулаагүй",
   "error": "Алдаа",
   "success": "Амжилттай"
 }

--- a/backend/services/automations/src/bullmq/initMQWorkers.ts
+++ b/backend/services/automations/src/bullmq/initMQWorkers.ts
@@ -1,9 +1,11 @@
 import type { Job } from 'bullmq';
+import type { Redis } from 'ioredis';
 import { createMQWorkerWithListeners } from 'erxes-api-shared/utils';
 import { actionHandlerWorker } from './actionHandlerWorker';
 import { triggerHandlerWorker } from './triggerWorker';
 import { debugInfo } from '../debugger';
 import { aiWorker } from './aiWorker';
+import { initScheduleWorker } from './scheduleWorker';
 
 type ICommonJobData = {
   subdomain: string;
@@ -14,9 +16,9 @@ export interface IJobData<TData> extends ICommonJobData {
 }
 
 const generateMQWorker = (
-  redis: any,
+  redis: Redis,
   queueName: string,
-  resolver: (job: Job) => Promise<any>,
+  resolver: (job: Job) => Promise<unknown>,
 ): Promise<void> => {
   return new Promise((resolve) => {
     createMQWorkerWithListeners(
@@ -31,13 +33,14 @@ const generateMQWorker = (
   });
 };
 
-export const initMQWorkers = async (redis: any) => {
+export const initMQWorkers = async (redis: Redis) => {
   debugInfo('Starting workers...');
 
   await Promise.all([
     generateMQWorker(redis, 'trigger', triggerHandlerWorker),
     generateMQWorker(redis, 'action', actionHandlerWorker),
     generateMQWorker(redis, 'aiAgent', aiWorker),
+    initScheduleWorker(redis),
   ]);
 
   debugInfo('All workers initialized');

--- a/backend/services/automations/src/bullmq/scheduleWorker.test.ts
+++ b/backend/services/automations/src/bullmq/scheduleWorker.test.ts
@@ -1,0 +1,159 @@
+const sendWorkerQueue = jest.fn();
+const executeActions = jest.fn();
+const getActionsMap = jest.fn((actions: unknown) => {
+  void actions;
+  return { first: { id: 'first' } };
+});
+
+jest.mock('erxes-api-shared/utils', () => ({
+  createMQWorkerWithListeners: jest.fn(),
+  getEnv: jest.fn(),
+  getSaasOrganizations: jest.fn(),
+  sendWorkerQueue: (...args: unknown[]) => sendWorkerQueue(...args),
+}));
+jest.mock('erxes-api-shared/core-modules', () => ({
+  AUTOMATION_CORE_TRIGGER_TYPES: { SCHEDULE: 'core:schedules.recurring' },
+  AUTOMATION_EXECUTION_STATUS: { ACTIVE: 'active' },
+}));
+
+jest.mock('../connectionResolver', () => ({ generateModels: jest.fn() }));
+jest.mock('../executions/executeActions', () => ({
+  executeActions: (...args: unknown[]) => executeActions(...args),
+}));
+jest.mock('../utils/utils', () => ({
+  getActionsMap: (actions: unknown) => getActionsMap(actions),
+}));
+
+import { AUTOMATION_CORE_TRIGGER_TYPES } from 'erxes-api-shared/core-modules';
+import {
+  executeScheduledAutomation,
+  syncTenantAutomationSchedules,
+} from './scheduleWorker';
+
+const scheduleTrigger = {
+  id: 'trigger-1',
+  type: AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+  actionId: 'first',
+  config: { cron: '0 9 * * 1-5', timezone: 'Asia/Ulaanbaatar' },
+};
+
+const automation = {
+  _id: 'automation-1',
+  status: 'active',
+  triggers: [scheduleTrigger],
+  actions: [{ id: 'first', type: 'sendEmail', config: {} }],
+};
+
+describe('Core Automation recurring schedules', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('upserts active schedule triggers and removes stale tenant schedulers', async () => {
+    const queue = {
+      upsertJobScheduler: jest.fn(),
+      getJobSchedulers: jest
+        .fn()
+        .mockResolvedValue([
+          { key: 'automation:schedule:os:stale:trigger' },
+          { key: 'automation:schedule:other:keep:trigger' },
+        ]),
+      removeJobScheduler: jest.fn(),
+    };
+    sendWorkerQueue.mockReturnValue(queue);
+    const models = {
+      Automations: {
+        find: jest.fn(() => ({
+          lean: jest.fn().mockResolvedValue([automation]),
+        })),
+      },
+    };
+
+    await syncTenantAutomationSchedules(models as never, 'os');
+
+    expect(queue.upsertJobScheduler).toHaveBeenCalledWith(
+      'automation:schedule:os:automation-1:trigger-1',
+      { pattern: '0 9 * * 1-5', tz: 'Asia/Ulaanbaatar' },
+      expect.objectContaining({
+        name: 'execute-recurring-automation',
+        data: {
+          kind: 'execute',
+          subdomain: 'os',
+          automationId: 'automation-1',
+          triggerId: 'trigger-1',
+        },
+      }),
+    );
+    expect(queue.removeJobScheduler).toHaveBeenCalledTimes(1);
+    expect(queue.removeJobScheduler).toHaveBeenCalledWith(
+      'automation:schedule:os:stale:trigger',
+    );
+  });
+
+  it('creates a normal automation execution and continues from the trigger action', async () => {
+    const execution = { _id: 'execution-1', status: 'active' };
+    const models = {
+      Executions: { create: jest.fn().mockResolvedValue(execution) },
+    };
+    const scheduledAt = new Date('2026-07-13T01:00:00.000Z');
+
+    await expect(
+      executeScheduledAutomation({
+        models: models as never,
+        subdomain: 'os',
+        automation: automation as never,
+        trigger: scheduleTrigger as never,
+        scheduledAt,
+      }),
+    ).resolves.toBe(execution);
+
+    expect(models.Executions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        automationId: 'automation-1',
+        triggerId: 'trigger-1',
+        targetId: 'trigger-1:2026-07-13T01:00:00.000Z',
+        target: {
+          _id: 'trigger-1:2026-07-13T01:00:00.000Z',
+          scheduledAt: '2026-07-13T01:00:00.000Z',
+          timezone: 'Asia/Ulaanbaatar',
+        },
+      }),
+    );
+    expect(executeActions).toHaveBeenCalledWith(
+      'os',
+      AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+      execution,
+      { first: { id: 'first' } },
+      'first',
+    );
+  });
+
+  it('skips malformed cron expressions without blocking reconciliation', async () => {
+    const queue = {
+      upsertJobScheduler: jest.fn(),
+      getJobSchedulers: jest.fn().mockResolvedValue([]),
+      removeJobScheduler: jest.fn(),
+    };
+    sendWorkerQueue.mockReturnValue(queue);
+    const models = {
+      Automations: {
+        find: jest.fn(() => ({
+          lean: jest.fn().mockResolvedValue([
+            {
+              ...automation,
+              triggers: [
+                { ...scheduleTrigger, config: { cron: 'every morning' } },
+              ],
+            },
+          ]),
+        })),
+      },
+    };
+
+    await expect(
+      syncTenantAutomationSchedules(models as never, 'os'),
+    ).resolves.toBeUndefined();
+    expect(queue.upsertJobScheduler).not.toHaveBeenCalled();
+    expect(queue.getJobSchedulers).toHaveBeenCalled();
+  });
+});

--- a/backend/services/automations/src/bullmq/scheduleWorker.ts
+++ b/backend/services/automations/src/bullmq/scheduleWorker.ts
@@ -1,0 +1,239 @@
+import type { Job } from 'bullmq';
+import type { Redis } from 'ioredis';
+import {
+  AUTOMATION_CORE_TRIGGER_TYPES,
+  AUTOMATION_EXECUTION_STATUS,
+  type IAutomationDocument,
+  type IAutomationTrigger,
+} from 'erxes-api-shared/core-modules';
+import {
+  createMQWorkerWithListeners,
+  getEnv,
+  getSaasOrganizations,
+  sendWorkerQueue,
+} from 'erxes-api-shared/utils';
+import { generateModels, type IModels } from '../connectionResolver';
+import { debugError } from '../debugger';
+import { executeActions } from '../executions/executeActions';
+import { getActionsMap } from '../utils/utils';
+
+const SCHEDULE_QUEUE = 'schedule';
+const RECONCILE_SCHEDULER_ID = 'automation:schedules:reconcile';
+const AUTOMATION_SCHEDULER_PREFIX = 'automation:schedule:';
+const RECONCILE_INTERVAL_MS = 60_000;
+
+type ScheduleJobData =
+  | { kind: 'reconcile'; subdomain?: string }
+  | {
+      kind: 'execute';
+      subdomain: string;
+      automationId: string;
+      triggerId: string;
+    };
+
+interface ScheduleConfig {
+  cron?: string;
+  timezone?: string;
+}
+
+const schedulerId = (
+  subdomain: string,
+  automationId: string,
+  triggerId: string,
+) => `${AUTOMATION_SCHEDULER_PREFIX}${subdomain}:${automationId}:${triggerId}`;
+
+const validateScheduleConfig = (config: ScheduleConfig) => {
+  const cron = config.cron?.trim();
+  const fields = cron?.split(/\s+/) ?? [];
+  if (!cron || fields.length < 5 || fields.length > 7) {
+    throw new Error(
+      'Recurring schedules require a 5, 6, or 7 field cron expression',
+    );
+  }
+
+  const timezone = config.timezone?.trim() || 'UTC';
+  new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format();
+
+  return { cron, timezone };
+};
+
+const scheduleTriggers = (automation: IAutomationDocument) =>
+  automation.triggers.filter(
+    (trigger) => trigger.type === AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+  );
+
+export const executeScheduledAutomation = async ({
+  models,
+  subdomain,
+  automation,
+  trigger,
+  scheduledAt,
+}: {
+  models: IModels;
+  subdomain: string;
+  automation: IAutomationDocument;
+  trigger: IAutomationTrigger;
+  scheduledAt: Date;
+}) => {
+  const timezone = trigger.config?.timezone || 'UTC';
+  const targetId = `${trigger.id}:${scheduledAt.toISOString()}`;
+  const target = {
+    _id: targetId,
+    scheduledAt: scheduledAt.toISOString(),
+    timezone,
+  };
+
+  const execution = await models.Executions.create({
+    automationId: automation._id,
+    triggerId: trigger.id,
+    triggerType: trigger.type,
+    triggerConfig: trigger.config,
+    targetId,
+    target,
+    status: AUTOMATION_EXECUTION_STATUS.ACTIVE,
+    description: 'Recurring schedule fired',
+    createdAt: scheduledAt,
+  });
+
+  await executeActions(
+    subdomain,
+    trigger.type,
+    execution,
+    await getActionsMap(automation.actions),
+    trigger.actionId,
+  );
+
+  return execution;
+};
+
+export const syncTenantAutomationSchedules = async (
+  models: IModels,
+  subdomain: string,
+) => {
+  const queue = sendWorkerQueue('automations', SCHEDULE_QUEUE);
+  const automations = await models.Automations.find({
+    status: 'active',
+    'triggers.type': AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+  }).lean();
+  const desiredIds = new Set<string>();
+
+  for (const automation of automations) {
+    for (const trigger of scheduleTriggers(automation)) {
+      try {
+        const { cron, timezone } = validateScheduleConfig(trigger.config || {});
+        const id = schedulerId(subdomain, automation._id, trigger.id);
+        desiredIds.add(id);
+        await queue.upsertJobScheduler(
+          id,
+          { pattern: cron, tz: timezone },
+          {
+            name: 'execute-recurring-automation',
+            data: {
+              kind: 'execute',
+              subdomain,
+              automationId: automation._id,
+              triggerId: trigger.id,
+            } satisfies ScheduleJobData,
+            opts: {
+              removeOnComplete: 100,
+              removeOnFail: 100,
+            },
+          },
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        debugError(
+          `Skipping invalid schedule ${subdomain}/${automation._id}/${trigger.id}: ${message}`,
+        );
+      }
+    }
+  }
+
+  const existing = await queue.getJobSchedulers(0, -1, true);
+  for (const row of existing) {
+    if (
+      row.key.startsWith(`${AUTOMATION_SCHEDULER_PREFIX}${subdomain}:`) &&
+      !desiredIds.has(row.key)
+    ) {
+      await queue.removeJobScheduler(row.key);
+    }
+  }
+};
+
+const tenants = async (): Promise<string[]> => {
+  if (getEnv({ name: 'VERSION' }) === 'saas') {
+    const organizations = await getSaasOrganizations();
+    return organizations.map(
+      (organization: { subdomain: string }) => organization.subdomain,
+    );
+  }
+  return ['os'];
+};
+
+export const syncAllAutomationSchedules = async () => {
+  for (const subdomain of await tenants()) {
+    const models = await generateModels(subdomain);
+    await syncTenantAutomationSchedules(models, subdomain);
+  }
+};
+
+const processScheduleJob = async (job: Job<ScheduleJobData>) => {
+  if (job.data.kind === 'reconcile') {
+    if (job.data.subdomain) {
+      const models = await generateModels(job.data.subdomain);
+      await syncTenantAutomationSchedules(models, job.data.subdomain);
+    } else {
+      await syncAllAutomationSchedules();
+    }
+    return { status: 'reconciled' };
+  }
+
+  const { subdomain, automationId, triggerId } = job.data;
+  const models = await generateModels(subdomain);
+  const automation = await models.Automations.findOne({
+    _id: automationId,
+    status: 'active',
+  });
+  const trigger = automation?.triggers.find(
+    (candidate) =>
+      candidate.id === triggerId &&
+      candidate.type === AUTOMATION_CORE_TRIGGER_TYPES.SCHEDULE,
+  );
+
+  if (!automation || !trigger) {
+    return { status: 'skipped' };
+  }
+
+  const execution = await executeScheduledAutomation({
+    models,
+    subdomain,
+    automation,
+    trigger,
+    scheduledAt: new Date(job.timestamp || Date.now()),
+  });
+  return { status: execution.status, executionId: execution._id };
+};
+
+export const initScheduleWorker = async (redis: Redis) => {
+  await new Promise<void>((resolve) => {
+    createMQWorkerWithListeners(
+      'automations',
+      SCHEDULE_QUEUE,
+      processScheduleJob,
+      redis,
+      resolve,
+    );
+  });
+
+  const queue = sendWorkerQueue('automations', SCHEDULE_QUEUE);
+  await queue.upsertJobScheduler(
+    RECONCILE_SCHEDULER_ID,
+    { every: RECONCILE_INTERVAL_MS },
+    {
+      name: 'reconcile-recurring-automations',
+      data: { kind: 'reconcile' } satisfies ScheduleJobData,
+      opts: { removeOnComplete: 10, removeOnFail: 10 },
+    },
+  );
+  await syncAllAutomationSchedules();
+};

--- a/backend/services/automations/src/bullmq/scheduleWorker.ts
+++ b/backend/services/automations/src/bullmq/scheduleWorker.ts
@@ -172,8 +172,15 @@ const tenants = async (): Promise<string[]> => {
 
 export const syncAllAutomationSchedules = async () => {
   for (const subdomain of await tenants()) {
-    const models = await generateModels(subdomain);
-    await syncTenantAutomationSchedules(models, subdomain);
+    try {
+      const models = await generateModels(subdomain);
+      await syncTenantAutomationSchedules(models, subdomain);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      debugError(
+        `Failed to reconcile schedules for tenant ${subdomain}: ${message}`,
+      );
+    }
   }
 };
 
@@ -235,5 +242,10 @@ export const initScheduleWorker = async (redis: Redis) => {
       opts: { removeOnComplete: 10, removeOnFail: 10 },
     },
   );
-  await syncAllAutomationSchedules();
+  try {
+    await syncAllAutomationSchedules();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    debugError(`Initial schedule sync failed: ${message}`);
+  }
 };

--- a/backend/services/automations/tsconfig.build.json
+++ b/backend/services/automations/tsconfig.build.json
@@ -7,5 +7,11 @@
     },
     "types": ["node"]
   },
-  "exclude": ["node_modules", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*spec.ts",
+    "**/*.test.ts",
+    "**/__tests__/**"
+  ]
 }

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/components/TriggerNodeConfigurationContent.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/components/TriggerNodeConfigurationContent.tsx
@@ -4,6 +4,8 @@ import {
   isCoreAutomationTriggerType,
 } from '@/automations/components/builder/nodes/triggers/coreAutomationTriggers';
 import { RenderPluginsComponentWrapper } from '@/automations/components/common/RenderPluginsComponentWrapper';
+import { Spinner } from 'erxes-ui';
+import { Suspense } from 'react';
 import { splitAutomationNodeType } from 'ui-modules';
 
 export const TriggerNodeConfigurationContent = ({
@@ -26,13 +28,15 @@ export const TriggerNodeConfigurationContent = ({
       TAutomationTriggerComponent.NodeContent,
     );
     return (
-      <div className="px-4 py-2">
-        {CoreTriggerComponent ? (
-          <CoreTriggerComponent config={config} />
-        ) : (
-          <></>
-        )}
-      </div>
+      <Suspense fallback={<Spinner />}>
+        <div className="px-4 py-2">
+          {CoreTriggerComponent ? (
+            <CoreTriggerComponent config={config} />
+          ) : (
+            <></>
+          )}
+        </div>
+      </Suspense>
     );
   }
 

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/components/TriggerNodeConfigurationContent.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/components/TriggerNodeConfigurationContent.tsx
@@ -3,8 +3,8 @@ import {
   getCoreAutomationTriggerComponent,
   isCoreAutomationTriggerType,
 } from '@/automations/components/builder/nodes/triggers/coreAutomationTriggers';
+import { TriggerContentLoadingFallback } from '@/automations/components/builder/sidebar/components/content/trigger/wrapper/TriggerContentLoadingFallback';
 import { RenderPluginsComponentWrapper } from '@/automations/components/common/RenderPluginsComponentWrapper';
-import { Spinner } from 'erxes-ui';
 import { Suspense } from 'react';
 import { splitAutomationNodeType } from 'ui-modules';
 
@@ -28,7 +28,7 @@ export const TriggerNodeConfigurationContent = ({
       TAutomationTriggerComponent.NodeContent,
     );
     return (
-      <Suspense fallback={<Spinner />}>
+      <Suspense fallback={<TriggerContentLoadingFallback />}>
         <div className="px-4 py-2">
           {CoreTriggerComponent ? (
             <CoreTriggerComponent config={config} />

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/coreAutomationTriggers.ts
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/coreAutomationTriggers.ts
@@ -1,8 +1,21 @@
 import WebhooksComponents from '@/automations/components/builder/nodes/triggers/webhooks/Webhooks';
 import { LazyAutomationComponent } from '@/automations/types';
+import { lazy } from 'react';
 
 const coreTriggers = {
   ...WebhooksComponents,
+  schedules: {
+    sidebar: lazy(() =>
+      import(
+        '@/automations/components/builder/nodes/triggers/schedules/ScheduleConfigForm'
+      ).then((module) => ({ default: module.ScheduleConfigForm })),
+    ),
+    nodeContent: lazy(() =>
+      import(
+        '@/automations/components/builder/nodes/triggers/schedules/ScheduleNodeContent'
+      ).then((module) => ({ default: module.ScheduleNodeContent })),
+    ),
+  },
 };
 
 type TriggerName = keyof typeof coreTriggers;

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/schedules/ScheduleConfigForm.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/schedules/ScheduleConfigForm.tsx
@@ -1,0 +1,104 @@
+import { AutomationTriggerSidebarCoreFormProps } from '@/automations/types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Form, Input, toast } from 'erxes-ui';
+import { useImperativeHandle } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+const cronExpressionPattern = /^(\S+\s+){4,6}\S+$/;
+
+const createScheduleConfigSchema = (
+  cronRequired: string,
+  cronFormat: string,
+  timezoneRequired: string,
+) =>
+  z.object({
+    cron: z
+      .string()
+      .trim()
+      .min(1, cronRequired)
+      .regex(cronExpressionPattern, cronFormat),
+    timezone: z.string().trim().min(1, timezoneRequired),
+  });
+
+interface ScheduleConfig {
+  cron: string;
+  timezone: string;
+}
+
+export const ScheduleConfigForm = ({
+  formRef,
+  handleSave,
+  activeNode,
+}: AutomationTriggerSidebarCoreFormProps) => {
+  const { t } = useTranslation('automations');
+  const form = useForm<ScheduleConfig>({
+    resolver: zodResolver(
+      createScheduleConfigSchema(
+        t('schedule-cron-required'),
+        t('schedule-cron-format-error'),
+        t('schedule-timezone-required'),
+      ),
+    ),
+    defaultValues: {
+      cron: activeNode?.config?.cron || '0 9 * * *',
+      timezone: activeNode?.config?.timezone || 'UTC',
+    },
+  });
+
+  useImperativeHandle(formRef, () => ({
+    submit: () =>
+      form.handleSubmit(handleSave, () => {
+        toast({
+          title: t('schedule-validation-title'),
+          description: t('schedule-validation-description'),
+          variant: 'destructive',
+        });
+      })(),
+  }));
+
+  return (
+    <FormProvider {...form}>
+      <div className="space-y-5">
+        <Form.Field
+          control={form.control}
+          name="cron"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>{t('schedule-cron-label')}</Form.Label>
+              <Form.Control>
+                <Input
+                  {...field}
+                  className="font-mono"
+                  placeholder="0 9 * * *"
+                />
+              </Form.Control>
+              <Form.Description>
+                {t('schedule-cron-description')}
+              </Form.Description>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="timezone"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>{t('schedule-timezone-label')}</Form.Label>
+              <Form.Control>
+                <Input {...field} placeholder="Asia/Ulaanbaatar" />
+              </Form.Control>
+              <Form.Description>
+                {t('schedule-timezone-description')}
+              </Form.Description>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      </div>
+    </FormProvider>
+  );
+};

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/schedules/ScheduleNodeContent.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/triggers/schedules/ScheduleNodeContent.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+import { AutomationActionNodeConfigProps } from 'ui-modules';
+
+interface ScheduleConfig {
+  cron?: string;
+  timezone?: string;
+}
+
+export const ScheduleNodeContent = ({
+  config,
+}: AutomationActionNodeConfigProps<ScheduleConfig>) => {
+  const { t } = useTranslation('automations');
+
+  return (
+    <div className="space-y-1 text-xs text-muted-foreground">
+      <p className="font-mono text-foreground">
+        {config?.cron || t('schedule-not-configured')}
+      </p>
+      <p>{config?.timezone || 'UTC'}</p>
+    </div>
+  );
+};

--- a/frontend/core-ui/src/modules/automations/components/builder/sidebar/components/content/trigger/components/CustomCoreTriggerContent.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/sidebar/components/content/trigger/components/CustomCoreTriggerContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import {
   getCoreAutomationTriggerComponent,
   TAutomationTriggerComponent,
@@ -7,6 +7,7 @@ import { useCoreCustomTriggerContent } from '@/automations/components/builder/si
 import { Button } from 'erxes-ui';
 import { CustomCoreTriggerContentProps } from '@/automations/components/builder/sidebar/types/sidebarContentTypes';
 import { TriggerContentWrapper } from '@/automations/components/builder/sidebar/components/content/trigger/wrapper/TriggerContentWrapper';
+import { TriggerContentLoadingFallback } from '@/automations/components/builder/sidebar/components/content/trigger/wrapper/TriggerContentLoadingFallback';
 
 /**
  * Custom core trigger content component for built-in core triggers
@@ -43,7 +44,9 @@ export const CustomCoreTriggerContent =
         footer={footerContent}
         aria-label={`Configure ${activeNode?.type || 'core trigger'} settings`}
       >
-        {Component && <Component {...updatedProps} />}
+        <Suspense fallback={<TriggerContentLoadingFallback />}>
+          {Component && <Component {...updatedProps} />}
+        </Suspense>
       </TriggerContentWrapper>
     );
   });


### PR DESCRIPTION
## Summary

- add a native `core:schedules.recurring` trigger to Core Automations
- reconcile active schedule triggers into BullMQ job schedulers per tenant
- execute scheduled occurrences through the existing Automation execution/action engine
- add cron/timezone configuration UI and English/Mongolian translations

## Data safety

This is additive. It does not migrate, rewrite, or delete existing Core Automation records. Reconciliation only reads active automations containing the new schedule trigger and manages scheduler entries with the `automation:schedule:` prefix.

## Verification

- `scheduleWorker.test.ts`: 3/3 passed
- `pnpm nx build core-ui --skip-nx-cache`: passed
- `pnpm nx build automations-service --skip-nx-cache`: passed
- `pnpm nx run core-api:build:packageJson --skip-nx-cache`: passed after the shared package build
- focused ESLint: passed for all changed TypeScript/TSX files
- repository critical-rule checks: passed for the schedule worker and schedule UI
- English and Mongolian automation locale JSON: parsed successfully

Full-project lint remains blocked by existing unrelated errors in Core UI and automations-service files outside this change.

## Summary by Sourcery

Introduce a recurring cron-based schedule trigger for core automations and wire it into the existing automation execution pipeline.

New Features:
- Add a new core automation trigger type for recurring schedules with cron and timezone support, including UI components and i18n strings for configuration.
- Introduce a dedicated schedule worker and BullMQ-based job schedulers to drive recurring automation executions per tenant.

Enhancements:
- Trigger schedule reconciliation when automations are created, updated, archived, or removed to keep tenant schedulers in sync.
- Extend automations service worker initialization with a typed Redis client and schedule worker bootstrap logic.

Tests:
- Add unit tests covering schedule reconciliation, job scheduler cleanup, and execution behavior for recurring automation schedules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new recurring schedule trigger for automations, with cron + timezone configuration in the builder UI.
  * Scheduled automations now automatically reconcile and execute on the configured cadence, keeping schedules in sync after automation add/edit/archive/restore/delete.
* **Bug Fixes**
  * Invalid cron settings are prevented in the UI and ignored during schedule reconciliation/execution.
* **Tests**
  * Added Jest tests covering schedule reconciliation, execution, stale cleanup, and malformed cron handling.
* **Documentation**
  * Added schedule-related English and Mongolian locale strings for the configuration UI.
* **Refactor**
  * Improved trigger configuration rendering with Suspense loading fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->