### PR TITLE
feat(ui-modules): add LLM provider API key fields

### DIFF
--- a/frontend/libs/ui-modules/src/modules/shared/components/LlmProviderApiKeyFields.tsx
+++ b/frontend/libs/ui-modules/src/modules/shared/components/LlmProviderApiKeyFields.tsx
@@ -1,0 +1,158 @@
+import { IconCheck, IconKey } from '@tabler/icons-react';
+import { Form, Input } from 'erxes-ui';
+import type { ComponentType } from 'react';
+import { Control, FieldPath, FieldValues, useWatch } from 'react-hook-form';
+
+export interface LlmProviderOption {
+  value: string;
+  label: string;
+  defaultModel?: string;
+  description?: string;
+  icon?: ComponentType<{ className?: string }>;
+  imageUrl?: string;
+}
+
+interface LlmProviderApiKeyFieldsProps<TFormValues extends FieldValues> {
+  control: Control<TFormValues>;
+  providerName: FieldPath<TFormValues>;
+  apiKeyName: FieldPath<TFormValues>;
+  providerOptions: readonly LlmProviderOption[];
+  providerLabel?: string;
+  apiKeyLabel?: string;
+  providerPlaceholder?: string;
+  apiKeyPlaceholder?: string;
+  disabled?: boolean;
+  showApiKey?: boolean;
+  onProviderChange?: (provider: string) => void;
+}
+
+const getInitials = (label: string) =>
+  label
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+export const LlmProviderApiKeyFields = <TFormValues extends FieldValues>({
+  control,
+  providerName,
+  apiKeyName,
+  providerOptions,
+  providerLabel = 'Provider',
+  apiKeyLabel = 'API key',
+  providerPlaceholder = 'Choose provider',
+  apiKeyPlaceholder = 'Paste your API key',
+  disabled = false,
+  showApiKey = true,
+  onProviderChange,
+}: LlmProviderApiKeyFieldsProps<TFormValues>) => {
+  const selectedValue = String(useWatch({ control, name: providerName }) || '');
+  const selectedProvider = providerOptions.find(
+    ({ value }) => value === selectedValue,
+  );
+
+  return (
+    <div className="space-y-5">
+      <Form.Field
+        control={control}
+        name={providerName}
+        render={({ field }) => (
+          <Form.Item>
+            <Form.Label>{providerLabel}</Form.Label>
+            <div
+              role="listbox"
+              aria-label={providerLabel}
+              className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+            >
+              {providerOptions.map((option) => {
+                const selected = option.value === String(field.value || '');
+                const ProviderIcon = option.icon;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    disabled={disabled}
+                    onClick={() => {
+                      field.onChange(option.value);
+                      onProviderChange?.(option.value);
+                    }}
+                    className={`relative flex min-h-[76px] items-center gap-3 rounded-md border p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
+                      selected
+                        ? 'border-primary bg-primary/5 shadow-sm'
+                        : 'border-border bg-background hover:border-primary/50 hover:bg-muted/40'
+                    }`}
+                  >
+                    <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted text-sm font-semibold text-foreground">
+                      {option.imageUrl ? (
+                        <img
+                          src={option.imageUrl}
+                          alt=""
+                          className="size-6 object-contain"
+                        />
+                      ) : ProviderIcon ? (
+                        <ProviderIcon className="size-5" />
+                      ) : (
+                        getInitials(option.label)
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-foreground">
+                        {option.label}
+                      </span>
+                      <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                        {option.defaultModel ||
+                          option.description ||
+                          providerPlaceholder}
+                      </span>
+                    </span>
+                    {selected && (
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                        <IconCheck className="size-3" />
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+            <Form.Message />
+          </Form.Item>
+        )}
+      />
+
+      {showApiKey && (
+        <Form.Field
+          control={control}
+          name={apiKeyName}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>
+                {selectedProvider
+                  ? `${selectedProvider.label} ${apiKeyLabel}`
+                  : apiKeyLabel}
+              </Form.Label>
+              <Form.Control>
+                <div className="relative">
+                  <IconKey className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    {...field}
+                    value={String(field.value || '')}
+                    type="password"
+                    placeholder={apiKeyPlaceholder}
+                    className="pl-9"
+                    autoComplete="off"
+                    disabled={disabled}
+                  />
+                </div>
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/libs/ui-modules/src/modules/shared/index.ts
+++ b/frontend/libs/ui-modules/src/modules/shared/index.ts
@@ -1,1 +1,2 @@
 export * from './components/SheetNavSidebar';
+export * from './components/LlmProviderApiKeyFields';


### PR DESCRIPTION
## Summary
- add a reusable visual LLM provider picker with optional provider image/icon support
- include a contextual masked API-key field in the same form component
- export the component from the shared ui-modules package

## Validation
- 
- 

## Notes
- 
> nx run ui-modules:lint

> eslint .

[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/approval/hooks/useApprovalLockStates.ts[24m[0m
[0m  [2m35:9[22m  [33mwarning[39m  The 'states' logical expression could make the dependencies of useMemo Hook (at line 41) change on every render. To fix this, wrap the initialization of 'states' in its own useMemo() Hook  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/components/Attributes.tsx[24m[0m
[0m  [2m2:18[22m  [33mwarning[39m  'Collapsible' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/components/AutomationOptionalConnect.tsx[24m[0m
[0m  [2m11:14[22m  [33mwarning[39m  Fragments should contain more than one child - otherwise, there’s no need for a Fragment at all  [2mreact/jsx-no-useless-fragment[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/components/placeholderInput/PlaceholderInputField.tsx[24m[0m
[0m  [2m56:8[22m  [33mwarning[39m  React Hook useMemo has an unnecessary dependency: 'enabledTypes'. Either exclude it or remove the dependency array  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/components/placeholderInput/commandList/ProducsCommandList.tsx[24m[0m
[0m  [2m14:59[22m  [33mwarning[39m  'error' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/components/placeholderInput/commandList/TagsCommandList.tsx[24m[0m
[0m  [2m14:55[22m  [33mwarning[39m  'error' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/hooks/usePlaceholderInputDetection.ts[24m[0m
[0m  [2m382:5[22m  [33mwarning[39m  React Hook useCallback has a missing dependency: 'onChange'. Either include it or remove the dependency array. If 'onChange' changes too often, find the parent component that defines it and wrap that definition in useCallback  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/hooks/usePlaceholderInputSuggestionPopover.ts[24m[0m
[0m   [2m1:38[22m  [33mwarning[39m  'useState' is defined but never used           [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m19:5[22m   [33mwarning[39m  'onChange' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m22:5[22m   [33mwarning[39m  'inputRef' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/hooks/usePopoverPosition.ts[24m[0m
[0m  [2m46:11[22m  [31merror[39m  'style' is never reassigned. Use 'const' instead  [2mprefer-const[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/hooks/useSelectionOnlyHandlers.ts[24m[0m
[0m  [2m19:34[22m  [31merror[39m  Unexpected empty arrow function  [2m@typescript-eslint/no-empty-function[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/hooks/useSuggestionMaps.ts[24m[0m
[0m  [2m26:9[22m  [31merror[39m  Redundant Boolean call  [2mno-extra-boolean-cast[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/automations/utils/placeholderInputDetectionUtils.ts[24m[0m
[0m   [2m11:50[22m  [33mwarning[39m  Unexpected string concatenation of literals  [2mno-useless-concat[22m[0m
[0m   [2m12:51[22m  [33mwarning[39m  Unexpected string concatenation of literals  [2mno-useless-concat[22m[0m
[0m   [2m15:61[22m  [33mwarning[39m  Unexpected string concatenation of literals  [2mno-useless-concat[22m[0m
[0m  [2m127:18[22m  [33mwarning[39m  Unnecessary escape character: \-             [2mno-useless-escape[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/brands/components/BrandBadge.tsx[24m[0m
[0m  [2m1:17[22m  [33mwarning[39m  'cn' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/documents/components/DocumentInEditor.tsx[24m[0m
[0m   [2m57:16[22m  [33mwarning[39m  '_error' is defined but never used              [2m@typescript-eslint/no-unused-vars[22m[0m
[0m   [2m60:18[22m  [33mwarning[39m  '_htmlError' is defined but never used          [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m158:18[22m  [33mwarning[39m  'setSearch' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/components/epxort/ExportFieldSelection.tsx[24m[0m
[0m  [2m8:3[22m  [33mwarning[39m  'ScrollArea' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/components/import/Import.tsx[24m[0m
[0m  [2m129:5[22m  [33mwarning[39m  'inputId' is assigned a value but never used                 [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m130:5[22m  [33mwarning[39m  'entityLabel' is assigned a value but never used             [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m131:5[22m  [33mwarning[39m  'isDragOver' is assigned a value but never used              [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m132:5[22m  [33mwarning[39m  'handleDragOver' is assigned a value but never used          [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m133:5[22m  [33mwarning[39m  'handleDragLeave' is assigned a value but never used         [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m134:5[22m  [33mwarning[39m  'handleDrop' is assigned a value but never used              [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m135:5[22m  [33mwarning[39m  'handleFileSelect' is assigned a value but never used        [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m136:5[22m  [33mwarning[39m  'handleClickUpload' is assigned a value but never used       [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m137:5[22m  [33mwarning[39m  'handleDownloadTemplate' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m138:5[22m  [33mwarning[39m  'isLoading' is assigned a value but never used               [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/components/import/ImportProvider.tsx[24m[0m
[0m  [2m1:10[22m  [33mwarning[39m  'IconHelpCircle' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m2:10[22m  [33mwarning[39m  'Button' is defined but never used          [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m2:18[22m  [33mwarning[39m  'Dialog' is defined but never used          [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m2:26[22m  [33mwarning[39m  'ScrollArea' is defined but never used      [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/hooks/export/useActiveExports.ts[24m[0m
[0m  [2m20:9[22m  [33mwarning[39m  The 'activeExports' logical expression could make the dependencies of useMemo Hook (at line 27) change on every render. To fix this, wrap the initialization of 'activeExports' in its own useMemo() Hook    [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m20:9[22m  [33mwarning[39m  The 'activeExports' logical expression could make the dependencies of useEffect Hook (at line 51) change on every render. To fix this, wrap the initialization of 'activeExports' in its own useMemo() Hook  [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m67:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m  [2m80:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/hooks/export/useExport.ts[24m[0m
[0m  [2m40:7[22m  [31merror[39m  Unnecessary try/catch wrapper  [2mno-useless-catch[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/hooks/export/useExportFieldSelection.ts[24m[0m
[0m  [2m24:9[22m  [33mwarning[39m  The 'headers' logical expression could make the dependencies of useEffect Hook (at line 35) change on every render. To fix this, wrap the initialization of 'headers' in its own useMemo() Hook  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/hooks/import/useImport.ts[24m[0m
[0m   [2m21:9[22m  [33mwarning[39m  The 'activeImports' logical expression could make the dependencies of useMemo Hook (at line 28) change on every render. To fix this, wrap the initialization of 'activeImports' in its own useMemo() Hook    [2mreact-hooks/exhaustive-deps[22m[0m
[0m   [2m21:9[22m  [33mwarning[39m  The 'activeImports' logical expression could make the dependencies of useEffect Hook (at line 52) change on every render. To fix this, wrap the initialization of 'activeImports' in its own useMemo() Hook  [2mreact-hooks/exhaustive-deps[22m[0m
[0m   [2m87:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m  [2m108:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m  [2m122:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m  [2m136:7[22m  [31merror[39m    Unnecessary try/catch wrapper                                                                                                                                                                                [2mno-useless-catch[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/import-export/hooks/import/useImportUploadHandler.ts[24m[0m
[0m   [2m91:5[22m  [33mwarning[39m  React Hook useCallback has an unnecessary dependency: 'toast'. Either exclude it or remove the dependency array. Outer scope values like 'toast' aren't valid dependencies because mutating them doesn't re-render the component  [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m170:6[22m  [33mwarning[39m  React Hook useCallback has an unnecessary dependency: 'toast'. Either exclude it or remove the dependency array. Outer scope values like 'toast' aren't valid dependencies because mutating them doesn't re-render the component  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/internal-notes/utils/parseInternalNote.tsx[24m[0m
[0m  [2m7:12[22m  [33mwarning[39m  'error' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/components/ActionsInline.tsx[24m[0m
[0m   [2m80:6[22m   [33mwarning[39m  React Hook useEffect has missing dependencies: 'setAction' and 'updateActions'. Either include them or remove the dependency array. If 'updateActions' changes too often, find the parent component that defines it and wrap that definition in useCallback  [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m108:26[22m  [33mwarning[39m  'loading' is assigned a value but never used                                                                                                                                                                                                                 [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/components/Permissions.tsx[24m[0m
[0m  [2m378:5[22m  [33mwarning[39m  React Hook React.useCallback has missing dependencies: 'reset' and 'toast'. Either include them or remove the dependency array  [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m440:6[22m  [33mwarning[39m  React Hook useEffect has missing dependencies: 'moduleName' and 'setValue'. Either include them or remove the dependency array  [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m446:6[22m  [33mwarning[39m  React Hook useEffect has a missing dependency: 'setValue'. Either include it or remove the dependency array                     [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/components/SelectActions.tsx[24m[0m
[0m  [2m9:3[22m  [33mwarning[39m  'useFilterContext' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/components/SelectModule.tsx[24m[0m
[0m  [2m12:3[22m   [33mwarning[39m  'useFilterQueryState' is defined but never used          [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m52:10[22m  [33mwarning[39m  'selectedModuleName' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/components/permission-columns.tsx[24m[0m
[0m  [2m11:3[22m  [33mwarning[39m  'useQueryState' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/permissions/types/permission.ts[24m[0m
[0m  [2m37:18[22m  [31merror[39m  An interface declaring no members is equivalent to its supertype  [2m@typescript-eslint/no-empty-object-type[22m[0m
[0m  [2m37:18[22m  [31merror[39m  An interface declaring no members is equivalent to its supertype  [2m@typescript-eslint/no-empty-interface[22m[0m
[0m  [2m39:18[22m  [31merror[39m  An interface declaring no members is equivalent to its supertype  [2m@typescript-eslint/no-empty-object-type[22m[0m
[0m  [2m39:18[22m  [31merror[39m  An interface declaring no members is equivalent to its supertype  [2m@typescript-eslint/no-empty-interface[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/products/categories/components/SelectCategory.tsx[24m[0m
[0m  [2m116:6[22m  [33mwarning[39m  React Hook useEffect has a missing dependency: 'categoryIds'. Either include it or remove the dependency array                            [2mreact-hooks/exhaustive-deps[22m[0m
[0m  [2m116:7[22m  [33mwarning[39m  React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/products/components/AddProductForm.tsx[24m[0m
[0m  [2m2:10[22m  [33mwarning[39m  'zodResolver' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/properties/components/FieldDate.tsx[24m[0m
[0m  [2m6:32[22m  [33mwarning[39m  'field' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/segments/components/form/SegmentConfigWidget.tsx[24m[0m
[0m  [2m13:10[22m  [33mwarning[39m  Fragments should contain more than one child - otherwise, there’s no need for a Fragment at all  [2mreact/jsx-no-useless-fragment[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/segments/components/form/SegmentGroup.tsx[24m[0m
[0m  [2m1:10[22m  [33mwarning[39m  'IconPlus' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/segments/hooks/useSegmentStats.ts[24m[0m
[0m  [2m23:7[22m  [33mwarning[39m  'conditionsConjunction' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m24:7[22m  [33mwarning[39m  'conditions' is assigned a value but never used             [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m26:7[22m  [33mwarning[39m  'config' is assigned a value but never used                 [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m27:7[22m  [33mwarning[39m  'subOf' is assigned a value but never used                  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/segments/utils/segmentsUtils.ts[24m[0m
[0m  [2m14:7[22m  [33mwarning[39m  Forbidden non-null assertion  [2m@typescript-eslint/no-non-null-assertion[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/structure/components/CreateUnitForm.tsx[24m[0m
[0m  [2m19:10[22m  [33mwarning[39m  'open' is assigned a value but never used     [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m19:16[22m  [33mwarning[39m  'setOpen' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/structure/hooks/usePositions.tsx[24m[0m
[0m  [2m1:10[22m  [33mwarning[39m  'OperationVariables' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/tags-new/utils/getTagTypeDescription.ts[24m[0m
[0m  [2m4:9[22m  [33mwarning[39m  'tagTypesEntries' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/tags/components/SelectTagType.tsx[24m[0m
[0m   [2m1:36[22m  [33mwarning[39m  'useState' is defined but never used       [2m@typescript-eslint/no-unused-vars[22m[0m
[0m  [2m21:10[22m  [33mwarning[39m  'open' is assigned a value but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/tags/components/SelectTags.tsx[24m[0m
[0m  [2m11:3[22m  [33mwarning[39m  'ScrollArea' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/tags/components/TagsColumns.tsx[24m[0m
[0m  [2m32:10[22m  [33mwarning[39m  'useTranslation' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/team-members/components/AssignMemberInEditor.tsx[24m[0m
[0m  [2m73:18[22m  [33mwarning[39m  'error' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/team-members/hooks/useUsersGroup.tsx[24m[0m
[0m  [2m1:20[22m  [33mwarning[39m  'OperationVariables' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/team-members/types/TeamMembers.ts[24m[0m
[0m  [2m1:10[22m  [33mwarning[39m  'SlashMenuProps' is defined but never used  [2m@typescript-eslint/no-unused-vars[22m[0m
[0m[0m
[0m[4m/home/batzorig/Desktop/erxess/erxes/frontend/libs/ui-modules/src/modules/templates/components/TemplateCategoryInline.tsx[24m[0m
[0m  [2m101:6[22m  [33mwarning[39m  React Hook useEffect has a missing dependency: 'categoryId'. Either include it or remove the dependency array  [2mreact-hooks/exhaustive-deps[22m[0m
[0m[0m
[0m[31m[1m✖ 87 problems (14 errors, 73 warnings)[22m[39m[0m
[0m[31m[1m[22m[39m[31m[1m  4 errors and 0 warnings potentially fixable with the `--fix` option.[22m[39m[0m
[0m[31m[1m[22m[39m[0m



 NX   Running target lint for project ui-modules failed

Failed tasks:

- ui-modules:lint

Hint: run the command with --verbose for more details. remains blocked by 14 pre-existing errors elsewhere in ui-modules.
- ui-modules has no configured Nx build target.

## Summary by Sourcery

Add a shared form component for selecting an LLM provider and entering its API key, and export it from the shared UI modules package.

New Features:
- Introduce a reusable LLM provider and API key form field component with support for provider icons or images.
- Expose the new LLM provider API key fields component through the shared ui-modules export for use across the app.