### PR TITLE
fix(content): align client portal category queries

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/category.ts
@@ -59,10 +59,8 @@ class CategoryQueryResolver extends BaseQueryResolver {
     const { language } = args;
     const clientPortalId = args.clientPortalId || clientPortal?._id;
 
-    const query: any = {
-      clientPortalId,
-      status: 'active',
-    };
+    const queryBuilder = getQueryBuilder('category', models);
+    const query = queryBuilder.buildQuery({ ...args, clientPortalId });
 
     return this.getListWithTranslations(
       models.Categories,

--- a/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/schemas/category.ts
@@ -51,7 +51,7 @@ export const queries = `
     cmsCategories(clientPortalId: String, language: String, searchValue: String, status: CategoryStatus, ${GQL_CURSOR_PARAM_DEFS}, sortField: String, sortDirection: String): PostCategoryListResponse
     cmsCategory(_id: String, slug: String, language: String, clientPortalId: String): PostCategory
 
-    cpCategories(clientPortalId: String, language: String): PostCategoryListResponse
+    cpCategories(clientPortalId: String, language: String, searchValue: String, status: CategoryStatus, ${GQL_CURSOR_PARAM_DEFS}, sortField: String, sortDirection: String): PostCategoryListResponse
     cpCmsCategoryDetail(_id: String, slug: String, language: String): PostCategory
 `;
 


### PR DESCRIPTION
## Why

`cpCategories` applied a hard-coded active-status filter while `cmsCategories` used the standard category query builder. This made the client-portal endpoint return a different, incomplete set of categories for the same portal.

## What Changed

- Reused the category query builder in `cpCategories` so its filtering behavior matches `cmsCategories`.
- Added the same optional search, status, sorting, and cursor-pagination arguments to the client-portal GraphQL query.

## Summary by Sourcery

Align client-portal category queries with the CMS category query behavior and arguments.

New Features:
- Expose search, status, sorting, and cursor-based pagination arguments on the cpCategories GraphQL query.

Enhancements:
- Reuse the standard category query builder for cpCategories so its filtering and querying logic matches cmsCategories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced category listing with search, status filtering, sorting, and cursor-based pagination.
  * Category results now respect the selected filtering and ordering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->