### PR TITLE
fix(operation): keep board card position stable when editing a task

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/task/components/TasksBoard.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TasksBoard.tsx
@@ -32,11 +32,25 @@ import { StatusInlineIcon } from '@/operation/components/StatusInline';
 const fetchedTasksState = atom<BoardItemProps[]>([]);
 export const allTasksMapState = atom<Record<string, ITask>>({});
 
+const taskSortMapState = atom<Record<string, string>>({});
+
 export const TasksBoard = () => {
   const { t } = useTranslation('operation');
   const { teamId } = useParams();
   const allTasksMap = useAtomValue(allTasksMapState);
   const { updateTask } = useUpdateTask();
+  const [tasks, setTasks] = useAtom(fetchedTasksState);
+  const setAllTasksMap = useSetAtom(allTasksMapState);
+  const setTaskSortMap = useSetAtom(taskSortMapState);
+  const setTaskCountByBoard = useSetAtom(taskCountByBoardAtom);
+
+
+  useEffect(() => {
+    setTasks([]);
+    setAllTasksMap({});
+    setTaskSortMap({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamId]);
 
   const { statuses, loading } = useGetStatusByTeam({
     variables: {
@@ -51,9 +65,6 @@ export const TasksBoard = () => {
     type: status.type.toString(),
     color: status.color,
   }));
-
-  const [tasks, setTasks] = useAtom(fetchedTasksState);
-  const setTaskCountByBoard = useSetAtom(taskCountByBoardAtom);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -76,18 +87,23 @@ export const TasksBoard = () => {
         status: overColumn,
       },
     });
+    const newSort = new Date().toISOString();
     setTasks((prev) =>
       prev.map((task) => {
         if (task.id === activeItem?._id) {
           return {
             ...task,
             column: overColumn,
-            sort: new Date().toISOString(),
+            sort: newSort,
           };
         }
         return task;
       }),
     );
+
+    if (activeItem?._id) {
+      setTaskSortMap((prev) => ({ ...prev, [activeItem._id]: newSort }));
+    }
     setTaskCountByBoard((prev) => ({
       ...prev,
       [activeItem?.status]: prev[activeItem?.status] - 1 || 0,
@@ -155,11 +171,26 @@ export const TasksBoardCards = ({ column }: { column: BoardColumnProps }) => {
     },
   });
   const setAllTasksMap = useSetAtom(allTasksMapState);
+  const [taskSortMap, setTaskSortMap] = useAtom(taskSortMapState);
+
+  useEffect(() => {
+    if (!tasks) return;
+    const unseen = tasks.filter((task) => !(task._id in taskSortMap));
+    if (unseen.length === 0) return;
+    setTaskSortMap((prev) => {
+      const next = { ...prev };
+      unseen.forEach((task) => {
+        if (!(task._id in next)) {
+          next[task._id] = task.updatedAt;
+        }
+      });
+      return next;
+    });
+  }, [tasks, taskSortMap, setTaskSortMap]);
 
   useEffect(() => {
     if (tasks) {
       setTaskCards((prev) => {
-        const prevSortById = new Map(prev.map((task) => [task.id, task.sort]));
         const previousTasks = prev.filter(
           (task) => !tasks.some((t) => t._id === task.id),
         );
@@ -168,7 +199,7 @@ export const TasksBoardCards = ({ column }: { column: BoardColumnProps }) => {
           ...tasks.map((task) => ({
             id: task._id,
             column: task.status,
-            sort: prevSortById.get(task._id) ?? task.updatedAt,
+            sort: taskSortMap[task._id] ?? task.updatedAt,
           })),
         ];
       });
@@ -180,7 +211,7 @@ export const TasksBoardCards = ({ column }: { column: BoardColumnProps }) => {
         return { ...prev, ...newTasks };
       });
     }
-  }, [tasks, setTaskCards, setAllTasksMap, column.id]);
+  }, [tasks, taskSortMap, setTaskCards, setAllTasksMap, column.id]);
 
   useEffect(() => {
     if (totalCount) {

--- a/frontend/plugins/operation_ui/src/modules/task/hooks/useGetTasks.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/hooks/useGetTasks.tsx
@@ -13,7 +13,7 @@ import {
 } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue } from 'jotai';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { currentUserState } from 'ui-modules';
 
@@ -139,7 +139,13 @@ export const useTasks = (
   options?: QueryHookOptions<ICursorListResponse<ITask>>,
 ) => {
   const { t } = useTranslation('operation');
-  const variables = useTasksVariables(options?.variables);
+  const rawVariables = useTasksVariables(options?.variables);
+
+  const variables = useMemo(
+    () => rawVariables,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(rawVariables)],
+  );
   const { toast } = useToast();
   const { data, loading, fetchMore, subscribeToMore } = useQuery<
     ICursorListResponse<ITask>


### PR DESCRIPTION
## Summary by Sourcery

Maintain stable card ordering on the tasks board when tasks are edited or moved, and ensure task queries use memoized variables for consistent behavior.

Enhancements:
- Introduce a dedicated atom to track per-task sort values and use it to preserve card positions across updates and drag-and-drop moves.
- Reset tasks, task map, sort map, and board task counts when the team context changes to avoid stale state.
- Initialize sort values for newly fetched tasks based on their last update time so their ordering remains predictable.
- Memoize task query variables in the tasks hook to reduce unnecessary re-renders or refetches caused by variable identity changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task board sorting after drag-and-drop so task order remains consistent.
  * Preserved custom task ordering when task data refreshes or updates in real time.
  * Reset task ordering appropriately when switching teams.
  * Improved task loading and subscription behavior by stabilizing task filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->