### PR TITLE
feat(tourism_ui): add default values to i18n t() calls in tourism plugin

### DIFF
--- a/frontend/plugins/tourism_ui/src/hooks/useVisitWebsite.ts
+++ b/frontend/plugins/tourism_ui/src/hooks/useVisitWebsite.ts
@@ -31,8 +31,8 @@ export const useVisitWebsite = (
 
       if (!url) {
         toast({
-          title: t('error'),
-          description: t('unable-to-open-website'),
+          title: t('error', 'Error'),
+          description: t('unable-to-open-website', 'Unable to open website, unexpected hostname format'),
           variant: 'destructive',
         });
         return;

--- a/frontend/plugins/tourism_ui/src/modules/pms/Settings.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/Settings.tsx
@@ -4,7 +4,7 @@ const Settings = () => {
   const { t } = useTranslation('tourism');
   return (
     <div>
-      <h1>{t('pms-settings')}</h1>
+      <h1>{t('pms-settings', 'PMS Settings')}</h1>
     </div>
   );
 };

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/ActionMenu.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/ActionMenu.tsx
@@ -28,21 +28,21 @@ export const ActionMenu = ({
   const { t } = useTranslation('tourism');
   const dropdownItems: DropdownItem[] = [
     {
-      label: t('edit'),
+      label: t('edit', 'Edit'),
       icon: <IconEdit size={16} stroke={1.5} />,
       onClick: onEdit,
     },
     ...(onVisitWebsite
       ? [
           {
-            label: t('open-website'),
+            label: t('open-website', 'Open website'),
             icon: <IconWorld size={16} stroke={1.5} />,
             onClick: onVisitWebsite,
           },
         ]
       : []),
     {
-      label: t('remove'),
+      label: t('remove', 'Remove'),
       icon: <IconTrash size={16} stroke={1.5} />,
       onClick: onDelete,
     },
@@ -57,7 +57,7 @@ export const ActionMenu = ({
           aria-haspopup="true"
           type="button"
         >
-          {t('action')}
+          {t('action', 'Action')}
           <IconChevronDown size={18} stroke={2} />
         </button>
       </Popover.Trigger>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsForm.tsx
@@ -194,15 +194,15 @@ const CreatePmsForm = ({
     editBranch(branchId, editVariables)
       .then(() => {
         toast({
-          title: t('success'),
-          description: t('pms-updated-successfully'),
+          title: t('success', 'Success'),
+          description: t('pms-updated-successfully', 'PMS updated successfully'),
         });
         onOpenChange?.(false);
         onSuccess?.();
       })
       .catch((e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
@@ -216,15 +216,15 @@ const CreatePmsForm = ({
       variables: createVariables,
       onError: (e: ApolloError) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: e.message,
           variant: 'destructive',
         });
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
-          description: t('pms-created-successfully'),
+          title: t('success', 'Success'),
+          description: t('pms-created-successfully', 'PMS created successfully'),
         });
         form.reset();
         onOpenChange?.(false);
@@ -323,8 +323,8 @@ const CreatePmsForm = ({
     if (mode === 'edit') {
       if (!branchId) {
         toast({
-          title: t('error'),
-          description: t('missing-branch-id-for-edit'),
+          title: t('error', 'Error'),
+          description: t('missing-branch-id-for-edit', 'Missing branch ID for edit mode'),
           variant: 'destructive',
         });
         return;
@@ -360,7 +360,7 @@ const CreatePmsForm = ({
             </div>
           ) : mode === 'edit' && detailError ? (
             <div className="flex flex-col justify-center items-center w-full h-full text-destructive">
-              <p>{t('failed-to-load-branch-details')}</p>
+              <p>{t('failed-to-load-branch-details', 'Failed to load branch details')}</p>
               <p className="text-sm">{detailError.message}</p>
             </div>
           ) : (

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsSheet.tsx
@@ -48,7 +48,7 @@ export const PmsCreateSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('create-pms')}
+          {t('create-pms', 'Create PMS')}
         </Button>
       </Sheet.Trigger>
       <Sheet.View
@@ -72,7 +72,7 @@ export const PmsCreateSheetHeader = ({
   return (
     <Sheet.Header className="p-5">
       <Sheet.Title>
-        {mode === 'edit' ? t('edit-pms') : t('create-pms-full')}
+        {mode === 'edit' ? t('edit-pms', 'Edit PMS /Property Management System/') : t('create-pms-full', 'Create PMS /Property Management System/')}
       </Sheet.Title>
       <Sheet.Close />
     </Sheet.Header>
@@ -126,7 +126,7 @@ export const PmsCreateSheetFooter = ({
   return (
     <Sheet.Footer className="flex sm:justify-between lg:p-5">
       <Button variant={'outline'} onClick={handlePreviousButton} type="button">
-        {currentStep === 1 ? t('cancel') : t('previous')}
+        {currentStep === 1 ? t('cancel', 'Cancel') : t('previous', 'Previous')}
       </Button>
       <Button
         disabled={currentStep === steps.length && loading}
@@ -136,12 +136,12 @@ export const PmsCreateSheetFooter = ({
         {currentStep === steps.length
           ? loading
             ? mode === 'edit'
-              ? t('saving')
-              : t('creating')
+              ? t('saving', 'Saving...')
+              : t('creating', 'Creating...')
             : mode === 'edit'
-              ? t('save')
-              : t('create')
-          : t('next')}
+              ? t('save', 'Save')
+              : t('create', 'Create')
+          : t('next', 'Next')}
       </Button>
     </Sheet.Footer>
   );

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/PmsList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/PmsList.tsx
@@ -35,11 +35,11 @@ function PmsListEmpty() {
         </div>
 
         <h2 className="mb-3 text-xl font-semibold text-foreground">
-          {t('property-management-system')}
+          {t('property-management-system', 'Property management system')}
         </h2>
 
         <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
-          {t('pms-empty-description')}
+          {t('pms-empty-description', 'A property management system is software designed to organize and manage property-related activities. It helps streamline trip planning, booking, payment management, customer information, and travel schedules.')}
         </p>
 
         <PmsCreateSheet />
@@ -97,7 +97,7 @@ function PmsBranchCard({
       <div className="flex justify-between items-center px-3 py-2">
         <div className="min-w-0">
           <div className="text-sm font-semibold truncate">
-            {branch.name || t('unnamed-branch')}
+            {branch.name || t('unnamed-branch', 'Unnamed Branch')}
           </div>
         </div>
 
@@ -118,10 +118,10 @@ function PmsBranchCard({
         <div className="flex gap-2 items-center min-w-0">
           <IconCalendarPlus size={16} className="shrink-0" />
           <span className="text-xs font-medium truncate">
-            {t('created')}:{' '}
+            {t('created', 'Created')}:{' '}
             {branch.createdAt
               ? format(new Date(branch.createdAt), 'dd MMM yyyy')
-              : t('na')}
+              : t('na', 'N/A')}
           </span>
         </div>
 
@@ -167,22 +167,22 @@ export function PmsList() {
     const branchName = list?.find((b) => b._id === branchId)?.name || '';
 
     confirm({
-      message: t('confirm-delete-branch', { name: branchName }),
+      message: t('confirm-delete-branch', 'Are you sure you want to permanently delete "{{name}}"?', { name: branchName }),
       options: confirmOptions,
     }).then(() => {
       removeBranch({
         variables: { id: branchId },
         onCompleted: () => {
           toast({
-            title: t('success'),
-            description: t('branch-removed-successfully'),
+            title: t('success', 'Success'),
+            description: t('branch-removed-successfully', 'Branch removed successfully'),
           });
         },
         onError: (e) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description:
-              e instanceof Error ? e.message : t('failed-to-remove-branch'),
+              e instanceof Error ? e.message : t('failed-to-remove-branch', 'Failed to remove branch'),
             variant: 'destructive',
           });
         },

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/payment/SelectPayment.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/payment/SelectPayment.tsx
@@ -128,13 +128,13 @@ const PaymentInline = ({
   }, [paymentIds, fetchedPayments, payments, updatePayments]);
 
   if (loading && paymentIds?.length && !payments?.length) {
-    return <span className="text-sm text-muted-foreground">{t('loading')}</span>;
+    return <span className="text-sm text-muted-foreground">{t('loading', 'Loading...')}</span>;
   }
 
   if (!payments?.length) {
     return (
       <span className="text-sm text-muted-foreground">
-        {placeholder || t('select-payment')}
+        {placeholder || t('select-payment', 'Select payment')}
       </span>
     );
   }
@@ -210,7 +210,7 @@ const SelectPaymentContent = () => {
         variant="secondary"
         wrapperClassName="flex-auto"
         focusOnMount
-        placeholder={t('search-payments')}
+        placeholder={t('search-payments', 'Search payments...')}
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
@@ -351,7 +351,7 @@ export const SelectPaymentDetail = ({
             </Button>
           ) : (
             <Combobox.TriggerBase className="font-medium">
-              {t('add-payment')} <IconPlus />
+              {t('add-payment', 'Add Payment')} <IconPlus />
             </Combobox.TriggerBase>
           )}
         </Popover.Trigger>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/admins/admins.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/admins/admins.tsx
@@ -21,7 +21,7 @@ const Admins = ({ control }: Props) => {
   const { t } = useTranslation('tourism');
   return (
     <PmsFormFieldsLayout>
-      <InfoCard title={t('users')}>
+      <InfoCard title={t('users', 'Users')}>
         <InfoCard.Content>
           {roleFields.map(({ name, label }) => (
             <Form.Field
@@ -41,7 +41,7 @@ const Admins = ({ control }: Props) => {
                       mode="multiple"
                       value={field.value || []}
                       onValueChange={(value) => field.onChange(value)}
-                      placeholder={t('choose-team-member')}
+                      placeholder={t('choose-team-member', 'Choose team member')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/appearance/appearance.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/appearance/appearance.tsx
@@ -78,7 +78,7 @@ const LogoField = ({
                       <div className="flex relative z-10 flex-col gap-3 justify-center items-center">
                         <IconUpload size={20} />
                         <span className="text-xs text-muted-foreground">
-                          {t('max-size-file-type')}
+                          {t('max-size-file-type', 'Max size: 15MB, File type: PNG')}
                         </span>
                       </div>
                     )}
@@ -87,7 +87,7 @@ const LogoField = ({
                       <div className="flex absolute inset-0 justify-center items-center transition-all duration-200 bg-black/0 group-hover:bg-black/20">
                         <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
                           <div className="px-2 py-1 text-xs font-medium text-black rounded-lg backdrop-blur-sm bg-white/90">
-                            {t('change')}
+                            {t('change', 'Change')}
                           </div>
                         </div>
                       </div>
@@ -125,22 +125,22 @@ const Appearance = ({ control }: { control: Control<PmsBranchFormType> }) => {
   return (
     <PmsFormFieldsLayout>
       <div className="grid grid-cols-2 gap-4">
-        <InfoCard title={t('logo-title')}>
+        <InfoCard title={t('logo-title', 'Logo')}>
           <InfoCard.Content>
-            <LogoField control={control} name="logo" label={t('main-logo')} />
+            <LogoField control={control} name="logo" label={t('main-logo', 'Main logo')} />
           </InfoCard.Content>
         </InfoCard>
 
-        <InfoCard title={t('main-colors')}>
+        <InfoCard title={t('main-colors', 'Main colors')}>
           <InfoCard.Content>
-            <Label>{t('colors')}</Label>
+            <Label>{t('colors', 'Colors')}</Label>
             <div className="flex gap-6">
               <Form.Field
                 control={control}
                 name="primaryColor"
                 render={({ field }) => (
                   <Form.Item className="space-y-2">
-                    <Label>{t('primary-label')}</Label>
+                    <Label>{t('primary-label', 'PRIMARY')}</Label>
                     <Form.Control>
                       <ColorPicker
                         className="w-20 h-8"
@@ -158,7 +158,7 @@ const Appearance = ({ control }: { control: Control<PmsBranchFormType> }) => {
                 name="secondaryColor"
                 render={({ field }) => (
                   <Form.Item className="space-y-2">
-                    <Label>{t('secondary')}</Label>
+                    <Label>{t('secondary', 'SECONDARY')}</Label>
                     <Form.Control>
                       <ColorPicker
                         className="w-20 h-8"
@@ -176,7 +176,7 @@ const Appearance = ({ control }: { control: Control<PmsBranchFormType> }) => {
                 name="thirdColor"
                 render={({ field }) => (
                   <Form.Item className="space-y-2">
-                    <Label>{t('third')}</Label>
+                    <Label>{t('third', 'THIRD')}</Label>
                     <Form.Control>
                       <ColorPicker
                         className="w-20 h-8"
@@ -193,17 +193,17 @@ const Appearance = ({ control }: { control: Control<PmsBranchFormType> }) => {
         </InfoCard>
       </div>
 
-      <InfoCard title={t('infos')}>
+      <InfoCard title={t('infos', 'Infos')}>
         <InfoCard.Content>
           <Form.Field
             control={control}
             name="website"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>{t('website')}</Form.Label>
+                <Form.Label>{t('website', 'Website')}</Form.Label>
 
                 <Form.Control>
-                  <Input {...field} placeholder={t('website-url')} />
+                  <Input {...field} placeholder={t('website-url', 'Website url')} />
                 </Form.Control>
                 <Form.Message className="text-destructive" />
               </Form.Item>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/CheckInCheckOutTime.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/CheckInCheckOutTime.tsx
@@ -18,12 +18,12 @@ const CheckInCheckOutTime = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('check-in-time')} <span className="text-destructive">*</span>
+              {t('check-in-time', 'Check in time')} <span className="text-destructive">*</span>
             </Form.Label>
             <Form.Control>
               <Select value={field.value} onValueChange={field.onChange}>
                 <Select.Trigger>
-                  <Select.Value placeholder={t('choose-check-in-time')} />
+                  <Select.Value placeholder={t('choose-check-in-time', 'Choose check in time')} />
                 </Select.Trigger>
                 <Select.Content className="max-h-52">
                   {times.map((time, index) => (
@@ -45,12 +45,12 @@ const CheckInCheckOutTime = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('check-in-amount')} <span className="text-destructive">*</span>
+              {t('check-in-amount', 'Check in amount')} <span className="text-destructive">*</span>
             </Form.Label>
             <Form.Control>
               <Input
                 {...field}
-                placeholder={t('check-in-amount')}
+                placeholder={t('check-in-amount', 'Check in amount')}
                 type="number"
                 min={0}
                 value={field.value ?? ''}
@@ -71,12 +71,12 @@ const CheckInCheckOutTime = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('check-out-time')} <span className="text-destructive">*</span>
+              {t('check-out-time', 'Check out time')} <span className="text-destructive">*</span>
             </Form.Label>
             <Form.Control>
               <Select value={field.value} onValueChange={field.onChange}>
                 <Select.Trigger>
-                  <Select.Value placeholder={t('choose-check-in-time')} />
+                  <Select.Value placeholder={t('choose-check-in-time', 'Choose check in time')} />
                 </Select.Trigger>
                 <Select.Content className="max-h-52">
                   {times.map((time, index) => (
@@ -98,12 +98,12 @@ const CheckInCheckOutTime = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('check-out-amount')} <span className="text-destructive">*</span>
+              {t('check-out-amount', 'Check out amount')} <span className="text-destructive">*</span>
             </Form.Label>
             <Form.Control>
               <Input
                 {...field}
-                placeholder={t('check-out-amount')}
+                placeholder={t('check-out-amount', 'Check out amount')}
                 type="number"
                 min={0}
                 value={field.value ?? ''}

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Discount.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Discount.tsx
@@ -15,7 +15,7 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
     <div className="space-y-4">
       <Button onClick={() => append({})}>
         <IconPlus />
-        {t('add-discount')}
+        {t('add-discount', 'Add discount')}
       </Button>
 
       {fields.map((field, index) => (
@@ -26,7 +26,7 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name={`discount.${index}.type`}
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('type')}</Form.Label>
+                  <Form.Label>{t('type', 'Type')}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
@@ -39,7 +39,7 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name={`discount.${index}.title`}
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('title')}</Form.Label>
+                  <Form.Label>{t('title', 'Title')}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
@@ -52,7 +52,7 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name={`discount.${index}.config`}
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('config')}</Form.Label>
+                  <Form.Label>{t('config', 'Config')}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
@@ -12,7 +12,7 @@ const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
   return (
     <PmsFormFieldsLayout>
       <div className="space-y-3">
-        <InfoCard title={t('basic-information')}>
+        <InfoCard title={t('basic-information', 'Basic Information')}>
           <InfoCard.Content className="space-y-2">
             <Form.Field
               control={control}
@@ -20,10 +20,10 @@ const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
               render={({ field }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t('name')} <span className="text-destructive">*</span>
+                    {t('name', 'Name')} <span className="text-destructive">*</span>
                   </Form.Label>
                   <Form.Control>
-                    <Input {...field} placeholder={t('write-here')} />
+                    <Input {...field} placeholder={t('write-here', 'Write here')} />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
                 </Form.Item>
@@ -35,9 +35,9 @@ const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name="description"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('description')}</Form.Label>
+                  <Form.Label>{t('description', 'Description')}</Form.Label>
                   <Form.Control>
-                    <Textarea {...field} placeholder={t('description-placeholder')} />
+                    <Textarea {...field} placeholder={t('description-placeholder', 'Description...')} />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
                 </Form.Item>
@@ -46,19 +46,19 @@ const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
           </InfoCard.Content>
         </InfoCard>
 
-        <InfoCard title={t('check-in-check-out-time')}>
+        <InfoCard title={t('check-in-check-out-time', 'Check In Check Out Time')}>
           <InfoCard.Content>
             <CheckInCheckOutTime control={control} />
           </InfoCard.Content>
         </InfoCard>
 
-        <InfoCard title={t('discount')}>
+        <InfoCard title={t('discount', 'Discount')}>
           <InfoCard.Content>
             <Discount control={control} />
           </InfoCard.Content>
         </InfoCard>
 
-        <InfoCard title={t('lock')}>
+        <InfoCard title={t('lock', 'Lock')}>
           <InfoCard.Content>
             <Lock control={control} />
           </InfoCard.Content>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Lock.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Lock.tsx
@@ -18,7 +18,7 @@ const Lock = ({ control }: { control: Control<PmsBranchFormType> }) => {
         name={'websiteReservationLock'}
         render={({ field }) => (
           <div className="flex flex-col gap-3">
-            <Label>{t('website-reservation-lock')}</Label>
+            <Label>{t('website-reservation-lock', 'Website Reservation Lock')}</Label>
             <Switch
               checked={Boolean(field.value)}
               onCheckedChange={field.onChange}
@@ -34,11 +34,11 @@ const Lock = ({ control }: { control: Control<PmsBranchFormType> }) => {
           name={'time'}
           render={({ field }) => (
             <Form.Item>
-              <Form.Label>{t('reservation-lock-duration')}</Form.Label>
+              <Form.Label>{t('reservation-lock-duration', 'Reservation lock duration')}</Form.Label>
               <Form.Control>
                 <Select value={field.value} onValueChange={field.onChange}>
                   <Select.Trigger>
-                    <Select.Value placeholder={t('choose-lock-duration')} />
+                    <Select.Value placeholder={t('choose-lock-duration', 'Choose lock duration')} />
                   </Select.Trigger>
                   <Select.Content className="max-h-52">
                     {lockDurations.map((duration, index) => (

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/payments/payments.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/payments/payments.tsx
@@ -16,14 +16,14 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
   return (
     <PmsFormFieldsLayout>
       <div className="space-y-3">
-        <InfoCard title={t('payments-title')}>
+        <InfoCard title={t('payments-title', 'Payments')}>
           <InfoCard.Content>
             <Form.Field
               control={control}
               name="paymentIds"
               render={({ field }) => (
                 <Form.Item className="flex flex-col">
-                  <Form.Label>{t('payments-title')}</Form.Label>
+                  <Form.Label>{t('payments-title', 'Payments')}</Form.Label>
 
                   <Form.Control>
                     <SelectPayment.FormItem
@@ -32,7 +32,7 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
                       onValueChange={(value) => {
                         field.onChange(Array.isArray(value) ? value : []);
                       }}
-                      placeholder={t('choose-payments')}
+                      placeholder={t('choose-payments', 'Choose payments')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
@@ -45,10 +45,10 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name="erxesAppToken"
               render={({ field }) => (
                 <Form.Item className="flex flex-col">
-                  <Form.Label>{t('erxes-app-token')}</Form.Label>
+                  <Form.Label>{t('erxes-app-token', 'Erxes app token')}</Form.Label>
 
                   <Form.Control>
-                    <Input {...field} placeholder={t('enter-erxes-app-token')} />
+                    <Input {...field} placeholder={t('enter-erxes-app-token', 'Enter erxes app token')} />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
                 </Form.Item>
@@ -57,14 +57,14 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
           </InfoCard.Content>
         </InfoCard>
 
-        <InfoCard title={t('other-payments')}>
+        <InfoCard title={t('other-payments', 'Other Payments')}>
           <InfoCard.Content>
             <p className="text-sm text-muted-foreground">
-              {t('other-payments-desc')}
+              {t('other-payments-desc', 'Type is must latin, some default types: golomtCard, khaanCard, TDBCard')}
             </p>
 
             <Button className="w-fit" type="button" onClick={() => append({})}>
-              <IconPlus /> {t('add-payments-method')}
+              <IconPlus /> {t('add-payments-method', 'Add payments method')}
             </Button>
 
             {fields.map((field, index) => (
@@ -75,7 +75,7 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
                     name={`otherPayments.${index}.type`}
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('type')}</Form.Label>
+                        <Form.Label>{t('type', 'Type')}</Form.Label>
                         <Form.Control>
                           <Input {...field} />
                         </Form.Control>
@@ -88,7 +88,7 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
                     name={`otherPayments.${index}.title`}
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('title')}</Form.Label>
+                        <Form.Label>{t('title', 'Title')}</Form.Label>
                         <Form.Control>
                           <Input {...field} />
                         </Form.Control>
@@ -101,7 +101,7 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
                     name={`otherPayments.${index}.config`}
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>{t('config')}</Form.Label>
+                        <Form.Label>{t('config', 'Config')}</Form.Label>
                         <Form.Control>
                           <Input {...field} />
                         </Form.Control>
@@ -116,7 +116,7 @@ const Payments = ({ control }: { control: Control<PmsBranchFormType> }) => {
                   type="button"
                   className="w-8 h-8"
                   aria-label={`Remove payment method ${index + 1}`}
-                  title={t('remove-payment-method')}
+                  title={t('remove-payment-method', 'Remove payment method')}
                   onClick={() => remove(index)}
                 >
                   <IconTrash />

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/SelectCategory.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/SelectCategory.tsx
@@ -172,9 +172,9 @@ const SelectCategoryContent = () => {
         ) : (
           <Command.Empty>
             <div className="flex flex-col gap-2 justify-center items-center text-sm text-center text-muted-foreground">
-              {t('no-categories-found')}
+              {t('no-categories-found', 'No categories found')}
               {/* <Button variant="secondary" size="sm" asChild>
-                <Link to="/settings/products/categories">{t('add-category')}</Link>
+                <Link to="/settings/products/categories">{t('add-category', 'Add Category')}</Link>
               </Button> */}
             </div>
           </Command.Empty>
@@ -307,7 +307,7 @@ const SelectCategoryValue = ({ placeholder }: { placeholder?: string }) => {
   }, [selectedCategoryIds, productCategories, setCategories]);
 
   if (categories.length === 0) {
-    return <Combobox.Value placeholder={placeholder || t('select-category')} />;
+    return <Combobox.Value placeholder={placeholder || t('select-category', 'Select category')} />;
   }
 
   const displayText =

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/SelectSalesFlow.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/SelectSalesFlow.tsx
@@ -81,13 +81,13 @@ const SelectBoardValue = ({ placeholder }: { placeholder?: string }) => {
   const { value, boards, loading } = useSelectBoardContext();
 
   if (loading) {
-    return <span className="text-accent-foreground/80">{t('loading-boards')}</span>;
+    return <span className="text-accent-foreground/80">{t('loading-boards', 'Loading boards...')}</span>;
   }
 
   if (!boards || boards.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-board')}
+        {placeholder || t('select-board', 'Select board')}
       </span>
     );
   }
@@ -97,7 +97,7 @@ const SelectBoardValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedBoard) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-board')}
+        {placeholder || t('select-board', 'Select board')}
       </span>
     );
   }
@@ -131,7 +131,7 @@ const SelectBoardContent = () => {
       <Command.List>
         <Command.Empty>
           <div className="text-muted-foreground">
-            {loading ? t('loading-boards') : t('no-boards-found')}
+            {loading ? t('loading-boards', 'Loading boards...') : t('no-boards-found', 'No boards found')}
           </div>
         </Command.Empty>
         {boards?.map((board) => (
@@ -244,14 +244,14 @@ const SelectPipelineValue = ({ placeholder }: { placeholder?: string }) => {
 
   if (loading) {
     return (
-      <span className="text-accent-foreground/80">{t('loading-pipelines')}</span>
+      <span className="text-accent-foreground/80">{t('loading-pipelines', 'Loading pipelines...')}</span>
     );
   }
 
   if (!pipelines || pipelines.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-pipeline')}
+        {placeholder || t('select-pipeline', 'Select pipeline')}
       </span>
     );
   }
@@ -261,7 +261,7 @@ const SelectPipelineValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedPipeline) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-pipeline')}
+        {placeholder || t('select-pipeline', 'Select pipeline')}
       </span>
     );
   }
@@ -294,10 +294,10 @@ const SelectPipelineContent = () => {
   const { pipelines, boardId, loading } = useSelectPipelineContext();
 
   const emptyMessage = loading
-    ? t('loading-pipelines')
+    ? t('loading-pipelines', 'Loading pipelines...')
     : boardId
-      ? t('no-pipelines-found')
-      : t('board-not-selected');
+      ? t('no-pipelines-found', 'No pipelines found')
+      : t('board-not-selected', 'Board not selected');
 
   return (
     <Command>
@@ -418,13 +418,13 @@ const SelectStageValue = ({ placeholder }: { placeholder?: string }) => {
   const { value, stages, loading } = useSelectStageContext();
 
   if (loading) {
-    return <span className="text-accent-foreground/80">{t('loading-stages')}</span>;
+    return <span className="text-accent-foreground/80">{t('loading-stages', 'Loading stages...')}</span>;
   }
 
   if (!stages || stages.length === 0 || !value) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-stage')}
+        {placeholder || t('select-stage', 'Select stage')}
       </span>
     );
   }
@@ -434,7 +434,7 @@ const SelectStageValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedStage) {
     return (
       <span className="text-accent-foreground/80">
-        {placeholder || t('select-stage')}
+        {placeholder || t('select-stage', 'Select stage')}
       </span>
     );
   }
@@ -464,10 +464,10 @@ const SelectStageContent = () => {
   const { stages, pipelineId, loading } = useSelectStageContext();
 
   const emptyMessage = loading
-    ? t('loading-stages')
+    ? t('loading-stages', 'Loading stages...')
     : pipelineId
-      ? t('no-stages-found')
-      : t('pipeline-not-selected');
+      ? t('no-stages-found', 'No stages found')
+      : t('pipeline-not-selected', 'Pipeline not selected');
 
   return (
     <Command>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/pipelineConfig.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/pipelineConfig/pipelineConfig.tsx
@@ -118,7 +118,7 @@ const PipelineConfig = ({
 
   return (
     <PmsFormFieldsLayout>
-      <InfoCard title={t('stage')}>
+      <InfoCard title={t('stage', 'Stage')}>
         <InfoCard.Content>
           <div className="grid grid-cols-2 gap-6">
             <Form.Field
@@ -126,12 +126,12 @@ const PipelineConfig = ({
               name="boardId"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('board')}</Label>
+                  <Label>{t('board', 'BOARD')}</Label>
                   <Form.Control>
                     <SelectBoardFormItem
                       value={field.value}
                       onValueChange={handleBoardChange}
-                      placeholder={t('choose-a-board')}
+                      placeholder={t('choose-a-board', 'Choose a board')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
@@ -144,13 +144,13 @@ const PipelineConfig = ({
               name="pipelineId"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('pipeline')}</Label>
+                  <Label>{t('pipeline', 'PIPELINE')}</Label>
                   <Form.Control>
                     <SelectPipelineFormItem
                       value={field.value}
                       boardId={boardId || ''}
                       onValueChange={handlePipelineChange}
-                      placeholder={t('choose-a-pipeline')}
+                      placeholder={t('choose-a-pipeline', 'Choose a pipeline')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
@@ -161,14 +161,14 @@ const PipelineConfig = ({
         </InfoCard.Content>
       </InfoCard>
 
-      <InfoCard title={t('room-categories')}>
+      <InfoCard title={t('room-categories', 'Room categories')}>
         <InfoCard.Content>
           <Form.Field
             control={form.control}
             name="roomsCategoryIds"
             render={({ field }) => (
               <Form.Item>
-                <Label>{t('room-categories')}</Label>
+                <Label>{t('room-categories', 'Room categories')}</Label>
                 <Form.Control>
                   <SelectCategory
                     mode="multiple"
@@ -187,7 +187,7 @@ const PipelineConfig = ({
               name="excludeRoomCategoryIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-room-categories')}</Label>
+                  <Label>{t('exclude-room-categories', 'Exclude room categories')}</Label>
                   <Form.Control>
                     <SelectCategory
                       currentCategoryIds={roomsCategoryIds}
@@ -206,14 +206,14 @@ const PipelineConfig = ({
               name="excludeRoomIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-rooms')}</Label>
+                  <Label>{t('exclude-rooms', 'Exclude rooms')}</Label>
                   <Form.Control>
                     <SelectProducts
                       mode="multiple"
                       value={field.value}
                       categories={roomsCategoryIds}
                       onValueChange={handleExcludeRoomChange}
-                      placeholder={t('select-rooms')}
+                      placeholder={t('select-rooms', 'Select rooms')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
@@ -224,14 +224,14 @@ const PipelineConfig = ({
         </InfoCard.Content>
       </InfoCard>
 
-      <InfoCard title={t('extra-product-categories')}>
+      <InfoCard title={t('extra-product-categories', 'Extra product categories')}>
         <InfoCard.Content>
           <Form.Field
             control={form.control}
             name="extrasCategoryIds"
             render={({ field }) => (
               <Form.Item>
-                <Label>{t('extra-product-categories')}</Label>
+                <Label>{t('extra-product-categories', 'Extra product categories')}</Label>
                 <Form.Control>
                   <SelectCategory
                     mode="multiple"
@@ -250,7 +250,7 @@ const PipelineConfig = ({
               name="excludeExtraProductCategoryIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-extra-product-categories')}</Label>
+                  <Label>{t('exclude-extra-product-categories', 'Exclude extra product categories')}</Label>
                   <Form.Control>
                     <SelectCategory
                       currentCategoryIds={extrasCategoryIds}
@@ -269,14 +269,14 @@ const PipelineConfig = ({
               name="excludeExtraProductIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-extra-products')}</Label>
+                  <Label>{t('exclude-extra-products', 'Exclude extra products')}</Label>
                   <Form.Control>
                     <SelectProducts
                       mode="multiple"
                       value={field.value}
                       categories={extrasCategoryIds}
                       onValueChange={handleExcludeExtraProductChange}
-                      placeholder={t('select-extra-products')}
+                      placeholder={t('select-extra-products', 'Select extra products')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
@@ -287,7 +287,7 @@ const PipelineConfig = ({
         </InfoCard.Content>
       </InfoCard>
 
-      <InfoCard title={t('appointment-product-categories')}>
+      <InfoCard title={t('appointment-product-categories', 'Appointment product categories')}>
         <InfoCard.Content>
           <Form.Field
             control={form.control}
@@ -299,7 +299,7 @@ const PipelineConfig = ({
                   onCheckedChange={handleAppointmentToggle}
                   className="w-10 h-6 [&_span]:size-4 [&_span]:data-[state=checked]:translate-x-[19px] rtl:[&_span]:data-[state=checked]:-translate-x-[19px]"
                 />
-                <Label>{t('enable-appointments')}</Label>
+                <Label>{t('enable-appointments', 'Enable appointments')}</Label>
               </div>
             )}
           />
@@ -309,7 +309,7 @@ const PipelineConfig = ({
             name="appointmentCategoryIds"
             render={({ field }) => (
               <Form.Item>
-                <Label>{t('appointment-categories')}</Label>
+                <Label>{t('appointment-categories', 'Appointment categories')}</Label>
                 <Form.Control>
                   <SelectCategory
                     mode="multiple"
@@ -328,7 +328,7 @@ const PipelineConfig = ({
               name="excludeAppointmentCategoryIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-appointment-categories')}</Label>
+                  <Label>{t('exclude-appointment-categories', 'Exclude appointment categories')}</Label>
                   <Form.Control>
                     <SelectCategory
                       currentCategoryIds={appointmentCategoryIds}
@@ -347,14 +347,14 @@ const PipelineConfig = ({
               name="excludeAppointmentIds"
               render={({ field }) => (
                 <Form.Item>
-                  <Label>{t('exclude-appointments')}</Label>
+                  <Label>{t('exclude-appointments', 'Exclude appointments')}</Label>
                   <Form.Control>
                     <SelectProducts
                       mode="multiple"
                       value={field.value}
                       categories={appointmentCategoryIds}
                       onValueChange={handleExcludeAppointmentChange}
-                      placeholder={t('select-appointments')}
+                      placeholder={t('select-appointments', 'Select appointments')}
                     />
                   </Form.Control>
                   <Form.Message className="text-destructive" />

--- a/frontend/plugins/tourism_ui/src/modules/tms/Settings.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/Settings.tsx
@@ -4,7 +4,7 @@ const Settings = () => {
   const { t } = useTranslation('tourism');
   return (
     <div>
-      <h1 className="justify-center text-center">{t('tms-settings')}</h1>
+      <h1 className="justify-center text-center">{t('tms-settings', 'TMS Settings')}</h1>
     </div>
   );
 };

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/BranchDetailView.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/BranchDetailView.tsx
@@ -38,12 +38,12 @@ export const BranchDetailView = () => {
         <IconBox size={64} stroke={1.5} className="text-muted-foreground" />
         <div className="space-y-5">
           <h2 className="text-lg font-semibold text-muted-foreground">
-            {t('branch-not-found')}
+            {t('branch-not-found', 'Branch not found')}
           </h2>
 
           <Button variant="outline" onClick={() => window.history.back()}>
             <IconArrowLeft size={16} />
-            {t('back-to-branches')}
+            {t('back-to-branches', 'Back to branches')}
           </Button>
         </div>
       </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/BranchSideBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/BranchSideBar.tsx
@@ -16,7 +16,7 @@ export const BranchSideBar = ({ activeTab }: { activeTab: string }) => {
   return (
     <Sidebar collapsible="none" className="flex-none border-r">
       <Sidebar.Group>
-        <Sidebar.GroupLabel>{t('tour-management')}</Sidebar.GroupLabel>
+        <Sidebar.GroupLabel>{t('tour-management', 'Tour Management')}</Sidebar.GroupLabel>
         <Sidebar.GroupContent>
           <Sidebar.Menu>
             {steps.map((step) => (

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/ImageUploadGrid.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/components/ImageUploadGrid.tsx
@@ -69,11 +69,11 @@ export const ImageUploadGrid = ({
             onClick={uploadProps.open}
           >
             {loading ? (
-              <span className="text-xs">{t('uploading')}</span>
+              <span className="text-xs">{t('uploading', 'Uploading...')}</span>
             ) : (
               <>
                 <IconUpload size={18} />
-                <span className="text-[11px]">{t('add-images')}</span>
+                <span className="text-[11px]">{t('add-images', 'Add images')}</span>
               </>
             )}
           </div>
@@ -82,7 +82,7 @@ export const ImageUploadGrid = ({
 
       {urls.length >= maxImages && (
         <p className="text-xs text-muted-foreground">
-          {t('max-images-allowed', { count: maxImages })}
+          {t('max-images-allowed', 'Maximum {{count}} images allowed', { count: maxImages })}
         </p>
       )}
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/_components/TourFieldLanguageSwitch.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/_components/TourFieldLanguageSwitch.tsx
@@ -23,7 +23,7 @@ export const TourFieldLanguageSwitch = ({
   return (
     <Select value={value} onValueChange={onValueChange}>
       <Select.Trigger className="h-8 min-w-40">
-        <Select.Value placeholder={t('select-language')} className="text-xs">
+        <Select.Value placeholder={t('select-language', 'Select language')} className="text-xs">
           {selected?.label || value}
         </Select.Value>
       </Select.Trigger>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityCommandBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityCommandBar.tsx
@@ -24,21 +24,21 @@ export const AmenityCommandBar = () => {
 
   const onRemove = () => {
     confirm({
-      message: t('confirm-delete-amenities', { count: selectedCount }),
+      message: t('confirm-delete-amenities', 'Are you sure you want to delete the {{count}} selected amenities?', { count: selectedCount }),
       options: confirmOptions,
     }).then(() => {
       removeAmenities({ variables: { ids: amenityIds } })
         .then(() => {
           table.resetRowSelection();
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('amenities-deleted-successfully'),
+            description: t('amenities-deleted-successfully', 'Amenities deleted successfully'),
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -49,7 +49,7 @@ export const AmenityCommandBar = () => {
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('x-selected', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('x-selected', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         <Button
           variant="secondary"
@@ -57,7 +57,7 @@ export const AmenityCommandBar = () => {
           onClick={onRemove}
         >
           <IconTrash />
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityCreateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityCreateSheet.tsx
@@ -108,8 +108,8 @@ export const AmenityCreateSheet = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-creating', 'Please enter values for the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(mainLanguage || allLanguages[0] || '');
@@ -119,8 +119,8 @@ export const AmenityCreateSheet = ({
   const handleSubmit = async (values: AmenityCreateFormType) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-required'),
+        title: t('error', 'Error'),
+        description: t('branch-required', 'Branch required'),
         variant: 'destructive',
       });
       return;
@@ -140,8 +140,8 @@ export const AmenityCreateSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('amenity-created-successfully'),
+        title: t('success', 'Success'),
+        description: t('amenity-created-successfully', 'Amenity created successfully'),
       });
 
       form.reset({
@@ -153,9 +153,9 @@ export const AmenityCreateSheet = ({
       handleOpenChange(false);
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-create-amenity'),
+          error instanceof Error ? error.message : t('failed-to-create-amenity', 'Failed to create amenity'),
         variant: 'destructive',
       });
     }
@@ -167,7 +167,7 @@ export const AmenityCreateSheet = ({
         <Sheet.Trigger asChild>
           <Button>
             <IconPlus />
-            {t('create-amenity')}
+            {t('create-amenity', 'Create amenity')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -179,7 +179,7 @@ export const AmenityCreateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('create-amenity')}</Sheet.Title>
+              <Sheet.Title>{t('create-amenity', 'Create amenity')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -212,10 +212,10 @@ export const AmenityCreateSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('creating') : t('create')}
+                {loading ? t('creating', 'Creating...') : t('create', 'Create')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityDuplicate.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityDuplicate.tsx
@@ -41,7 +41,7 @@ export const AmenityDuplicate = ({
       .filter((translation) => translation.name);
 
     confirm({
-      message: t('confirm-duplicate-amenity'),
+      message: t('confirm-duplicate-amenity', 'Are you sure you want to duplicate this amenity?'),
       options: { confirmationValue: 'duplicate' },
     })
       .then(() => {
@@ -56,16 +56,16 @@ export const AmenityDuplicate = ({
           },
           onCompleted: () => {
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('amenity-duplicated-successfully'),
+              description: t('amenity-duplicated-successfully', 'Amenity duplicated successfully'),
             });
           },
           onError: (e: unknown) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description:
-                e instanceof Error ? e.message : t('unknown-error-occurred'),
+                e instanceof Error ? e.message : t('unknown-error-occurred', 'Unknown error occurred'),
               variant: 'destructive',
             });
           },
@@ -74,7 +74,7 @@ export const AmenityDuplicate = ({
       .catch((e: unknown) => {
         if (e instanceof Error) {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityEditSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityEditSheet.tsx
@@ -139,16 +139,16 @@ export const AmenityEditSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('amenity-updated-successfully'),
+        title: t('success', 'Success'),
+        description: t('amenity-updated-successfully', 'Amenity updated successfully'),
       });
 
       handleOpenChange(false);
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-update-amenity'),
+          error instanceof Error ? error.message : t('failed-to-update-amenity', 'Failed to update amenity'),
         variant: 'destructive',
       });
     }
@@ -172,7 +172,7 @@ export const AmenityEditSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('edit-amenity')}</Sheet.Title>
+              <Sheet.Title>{t('edit-amenity', 'Edit amenity')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -205,10 +205,10 @@ export const AmenityEditSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('updating') : t('update')}
+                {loading ? t('updating', 'Updating...') : t('update', 'Update')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityFilter.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityFilter.tsx
@@ -12,7 +12,7 @@ const AmenityFilterPopover = () => {
         <Combobox.Content>
           <Filter.View>
             <Command>
-              <Filter.CommandInput placeholder={t('filter')} variant="secondary" />
+              <Filter.CommandInput placeholder={t('filter', 'Filter')} variant="secondary" />
               <Command.List className="p-1">
                 <Filter.SearchValueTrigger />
               </Command.List>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityFormFields.tsx
@@ -28,12 +28,12 @@ export const AmenityNameField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('name', 'Name')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
             <Input
-              placeholder={t('amenity-name-placeholder')}
+              placeholder={t('amenity-name-placeholder', 'e.g., Free WiFi, Swimming Pool, Parking')}
               {...field}
             />
           </Form.Control>
@@ -56,7 +56,7 @@ export const AmenityIconField = ({
       name="icon"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('icon')}</Form.Label>
+          <Form.Label>{t('icon', 'Icon')}</Form.Label>
           <Form.Control>
             <AmenityIconPicker
               value={field.value}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityIconPicker.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityIconPicker.tsx
@@ -47,7 +47,7 @@ export const AmenityIconPicker = forwardRef<
 
       <Combobox.Content className="w-60 min-w-60">
         <Command>
-          <Command.Input placeholder={t('search-icon')} />
+          <Command.Input placeholder={t('search-icon', 'Search icon...')} />
           <Command.List className="max-h-[200px] overflow-y-auto hide-scroll [&>div]:flex [&>div]:flex-wrap [&>div]:gap-2 justify-center">
             <Command.Item
               value="No icon"

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityMoreCell.tsx
@@ -40,21 +40,21 @@ export const AmenityMoreColumn = ({
 
   const handleDelete = () => {
     confirm({
-      message: t('confirm-delete-amenity'),
+      message: t('confirm-delete-amenity', 'Are you sure you want to delete this amenity?'),
       options: { confirmationValue: 'delete' },
     })
       .then(() => {
         removeAmenities({ variables: { ids: [amenity._id] } })
           .then(() => {
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('amenity-deleted-successfully'),
+              description: t('amenity-deleted-successfully', 'Amenity deleted successfully'),
             });
           })
           .catch((e: any) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e.message,
               variant: 'destructive',
             });
@@ -63,7 +63,7 @@ export const AmenityMoreColumn = ({
       .catch((e: unknown) => {
         if (e instanceof Error) {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -82,7 +82,7 @@ export const AmenityMoreColumn = ({
             <Command.List>
               <Command.Item value="edit" onSelect={handleEdit}>
                 <IconEdit className="w-4 h-4" />
-                {t('edit')}
+                {t('edit', 'Edit')}
               </Command.Item>
               <AmenityDuplicate amenity={amenity} branchId={branchId}>
                 {({ onClick, disabled }) => (
@@ -92,13 +92,13 @@ export const AmenityMoreColumn = ({
                     disabled={disabled}
                   >
                     <IconCopy className="w-4 h-4" />
-                    {t('duplicate')}
+                    {t('duplicate', 'Duplicate')}
                   </Command.Item>
                 )}
               </AmenityDuplicate>
               <Command.Item value="delete" onSelect={handleDelete}>
                 <IconTrash className="w-4 h-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Command.Item>
             </Command.List>
           </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityRecordTable.tsx
@@ -101,11 +101,11 @@ function EmptyStateRow({
       />
 
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-amenities-yet')}
+        {t('no-amenities-yet', 'No amenities yet')}
       </h2>
 
       <p className="max-w-sm text-sm text-muted-foreground">
-        {t('no-amenities-yet-desc')}
+        {t('no-amenities-yet-desc', 'Create your first amenity to get started.')}
       </p>
 
       <AmenityCreateSheet

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryCommandBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryCommandBar.tsx
@@ -24,7 +24,7 @@ export const CategoryCommandBar = () => {
 
   const onRemove = () => {
     confirm({
-      message: t('confirm-delete-categories', { count: selectedCount }),
+      message: t('confirm-delete-categories', 'Are you sure you want to delete the {{count}} selected categories?', { count: selectedCount }),
       options: confirmOptions,
     }).then(() => {
       Promise.all(
@@ -33,14 +33,14 @@ export const CategoryCommandBar = () => {
         .then(() => {
           table.resetRowSelection();
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('categories-deleted-successfully'),
+            description: t('categories-deleted-successfully', 'Categories deleted successfully'),
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -51,7 +51,7 @@ export const CategoryCommandBar = () => {
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('x-selected', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('x-selected', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         <Button
           variant="secondary"
@@ -59,7 +59,7 @@ export const CategoryCommandBar = () => {
           onClick={onRemove}
         >
           <IconTrash />
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryCreateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryCreateSheet.tsx
@@ -99,8 +99,8 @@ export const CategoryCreateSheet = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-creating', 'Please enter values for the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(mainLanguage || allLanguages[0] || '');
@@ -123,8 +123,8 @@ export const CategoryCreateSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('category-created-successfully'),
+        title: t('success', 'Success'),
+        description: t('category-created-successfully', 'Category created successfully'),
       });
 
       form.reset({
@@ -137,9 +137,9 @@ export const CategoryCreateSheet = ({
       handleOpenChange(false);
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-create-category'),
+          error instanceof Error ? error.message : t('failed-to-create-category', 'Failed to create category'),
         variant: 'destructive',
       });
     }
@@ -151,7 +151,7 @@ export const CategoryCreateSheet = ({
         <Sheet.Trigger asChild>
           <Button>
             <IconPlus />
-            {t('create-category')}
+            {t('create-category', 'Create category')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -163,7 +163,7 @@ export const CategoryCreateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('create-category')}</Sheet.Title>
+              <Sheet.Title>{t('create-category', 'Create category')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex gap-2 items-center ml-auto">
                   <TourFieldLanguageSwitch
@@ -202,11 +202,11 @@ export const CategoryCreateSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
 
               <Button type="submit" disabled={loading}>
-                {loading ? t('creating') : t('create')}
+                {loading ? t('creating', 'Creating...') : t('create', 'Create')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryEditSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryEditSheet.tsx
@@ -129,16 +129,16 @@ export const CategoryEditSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('category-updated-successfully'),
+        title: t('success', 'Success'),
+        description: t('category-updated-successfully', 'Category updated successfully'),
       });
 
       handleOpenChange(false);
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-update-category'),
+          error instanceof Error ? error.message : t('failed-to-update-category', 'Failed to update category'),
         variant: 'destructive',
       });
     }
@@ -162,7 +162,7 @@ export const CategoryEditSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('edit-category')}</Sheet.Title>
+              <Sheet.Title>{t('edit-category', 'Edit category')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex gap-2 items-center ml-auto">
                   <TourFieldLanguageSwitch
@@ -201,11 +201,11 @@ export const CategoryEditSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
 
               <Button type="submit" disabled={loading}>
-                {loading ? t('updating') : t('update')}
+                {loading ? t('updating', 'Updating...') : t('update', 'Update')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryFilter.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryFilter.tsx
@@ -12,7 +12,7 @@ const CategoryFilterPopover = () => {
         <Combobox.Content>
           <Filter.View>
             <Command>
-              <Filter.CommandInput placeholder={t('filter')} variant="secondary" />
+              <Filter.CommandInput placeholder={t('filter', 'Filter')} variant="secondary" />
               <Command.List className="p-1">
                 <Filter.SearchValueTrigger />
               </Command.List>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryFormFields.tsx
@@ -30,12 +30,12 @@ export const CategoryNameField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('name', 'Name')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
             <Input
-              placeholder={t('category-name-placeholder')}
+              placeholder={t('category-name-placeholder', 'e.g., Adventure Tours, Cultural Tours')}
               {...field}
             />
           </Form.Control>
@@ -59,10 +59,10 @@ export const CategoryCodeField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('code')} <span className="text-destructive">*</span>
+            {t('code', 'Code')} <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
-            <Input placeholder={t('category-code-placeholder')} {...field} />
+            <Input placeholder={t('category-code-placeholder', 'e.g., ADV, CUL')} {...field} />
           </Form.Control>
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -87,7 +87,7 @@ export const CategoryParentIdField = ({
       name="parentId"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('parent-category')}</Form.Label>
+          <Form.Label>{t('parent-category', 'Parent category')}</Form.Label>
           <Form.Control>
             <SelectParentCategory
               selected={field.value}
@@ -117,7 +117,7 @@ export const CategoryAttachmentField = ({
       name="attachment"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('category-image')}</Form.Label>
+          <Form.Label>{t('category-image', 'Category Image')}</Form.Label>
 
           <Form.Control>
             <Upload.Root
@@ -149,11 +149,11 @@ export const CategoryAttachmentField = ({
                 {!field.value?.url && (
                   <div className="flex flex-col gap-2 justify-center items-center text-sm text-muted-foreground">
                     {isLoading ? (
-                      <span>{t('uploading')}</span>
+                      <span>{t('uploading', 'Uploading...')}</span>
                     ) : (
                       <>
                         <IconUpload size={22} />
-                        <span>{t('upload-category-image')}</span>
+                        <span>{t('upload-category-image', 'Upload category image')}</span>
                       </>
                     )}
                   </div>
@@ -162,7 +162,7 @@ export const CategoryAttachmentField = ({
                 {field.value?.url && (
                   <div className="flex absolute inset-0 justify-center items-center transition bg-black/0 group-hover:bg-black/30">
                     <span className="px-2 py-1 text-xs font-medium text-white rounded opacity-0 group-hover:opacity-100 bg-black/70">
-                      {t('change-image')}
+                      {t('change-image', 'Change image')}
                     </span>
                   </div>
                 )}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryMoreCell.tsx
@@ -49,21 +49,21 @@ export const CategoryMoreColumn = (
 
   const handleDelete = () => {
     confirm({
-      message: t('confirm-delete-category'),
+      message: t('confirm-delete-category', 'Are you sure you want to delete this category?'),
       options: { confirmationValue: 'delete' },
     })
       .then(() => {
         deleteCategory({ variables: { id: category._id } })
           .then(() => {
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('category-deleted-successfully'),
+              description: t('category-deleted-successfully', 'Category deleted successfully'),
             });
           })
           .catch((e: any) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e.message,
               variant: 'destructive',
             });
@@ -72,7 +72,7 @@ export const CategoryMoreColumn = (
       .catch((e: unknown) => {
         if (e instanceof Error) {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -91,11 +91,11 @@ export const CategoryMoreColumn = (
             <Command.List>
               <Command.Item value="edit" onSelect={handleEdit}>
                 <IconEdit className="w-4 h-4" />
-                {t('edit')}
+                {t('edit', 'Edit')}
               </Command.Item>
               <Command.Item value="delete" onSelect={handleDelete}>
                 <IconTrash className="w-4 h-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Command.Item>
             </Command.List>
           </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryRecordTable.tsx
@@ -98,11 +98,11 @@ function EmptyStateRow({
       />
 
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-categories-yet')}
+        {t('no-categories-yet', 'No categories yet')}
       </h2>
 
       <p className="max-w-sm text-sm text-muted-foreground">
-        {t('no-categories-yet-desc')}
+        {t('no-categories-yet-desc', 'Create your first category to get started.')}
       </p>
 
       <CategoryCreateSheet

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/SelectParentCategory.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/SelectParentCategory.tsx
@@ -159,7 +159,7 @@ export const SelectParentCategoryTrigger = React.forwardRef<
   return (
     <Combobox.Trigger ref={ref} className={className} {...props}>
       <SelectParentCategoryBadge category={selectedCategory} />
-      {!selectedCategory && <Combobox.Value placeholder={t('select-category')} />}
+      {!selectedCategory && <Combobox.Value placeholder={t('select-category', 'Select category')} />}
       {loading && (
         <>
           <Skeleton className="w-4 h-4" />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/CategorySelector.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/CategorySelector.tsx
@@ -61,7 +61,7 @@ export const CategorySelector = ({
   if (loading) {
     return (
       <Command.Item disabled className="h-8">
-        {t('loading')}
+        {t('loading', 'Loading...')}
       </Command.Item>
     );
   }

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementCommandBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementCommandBar.tsx
@@ -25,21 +25,21 @@ export const ElementCommandBar = () => {
 
   const onRemove = () => {
     confirm({
-      message: t('confirm-delete-elements', { count: selectedCount }),
+      message: t('confirm-delete-elements', 'Are you sure you want to delete the {{count}} selected elements?', { count: selectedCount }),
       options: confirmOptions,
     }).then(() => {
       removeElements(elementIds)
         .then(() => {
           table.resetRowSelection();
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('elements-deleted-successfully'),
+            description: t('elements-deleted-successfully', 'Elements deleted successfully'),
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -50,7 +50,7 @@ export const ElementCommandBar = () => {
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('x-selected', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('x-selected', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         <Button
           variant="secondary"
@@ -59,7 +59,7 @@ export const ElementCommandBar = () => {
           onClick={onRemove}
         >
           {loading ? <Spinner /> : <IconTrash />}
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementCreateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementCreateSheet.tsx
@@ -101,8 +101,8 @@ export const ElementCreateSheet = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-creating', 'Please enter values for the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(resolvedPrimaryLanguage);
@@ -112,8 +112,8 @@ export const ElementCreateSheet = ({
   const handleSubmit = async (values: ElementCreateFormType) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-required'),
+        title: t('error', 'Error'),
+        description: t('branch-required', 'Branch required'),
         variant: 'destructive',
       });
       return;
@@ -135,7 +135,7 @@ export const ElementCreateSheet = ({
         },
       });
 
-      toast({ title: t('success'), description: t('element-created-successfully') });
+      toast({ title: t('success', 'Success'), description: t('element-created-successfully', 'Element created successfully') });
       form.reset({
         name: '',
         note: '',
@@ -151,7 +151,7 @@ export const ElementCreateSheet = ({
       toast({
         title: 'Error',
         description:
-          error instanceof Error ? error.message : t('failed-to-create-element'),
+          error instanceof Error ? error.message : t('failed-to-create-element', 'Failed to create element'),
         variant: 'destructive',
       });
     }
@@ -163,7 +163,7 @@ export const ElementCreateSheet = ({
         <Sheet.Trigger asChild>
           <Button type="button">
             <IconPlus />
-            {t('create-element')}
+            {t('create-element', 'Create element')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -178,7 +178,7 @@ export const ElementCreateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('create-element')}</Sheet.Title>
+              <Sheet.Title>{t('create-element', 'Create element')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -230,10 +230,10 @@ export const ElementCreateSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('creating') : t('create')}
+                {loading ? t('creating', 'Creating...') : t('create', 'Create')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementDuplicate.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementDuplicate.tsx
@@ -71,7 +71,7 @@ export const ElementDuplicate = ({
     };
 
     confirm({
-      message: t('confirm-duplicate-element'),
+      message: t('confirm-duplicate-element', 'Are you sure you want to duplicate this element?'),
       options: { confirmationValue: 'duplicate' },
     }).then(async () => {
       try {
@@ -88,25 +88,25 @@ export const ElementDuplicate = ({
           variables: buildDuplicatePayload(source),
           onCompleted: () => {
             toast({
-              title: t('success'),
+              title: t('success', 'Success'),
               variant: 'success',
-              description: t('element-duplicated-successfully'),
+              description: t('element-duplicated-successfully', 'Element duplicated successfully'),
             });
           },
           onError: (e: unknown) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description:
-                e instanceof Error ? e.message : t('failed-to-create-element'),
+                e instanceof Error ? e.message : t('failed-to-create-element', 'Failed to create element'),
               variant: 'destructive',
             });
           },
         });
       } catch (e: unknown) {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            e instanceof Error ? e.message : t('failed-to-load-element-detail'),
+            e instanceof Error ? e.message : t('failed-to-load-element-detail', 'Failed to load element detail'),
           variant: 'destructive',
         });
       }

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementEditSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementEditSheet.tsx
@@ -130,13 +130,13 @@ export const ElementEditSheet = ({
         },
       });
 
-      toast({ title: t('success'), description: t('element-updated-successfully') });
+      toast({ title: t('success', 'Success'), description: t('element-updated-successfully', 'Element updated successfully') });
       handleOpenChange(false);
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-update-element'),
+          error instanceof Error ? error.message : t('failed-to-update-element', 'Failed to update element'),
         variant: 'destructive',
       });
     }
@@ -163,7 +163,7 @@ export const ElementEditSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('edit-element')}</Sheet.Title>
+              <Sheet.Title>{t('edit-element', 'Edit element')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -215,10 +215,10 @@ export const ElementEditSheet = ({
                 disabled={loading}
                 onClick={() => handleOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('updating') : t('update')}
+                {loading ? t('updating', 'Updating...') : t('update', 'Update')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementFilter.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementFilter.tsx
@@ -17,7 +17,7 @@ function SelectCategoryFilterItem() {
   return (
     <Filter.Item value="category">
       <IconTags />
-      {t('category')}
+      {t('category', 'Category')}
     </Filter.Item>
   );
 }
@@ -31,9 +31,9 @@ function SelectCategoryFilterView() {
   return (
     <Filter.View filterKey="category">
       <Command>
-        <Command.Input placeholder={t('search-category')} />
+        <Command.Input placeholder={t('search-category', 'Search category')} />
         <Command.List>
-          <Command.Empty>{t('no-category-found')}</Command.Empty>
+          <Command.Empty>{t('no-category-found', 'No category found.')}</Command.Empty>
           <CategorySelector
             value={categoryId ?? undefined}
             onChange={(value) => setCategoryId(value)}
@@ -53,7 +53,7 @@ const ElementFilterPopover = () => {
         <Combobox.Content>
           <Filter.View>
             <Command>
-              <Filter.CommandInput placeholder={t('filter')} variant="secondary" />
+              <Filter.CommandInput placeholder={t('filter', 'Filter')} variant="secondary" />
               <Command.List className="p-1">
                 <Filter.SearchValueTrigger />
                 <Command.Separator className="my-1" />
@@ -95,10 +95,10 @@ export const ElementFilter = () => {
         <Filter.BarItem queryKey="categoryId">
           <Filter.BarName>
             <IconTags />
-            {t('category')}
+            {t('category', 'Category')}
           </Filter.BarName>
           <Filter.BarButton filterKey="category">
-            {selectedCategoryLabel || t('select-category')}
+            {selectedCategoryLabel || t('select-category', 'Select category')}
           </Filter.BarButton>
         </Filter.BarItem>
         <ElementsTotalCount />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementFormFields.tsx
@@ -41,11 +41,11 @@ export const ElementNameField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('name', 'Name')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
-            <Input placeholder={t('element-name')} {...field} />
+            <Input placeholder={t('element-name', 'Element name')} {...field} />
           </Form.Control>
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -67,10 +67,10 @@ export const ElementNoteField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('note')}<span className="text-primary">{labelSuffix}</span>
+            {t('note', 'Note')}<span className="text-primary">{labelSuffix}</span>
           </Form.Label>
           <Form.Description>
-            {t('not-visible-for-clients')}
+            {t('not-visible-for-clients', 'Not visible for clients and agents.')}
           </Form.Description>
           <Form.Control>
             <Editor
@@ -99,7 +99,7 @@ export const ElementStartTimeField = ({
       name="startTime"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('start-time')}</Form.Label>
+          <Form.Label>{t('start-time', 'Start Time')}</Form.Label>
           <Form.Control>
             <Input type="time" {...field} />
           </Form.Control>
@@ -122,7 +122,7 @@ export const ElementDurationField = ({
       name="duration"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('duration-minutes')}</Form.Label>
+          <Form.Label>{t('duration-minutes', 'Duration (minutes)')}</Form.Label>
           <Form.Control>
             <Input type="number" placeholder="0" {...field} />
           </Form.Control>
@@ -152,7 +152,7 @@ export const ElementCostField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('cost')}</Form.Label>
+          <Form.Label>{t('cost', 'Cost')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementMoreCell.tsx
@@ -40,20 +40,20 @@ export const ElementMoreColumn = ({
 
   const handleDelete = () => {
     confirm({
-      message: t('confirm-delete-element'),
+      message: t('confirm-delete-element', 'Are you sure you want to delete this element?'),
       options: { confirmationValue: 'delete' },
     }).then(() => {
       removeElements([element._id])
         .then(() => {
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('element-deleted-successfully'),
+            description: t('element-deleted-successfully', 'Element deleted successfully'),
           });
         })
         .catch((e: any) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -72,7 +72,7 @@ export const ElementMoreColumn = ({
             <Command.List>
               <Command.Item value="edit" onSelect={handleEdit}>
                 <IconEdit className="w-4 h-4" />
-                {t('edit')}
+                {t('edit', 'Edit')}
               </Command.Item>
               <ElementDuplicate element={element} branchId={branchId}>
                 {({ onClick, disabled }) => (
@@ -82,13 +82,13 @@ export const ElementMoreColumn = ({
                     disabled={disabled}
                   >
                     <IconCopy className="w-4 h-4" />
-                    {t('duplicate')}
+                    {t('duplicate', 'Duplicate')}
                   </Command.Item>
                 )}
               </ElementDuplicate>
               <Command.Item value="delete" onSelect={handleDelete}>
                 <IconTrash className="w-4 h-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Command.Item>
             </Command.List>
           </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementRecordTable.tsx
@@ -105,11 +105,11 @@ function EmptyStateRow({
       <IconPuzzle size={64} stroke={1.5} className="text-muted-foreground" />
 
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-elements-yet')}
+        {t('no-elements-yet', 'No elements yet')}
       </h2>
 
       <p className="max-w-sm text-sm text-muted-foreground">
-        {t('no-elements-yet-desc')}
+        {t('no-elements-yet-desc', 'Create your first element to get started.')}
       </p>
 
       <ElementCreateSheet

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/SelectElementCategories.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/SelectElementCategories.tsx
@@ -76,7 +76,7 @@ export const SelectElementCategories = ({
 
         return (
           <Form.Item>
-            <Form.Label>{t('categories')}</Form.Label>
+            <Form.Label>{t('categories', 'Categories')}</Form.Label>
             <Form.Control>
               <div className="space-y-3">
                 <Popover open={open} onOpenChange={setOpen}>
@@ -90,24 +90,24 @@ export const SelectElementCategories = ({
                     >
                       <span className="truncate">
                         {selectedIds.length > 0
-                          ? t('categories-selected', { count: selectedIds.length })
-                          : t('select-categories')}
+                          ? t('categories-selected', '{{count}} categor{{count, plural, one{y} other{ies}}} selected', { count: selectedIds.length })
+                          : t('select-categories', 'Select categories')}
                       </span>
                     </Button>
                   </Popover.Trigger>
                   <Popover.Content className="w-[400px] p-0" align="start">
                     <Command className="rounded-lg border shadow-md">
                       <Command.Input
-                        placeholder={t('search-categories')}
+                        placeholder={t('search-categories', 'Search categories')}
                         className="h-8"
                       />
                       <Command.Empty className="py-6 text-sm text-center">
-                        {t('no-categories-found')}
+                        {t('no-categories-found', 'No categories found')}
                       </Command.Empty>
                       <Command.Group className="max-h-[300px] overflow-auto">
                         {loading ? (
                           <Command.Item disabled className="h-8">
-                            {t('loading')}
+                            {t('loading', 'Loading...')}
                           </Command.Item>
                         ) : (
                           flattenedCategories.map(({ category, level }) => {

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryCommandBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryCommandBar.tsx
@@ -55,21 +55,21 @@ export const ItineraryCommandBar = ({
     }
 
     confirm({
-      message: t('confirm-delete-itineraries', { count: selectedCount }),
+      message: t('confirm-delete-itineraries', 'Are you sure you want to delete the {{count}} selected itineraries?', { count: selectedCount }),
       options: confirmOptions,
     }).then(() => {
       removeItineraries(itineraryIds)
         .then(() => {
           table.resetRowSelection();
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('itineraries-deleted-successfully'),
+            description: t('itineraries-deleted-successfully', 'Itineraries deleted successfully'),
           });
         })
         .catch((e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -88,7 +88,7 @@ export const ItineraryCommandBar = ({
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('x-selected', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('x-selected', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         {selectedCount === 1 && (
           <>
@@ -112,7 +112,7 @@ export const ItineraryCommandBar = ({
           onClick={handleRemove}
         >
           {loading ? <Spinner /> : <IconTrash />}
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryCreateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryCreateSheet.tsx
@@ -187,8 +187,8 @@ export const ItineraryCreateSheet = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-creating', 'Please enter values for the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(mainLanguage || allLanguages[0] || '');
@@ -198,7 +198,7 @@ export const ItineraryCreateSheet = ({
     const firstError = extractFirstError(errors);
     if (firstError) {
       toast({
-        title: t('validation-error'),
+        title: t('validation-error', 'Validation Error'),
         description: firstError,
         variant: 'destructive',
       });
@@ -208,8 +208,8 @@ export const ItineraryCreateSheet = ({
   const handleSubmit = async (values: ItineraryCreateFormType) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-required-for-itinerary'),
+        title: t('error', 'Error'),
+        description: t('branch-required-for-itinerary', 'Branch is required to create an itinerary'),
         variant: 'destructive',
       });
       return;
@@ -217,8 +217,8 @@ export const ItineraryCreateSheet = ({
 
     if (!values.groupDays || values.groupDays.length === 0) {
       toast({
-        title: t('error'),
-        description: t('at-least-one-day-required'),
+        title: t('error', 'Error'),
+        description: t('at-least-one-day-required', 'At least one day is required'),
         variant: 'destructive',
       });
       return;
@@ -285,8 +285,8 @@ export const ItineraryCreateSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('itinerary-created-successfully'),
+        title: t('success', 'Success'),
+        description: t('itinerary-created-successfully', 'Itinerary created successfully'),
       });
 
       form.reset();
@@ -294,10 +294,10 @@ export const ItineraryCreateSheet = ({
       handleOpenChange(false);
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : t('failed-to-create-itinerary');
+        error instanceof Error ? error.message : t('failed-to-create-itinerary', 'Failed to create itinerary');
 
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: message,
         variant: 'destructive',
       });
@@ -315,7 +315,7 @@ export const ItineraryCreateSheet = ({
         <Sheet.Trigger asChild>
           <Button>
             <IconPlus />
-            {t('create-itinerary')}
+            {t('create-itinerary', 'Create itinerary')}
           </Button>
         </Sheet.Trigger>
       )}
@@ -329,7 +329,7 @@ export const ItineraryCreateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('create-itinerary')}</Sheet.Title>
+              <Sheet.Title>{t('create-itinerary', 'Create itinerary')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -439,8 +439,8 @@ export const ItineraryCreateSheet = ({
                           size="sm"
                         >
                           {showMoreOptions
-                            ? t('hide-more-options')
-                            : t('show-more-options')}
+                            ? t('hide-more-options', 'Hide more options')
+                            : t('show-more-options', 'Show more options')}
                           <IconChevronDown
                             size={12}
                             strokeWidth={2}
@@ -465,7 +465,7 @@ export const ItineraryCreateSheet = ({
                     onClick={() => handleOpenChange(false)}
                     disabled={loading}
                   >
-                    {t('cancel')}
+                    {t('cancel', 'Cancel')}
                   </Button>
 
                   <Button
@@ -473,7 +473,7 @@ export const ItineraryCreateSheet = ({
                     disabled={loading}
                     onClick={handleNextStep}
                   >
-                    {t('next')}
+                    {t('next', 'Next')}
                   </Button>
                 </div>
               ) : (
@@ -487,11 +487,11 @@ export const ItineraryCreateSheet = ({
                     }}
                     disabled={loading}
                   >
-                    {t('back')}
+                    {t('back', 'Back')}
                   </Button>
 
                   <Button type="submit" disabled={loading}>
-                    {loading ? t('creating') : t('create')}
+                    {loading ? t('creating', 'Creating...') : t('create', 'Create')}
                   </Button>
                 </div>
               )}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryDuplicateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryDuplicateSheet.tsx
@@ -152,7 +152,7 @@ export const ItineraryDuplicateSheet = ({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <Sheet.View className="w-[400px] sm:max-w-[400px] p-0">
           <Sheet.Header>
-            <Sheet.Title>{t('duplicate-itinerary')}</Sheet.Title>
+            <Sheet.Title>{t('duplicate-itinerary', 'Duplicate itinerary')}</Sheet.Title>
           </Sheet.Header>
           <Sheet.Content className="flex items-center justify-center py-12">
             <Spinner />
@@ -193,18 +193,18 @@ export const ItineraryDuplicateSheet = ({
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
+          title: t('success', 'Success'),
           variant: 'success',
-          description: t('itinerary-duplicated-successfully'),
+          description: t('itinerary-duplicated-successfully', 'Itinerary duplicated successfully'),
         });
         onOpenChange(false);
         form.reset();
       },
       onError: (e: unknown) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            e instanceof Error ? e.message : t('failed-to-duplicate-itinerary'),
+            e instanceof Error ? e.message : t('failed-to-duplicate-itinerary', 'Failed to duplicate itinerary'),
           variant: 'destructive',
         });
       },
@@ -220,7 +220,7 @@ export const ItineraryDuplicateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('duplicate-itinerary')}</Sheet.Title>
+              <Sheet.Title>{t('duplicate-itinerary', 'Duplicate itinerary')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -251,10 +251,10 @@ export const ItineraryDuplicateSheet = ({
                 disabled={loading}
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('duplicating') : t('duplicate')}
+                {loading ? t('duplicating', 'Duplicating…') : t('duplicate', 'Duplicate')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryEditSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryEditSheet.tsx
@@ -222,8 +222,8 @@ export const ItineraryEditSheet = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-updating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-updating', 'Please enter values for the main language before updating.'),
         variant: 'destructive',
       });
       setSelectedLang(mainLanguage || allLanguages[0] || '');
@@ -233,7 +233,7 @@ export const ItineraryEditSheet = ({
     const firstError = extractFirstError(errors);
     if (firstError) {
       toast({
-        title: t('validation-error'),
+        title: t('validation-error', 'Validation Error'),
         description: firstError,
         variant: 'destructive',
       });
@@ -243,8 +243,8 @@ export const ItineraryEditSheet = ({
   const handleSubmit = async (values: ItineraryCreateFormType) => {
     if (!itineraryId) {
       toast({
-        title: t('error'),
-        description: t('itinerary-id-required'),
+        title: t('error', 'Error'),
+        description: t('itinerary-id-required', 'Itinerary ID is required'),
         variant: 'destructive',
       });
       return;
@@ -252,8 +252,8 @@ export const ItineraryEditSheet = ({
 
     if (!values.groupDays || values.groupDays.length === 0) {
       toast({
-        title: t('error'),
-        description: t('at-least-one-day-required'),
+        title: t('error', 'Error'),
+        description: t('at-least-one-day-required', 'At least one day is required'),
         variant: 'destructive',
       });
       return;
@@ -320,17 +320,17 @@ export const ItineraryEditSheet = ({
       });
 
       toast({
-        title: t('success'),
-        description: t('itinerary-updated-successfully'),
+        title: t('success', 'Success'),
+        description: t('itinerary-updated-successfully', 'Itinerary updated successfully'),
       });
 
       handleOpenChange(false);
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : t('failed-to-update-itinerary');
+        error instanceof Error ? error.message : t('failed-to-update-itinerary', 'Failed to update itinerary');
 
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: message,
         variant: 'destructive',
       });
@@ -358,7 +358,7 @@ export const ItineraryEditSheet = ({
               className="flex flex-col h-full"
             >
               <Sheet.Header>
-                <Sheet.Title>{t('edit-itinerary')}</Sheet.Title>
+                <Sheet.Title>{t('edit-itinerary', 'Edit itinerary')}</Sheet.Title>
                 {allLanguages.length > 1 && (
                   <div className="flex items-center gap-2 ml-auto">
                     <TourFieldLanguageSwitch
@@ -469,8 +469,8 @@ export const ItineraryEditSheet = ({
                             size="sm"
                           >
                             {showMoreOptions
-                              ? t('hide-more-options')
-                              : t('show-more-options')}
+                              ? t('hide-more-options', 'Hide more options')
+                              : t('show-more-options', 'Show more options')}
                             <IconChevronDown
                               size={12}
                               strokeWidth={2}
@@ -495,7 +495,7 @@ export const ItineraryEditSheet = ({
                       onClick={() => handleOpenChange(false)}
                       disabled={editLoading}
                     >
-                      {t('cancel')}
+                      {t('cancel', 'Cancel')}
                     </Button>
 
                     <Button
@@ -503,7 +503,7 @@ export const ItineraryEditSheet = ({
                       disabled={editLoading}
                       onClick={handleNextStep}
                     >
-                      {t('next')}
+                      {t('next', 'Next')}
                     </Button>
                   </div>
                 ) : (
@@ -517,11 +517,11 @@ export const ItineraryEditSheet = ({
                       }}
                       disabled={editLoading}
                     >
-                      {t('back')}
+                      {t('back', 'Back')}
                     </Button>
 
                     <Button type="submit" disabled={editLoading}>
-                      {editLoading ? t('updating') : t('update')}
+                      {editLoading ? t('updating', 'Updating...') : t('update', 'Update')}
                     </Button>
                   </div>
                 )}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryFilter.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryFilter.tsx
@@ -12,7 +12,7 @@ const ItineraryFilterPopover = () => {
         <Combobox.Content>
           <Filter.View>
             <Command>
-              <Filter.CommandInput placeholder={t('filter')} variant="secondary" />
+              <Filter.CommandInput placeholder={t('filter', 'Filter')} variant="secondary" />
               <Command.List className="p-1">
                 <Filter.SearchValueTrigger />
               </Command.List>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryFormFields.tsx
@@ -57,12 +57,12 @@ export const ItineraryNameField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('name', 'Name')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
             <Input
-              placeholder={t('itinerary-name')}
+              placeholder={t('itinerary-name', 'Itinerary name')}
               {...field}
               value={field.value || ''}
             />
@@ -86,7 +86,7 @@ export const ItineraryColorField = ({
       name="color"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('color')}</Form.Label>
+          <Form.Label>{t('color', 'Color')}</Form.Label>
           <Form.Control>
             <ColorPicker
               value={field.value}
@@ -116,7 +116,7 @@ export const ItineraryContentField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('content')}<span className="text-primary">{labelSuffix}</span>
+            {t('content', 'Content')}<span className="text-primary">{labelSuffix}</span>
           </Form.Label>
           <Form.Control>
             <Editor
@@ -147,7 +147,7 @@ export const ItineraryGuideCostField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('guides-daily-wage')}</Form.Label>
+          <Form.Label>{t('guides-daily-wage', 'Guide\'s daily wage')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -186,7 +186,7 @@ export const ItineraryDriverCostField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('drivers-daily-wage')}</Form.Label>
+          <Form.Label>{t('drivers-daily-wage', 'Driver\'s daily wage')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -225,7 +225,7 @@ export const ItineraryFoodCostField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('daily-cost-of-food')}</Form.Label>
+          <Form.Label>{t('daily-cost-of-food', 'Daily cost of food per person')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -264,7 +264,7 @@ export const ItineraryGasCostField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('gasoline-fee-per-car')}</Form.Label>
+          <Form.Label>{t('gasoline-fee-per-car', 'Gasoline fee per car')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -303,7 +303,7 @@ export const ItineraryGuideCostExtraField = ({
       name={name}
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('total-price-additive-assistant')}</Form.Label>
+          <Form.Label>{t('total-price-additive-assistant', 'Total price of a additive assistant')}</Form.Label>
           <Form.Control>
             <div className="relative">
               <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -344,7 +344,7 @@ export const ItineraryImageField = ({
 
         return (
           <Form.Item>
-            <Form.Label>{t('itinerary-image')}</Form.Label>
+            <Form.Label>{t('itinerary-image', 'Itinerary Image')}</Form.Label>
 
             <Form.Control>
               <Upload.Root
@@ -379,11 +379,11 @@ export const ItineraryImageField = ({
                   {!imageUrl && (
                     <div className="flex flex-col gap-2 justify-center items-center text-sm text-muted-foreground">
                       {isLoading ? (
-                        <span>{t('uploading')}</span>
+                        <span>{t('uploading', 'Uploading...')}</span>
                       ) : (
                         <>
                           <IconUpload size={22} />
-                          <span>{t('upload-itinerary-image')}</span>
+                          <span>{t('upload-itinerary-image', 'Upload itinerary image')}</span>
                         </>
                       )}
                     </div>
@@ -392,7 +392,7 @@ export const ItineraryImageField = ({
                   {imageUrl && (
                     <div className="flex absolute inset-0 justify-center items-center transition bg-black/0 group-hover:bg-black/30">
                       <span className="px-2 py-1 text-xs font-medium text-white rounded opacity-0 bg-black/70 group-hover:opacity-100">
-                        {t('change-image')}
+                        {t('change-image', 'Change image')}
                       </span>
                     </div>
                   )}
@@ -436,7 +436,7 @@ export const ItineraryPersonCostField = ({
   const { t } = useTranslation('tourism');
   return (
     <div className="space-y-3">
-      <Form.Label>{t('daily-cost-per-person')}</Form.Label>
+      <Form.Label>{t('daily-cost-per-person', 'The daily cost per person')}</Form.Label>
       <div className="grid grid-cols-1 gap-2">
         {Array.from({ length: duration }, (_, i) => {
           const dayKey = `day${i + 1}`;
@@ -450,7 +450,7 @@ export const ItineraryPersonCostField = ({
                   <Form.Control className="flex-1">
                     <Input
                       type="number"
-                      placeholder={t('cost-for-day', { day: i + 1 })}
+                      placeholder={t('cost-for-day', 'Cost for day {{day}}', { day: i + 1 })}
                       value={field.value || 0}
                       onChange={(e) => field.onChange(Number(e.target.value))}
                     />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryMoreCell.tsx
@@ -45,20 +45,20 @@ export const ItineraryMoreColumn = ({
 
   const handleDelete = () => {
     confirm({
-      message: t('confirm-delete-itinerary'),
+      message: t('confirm-delete-itinerary', 'Are you sure you want to delete this itinerary?'),
       options: { confirmationValue: 'delete' },
     }).then(() => {
       removeItineraries([itinerary._id])
         .then(() => {
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('itinerary-deleted-successfully'),
+            description: t('itinerary-deleted-successfully', 'Itinerary deleted successfully'),
           });
         })
         .catch((e: any) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -77,15 +77,15 @@ export const ItineraryMoreColumn = ({
             <Command.List>
               <Command.Item value="edit" onSelect={handleEdit}>
                 <IconEdit className="w-4 h-4" />
-                {t('edit')}
+                {t('edit', 'Edit')}
               </Command.Item>
               <Command.Item value="duplicate" onSelect={handleDuplicate}>
                 <IconCopy className="w-4 h-4" />
-                {t('duplicate')}
+                {t('duplicate', 'Duplicate')}
               </Command.Item>
               <Command.Item value="delete" onSelect={handleDelete}>
                 <IconTrash className="w-4 h-4" />
-                {t('delete')}
+                {t('delete', 'Delete')}
               </Command.Item>
             </Command.List>
           </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryRecordTable.tsx
@@ -159,10 +159,10 @@ function EmptyStateRow({
     <div className="flex flex-col items-center justify-center gap-3 p-6 w-full min-h-[80vh] text-center">
       <IconRoute size={64} stroke={1.5} className="text-muted-foreground" />
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-itinerary-yet')}
+        {t('no-itinerary-yet', 'No itinerary yet')}
       </h2>
       <p className="max-w-sm text-sm text-muted-foreground">
-        {t('no-itinerary-yet-desc')}
+        {t('no-itinerary-yet-desc', 'Create your first itinerary to get started.')}
       </p>
       <ItineraryCreateSheet
         branchId={branchId}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/SelectItinerary.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/SelectItinerary.tsx
@@ -65,7 +65,7 @@ const ItineraryItemLabel = ({ itinerary }: { itinerary: IItinerary }) => {
       <span className="truncate">{itinerary.name}</span>
       {itinerary.duration && (
         <span className="text-xs text-muted-foreground shrink-0">
-          ({itinerary.duration} {t('days')})
+          ({itinerary.duration} {t('days', '{{count}} days')})
         </span>
       )}
     </div>
@@ -123,7 +123,7 @@ const SelectItineraryContent = () => {
         variant="secondary"
         wrapperClassName="flex-auto"
         focusOnMount
-        placeholder={t('search-itineraries')}
+        placeholder={t('search-itineraries', 'Search itineraries...')}
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         {!isInitialLoading && selectedItinerary && (
@@ -159,7 +159,7 @@ const SelectItineraryValue = ({ placeholder }: { placeholder?: string }) => {
   if (!selectedItinerary) {
     return (
       <span className="text-muted-foreground">
-        {placeholder || t('select-itinerary')}
+        {placeholder || t('select-itinerary', 'Select itinerary')}
       </span>
     );
   }
@@ -169,7 +169,7 @@ const SelectItineraryValue = ({ placeholder }: { placeholder?: string }) => {
       <span className="truncate">{selectedItinerary.name}</span>
       {selectedItinerary.duration && (
         <span className="text-xs text-muted-foreground shrink-0">
-          ({selectedItinerary.duration} {t('days')})
+          ({selectedItinerary.duration} {t('days', '{{count}} days')})
         </span>
       )}
     </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayAmenitiesSelect.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayAmenitiesSelect.tsx
@@ -30,7 +30,7 @@ export const DayAmenitiesSelect = ({ field, availableAmenities }: Props) => {
 
   return (
     <Form.Item>
-      <Form.Label>{t('amenities')}</Form.Label>
+      <Form.Label>{t('amenities', 'Amenities')}</Form.Label>
 
       <Form.Control>
         <Popover open={open} onOpenChange={setOpen}>
@@ -44,8 +44,8 @@ export const DayAmenitiesSelect = ({ field, availableAmenities }: Props) => {
             >
               <span className="truncate">
                 {selectedIds.length > 0
-                  ? t('amenities-selected', { count: selectedIds.length })
-                  : t('select-amenities')}
+                  ? t('amenities-selected', '{{count}} amenit{{count, plural, one{y} other{ies}}} selected', { count: selectedIds.length })
+                  : t('select-amenities', 'Select amenities')}
               </span>
             </Button>
           </Popover.Trigger>
@@ -53,11 +53,11 @@ export const DayAmenitiesSelect = ({ field, availableAmenities }: Props) => {
           <Popover.Content className="w-[320px] p-0" align="start">
             <Command>
               <Command.Input
-                placeholder={t('search-amenities')}
+                placeholder={t('search-amenities', 'Search amenities...')}
                 className="h-9"
               />
 
-              <Command.Empty>{t('no-amenities-found')}</Command.Empty>
+              <Command.Empty>{t('no-amenities-found', 'No amenities found.')}</Command.Empty>
 
               <Command.Group className="max-h-[300px] overflow-auto">
                 {amenities.map((amenity) => {

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayForm.tsx
@@ -51,12 +51,12 @@ export const DayForm = ({
             className="cursor-move text-muted-foreground"
             size={20}
           />
-          <h3 className="text-lg font-semibold">{t('day-title', { number: dayIndex + 1 })}</h3>
+          <h3 className="text-lg font-semibold">{t('day-title', 'Day {{number}}', { number: dayIndex + 1 })}</h3>
         </div>
 
         <div className="flex items-center gap-4">
           <span className="text-sm text-muted-foreground">
-            {t('day-cost')}{' '}
+            {t('day-cost', 'day cost:')}{' '}
             <span className="font-semibold">
               {dayCost} {currencySymbol}
             </span>
@@ -82,12 +82,12 @@ export const DayForm = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('day-title-label')}<span className="text-primary">{labelSuffix}</span>{' '}
+              {t('day-title-label', 'Day Title')}<span className="text-primary">{labelSuffix}</span>{' '}
               <span className="text-destructive">*</span>
             </Form.Label>
 
             <Form.Control>
-              <Input {...field} placeholder={t('enter-day-title')} />
+              <Input {...field} placeholder={t('enter-day-title', 'Enter the title for this day')} />
             </Form.Control>
 
             <Form.Message className="text-destructive" />
@@ -98,7 +98,7 @@ export const DayForm = ({
       <div className="border-2 border-dashed rounded-lg min-h-[120px] flex items-center justify-center">
         {droppedElements.length === 0 ? (
           <p className="text-sm text-center text-muted-foreground">
-            {t('please-drag-drop-elements')}
+            {t('please-drag-drop-elements', 'Please drag and drop from elements')}
           </p>
         ) : (
           <div className="w-full p-4">
@@ -134,7 +134,7 @@ export const DayForm = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>
-              {t('description-for-customers')}
+              {t('description-for-customers', 'Description for customers')}
               <span className="text-primary">{labelSuffix}</span>
             </Form.Label>
 
@@ -154,7 +154,7 @@ export const DayForm = ({
         name={`groupDays.${dayIndex}.images`}
         render={({ field }) => (
           <Form.Item>
-            <Form.Label>{t('upload-images')}</Form.Label>
+            <Form.Label>{t('upload-images', 'Upload Images')}</Form.Label>
 
             <ImageUploadGrid
               value={field.value}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/DayList.tsx
@@ -88,7 +88,7 @@ export const DayList = ({
           className="flex items-center w-full gap-2"
         >
           <IconPlus size={18} />
-          {t('add-day')}
+          {t('add-day', 'Add Day')}
         </Button>
       </div>
     </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/ElementsPanel.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/itinerary-builder/components/ElementsPanel.tsx
@@ -54,20 +54,20 @@ export const ElementsPanel = ({
   const handleDelete = async (element: IElement) => {
     try {
       await confirm({
-        message: t('confirm-delete-named-element', { name: element.name }),
+        message: t('confirm-delete-named-element', 'Are you sure you want to delete "{{name}}"?', { name: element.name }),
         options: confirmOptions,
       });
 
       await removeElements([element._id]);
 
       toast({
-        title: t('success'),
-        description: t('element-deleted-successfully'),
+        title: t('success', 'Success'),
+        description: t('element-deleted-successfully', 'Element deleted successfully'),
         variant: 'success',
       });
     } catch (e: unknown) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: (e as Error).message,
         variant: 'destructive',
       });
@@ -106,7 +106,7 @@ export const ElementsPanel = ({
               />
 
               <Input
-                placeholder={t('search-elements')}
+                placeholder={t('search-elements', 'Search elements...')}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="pl-9"
@@ -119,7 +119,7 @@ export const ElementsPanel = ({
               onClick={handleCreateOpen}
             >
               <IconPlus size={16} />
-              {t('add-element')}
+              {t('add-element', 'Add Element')}
             </Button>
           </div>
         </div>
@@ -127,7 +127,7 @@ export const ElementsPanel = ({
         <div className="overflow-y-auto flex-1 p-3 space-y-2">
           {!filteredElements.length && (
             <p className="py-6 text-sm text-center text-muted-foreground">
-              {search ? t('no-elements-found') : t('no-elements-available')}
+              {search ? t('no-elements-found', 'No elements found') : t('no-elements-available', 'No elements available')}
             </p>
           )}
 
@@ -153,7 +153,7 @@ export const ElementsPanel = ({
                     size="icon"
                     variant="outline"
                     className="w-6 h-6"
-                    aria-label={t('edit-element-label')}
+                    aria-label={t('edit-element-label', 'Edit element')}
                     onClick={(e) => {
                       e.stopPropagation();
                       setEditElement(element);
@@ -167,7 +167,7 @@ export const ElementsPanel = ({
                     size="icon"
                     variant="outline"
                     className="w-6 h-6"
-                    aria-label={t('delete-element-label')}
+                    aria-label={t('delete-element-label', 'Delete element')}
                     onClick={(e) => {
                       e.stopPropagation();
                       handleDelete(element);

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/CustomizePdfDialog.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/CustomizePdfDialog.tsx
@@ -118,16 +118,16 @@ export const CustomizePdfDialog: React.FC<CustomizePdfDialogProps> = ({
         <div className="grid md:grid-cols-[1.15fr_0.85fr] max-h-[80vh]">
           <section className="min-h-0 overflow-y-auto bg-background">
             <Dialog.Header className="px-6 py-6 border-b bg-muted/30">
-              <Dialog.Title className="text-xl">{t('customize-pdf')}</Dialog.Title>
+              <Dialog.Title className="text-xl">{t('customize-pdf', 'Customize PDF')}</Dialog.Title>
               <Dialog.Description className="max-w-xl text-sm leading-6">
-                {t('customize-pdf-desc')}
+                {t('customize-pdf-desc', 'Control which sections appear and shape the language used in the exported itinerary.')}
               </Dialog.Description>
             </Dialog.Header>
 
             <div className="px-6 py-5 space-y-4">
               <div className="flex items-center gap-2 text-xs font-medium tracking-[0.18em] uppercase text-muted-foreground">
                 <IconLayoutGrid size={14} />
-                {t('visible-sections')}
+                {t('visible-sections', 'Visible Sections')}
               </div>
 
               <div className="grid gap-3">
@@ -170,10 +170,10 @@ export const CustomizePdfDialog: React.FC<CustomizePdfDialogProps> = ({
             <div className="px-6 py-6 border-b bg-background/70 backdrop-blur">
               <div className="flex items-center gap-2 text-xs font-medium tracking-[0.18em] uppercase text-muted-foreground">
                 <IconForms size={14} />
-                {t('static-text')}
+                {t('static-text', 'Static Text')}
               </div>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                {t('rename-built-in-labels')}
+                {t('rename-built-in-labels', 'Rename the built-in labels shown across the cover, day blocks, and notes page.')}
               </p>
             </div>
 
@@ -181,7 +181,7 @@ export const CustomizePdfDialog: React.FC<CustomizePdfDialogProps> = ({
               <div className="px-4 py-4 border shadow-sm rounded-2xl border-border/60 bg-background">
                 <div className="flex items-center gap-2 mb-4 text-xs font-medium tracking-[0.18em] uppercase text-muted-foreground">
                   <IconFileDescription size={14} />
-                  {t('label-editor')}
+                  {t('label-editor', 'Label Editor')}
                 </div>
 
                 <div className="space-y-4">
@@ -206,17 +206,17 @@ export const CustomizePdfDialog: React.FC<CustomizePdfDialogProps> = ({
 
               <div className="px-4 py-4 border border-dashed rounded-2xl border-border/70 bg-background/70">
                 <p className="text-sm leading-6 text-muted-foreground">
-                  {t('preview-refreshes-auto')}
+                  {t('preview-refreshes-auto', 'Preview refreshes automatically when these values change. Use short labels for the cleanest PDF layout.')}
                 </p>
               </div>
             </div>
 
             <Dialog.Footer className="sticky bottom-0 px-6 py-4 border-t bg-background/95 backdrop-blur">
               <Button variant="outline" onClick={onReset}>
-                {t('reset-to-defaults')}
+                {t('reset-to-defaults', 'Reset to defaults')}
               </Button>
               <Button variant="outline" onClick={() => onOpenChange(false)}>
-                {t('close')}
+                {t('close', 'Close')}
               </Button>
             </Dialog.Footer>
           </aside>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/ExportPDFButton.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/pdf/ExportPDFButton.tsx
@@ -204,8 +204,8 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
 
   const previewStatusText =
     previewLoading || shouldWaitForResources
-      ? t('preparing-pdf-preview')
-      : t('preview-refreshes-after-edits');
+      ? t('preparing-pdf-preview', 'Preparing PDF preview...')
+      : t('preview-refreshes-after-edits', 'Preview refreshes automatically after edits and customization changes.');
 
   const revokePreviewUrl = useCallback(() => {
     if (previewObjectUrlRef.current) {
@@ -249,7 +249,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
   const generatePreview = useCallback(
     async (force = false) => {
       if (!itinerary) {
-        setPreviewError(t('no-itinerary-data'));
+        setPreviewError(t('no-itinerary-data', 'No itinerary data available.'));
         return;
       }
 
@@ -281,8 +281,8 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
 
         if (totalImages > 0 && loadedImages < totalImages) {
           toast({
-            title: t('some-images-failed'),
-            description: t('some-images-failed-desc', { failed: totalImages - loadedImages, total: totalImages }),
+            title: t('some-images-failed', 'Some images failed to load'),
+            description: t('some-images-failed-desc', '{{failed}} of {{total}} image(s) could not be loaded. The preview may have missing images.', { failed: totalImages - loadedImages, total: totalImages }),
           });
         }
 
@@ -302,7 +302,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
 
         setPreviewBlob(null);
         setPreviewError(
-          err instanceof Error ? err.message : t('failed-to-generate-preview'),
+          err instanceof Error ? err.message : t('failed-to-generate-preview', 'Failed to generate preview.'),
         );
       } finally {
         if (isMountedRef.current && requestId === previewRequestIdRef.current) {
@@ -333,8 +333,8 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
     triggerDownload(url, generateFilename(itinerary.name));
 
     toast({
-      title: t('pdf-downloaded'),
-      description: t('pdf-downloaded-desc', { name: itinerary.name || 'Itinerary' }),
+      title: t('pdf-downloaded', 'PDF downloaded'),
+      description: t('pdf-downloaded-desc', '"{{name}}" has been downloaded.', { name: itinerary.name || 'Itinerary' }),
       variant: 'success',
     });
   }, [itinerary, previewBlob, toast, triggerDownload]);
@@ -447,11 +447,11 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
           await refetchItinerary?.();
         } catch (error) {
           toast({
-            title: t('refresh-failed'),
+            title: t('refresh-failed', 'Refresh failed'),
             description:
               error instanceof Error
                 ? error.message
-                : t('failed-to-reload-itinerary'),
+                : t('failed-to-reload-itinerary', 'Failed to reload itinerary details.'),
             variant: 'destructive',
           });
         } finally {
@@ -523,7 +523,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
         onClick={() => handlePreviewOpenChange(true)}
       >
         <IconFileTypePdf size={16} />
-        {size !== 'icon' && t('preview-pdf')}
+        {size !== 'icon' && t('preview-pdf', 'Preview PDF')}
       </Button>
 
       <Dialog open={previewOpen} onOpenChange={handlePreviewOpenChange}>
@@ -539,12 +539,12 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
           </Dialog.Close>
 
           <Dialog.Header className="px-6 py-4 space-y-1 border-b pr-14">
-            <Dialog.Title>{t('itinerary-pdf-preview')}</Dialog.Title>
+            <Dialog.Title>{t('itinerary-pdf-preview', 'Itinerary PDF preview')}</Dialog.Title>
             <Dialog.Description>
-              {t('preview-before-download')}
+              {t('preview-before-download', 'Preview before download. You can edit and refresh here.')}
             </Dialog.Description>
             <div className="pt-2 space-y-2">
-              <Label htmlFor="template-select">{t('template')}</Label>
+              <Label htmlFor="template-select">{t('template', 'Template')}</Label>
               <Select
                 value={selectedTemplate}
                 onValueChange={handleTemplateChange}
@@ -573,7 +573,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
               <div className="flex items-center justify-center h-full">
                 <div className="flex items-center gap-3 text-sm text-muted-foreground">
                   <Spinner />
-                  {t('preparing-pdf-preview')}
+                  {t('preparing-pdf-preview', 'Preparing PDF preview...')}
                 </div>
               </div>
             ) : previewError ? (
@@ -583,18 +583,18 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
                 </p>
                 <Button variant="outline" onClick={handleRefreshPreview}>
                   <IconRefresh size={16} />
-                  {t('retry-preview')}
+                  {t('retry-preview', 'Retry preview')}
                 </Button>
               </div>
             ) : previewUrl ? (
               <iframe
-                title={t('itinerary-pdf-preview')}
+                title={t('itinerary-pdf-preview', 'Itinerary PDF preview')}
                 src={previewUrl}
                 className="w-full h-full bg-white border-0"
               />
             ) : (
               <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-                {t('no-preview-available')}
+                {t('no-preview-available', 'No preview available yet.')}
               </div>
             )}
           </div>
@@ -609,7 +609,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
                 disabled={!itinerary}
               >
                 <IconAdjustmentsHorizontal size={16} />
-                {t('customize')}
+                {t('customize', 'Customize')}
               </Button>
 
               <Button
@@ -620,7 +620,7 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
                 }
               >
                 {previewLoading ? <Spinner /> : <IconRefresh size={16} />}
-                {t('refresh')}
+                {t('refresh', 'Refresh')}
               </Button>
 
               <Button
@@ -629,12 +629,12 @@ export const ExportPDFButton: React.FC<ExportPDFButtonProps> = ({
                 disabled={!canEdit}
               >
                 <IconEdit size={16} />
-                {t('edit-itinerary')}
+                {t('edit-itinerary', 'Edit itinerary')}
               </Button>
 
               <Button onClick={handleDownload} disabled={!canDownload}>
                 <IconDownload size={16} />
-                {t('download-pdf')}
+                {t('download-pdf', 'Download PDF')}
               </Button>
             </div>
           </Dialog.Footer>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/pages/CustomFieldsPage.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/pages/CustomFieldsPage.tsx
@@ -188,12 +188,12 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [addType] = useMutation(TOUR_CUSTOM_TYPE_ADD, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('tour-type-created') });
+      toast({ title: t('success', 'Success'), description: t('tour-type-created', 'Tour type created') });
       refetchTypes();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -201,12 +201,12 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [editType] = useMutation(TOUR_CUSTOM_TYPE_EDIT, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('tour-type-updated') });
+      toast({ title: t('success', 'Success'), description: t('tour-type-updated', 'Tour type updated') });
       refetchTypes();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -214,13 +214,13 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [removeType] = useMutation(TOUR_CUSTOM_TYPE_REMOVE, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('tour-type-removed') });
+      toast({ title: t('success', 'Success'), description: t('tour-type-removed', 'Tour type removed') });
       refetchTypes();
       refetchGroups();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -228,12 +228,12 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [addGroup] = useMutation(TOUR_CUSTOM_FIELD_GROUP_ADD, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('field-group-created') });
+      toast({ title: t('success', 'Success'), description: t('field-group-created', 'Field group created') });
       refetchGroups();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -241,12 +241,12 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [editGroup] = useMutation(TOUR_CUSTOM_FIELD_GROUP_EDIT, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('field-group-updated') });
+      toast({ title: t('success', 'Success'), description: t('field-group-updated', 'Field group updated') });
       refetchGroups();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -254,13 +254,13 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const [removeGroup] = useMutation(TOUR_CUSTOM_FIELD_GROUP_REMOVE, {
     onCompleted: () => {
-      toast({ title: t('success'), description: t('field-group-removed') });
+      toast({ title: t('success', 'Success'), description: t('field-group-removed', 'Field group removed') });
       setSelectedGroup(null);
       refetchGroups();
     },
     onError: (error) =>
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: error.message,
         variant: 'destructive',
       }),
@@ -268,13 +268,13 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
 
   const handleRemoveType = (type: ITourCustomPostType) => {
     confirm({
-      message: t('confirm-delete-tour-type', { label: type.label }),
+      message: t('confirm-delete-tour-type', 'Delete "{{label}}" tour type?', { label: type.label }),
     }).then(() => removeType({ variables: { _id: type._id } }));
   };
 
   const handleRemoveGroup = (group: ITourCustomFieldGroup) => {
     confirm({
-      message: t('confirm-delete-field-group', { label: group.label }),
+      message: t('confirm-delete-field-group', 'Delete "{{label}}" field group and all its fields?', { label: group.label }),
     }).then(() => removeGroup({ variables: { _id: group._id } }));
   };
 
@@ -313,7 +313,7 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
     field: ITourCustomField,
   ) => {
     confirm({
-      message: t('confirm-delete-field', { label: field.label }),
+      message: t('confirm-delete-field', 'Delete "{{label}}" field?', { label: field.label }),
     }).then(() => {
       const fields = (group.fields || []).filter(
         (item) => item._id !== field._id,
@@ -327,7 +327,7 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
       <PageSubHeader>
         <div className="flex items-center gap-2 text-sm font-medium">
           <IconSettings size={16} />
-          {t('custom-fields')}
+          {t('custom-fields', 'Custom Fields')}
         </div>
         <div className="flex items-center gap-2 ml-auto">
           <Button
@@ -339,7 +339,7 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
             }}
           >
             <IconPlus size={16} />
-            {t('tour-type')}
+            {t('tour-type', 'Tour Type')}
           </Button>
           <Button
             size="sm"
@@ -349,7 +349,7 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
             }}
           >
             <IconPlus size={16} />
-            {t('field-group')}
+            {t('field-group', 'Field Group')}
           </Button>
         </div>
       </PageSubHeader>
@@ -357,8 +357,8 @@ export const CustomFieldsPage = ({ branch }: { branch: IBranch }) => {
       <div className="flex-auto min-h-0 p-4 overflow-auto">
         <Tabs defaultValue="groups" className="flex flex-col gap-4">
           <Tabs.List className="w-fit">
-            <Tabs.Trigger value="groups">{t('field-groups')}</Tabs.Trigger>
-            <Tabs.Trigger value="types">{t('tour-types')}</Tabs.Trigger>
+            <Tabs.Trigger value="groups">{t('field-groups', 'Field Groups')}</Tabs.Trigger>
+            <Tabs.Trigger value="types">{t('tour-types', 'Tour Types')}</Tabs.Trigger>
           </Tabs.List>
 
           <Tabs.Content value="groups" className="min-h-0">
@@ -514,9 +514,9 @@ const TourTypesView = ({
       <Table>
         <Table.Header>
           <Table.Row>
-            <Table.Head className="w-[45%] px-4">{t('label')}</Table.Head>
-            <Table.Head className="px-4">{t('key')}</Table.Head>
-            <Table.Head className="px-4 w-28">{t('status')}</Table.Head>
+            <Table.Head className="w-[45%] px-4">{t('label', 'Label')}</Table.Head>
+            <Table.Head className="px-4">{t('key', 'Key')}</Table.Head>
+            <Table.Head className="px-4 w-28">{t('status', 'Status')}</Table.Head>
             <Table.Head className="w-20" />
           </Table.Row>
         </Table.Header>
@@ -524,7 +524,7 @@ const TourTypesView = ({
           {customTypes.length === 0 ? (
             <Table.Row>
               <Table.Cell colSpan={4} className="h-24 text-center">
-                {t('no-custom-tour-types-yet')}
+                {t('no-custom-tour-types-yet', 'No custom tour types yet')}
               </Table.Cell>
             </Table.Row>
           ) : (
@@ -547,7 +547,7 @@ const TourTypesView = ({
                   <Badge
                     variant={type.isActive === false ? 'secondary' : 'default'}
                   >
-                    {type.isActive === false ? t('inactive') : t('active')}
+                    {type.isActive === false ? t('inactive', 'Inactive') : t('active', 'Active')}
                   </Badge>
                 </Table.Cell>
                 <Table.Cell className="px-2 py-2">
@@ -613,7 +613,7 @@ const FieldGroupsView = ({
   if (!groups.length) {
     return (
       <div className="flex items-center justify-center h-40 border rounded-lg text-muted-foreground">
-        {t('no-custom-field-groups-yet')}
+        {t('no-custom-field-groups-yet', 'No custom field groups yet')}
       </div>
     );
   }
@@ -624,7 +624,7 @@ const FieldGroupsView = ({
         <Table>
           <Table.Header>
             <Table.Row>
-              <Table.Head className="px-4">{t('field-group')}</Table.Head>
+              <Table.Head className="px-4">{t('field-group', 'Field Group')}</Table.Head>
               <Table.Head className="w-20" />
             </Table.Row>
           </Table.Header>
@@ -640,7 +640,7 @@ const FieldGroupsView = ({
               >
                 <Table.Cell className="min-w-0 px-4 py-3 whitespace-normal">
                   <div className="font-medium leading-5 break-words [overflow-wrap:anywhere]">
-                    {group.label || t('untitled-group')}
+                    {group.label || t('untitled-group', 'Untitled group')}
                   </div>
                   {group.code && (
                     <div className="text-xs text-muted-foreground break-words [overflow-wrap:anywhere]">
@@ -649,7 +649,7 @@ const FieldGroupsView = ({
                   )}
                   <div className="flex flex-wrap gap-1.5 mt-2">
                     {(group.customTourTypeIds || []).length === 0 ? (
-                      <Badge variant="secondary">{t('all-tours')}</Badge>
+                      <Badge variant="secondary">{t('all-tours', 'All tours')}</Badge>
                     ) : (
                       (group.customTourTypeIds || []).map((typeId) => (
                         <Badge
@@ -708,7 +708,7 @@ const FieldGroupsView = ({
           />
         ) : (
           <div className="flex items-center justify-center h-full text-muted-foreground">
-            {t('select-a-field-group')}
+            {t('select-a-field-group', 'Select a field group')}
           </div>
         )}
       </div>
@@ -741,21 +741,21 @@ const FieldList = ({
             {group.label}
           </div>
           <div className="text-xs text-muted-foreground">
-            {t('fields-count', { count: fields.length })}
+            {t('fields-count', '{{count}} field{{count, plural, one{} other{s}}}', { count: fields.length })}
           </div>
         </div>
         <Button size="sm" className="ml-auto" onClick={() => onAddField(group)}>
           <IconPlus size={16} />
-          {t('add-field')}
+          {t('add-field', 'Add Field')}
         </Button>
       </div>
       <div className="overflow-auto">
         <Table>
           <Table.Header>
             <Table.Row>
-              <Table.Head className="w-[45%] px-4">{t('field')}</Table.Head>
-              <Table.Head className="px-4">{t('type')}</Table.Head>
-              <Table.Head className="w-24 px-4">{t('required')}</Table.Head>
+              <Table.Head className="w-[45%] px-4">{t('field', 'Field')}</Table.Head>
+              <Table.Head className="px-4">{t('type', 'Type')}</Table.Head>
+              <Table.Head className="w-24 px-4">{t('required', 'Required')}</Table.Head>
               <Table.Head className="w-20" />
             </Table.Row>
           </Table.Header>
@@ -763,7 +763,7 @@ const FieldList = ({
             {fields.length === 0 ? (
               <Table.Row>
                 <Table.Cell colSpan={4} className="h-24 text-center">
-                  {t('no-fields-in-group')}
+                  {t('no-fields-in-group', 'No fields in this group')}
                 </Table.Cell>
               </Table.Row>
             ) : (
@@ -779,7 +779,7 @@ const FieldList = ({
                     {field.type}
                   </Table.Cell>
                   <Table.Cell className="px-4 py-3">
-                    {field.isRequired ? t('yes') : t('no')}
+                    {field.isRequired ? t('yes', 'Yes') : t('no', 'No')}
                   </Table.Cell>
                   <Table.Cell className="px-2 py-2">
                     <div className="flex justify-end gap-1">
@@ -850,7 +850,7 @@ const TourTypeDrawer = ({
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
           <Sheet.Title>
-            {editingType ? t('edit-tour-type') : t('new-tour-type')}
+            {editingType ? t('edit-tour-type', 'Edit Tour Type') : t('new-tour-type', 'New Tour Type')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -863,7 +863,7 @@ const TourTypeDrawer = ({
               <TextField
                 form={form}
                 name="label"
-                label={t('label')}
+                label={t('label', 'Label')}
                 onChange={(value) => {
                   if (!editingType && !form.getValues('code')) {
                     form.setValue('code', generateCode(value));
@@ -873,12 +873,12 @@ const TourTypeDrawer = ({
                   }
                 }}
               />
-              <TextField form={form} name="pluralLabel" label={t('plural-label')} />
-              <TextField form={form} name="code" label={t('key')} />
+              <TextField form={form} name="pluralLabel" label={t('plural-label', 'Plural Label')} />
+              <TextField form={form} name="code" label={t('key', 'Key')} />
               <TextAreaField
                 form={form}
                 name="description"
-                label={t('description')}
+                label={t('description', 'Description')}
               />
               <Form.Field
                 control={form.control}
@@ -891,7 +891,7 @@ const TourTypeDrawer = ({
                         onCheckedChange={field.onChange}
                       />
                     </Form.Control>
-                    <Form.Label>{t('active')}</Form.Label>
+                    <Form.Label>{t('active', 'Active')}</Form.Label>
                   </Form.Item>
                 )}
               />
@@ -902,9 +902,9 @@ const TourTypeDrawer = ({
                 variant="outline"
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
-              <Button type="submit">{editingType ? t('save') : t('create')}</Button>
+              <Button type="submit">{editingType ? t('save', 'Save') : t('create', 'Create')}</Button>
             </Sheet.Footer>
           </form>
         </Form>
@@ -938,7 +938,7 @@ const FieldGroupDrawer = ({
   const typeSelectOptions = useMemo(
     () =>
       typeOptions.map((type) => ({
-        label: type.label || type.code || t('unnamed-type'),
+        label: type.label || type.code || t('unnamed-type', 'Unnamed type'),
         value: type._id,
       })),
     [typeOptions, t],
@@ -958,7 +958,7 @@ const FieldGroupDrawer = ({
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
           <Sheet.Title>
-            {editingGroup ? t('edit-field-group') : t('new-field-group')}
+            {editingGroup ? t('edit-field-group', 'Edit Field Group') : t('new-field-group', 'New Field Group')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -971,14 +971,14 @@ const FieldGroupDrawer = ({
               <TextField
                 form={form}
                 name="label"
-                label={t('label')}
+                label={t('label', 'Label')}
                 onChange={(value) => {
                   if (!editingGroup && !form.getValues('code')) {
                     form.setValue('code', generateCode(value));
                   }
                 }}
               />
-              <TextField form={form} name="code" label={t('key')} />
+              <TextField form={form} name="code" label={t('key', 'Key')} />
               <Form.Field
                 control={form.control}
                 name="customTourTypeIds"
@@ -987,16 +987,16 @@ const FieldGroupDrawer = ({
 
                   return (
                     <Form.Item>
-                      <Form.Label>{t('show-on-tour-types')}</Form.Label>
+                      <Form.Label>{t('show-on-tour-types', 'Show On Tour Types')}</Form.Label>
                       <Form.Control>
                         <MultipleSelector
                           value={typeSelectOptions.filter((option) =>
                             selectedValues.includes(option.value),
                           )}
                           options={typeSelectOptions}
-                          placeholder={t('select-tour-types')}
+                          placeholder={t('select-tour-types', 'Select tour types')}
                           hidePlaceholderWhenSelected
-                          emptyIndicator={t('no-tour-types')}
+                          emptyIndicator={t('no-tour-types', 'No tour types')}
                           onChange={(options) =>
                             field.onChange(
                               options.map((option) => option.value),
@@ -1015,9 +1015,9 @@ const FieldGroupDrawer = ({
                 variant="outline"
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
-              <Button type="submit">{editingGroup ? t('save') : t('create')}</Button>
+              <Button type="submit">{editingGroup ? t('save', 'Save') : t('create', 'Create')}</Button>
             </Sheet.Footer>
           </form>
         </Form>
@@ -1053,7 +1053,7 @@ const FieldDrawer = ({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <Sheet.View className="p-0 sm:max-w-lg">
         <Sheet.Header>
-          <Sheet.Title>{editingField ? t('edit-field') : t('new-field')}</Sheet.Title>
+          <Sheet.Title>{editingField ? t('edit-field', 'Edit Field') : t('new-field', 'New Field')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
         <Form {...form}>
@@ -1065,27 +1065,27 @@ const FieldDrawer = ({
               <TextField
                 form={form}
                 name="label"
-                label={t('label')}
+                label={t('label', 'Label')}
                 onChange={(value) => {
                   if (!editingField && !form.getValues('code')) {
                     form.setValue('code', generateCode(value));
                   }
                 }}
               />
-              <TextField form={form} name="code" label={t('key')} />
+              <TextField form={form} name="code" label={t('key', 'Key')} />
               <Form.Field
                 control={form.control}
                 name="type"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('field-type')}</Form.Label>
+                    <Form.Label>{t('field-type', 'Field Type')}</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <Select.Trigger>
-                          <Select.Value placeholder={t('select-field-type')} />
+                          <Select.Value placeholder={t('select-field-type', 'Select field type')} />
                         </Select.Trigger>
                         <Select.Content>
                           {FIELD_TYPES.map((option) => (
@@ -1105,14 +1105,14 @@ const FieldDrawer = ({
               <TextAreaField
                 form={form}
                 name="description"
-                label={t('description')}
+                label={t('description', 'Description')}
               />
               {needsOptions && (
                 <TextField
                   form={form}
                   name="options"
-                  label={t('options')}
-                  placeholder={t('option-placeholder')}
+                  label={t('options', 'Options')}
+                  placeholder={t('option-placeholder', 'Option A, Option B')}
                 />
               )}
               <Form.Field
@@ -1126,7 +1126,7 @@ const FieldDrawer = ({
                         onCheckedChange={field.onChange}
                       />
                     </Form.Control>
-                    <Form.Label>{t('required')}</Form.Label>
+                    <Form.Label>{t('required', 'Required')}</Form.Label>
                   </Form.Item>
                 )}
               />
@@ -1137,9 +1137,9 @@ const FieldDrawer = ({
                 variant="outline"
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
-              <Button type="submit">{editingField ? t('save') : t('create')}</Button>
+              <Button type="submit">{editingField ? t('save', 'Save') : t('create', 'Create')}</Button>
             </Sheet.Footer>
           </form>
         </Form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/pages/TourPage.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/pages/TourPage.tsx
@@ -23,8 +23,8 @@ export const TourPage = ({ branch }: { branch: IBranch }) => {
                 setIsGroup(value === 'grouped' ? true : null);
               }}
             >
-              <ToggleGroup.Item value="list">{t('tours-list')}</ToggleGroup.Item>
-              <ToggleGroup.Item value="grouped">{t('grouped')}</ToggleGroup.Item>
+              <ToggleGroup.Item value="list">{t('tours-list', 'Tours')}</ToggleGroup.Item>
+              <ToggleGroup.Item value="grouped">{t('grouped', 'Grouped')}</ToggleGroup.Item>
             </ToggleGroup>
           )}
           <ToursViewControl />

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/OrderDetailSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/OrderDetailSheet.tsx
@@ -120,7 +120,7 @@ function CustomerInlineCard({
   return (
     <CustomersInline.Provider
       customerIds={[customerId]}
-      placeholder={t('unnamed-customer')}
+      placeholder={t('unnamed-customer', 'Unnamed customer')}
     >
       <Card className="bg-background border-border/60">
         <div className="flex items-center gap-3 p-3">
@@ -173,7 +173,7 @@ export const OrderDetailSheet = ({
   const isBusy = updating || saving;
   const missingOrderMessage = error
     ? error.message
-    : t('booking-not-loaded');
+    : t('booking-not-loaded', 'Booking details could not be loaded for this order.');
 
   useEffect(() => {
     setStatusValue(initialEditStatus);
@@ -224,21 +224,21 @@ export const OrderDetailSheet = ({
 
     const trimmedInternalNote = internalNoteValue.trim();
     if (!statusValue) {
-      setValidationError(t('please-select-terminal-status'));
+      setValidationError(t('please-select-terminal-status', 'Please select a terminal status before saving'));
       return;
     }
 
     const requiresExplanation = TERMINAL_ORDER_STATUSES.has(statusValue);
 
     if (requiresExplanation && !trimmedInternalNote) {
-      setValidationError(t('please-add-explanation'));
+      setValidationError(t('please-add-explanation', 'Please add an explanation for cancelled or refunded bookings'));
       return;
     }
 
     try {
       if (statusValue === 'cancelled' || statusValue === 'refunded') {
         await confirm({
-          message: t('confirm-update-booking', { status: statusValue }),
+          message: t('confirm-update-booking', 'Are you sure you want to mark this booking as {{status}}?', { status: statusValue }),
           options: { confirmationValue: statusValue },
         });
       }
@@ -269,8 +269,8 @@ export const OrderDetailSheet = ({
       await onUpdated?.();
 
       toast({
-        title: t('success'),
-        description: t('booking-updated-successfully'),
+        title: t('success', 'Success'),
+        description: t('booking-updated-successfully', 'Booking details updated successfully'),
       });
 
       setEditOpen(false);
@@ -280,9 +280,9 @@ export const OrderDetailSheet = ({
       }
 
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-update-booking'),
+          error instanceof Error ? error.message : t('failed-to-update-booking', 'Failed to update booking'),
         variant: 'destructive',
       });
     } finally {
@@ -300,7 +300,7 @@ export const OrderDetailSheet = ({
         ) : !hasLoadedOrder ? (
           <>
             <Sheet.Header>
-              <Sheet.Title>{t('order-details')}</Sheet.Title>
+              <Sheet.Title>{t('order-details', 'Order Details')}</Sheet.Title>
               <Sheet.Close />
             </Sheet.Header>
 
@@ -310,7 +310,7 @@ export const OrderDetailSheet = ({
                   {missingOrderMessage}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {t('reload-booking-list')}
+                  {t('reload-booking-list', 'Reload the booking list and try opening this order again.')}
                 </p>
               </div>
             </Sheet.Content>
@@ -321,14 +321,14 @@ export const OrderDetailSheet = ({
                 variant="outline"
                 onClick={() => onOpenChange(false)}
               >
-                {t('close')}
+                {t('close', 'Close')}
               </Button>
             </Sheet.Footer>
           </>
         ) : (
           <>
             <Sheet.Header>
-              <Sheet.Title>{t('order-details')}</Sheet.Title>
+              <Sheet.Title>{t('order-details', 'Order Details')}</Sheet.Title>
               <Sheet.Close />
             </Sheet.Header>
 
@@ -339,7 +339,7 @@ export const OrderDetailSheet = ({
                     <div className="flex items-start justify-between gap-4">
                       <div className="min-w-0 space-y-1">
                         <div className="text-xs font-medium tracking-wide uppercase text-muted-foreground">
-                          {t('booking-summary')}
+                          {t('booking-summary', 'Booking Summary')}
                         </div>
                         <div className="font-mono text-sm break-all text-foreground">
                           {order?._id ?? '—'}
@@ -353,7 +353,7 @@ export const OrderDetailSheet = ({
                       <div className="p-3 border rounded-xl bg-muted/40 border-border/60">
                         <div className="inline-flex items-center gap-2 text-xs tracking-wide uppercase text-muted-foreground">
                           <IconCoin className="w-4 h-4" />
-                          {t('amount')}
+                          {t('amount', 'Amount')}
                         </div>
                         <div className="mt-2 text-lg font-semibold text-foreground">
                           {formatAmount(order?.amount)}
@@ -363,7 +363,7 @@ export const OrderDetailSheet = ({
                       <div className="p-3 border rounded-xl bg-muted/40 border-border/60">
                         <div className="inline-flex items-center gap-2 text-xs tracking-wide uppercase text-muted-foreground">
                           <IconUsers className="w-4 h-4" />
-                          {t('people')}
+                          {t('people', 'people')}
                         </div>
                         <div className="mt-2 text-lg font-semibold text-foreground">
                           {order?.numberOfPeople ?? '—'}
@@ -376,12 +376,12 @@ export const OrderDetailSheet = ({
                     <div className="space-y-3">
                       <DetailRow
                         icon={IconTag}
-                        label={t('detail-row-type')}
+                        label={t('detail-row-type', 'Type')}
                         value={order?.type || '—'}
                       />
                       <DetailRow
                         icon={IconCalendarEventFilled}
-                        label={t('detail-row-created-at')}
+                        label={t('detail-row-created-at', 'Created At')}
                         value={formatDate(order?.createdAt)}
                       />
                     </div>
@@ -391,11 +391,11 @@ export const OrderDetailSheet = ({
                 {order?.customerId && (
                   <div className="space-y-2">
                     <div className="text-xs font-medium tracking-wide uppercase text-muted-foreground">
-                      {t('main-customer')}
+                      {t('main-customer', 'Main Customer')}
                     </div>
                     <CustomerInlineCard
                       customerId={order.customerId}
-                      label={t('primary')}
+                      label={t('primary', 'Primary')}
                     />
                   </div>
                 )}
@@ -404,17 +404,17 @@ export const OrderDetailSheet = ({
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
                       <div className="text-xs font-medium tracking-wide uppercase text-muted-foreground">
-                        {t('additional-customers-label')}
+                        {t('additional-customers-label', 'Additional Customers')}
                       </div>
                       <Tooltip.Provider>
                         <Tooltip>
                           <Tooltip.Trigger asChild>
                             <span className="px-2 py-1 text-[11px] font-medium rounded-full bg-primary/10 text-primary">
-                              {t('customers-linked', { count: additionalCustomers.length })}
+                              {t('customers-linked', '{{count}} linked', { count: additionalCustomers.length })}
                             </span>
                           </Tooltip.Trigger>
                           <Tooltip.Content>
-                            {t('customers-linked-tooltip')}
+                            {t('customers-linked-tooltip', 'Customers linked to this booking')}
                           </Tooltip.Content>
                         </Tooltip>
                       </Tooltip.Provider>
@@ -425,7 +425,7 @@ export const OrderDetailSheet = ({
                         <CustomerInlineCard
                           key={customerId}
                           customerId={customerId}
-                          label={t('additional-customer', { index: index + 1 })}
+                          label={t('additional-customer', 'Additional {{index}}', { index: index + 1 })}
                         />
                       ))}
                     </div>
@@ -437,7 +437,7 @@ export const OrderDetailSheet = ({
                     <div className="p-4 space-y-2">
                       <div className="inline-flex items-center gap-2 text-xs font-medium tracking-wide uppercase text-muted-foreground">
                         <IconFileDescription className="w-4 h-4" />
-                        {t('booking-note')}
+                        {t('booking-note', 'Note')}
                       </div>
                       <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">
                         {order.note}
@@ -451,7 +451,7 @@ export const OrderDetailSheet = ({
                     <div className="p-4 space-y-2">
                       <div className="inline-flex items-center gap-2 text-xs font-medium tracking-wide uppercase text-muted-foreground">
                         <IconFileDescription className="w-4 h-4" />
-                        {t('internal-note')}
+                        {t('internal-note', 'Internal note')}
                       </div>
                       <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">
                         {order.internalNote}
@@ -469,7 +469,7 @@ export const OrderDetailSheet = ({
                 onClick={() => handleEditOpenChange(true)}
                 disabled={isBusy || !hasLoadedOrder}
               >
-                {t('edit-booking')}
+                {t('edit-booking', 'Edit')}
               </Button>
               <Button
                 type="button"
@@ -477,7 +477,7 @@ export const OrderDetailSheet = ({
                 onClick={() => onOpenChange(false)}
                 disabled={isBusy}
               >
-                {t('close')}
+                {t('close', 'Close')}
               </Button>
             </Sheet.Footer>
           </>
@@ -487,16 +487,16 @@ export const OrderDetailSheet = ({
       <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
         <Dialog.Content className="sm:max-w-[520px]">
           <Dialog.Header>
-            <Dialog.Title>{t('edit-booking-title')}</Dialog.Title>
+            <Dialog.Title>{t('edit-booking-title', 'Edit Booking')}</Dialog.Title>
             <Dialog.Description>
-              {t('edit-booking-desc')}
+              {t('edit-booking-desc', 'Update booking status and internal note.')}
             </Dialog.Description>
           </Dialog.Header>
 
           <div className="grid gap-4 py-2">
             <div className="space-y-2">
               <div className="text-xs font-medium tracking-wide uppercase text-muted-foreground">
-                {t('status')}
+                {t('status', 'Status')}
               </div>
               <Select
                 value={statusValue || undefined}
@@ -508,7 +508,7 @@ export const OrderDetailSheet = ({
                 }}
               >
                 <Select.Trigger>
-                  <Select.Value placeholder={t('select-booking-status')} />
+                  <Select.Value placeholder={t('select-booking-status', 'Select status')} />
                 </Select.Trigger>
                 <Select.Content>
                   {ORDER_STATUS_OPTIONS.map((option) => (
@@ -522,7 +522,7 @@ export const OrderDetailSheet = ({
 
             <div className="space-y-2">
               <div className="text-xs font-medium tracking-wide uppercase text-muted-foreground">
-                {t('internal-note')}
+                {t('internal-note', 'Internal note')}
               </div>
               <Textarea
                 value={internalNoteValue}
@@ -532,11 +532,11 @@ export const OrderDetailSheet = ({
                     setValidationError(null);
                   }
                 }}
-                placeholder={t('add-internal-note')}
+                placeholder={t('add-internal-note', 'Add an explanation or internal note...')}
                 className="min-h-28"
               />
               <p className="text-xs text-muted-foreground">
-                {t('explanation-required-for-cancel')}
+                {t('explanation-required-for-cancel', 'Explanation is required for cancelled and refunded bookings.')}
               </p>
               {validationError && (
                 <p className="text-sm text-destructive">{validationError}</p>
@@ -551,7 +551,7 @@ export const OrderDetailSheet = ({
               onClick={() => handleEditOpenChange(false)}
               disabled={isBusy}
             >
-              {t('close')}
+              {t('close', 'Close')}
             </Button>
             <Button
               type="button"
@@ -560,7 +560,7 @@ export const OrderDetailSheet = ({
                 isBusy || !isDirty || !hasSelectedStatus || !hasLoadedOrder
               }
             >
-              {isBusy ? t('saving') : t('save-changes')}
+              {isBusy ? t('saving', 'Saving...') : t('save-changes', 'Save Changes')}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/SelectTourCategory.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/SelectTourCategory.tsx
@@ -59,21 +59,21 @@ export const SelectTourCategory = ({
         >
           <span className="truncate">
             {value.length > 0
-              ? t('categories-selected', { count: value.length })
+              ? t('categories-selected', '{{count}} categor{{count, plural, one{y} other{ies}}} selected', { count: value.length })
               : placeholder}
           </span>
         </Button>
       </Popover.Trigger>
       <Popover.Content className="w-[400px] p-0" align="start">
         <Command className="rounded-lg border shadow-md">
-          <Command.Input placeholder={t('search-categories')} className="h-8" />
+          <Command.Input placeholder={t('search-categories', 'Search categories')} className="h-8" />
           <Command.Empty className="py-6 text-sm text-center">
-            {t('no-categories-found')}
+            {t('no-categories-found', 'No categories found')}
           </Command.Empty>
           <Command.Group className="max-h-[300px] overflow-auto">
             {loading ? (
               <Command.Item disabled className="h-8">
-                {t('loading')}
+                {t('loading', 'Loading...')}
               </Command.Item>
             ) : (
               (categories as ITourCategory[]).map((category) => {

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCalendar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCalendar.tsx
@@ -194,8 +194,8 @@ export const TourCalendar = ({
   const handleDelete = (tourId: string, tourName?: string) => {
     confirm({
       message: tourName
-        ? t('confirm-delete-named-tour', { name: tourName })
-        : t('confirm-delete-tour'),
+        ? t('confirm-delete-named-tour', 'Are you sure you want to delete {{name}}?', { name: tourName })
+        : t('confirm-delete-tour', 'Are you sure you want to delete this tour?'),
       options: confirmOptions,
     })
       .then(() => {
@@ -207,7 +207,7 @@ export const TourCalendar = ({
           onError: (error: ApolloError) => {
             setDeletingTourId(null);
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: error.message,
               variant: 'destructive',
             });
@@ -215,8 +215,8 @@ export const TourCalendar = ({
           onCompleted: () => {
             setDeletingTourId(null);
             toast({
-              title: t('success'),
-              description: t('tour-deleted-successfully'),
+              title: t('success', 'Success'),
+              description: t('tour-deleted-successfully', 'Tour deleted successfully'),
               variant: 'success',
             });
           },
@@ -228,7 +228,7 @@ export const TourCalendar = ({
   return (
     <div className="flex flex-col overflow-hidden border rounded-md bg-sidebar">
       <div className="flex items-center justify-between gap-2 px-4 py-2 border-b bg-sidebar">
-        <div className="text-sm font-medium">{t('tours-calendar')}</div>
+        <div className="text-sm font-medium">{t('tours-calendar', 'Tours calendar')}</div>
 
         <div className="flex items-center gap-2">
           <Button
@@ -276,7 +276,7 @@ export const TourCalendar = ({
       {showEmptyMonthMessage ? (
         <div className="flex items-center justify-center px-6 py-10 bg-background">
           <div className="inline-flex items-center justify-center flex-1 max-w-xl px-4 py-3 text-sm text-center border border-dashed rounded-md bg-background text-muted-foreground">
-            {t('no-tours-in-month', { month: monthLabel, year: currentYear })}
+            {t('no-tours-in-month', 'No tours start in {{month}} {{year}}.', { month: monthLabel, year: currentYear })}
           </div>
         </div>
       ) : (
@@ -289,7 +289,7 @@ export const TourCalendar = ({
               }}
             >
               <div className="sticky left-0 z-40 px-3 py-2 font-medium border-r bg-background text-foreground">
-                {t('calendar-tours-col')}
+                {t('calendar-tours-col', 'Tours')}
               </div>
 
               {days.map((day) => {
@@ -327,13 +327,13 @@ export const TourCalendar = ({
 
               {!loading && error && (
                 <div className="flex items-center justify-center py-10 text-sm text-destructive">
-                  {error.message || t('failed-to-load-tours')}
+                  {error.message || t('failed-to-load-tours', 'Failed to load tours')}
                 </div>
               )}
 
               {!loading && !error && (!tours || tours.length === 0) && (
                 <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
-                  {t('no-tours-to-display')}
+                  {t('no-tours-to-display', 'No tours to display')}
                 </div>
               )}
               {visibleRows.map((tour: ITour) => (

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCalendarRowActions.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCalendarRowActions.tsx
@@ -29,7 +29,7 @@ export const TourCalendarRowActions = ({
       <DropdownMenu.Content align="end" className="w-24 min-w-0">
         <DropdownMenu.Item onClick={onEdit}>
           <IconEdit size={16} />
-          {t('edit')}
+          {t('edit', 'Edit')}
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
         <DropdownMenu.Item
@@ -38,7 +38,7 @@ export const TourCalendarRowActions = ({
           className="text-destructive"
         >
           {deleting ? <Spinner className="size-4" /> : <IconTrash size={16} />}
-          {t('delete')}
+          {t('delete', 'Delete')}
         </DropdownMenu.Item>
       </DropdownMenu.Content>
     </DropdownMenu>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCommandBar.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCommandBar.tsx
@@ -59,7 +59,7 @@ export const TourCommandBar = ({
     }
 
     confirm({
-      message: t('confirm-delete-tours', { count: selectedCount }),
+      message: t('confirm-delete-tours', 'Are you sure you want to delete the {{count}} selected tours?', { count: selectedCount }),
       options: confirmOptions,
     }).then(() => {
       removeTours({
@@ -68,7 +68,7 @@ export const TourCommandBar = ({
         },
         onError: (e: ApolloError) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -76,9 +76,9 @@ export const TourCommandBar = ({
         onCompleted: () => {
           table.resetRowSelection();
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('tours-deleted-successfully'),
+            description: t('tours-deleted-successfully', 'Tours deleted successfully'),
           });
         },
       });
@@ -96,7 +96,7 @@ export const TourCommandBar = ({
   return (
     <CommandBar open={selectedCount > 0}>
       <CommandBar.Bar>
-        <CommandBar.Value>{t('x-selected', { count: selectedCount })}</CommandBar.Value>
+        <CommandBar.Value>{t('x-selected', '{{count}} selected', { count: selectedCount })}</CommandBar.Value>
         <Separator.Inline />
         {selectedCount === 1 && (
           <>
@@ -121,7 +121,7 @@ export const TourCommandBar = ({
           onClick={handleRemove}
         >
           {loading ? <Spinner /> : <IconTrash />}
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateForm.tsx
@@ -286,8 +286,8 @@ export const TourCreateForm = ({
   const handleSubmit = async (values: TourFormValues) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-required'),
+        title: t('error', 'Error'),
+        description: t('branch-required', 'Branch required'),
         variant: 'destructive',
       });
       return;
@@ -295,8 +295,8 @@ export const TourCreateForm = ({
 
     if (!values.pricingOptions || values.pricingOptions.length === 0) {
       toast({
-        title: t('error'),
-        description: t('at-least-one-pricing'),
+        title: t('error', 'Error'),
+        description: t('at-least-one-pricing', 'At least one pricing option is required'),
         variant: 'destructive',
       });
       return;
@@ -416,17 +416,17 @@ export const TourCreateForm = ({
       }
 
       toast({
-        title: t('success'),
-        description: t('tour-created-successfully'),
+        title: t('success', 'Success'),
+        description: t('tour-created-successfully', 'Tour created successfully'),
       });
 
       form.reset();
       onSuccess?.();
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-create-tour'),
+          error instanceof Error ? error.message : t('failed-to-create-tour', 'Failed to create tour'),
         variant: 'destructive',
       });
     }
@@ -436,8 +436,8 @@ export const TourCreateForm = ({
     const nameValue = form.getValues('name');
     if (!nameValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-main-lang-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-main-lang-before-creating', 'Please enter values for the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(resolvedPrimaryLanguage);
@@ -451,7 +451,7 @@ export const TourCreateForm = ({
         className="flex flex-col h-full"
       >
         <Sheet.Header>
-          <Sheet.Title>{t('create-tour')}</Sheet.Title>
+          <Sheet.Title>{t('create-tour', 'Create tour')}</Sheet.Title>
           {allLanguages.length > 1 && (
             <div className="flex items-center gap-2 ml-auto">
               <TourFieldLanguageSwitch
@@ -542,7 +542,7 @@ export const TourCreateForm = ({
 
             <div className="flex items-center">
               <div className="flex-1 border-t" />
-              <Form.Label className="mx-2">{t('duration-info')}</Form.Label>
+              <Form.Label className="mx-2">{t('duration-info', 'Duration Info')}</Form.Label>
               <div className="flex-1 border-t" />
             </div>
 
@@ -560,7 +560,7 @@ export const TourCreateForm = ({
 
             <div className="flex items-center">
               <div className="flex-1 border-t" />
-              <Form.Label className="mx-2">{t('crew')}</Form.Label>
+              <Form.Label className="mx-2">{t('crew', 'Crew')}</Form.Label>
               <div className="flex-1 border-t" />
             </div>
 
@@ -568,7 +568,7 @@ export const TourCreateForm = ({
 
             <div className="flex items-center">
               <div className="flex-1 border-t" />
-              <Form.Label className="mx-2">{t('pricing-info')}</Form.Label>
+              <Form.Label className="mx-2">{t('pricing-info', 'Pricing Info')}</Form.Label>
               <div className="flex-1 border-t" />
             </div>
 
@@ -593,7 +593,7 @@ export const TourCreateForm = ({
 
             <div className="flex items-center">
               <div className="flex-1 border-t" />
-              <Form.Label className="mx-2">{t('more-info')}</Form.Label>
+              <Form.Label className="mx-2">{t('more-info', 'More Info')}</Form.Label>
               <div className="flex-1 border-t" />
             </div>
 
@@ -606,13 +606,13 @@ export const TourCreateForm = ({
             <div className="pt-4 space-y-4">
               <Tabs defaultValue="info1" className="w-full">
                 <Tabs.List className="grid w-full grid-cols-5">
-                  <Tabs.Trigger value="info1">{t('included')}</Tabs.Trigger>
-                  <Tabs.Trigger value="info2">{t('not-included')}</Tabs.Trigger>
-                  <Tabs.Trigger value="info3">{t('highlights')}</Tabs.Trigger>
+                  <Tabs.Trigger value="info1">{t('included', 'Included')}</Tabs.Trigger>
+                  <Tabs.Trigger value="info2">{t('not-included', 'Not Included')}</Tabs.Trigger>
+                  <Tabs.Trigger value="info3">{t('highlights', 'Highlights')}</Tabs.Trigger>
                   <Tabs.Trigger value="info4">
-                    {t('additional-information')}
+                    {t('additional-information', 'Additional Information')}
                   </Tabs.Trigger>
-                  <Tabs.Trigger value="info5">{t('notes')}</Tabs.Trigger>
+                  <Tabs.Trigger value="info5">{t('notes', 'Notes')}</Tabs.Trigger>
                 </Tabs.List>
 
                 <Tabs.Content value="info1" className="pt-4">
@@ -666,11 +666,11 @@ export const TourCreateForm = ({
             disabled={loading}
             onClick={onSuccess}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
 
           <Button type="submit" disabled={loading}>
-            {loading ? t('creating') : t('create')}
+            {loading ? t('creating', 'Creating...') : t('create', 'Create')}
           </Button>
         </Sheet.Footer>
       </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCreateSheet.tsx
@@ -41,7 +41,7 @@ export const TourCreateSheet = ({
         <Sheet.Trigger asChild>
           <Button>
             <IconPlus />
-            {t('create-tour')}
+            {t('create-tour', 'Create tour')}
           </Button>
         </Sheet.Trigger>
       )}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomFieldInput.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomFieldInput.tsx
@@ -107,11 +107,11 @@ const FileFieldInput = ({
         disabled={uploadProps.loading}
       >
         <IconUpload size={16} />
-        {uploadProps.loading ? t('uploading') : t('upload-file')}
+        {uploadProps.loading ? t('uploading', 'Uploading...') : t('upload-file', 'Upload file')}
       </Button>
       {!!uploadProps.errors.length && (
         <p className="text-xs text-destructive">
-          {uploadProps.errors[0]?.message || t('upload-failed')}
+          {uploadProps.errors[0]?.message || t('upload-failed', 'Upload failed')}
         </p>
       )}
     </div>
@@ -132,7 +132,7 @@ export const TourCustomFieldInput = ({
         <Input
           type={field.type === 'text' ? 'text' : field.type}
           placeholder={
-            field.placeholder || t('enter-field-placeholder', { label: field.label.toLowerCase() })
+            field.placeholder || t('enter-field-placeholder', 'Enter {{label}}', { label: field.label.toLowerCase() })
           }
           value={typeof value === 'string' ? value : ''}
           onChange={(e) => onChange(e.target.value)}
@@ -143,7 +143,7 @@ export const TourCustomFieldInput = ({
       return (
         <Textarea
           placeholder={
-            field.placeholder || t('enter-field-placeholder', { label: field.label.toLowerCase() })
+            field.placeholder || t('enter-field-placeholder', 'Enter {{label}}', { label: field.label.toLowerCase() })
           }
           rows={6}
           value={typeof value === 'string' ? value : ''}
@@ -157,7 +157,7 @@ export const TourCustomFieldInput = ({
         <Input
           type="number"
           placeholder={
-            field.placeholder || t('enter-field-placeholder', { label: field.label.toLowerCase() })
+            field.placeholder || t('enter-field-placeholder', 'Enter {{label}}', { label: field.label.toLowerCase() })
           }
           value={typeof value === 'string' ? value : ''}
           onChange={(e) => onChange(e.target.value)}
@@ -171,7 +171,7 @@ export const TourCustomFieldInput = ({
           onChange={(date) =>
             onChange(date ? (date as Date).toISOString() : '')
           }
-          placeholder={field.placeholder || t('select-date')}
+          placeholder={field.placeholder || t('select-date', 'Select date')}
         />
       );
 
@@ -188,7 +188,7 @@ export const TourCustomFieldInput = ({
           <Select.Trigger className="w-full">
             <Select.Value
               placeholder={
-                field.placeholder || t('select-field-placeholder', { label: field.label.toLowerCase() })
+                field.placeholder || t('select-field-placeholder', 'Select {{label}}', { label: field.label.toLowerCase() })
               }
             />
           </Select.Trigger>
@@ -237,10 +237,10 @@ export const TourCustomFieldInput = ({
           )}
           options={options}
           placeholder={
-            field.placeholder || t('select-field-placeholder', { label: field.label.toLowerCase() })
+            field.placeholder || t('select-field-placeholder', 'Select {{label}}', { label: field.label.toLowerCase() })
           }
           hidePlaceholderWhenSelected
-          emptyIndicator={t('no-options')}
+          emptyIndicator={t('no-options', 'No options')}
           onChange={(options: Array<{ value: string }>) =>
             onChange(options.map((option) => option.value))
           }
@@ -258,7 +258,7 @@ export const TourCustomFieldInput = ({
       return (
         <Input
           placeholder={
-            field.placeholder || t('enter-field-placeholder', { label: field.label.toLowerCase() })
+            field.placeholder || t('enter-field-placeholder', 'Enter {{label}}', { label: field.label.toLowerCase() })
           }
           value={typeof value === 'string' ? value : ''}
           onChange={(e) => onChange(e.target.value)}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomFieldsSection.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomFieldsSection.tsx
@@ -27,19 +27,19 @@ export const TourTypeField = ({
       name="customTourTypeId"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('tour-type')}</Form.Label>
+          <Form.Label>{t('tour-type', 'Tour Type')}</Form.Label>
           <Form.Control>
             <Select
               value={field.value || ''}
               onValueChange={(value) => field.onChange(value)}
             >
               <Select.Trigger className="w-full">
-                <Select.Value placeholder={t('select-tour-type')} />
+                <Select.Value placeholder={t('select-tour-type', 'Select tour type')} />
               </Select.Trigger>
               <Select.Content>
                 {customTypes.map((type) => (
                   <Select.Item key={type._id} value={type._id}>
-                    {type.label || type.code || t('unnamed-type')}
+                    {type.label || type.code || t('unnamed-type', 'Unnamed type')}
                   </Select.Item>
                 ))}
               </Select.Content>
@@ -71,7 +71,7 @@ export const TourCustomFieldsSection = ({
 
   return (
     <div className="pt-6 mt-2 space-y-3 border-t">
-      <div className="text-sm font-semibold text-foreground">{t('tour-custom-fields')}</div>
+      <div className="text-sm font-semibold text-foreground">{t('tour-custom-fields', 'Custom Fields')}</div>
       {fieldGroups.map((group) => (
         <Collapsible key={group._id} defaultOpen className="group">
           <Collapsible.Trigger asChild>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomersPanel.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourCustomersPanel.tsx
@@ -25,10 +25,10 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
       <div className="flex flex-col items-center justify-center h-full gap-3 px-4 text-center">
         <IconUsers className="w-8 h-8 text-muted-foreground" />
 
-        <h3 className="text-base font-semibold">{t('no-customers-yet')}</h3>
+        <h3 className="text-base font-semibold">{t('no-customers-yet', 'No customers yet')}</h3>
 
         <p className="max-w-xs text-sm text-muted-foreground">
-          {t('no-customers-yet-desc')}
+          {t('no-customers-yet-desc', 'This tour does not have any booked customers yet. Once an order is created, customers will appear here.')}
         </p>
       </div>
     );
@@ -38,7 +38,7 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
     <div className="p-3 space-y-3">
       <div className="flex items-center justify-between px-1">
         <span className="text-xs text-muted-foreground">
-          {t('customers-count', { count: customerIds.length })}
+          {t('customers-count', '{{count}} customer{{count, plural, one{} other{s}}}', { count: customerIds.length })}
         </span>
 
         <Button
@@ -47,7 +47,7 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
           className="px-2 text-xs h-7"
           onClick={() => refetch()}
         >
-          {t('refresh')}
+          {t('refresh', 'Refresh')}
         </Button>
       </div>
 
@@ -72,7 +72,7 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
                 <div className="flex items-center justify-between gap-2 text-muted-foreground">
                   <span className="inline-flex items-center gap-2">
                     <IconPhone className="w-4 h-4" />
-                    {t('phone')}
+                    {t('phone', 'Phone')}
                   </span>
                   <span className="text-foreground">
                     {customer.primaryPhone || '-'}
@@ -82,7 +82,7 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
                 <div className="flex items-center justify-between gap-2 text-muted-foreground">
                   <span className="inline-flex items-center gap-2">
                     <IconMail className="w-4 h-4" />
-                    {t('email')}
+                    {t('email', 'Email')}
                   </span>
                   <Tooltip.Provider>
                     <Tooltip>
@@ -111,7 +111,7 @@ export const TourCustomersPanel = ({ tourId }: { tourId: string }) => {
                   navigate(`/contacts/customers?contactId=${customer._id}`)
                 }
               >
-                {t('view-customer')}
+                {t('view-customer', 'View customer')}
                 <IconUser className="w-4 h-4" />
               </Button>
             </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDateSchedulingField.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDateSchedulingField.tsx
@@ -68,11 +68,11 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
           onCheckedChange={handleFlexibleChange}
         />
         <div className="space-y-1">
-          <Form.Label>{t('flexible-dates')}</Form.Label>
+          <Form.Label>{t('flexible-dates', 'Flexible dates (anytime within range)')}</Form.Label>
           <Form.Description className="text-xs">
             {isFlexibleDate
-              ? t('customers-can-choose-date')
-              : t('tour-has-specific-dates')}
+              ? t('customers-can-choose-date', 'Customers can choose their start date within a range')
+              : t('tour-has-specific-dates', 'Tour has specific start and end dates')}
           </Form.Description>
         </div>
       </Form.Item>
@@ -82,7 +82,7 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
           <div className="grid gap-4 md:grid-cols-2">
             <Form.Item>
               <Form.Label>
-                {t('available-from')} <span className="text-destructive">*</span>
+                {t('available-from', 'Available from')} <span className="text-destructive">*</span>
               </Form.Label>
               <Form.Control>
                 <RHFDatePicker
@@ -95,7 +95,7 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
 
             <Form.Item>
               <Form.Label>
-                {t('available-until-label')} <span className="text-destructive">*</span>
+                {t('available-until-label', 'Available until')} <span className="text-destructive">*</span>
               </Form.Label>
               <Form.Control>
                 <RHFDatePicker
@@ -115,11 +115,11 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
               onCheckedChange={handleGroupChange}
             />
             <div className="space-y-1">
-              <Form.Label>{t('group-tour')}</Form.Label>
+              <Form.Label>{t('group-tour', 'Group tour (multiple start dates)')}</Form.Label>
               <Form.Description className="text-xs">
                 {isGroupTour
-                  ? t('create-one-tour-per-date')
-                  : t('create-single-tour-date')}
+                  ? t('create-one-tour-per-date', 'Create one tour per selected start date')
+                  : t('create-single-tour-date', 'Create a single tour date')}
               </Form.Description>
             </div>
           </Form.Item>
@@ -127,13 +127,13 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
           <div className="grid gap-4 md:grid-cols-2">
             <Form.Item>
               <Form.Label>
-                {isGroupTour ? t('start-dates') : t('start-date')}{' '}
+                {isGroupTour ? t('start-dates', 'Start Dates') : t('start-date', 'Start date')}{' '}
                 <span className="text-destructive">*</span>
               </Form.Label>
 
               {isGroupTour && (
                 <Form.Description className="text-xs">
-                  {t('select-multiple-start-dates')}
+                  {t('select-multiple-start-dates', 'Select multiple available start dates for this group tour')}
                 </Form.Description>
               )}
 
@@ -149,7 +149,7 @@ export const TourDateSchedulingField = ({ control, setValue }: Props) => {
 
             {!isGroupTour && (
               <Form.Item>
-                <Form.Label>{t('end-date')}</Form.Label>
+                <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                 <Form.Control>
                   <RHFDatePicker control={control} name="endDate" disabled />
                 </Form.Control>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourDuplicateSheet.tsx
@@ -129,7 +129,7 @@ export const TourDuplicateSheet = ({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <Sheet.View className="w-[400px] sm:max-w-[400px] p-0">
           <Sheet.Header>
-            <Sheet.Title>{t('duplicate-tour')}</Sheet.Title>
+            <Sheet.Title>{t('duplicate-tour', 'Duplicate tour')}</Sheet.Title>
           </Sheet.Header>
           <Sheet.Content className="flex items-center justify-center py-12">
             <Spinner />
@@ -269,8 +269,8 @@ const FixedDuplicateSheet = ({
   const handleSubmit = async (values: FixedFormType) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-not-selected'),
+        title: t('error', 'Error'),
+        description: t('branch-not-selected', 'Branch not selected — cannot duplicate tour'),
         variant: 'destructive',
       });
       return;
@@ -320,18 +320,18 @@ const FixedDuplicateSheet = ({
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
+          title: t('success', 'Success'),
           variant: 'success',
-          description: t('tour-duplicated-successfully'),
+          description: t('tour-duplicated-successfully', 'Tour duplicated successfully'),
         });
         onOpenChange(false);
         form.reset();
       },
       onError: (e: unknown) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            e instanceof Error ? e.message : t('failed-to-duplicate-tour'),
+            e instanceof Error ? e.message : t('failed-to-duplicate-tour', 'Failed to duplicate tour'),
           variant: 'destructive',
         });
       },
@@ -347,7 +347,7 @@ const FixedDuplicateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('duplicate-tour')}</Sheet.Title>
+              <Sheet.Title>{t('duplicate-tour', 'Duplicate tour')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -367,9 +367,9 @@ const FixedDuplicateSheet = ({
                   name={fieldPaths.name}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('name')}</Form.Label>
+                      <Form.Label>{t('name', 'Name')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-name')} {...field} />
+                        <Input placeholder={t('enter-name', 'Enter name')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -382,9 +382,9 @@ const FixedDuplicateSheet = ({
                   name={fieldPaths.refNumber}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('ref-number-label')}</Form.Label>
+                      <Form.Label>{t('ref-number-label', 'Ref number')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-ref-number')} {...field} />
+                        <Input placeholder={t('enter-ref-number', 'Enter ref number')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -396,7 +396,7 @@ const FixedDuplicateSheet = ({
                   name="startDate"
                   render={() => (
                     <Form.Item>
-                      <Form.Label>{t('start-date')}</Form.Label>
+                      <Form.Label>{t('start-date', 'Start date')}</Form.Label>
                       <Form.Control>
                         <RHFDatePicker
                           control={form.control}
@@ -418,10 +418,10 @@ const FixedDuplicateSheet = ({
                 disabled={loading}
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('duplicating') : t('duplicate')}
+                {loading ? t('duplicating', 'Duplicating…') : t('duplicate', 'Duplicate')}
               </Button>
             </Sheet.Footer>
           </form>
@@ -520,8 +520,8 @@ const FlexibleDuplicateSheet = ({
   const handleSubmit = async (values: FlexibleFormType) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-not-selected'),
+        title: t('error', 'Error'),
+        description: t('branch-not-selected', 'Branch not selected — cannot duplicate tour'),
         variant: 'destructive',
       });
       return;
@@ -570,18 +570,18 @@ const FlexibleDuplicateSheet = ({
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
+          title: t('success', 'Success'),
           variant: 'success',
-          description: t('tour-duplicated-successfully'),
+          description: t('tour-duplicated-successfully', 'Tour duplicated successfully'),
         });
         onOpenChange(false);
         form.reset();
       },
       onError: (e: unknown) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            e instanceof Error ? e.message : t('failed-to-duplicate-tour'),
+            e instanceof Error ? e.message : t('failed-to-duplicate-tour', 'Failed to duplicate tour'),
           variant: 'destructive',
         });
       },
@@ -597,7 +597,7 @@ const FlexibleDuplicateSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('duplicate-tour')}</Sheet.Title>
+              <Sheet.Title>{t('duplicate-tour', 'Duplicate tour')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -617,9 +617,9 @@ const FlexibleDuplicateSheet = ({
                   name={fieldPaths.name}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('name')}</Form.Label>
+                      <Form.Label>{t('name', 'Name')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-name')} {...field} />
+                        <Input placeholder={t('enter-name', 'Enter name')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -632,9 +632,9 @@ const FlexibleDuplicateSheet = ({
                   name={fieldPaths.refNumber}
                   render={({ field }) => (
                     <Form.Item>
-                      <Form.Label>{t('ref-number-label')}</Form.Label>
+                      <Form.Label>{t('ref-number-label', 'Ref number')}</Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-ref-number')} {...field} />
+                        <Input placeholder={t('enter-ref-number', 'Enter ref number')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -646,7 +646,7 @@ const FlexibleDuplicateSheet = ({
                   name="availableFrom"
                   render={() => (
                     <Form.Item>
-                      <Form.Label>{t('available-from-label')}</Form.Label>
+                      <Form.Label>{t('available-from-label', 'Available from')}</Form.Label>
                       <Form.Control>
                         <RHFDatePicker
                           control={form.control}
@@ -664,7 +664,7 @@ const FlexibleDuplicateSheet = ({
                   name="availableTo"
                   render={() => (
                     <Form.Item>
-                      <Form.Label>{t('available-to')}</Form.Label>
+                      <Form.Label>{t('available-to', 'Available to')}</Form.Label>
                       <Form.Control>
                         <RHFDatePicker
                           control={form.control}
@@ -686,10 +686,10 @@ const FlexibleDuplicateSheet = ({
                 disabled={loading}
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('duplicating') : t('duplicate')}
+                {loading ? t('duplicating', 'Duplicating…') : t('duplicate', 'Duplicate')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourEditForm.tsx
@@ -346,8 +346,8 @@ export const TourEditForm = ({
   const handleSubmit = async (values: TourFormValues) => {
     if (!tourId) {
       toast({
-        title: t('error'),
-        description: t('tour-id-required'),
+        title: t('error', 'Error'),
+        description: t('tour-id-required', 'Tour ID required'),
         variant: 'destructive',
       });
       return;
@@ -355,8 +355,8 @@ export const TourEditForm = ({
 
     if (!values.pricingOptions || values.pricingOptions.length === 0) {
       toast({
-        title: t('error'),
-        description: t('at-least-one-pricing'),
+        title: t('error', 'Error'),
+        description: t('at-least-one-pricing', 'At least one pricing option is required'),
         variant: 'destructive',
       });
       return;
@@ -401,8 +401,8 @@ export const TourEditForm = ({
 
       if (additionalDates.length > 0 && !targetBranchId) {
         toast({
-          title: t('error'),
-          description: t('branch-id-required-dates'),
+          title: t('error', 'Error'),
+          description: t('branch-id-required-dates', 'Branch ID is required to create additional tours for the selected dates'),
           variant: 'destructive',
         });
         return;
@@ -466,19 +466,19 @@ export const TourEditForm = ({
       }
 
       toast({
-        title: t('success'),
+        title: t('success', 'Success'),
         description:
           additionalDates.length > 0
-            ? t('tour-updated-and-created', { count: additionalDates.length })
-            : t('tour-updated-successfully'),
+            ? t('tour-updated-and-created', 'Tour updated and {{count}} new tour(s) created', { count: additionalDates.length })
+            : t('tour-updated-successfully', 'Tour updated successfully'),
       });
 
       onSuccess?.();
     } catch (error) {
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description:
-          error instanceof Error ? error.message : t('failed-to-update-tour'),
+          error instanceof Error ? error.message : t('failed-to-update-tour', 'Failed to update tour'),
         variant: 'destructive',
       });
     }
@@ -492,7 +492,7 @@ export const TourEditForm = ({
         className="flex flex-col h-full"
       >
         <Sheet.Header>
-          <Sheet.Title>{t('edit-tour')}</Sheet.Title>
+          <Sheet.Title>{t('edit-tour', 'Edit tour')}</Sheet.Title>
           {allLanguages.length > 1 && (
             <div className="flex items-center gap-2 ml-auto">
               <TourFieldLanguageSwitch
@@ -590,7 +590,7 @@ export const TourEditForm = ({
 
                 <div className="flex items-center">
                   <div className="flex-1 border-t" />
-                  <Form.Label className="mx-2">{t('duration-info')}</Form.Label>
+                  <Form.Label className="mx-2">{t('duration-info', 'Duration Info')}</Form.Label>
                   <div className="flex-1 border-t" />
                 </div>
 
@@ -608,7 +608,7 @@ export const TourEditForm = ({
 
                 <div className="flex items-center">
                   <div className="flex-1 border-t" />
-                  <Form.Label className="mx-2">{t('crew')}</Form.Label>
+                  <Form.Label className="mx-2">{t('crew', 'Crew')}</Form.Label>
                   <div className="flex-1 border-t" />
                 </div>
 
@@ -616,7 +616,7 @@ export const TourEditForm = ({
 
                 <div className="flex items-center">
                   <div className="flex-1 border-t" />
-                  <Form.Label className="mx-2">{t('pricing-info')}</Form.Label>
+                  <Form.Label className="mx-2">{t('pricing-info', 'Pricing Info')}</Form.Label>
                   <div className="flex-1 border-t" />
                 </div>
 
@@ -641,7 +641,7 @@ export const TourEditForm = ({
 
                 <div className="flex items-center">
                   <div className="flex-1 border-t" />
-                  <Form.Label className="mx-2">{t('more-info')}</Form.Label>
+                  <Form.Label className="mx-2">{t('more-info', 'More Info')}</Form.Label>
                   <div className="flex-1 border-t" />
                 </div>
 
@@ -654,13 +654,13 @@ export const TourEditForm = ({
                 <div className="space-y-4">
                   <Tabs defaultValue="info1" className="w-full">
                     <Tabs.List className="grid w-full grid-cols-5">
-                      <Tabs.Trigger value="info1">{t('included')}</Tabs.Trigger>
-                      <Tabs.Trigger value="info2">{t('not-included')}</Tabs.Trigger>
-                      <Tabs.Trigger value="info3">{t('highlights')}</Tabs.Trigger>
+                      <Tabs.Trigger value="info1">{t('included', 'Included')}</Tabs.Trigger>
+                      <Tabs.Trigger value="info2">{t('not-included', 'Not Included')}</Tabs.Trigger>
+                      <Tabs.Trigger value="info3">{t('highlights', 'Highlights')}</Tabs.Trigger>
                       <Tabs.Trigger value="info4">
-                        {t('additional-information')}
+                        {t('additional-information', 'Additional Information')}
                       </Tabs.Trigger>
-                      <Tabs.Trigger value="info5">{t('notes')}</Tabs.Trigger>
+                      <Tabs.Trigger value="info5">{t('notes', 'Notes')}</Tabs.Trigger>
                     </Tabs.List>
 
                     <Tabs.Content value="info1" className="pt-4">
@@ -721,11 +721,11 @@ export const TourEditForm = ({
             disabled={loading}
             onClick={onSuccess}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
 
           <Button type="submit" disabled={loading}>
-            {loading ? t('updating') : t('update')}
+            {loading ? t('updating', 'Updating...') : t('update', 'Update')}
           </Button>
         </Sheet.Footer>
       </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFilter.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFilter.tsx
@@ -39,7 +39,7 @@ function SelectStatusFilterItem() {
   return (
     <Filter.Item value="status">
       <IconProgressCheck />
-      {t('status')}
+      {t('status', 'Status')}
     </Filter.Item>
   );
 }
@@ -49,7 +49,7 @@ function SelectDateStatusFilterItem() {
   return (
     <Filter.Item value="date_status">
       <IconCalendarEvent />
-      {t('date-status')}
+      {t('date-status', 'Date status')}
     </Filter.Item>
   );
 }
@@ -59,7 +59,7 @@ function SelectCategoryFilterItem() {
   return (
     <Filter.Item value="categoryIds">
       <IconListTree />
-      {t('category')}
+      {t('category', 'Category')}
     </Filter.Item>
   );
 }
@@ -69,7 +69,7 @@ function SelectTourSearchFilterItem() {
   return (
     <Filter.Item value="tourSearchValue" inDialog>
       <IconSearch />
-      {t('search')}
+      {t('search', 'Search')}
     </Filter.Item>
   );
 }
@@ -82,7 +82,7 @@ function TourSearchValueBarItem() {
     <Filter.BarItem queryKey="tourSearchValue">
       <Filter.BarName>
         <IconSearch />
-        {t('search')}
+        {t('search', 'Search')}
       </Filter.BarName>
       <Filter.BarButton filterKey="tourSearchValue" inDialog>
         {tourSearchValue}
@@ -98,7 +98,7 @@ function SelectStatusFilterView() {
   return (
     <Filter.View filterKey="status">
       <Command>
-        <Command.Input placeholder={t('search-status')} />
+        <Command.Input placeholder={t('search-status', 'Search status')} />
         <Command.List>
           {STATUS_OPTIONS.map((item) => (
             <Command.Item
@@ -143,11 +143,11 @@ function SelectCategoryFilterView({ branchId }: { branchId: string }) {
   return (
     <Filter.View filterKey="categoryIds">
       <Command>
-        <Command.Input placeholder={t('search-categories')} />
+        <Command.Input placeholder={t('search-categories', 'Search categories')} />
         <Command.List>
-          <Command.Empty>{t('no-categories-found')}</Command.Empty>
+          <Command.Empty>{t('no-categories-found', 'No categories found')}</Command.Empty>
           {loading ? (
-            <Command.Item disabled>{t('loading')}</Command.Item>
+            <Command.Item disabled>{t('loading', 'Loading...')}</Command.Item>
           ) : (
             categories.map((category: ICategory) => {
               const isSelected = value.includes(category._id);
@@ -179,7 +179,7 @@ function SelectDateStatusFilterView() {
   return (
     <Filter.View filterKey="date_status">
       <Command>
-        <Command.Input placeholder={t('search-date-status')} />
+        <Command.Input placeholder={t('search-date-status', 'Search date status')} />
         <Command.List>
           {DATE_STATUS_OPTIONS.map((item) => (
             <Command.Item
@@ -206,7 +206,7 @@ const TourFilterPopover = ({ branchId }: { branchId: string }) => {
         <Combobox.Content>
           <Filter.View>
             <Command>
-              <Filter.CommandInput placeholder={t('filter')} variant="secondary" />
+              <Filter.CommandInput placeholder={t('filter', 'Filter')} variant="secondary" />
               <Command.List className="p-1">
                 <SelectTourSearchFilterItem />
                 <Command.Separator className="my-1" />
@@ -223,7 +223,7 @@ const TourFilterPopover = ({ branchId }: { branchId: string }) => {
       </Filter.Popover>
       <Filter.Dialog>
         <Filter.View filterKey="tourSearchValue" inDialog>
-          <Filter.DialogStringView filterKey="tourSearchValue" label={t('search')} />
+          <Filter.DialogStringView filterKey="tourSearchValue" label={t('search', 'Search')} />
         </Filter.View>
       </Filter.Dialog>
     </>
@@ -266,7 +266,7 @@ export const TourFilter = ({ branchId }: { branchId: string }) => {
     selectedCategoryNames.length > 0
       ? selectedCategoryNames.join(', ')
       : selectedCategoryIds.length > 0
-        ? t('x-selected', { count: selectedCategoryIds.length })
+        ? t('x-selected', '{{count}} selected', { count: selectedCategoryIds.length })
         : undefined;
 
   return (
@@ -278,30 +278,30 @@ export const TourFilter = ({ branchId }: { branchId: string }) => {
         <Filter.BarItem queryKey="status">
           <Filter.BarName>
             <IconProgressCheck />
-            {t('status')}
+            {t('status', 'Status')}
           </Filter.BarName>
           <Filter.BarButton filterKey="status">
-            {selectedStatusLabel || t('select-status')}
+            {selectedStatusLabel || t('select-status', 'Select status')}
           </Filter.BarButton>
         </Filter.BarItem>
 
         <Filter.BarItem queryKey="date_status">
           <Filter.BarName>
             <IconCalendarEvent />
-            {t('date-status')}
+            {t('date-status', 'Date status')}
           </Filter.BarName>
           <Filter.BarButton filterKey="date_status">
-            {selectedDateStatusLabel || t('select-date-status')}
+            {selectedDateStatusLabel || t('select-date-status', 'Select date status')}
           </Filter.BarButton>
         </Filter.BarItem>
 
         <Filter.BarItem queryKey="categoryIds">
           <Filter.BarName>
             <IconListTree />
-            {t('category')}
+            {t('category', 'Category')}
           </Filter.BarName>
           <Filter.BarButton filterKey="categoryIds">
-            {selectedCategoryLabel || t('select-category')}
+            {selectedCategoryLabel || t('select-category', 'Select category')}
           </Filter.BarButton>
         </Filter.BarItem>
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourFormFields.tsx
@@ -59,11 +59,11 @@ export const TourNameField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('name', 'Name')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
-            <Input placeholder={t('tour-name')} {...field} />
+            <Input placeholder={t('tour-name', 'Tour name')} {...field} />
           </Form.Control>
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -85,11 +85,11 @@ export const TourRefNumberField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('ref-number')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('ref-number', 'Ref Number')}<span className="text-primary">{labelSuffix}</span>{' '}
             <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
-            <Input placeholder={t('ref-number-label')} {...field} />
+            <Input placeholder={t('ref-number-label', 'Ref number')} {...field} />
           </Form.Control>
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -116,7 +116,7 @@ export const TourStatusField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('status')} <span className="text-destructive">*</span>
+            {t('status', 'Status')} <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
             <Select onValueChange={field.onChange} value={field.value}>
@@ -126,7 +126,7 @@ export const TourStatusField = ({
                 {field.value
                   ? TOUR_STATUS_OPTIONS.find((opt) => opt.value === field.value)
                       ?.label
-                  : t('select-status')}
+                  : t('select-status', 'Select status')}
               </Select.Trigger>
               <Select.Content>
                 {TOUR_STATUS_OPTIONS.map((option) => (
@@ -157,7 +157,7 @@ export const TourDescriptionField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('content')}<span className="text-primary">{labelSuffix}</span>{' '}
+            {t('content', 'Content')}<span className="text-primary">{labelSuffix}</span>{' '}
           </Form.Label>
           <Form.Control>
             <Editor
@@ -185,7 +185,7 @@ export const TourDurationField = ({
       name="duration"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('duration-days')}</Form.Label>
+          <Form.Label>{t('duration-days', 'Duration (days)')}</Form.Label>
           <Form.Control>
             <Input type="number" placeholder="1" {...field} disabled />
           </Form.Control>
@@ -208,7 +208,7 @@ export const TourGroupSizeField = ({
       name="groupSize"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('group-size')}</Form.Label>
+          <Form.Label>{t('group-size', 'Group Size')}</Form.Label>
           <Form.Control>
             <Input type="number" placeholder="0" {...field} />
           </Form.Control>
@@ -327,7 +327,7 @@ export const TourInfo5Field = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Description>
-            {t('not-visible-for-clients')}
+            {t('not-visible-for-clients', 'Not visible for clients and agents.')}
           </Form.Description>
           <Form.Control>
             <Editor
@@ -359,7 +359,7 @@ export const TourAdvanceCheckField = ({
             <Switch checked={field.value} onCheckedChange={field.onChange} />
           </Form.Control>
 
-          <Form.Label className="cursor-pointer">{t('advance-check')}</Form.Label>
+          <Form.Label className="cursor-pointer">{t('advance-check', 'Advance Check')}</Form.Label>
 
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -379,7 +379,7 @@ export const TourAdvancePercentField = ({
       name="advancePercent"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('advance-percent')}</Form.Label>
+          <Form.Label>{t('advance-percent', 'Advance Percent')}</Form.Label>
           <Form.Control>
             <Input type="number" placeholder="0" min="0" max="100" {...field} />
           </Form.Control>
@@ -402,7 +402,7 @@ export const TourJoinPercentField = ({
       name="joinPercent"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('join-percent')}</Form.Label>
+          <Form.Label>{t('join-percent', 'Join Percent')}</Form.Label>
           <Form.Control>
             <Input type="number" placeholder="0" min="0" max="100" {...field} />
           </Form.Control>
@@ -430,14 +430,14 @@ export const TourItineraryIdField = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('itinerary-required')}
+            {t('itinerary-required', 'Itinerary *')}
           </Form.Label>
           <SelectItinerary.FormItem
             value={field.value}
             onValueChange={field.onChange}
             branchId={branchId}
             language={language}
-            placeholder={t('select-itinerary-placeholder')}
+            placeholder={t('select-itinerary-placeholder', 'Select itinerary')}
           />
           <Form.Message className="text-destructive" />
         </Form.Item>
@@ -462,12 +462,12 @@ export const TourCategoryField = ({
       name="categoryIds"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('categories')}</Form.Label>
+          <Form.Label>{t('categories', 'Categories')}</Form.Label>
           <Form.Control>
             <SelectTourCategory
               value={field.value}
               onValueChange={field.onChange}
-              placeholder={t('select-categories-placeholder')}
+              placeholder={t('select-categories-placeholder', 'Select categories')}
               branchId={branchId}
               language={language}
             />
@@ -493,7 +493,7 @@ export const TourImageThumbnailField = ({
       name="imageThumbnail"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('thumbnail-image')}</Form.Label>
+          <Form.Label>{t('thumbnail-image', 'Thumbnail Image')}</Form.Label>
 
           <Form.Control>
             <Upload.Root
@@ -525,11 +525,11 @@ export const TourImageThumbnailField = ({
                 {!field.value && (
                   <div className="flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
                     {isLoading ? (
-                      <span>{t('uploading')}</span>
+                      <span>{t('uploading', 'Uploading...')}</span>
                     ) : (
                       <>
                         <IconUpload size={22} />
-                        <span>{t('upload-thumbnail')}</span>
+                        <span>{t('upload-thumbnail', 'Upload thumbnail')}</span>
                       </>
                     )}
                   </div>
@@ -538,7 +538,7 @@ export const TourImageThumbnailField = ({
                 {field.value && (
                   <div className="absolute inset-0 flex items-center justify-center transition bg-black/0 group-hover:bg-black/30">
                     <span className="px-2 py-1 text-xs font-medium text-white rounded opacity-0 group-hover:opacity-100 bg-black/70">
-                      {t('change-image')}
+                      {t('change-image', 'Change image')}
                     </span>
                   </div>
                 )}
@@ -584,7 +584,7 @@ export const TourImagesField = ({
       name="images"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('tour-images')}</Form.Label>
+          <Form.Label>{t('tour-images', 'Tour Images')}</Form.Label>
 
           <Form.Control>
             <ImageUploadGrid
@@ -615,7 +615,7 @@ export const TourAttachmentsField = ({
       name="attachment"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('attachment-pdf')}</Form.Label>
+          <Form.Label>{t('attachment-pdf', 'Attachment (PDF)')}</Form.Label>
 
           <Form.Control>
             <Upload.Root
@@ -643,11 +643,11 @@ export const TourAttachmentsField = ({
                 {!field.value ? (
                   <div className="flex items-center justify-center w-full gap-2 text-sm text-muted-foreground">
                     {isLoading ? (
-                      <span>{t('uploading')}</span>
+                      <span>{t('uploading', 'Uploading...')}</span>
                     ) : (
                       <>
                         <IconUpload size={18} />
-                        <span>{t('upload-pdf')}</span>
+                        <span>{t('upload-pdf', 'Upload PDF')}</span>
                       </>
                     )}
                   </div>
@@ -708,22 +708,22 @@ export const TourGuidesField = ({
         <div className='space-y-2'>
           <Form.Label className="flex items-center gap-2">
             <IconUsers size={16} />
-            {t('tour-crew')}
+            {t('tour-crew', 'Tour Crew')}
           </Form.Label>
           <Form.Description>
-            {t('assign-crew-desc')}
+            {t('assign-crew-desc', 'Assign team members as tour leader, driver, guide, etc.')}
           </Form.Description>
         </div>
 
         <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
           <IconPlus size={16} />
-          {t('add-crew-member')}
+          {t('add-crew-member', 'Add Crew Member')}
         </Button>
       </div>
 
       {fields.length === 0 ? (
         <div className="px-4 py-6 text-sm text-center border border-dashed rounded-lg text-muted-foreground">
-          {t('no-crew-assigned')}
+          {t('no-crew-assigned', 'No crew assigned yet. Click "Add Crew Member" to assign roles.')}
         </div>
       ) : (
         <div className="space-y-3">
@@ -740,7 +740,7 @@ export const TourGuidesField = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('role-required')}
+                      {t('role-required', 'Role *')}
                     </Form.Label>
                     <Select
                       onValueChange={roleField.onChange}
@@ -755,7 +755,7 @@ export const TourGuidesField = ({
                           ? GUIDE_TYPES.find(
                               (opt) => opt.value === roleField.value,
                             )?.label ?? roleField.value
-                          : t('select-role')}
+                          : t('select-role', 'Select role')}
                       </Select.Trigger>
                       <Select.Content>
                         {GUIDE_TYPES.map((option) => (
@@ -781,7 +781,7 @@ export const TourGuidesField = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('team-member-required')}
+                      {t('team-member-required', 'Team Member *')}
                     </Form.Label>
                     <SelectMember.FormItem
                       mode="single"
@@ -791,7 +791,7 @@ export const TourGuidesField = ({
                           typeof value === 'string' ? value : '',
                         )
                       }
-                      placeholder={t('select-team-member')}
+                      placeholder={t('select-team-member', 'Select team member')}
                     />
                     <Form.Message>{fieldState.error?.message}</Form.Message>
                   </div>
@@ -803,7 +803,7 @@ export const TourGuidesField = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => remove(index)}
-                aria-label={t('remove-crew-member', { index: index + 1 })}
+                aria-label={t('remove-crew-member', 'Remove crew member {{index}}', { index: index + 1 })}
                 className="mt-7"
               >
                 <IconTrash size={16} />
@@ -873,16 +873,16 @@ const TourPricingOptionsFieldContent = ({
     <Form.Item className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <Form.Label>{t('pricing-options')}</Form.Label>
+          <Form.Label>{t('pricing-options', 'Pricing Options')}</Form.Label>
           <Form.Description>
-            {t('pricing-options-desc')}
+            {t('pricing-options-desc', 'Define packages, group sizes and pricing')}
           </Form.Description>
         </div>
 
         <div className="flex gap-2">
           <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
             <IconPlus size={16} />
-            {t('add-pricing-option')}
+            {t('add-pricing-option', 'Add Pricing Option')}
           </Button>
         </div>
       </div>
@@ -895,7 +895,7 @@ const TourPricingOptionsFieldContent = ({
           >
             <div className="flex items-start justify-between">
               <Label className="flex items-center gap-2">
-                {t('package')}
+                {t('package', 'Package:')}
                 <Badge variant="secondary" className="px-2 py-0.5 font-medium">
                   {index + 1}
                 </Badge>
@@ -905,7 +905,7 @@ const TourPricingOptionsFieldContent = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => handleRemove(index)}
-                aria-label={t('remove-pricing-option', { index: index + 1 })}
+                aria-label={t('remove-pricing-option', 'Remove pricing option {{index}}', { index: index + 1 })}
               >
                 <IconTrash size={16} />
               </Button>
@@ -920,14 +920,14 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('package-title')}
+                      {t('package-title', 'Package Title')}
                       <span className="text-primary">{labelSuffix}</span>{' '}
                       <span className="text-destructive">*</span>
                     </Form.Label>
                     <Input
                       {...field}
                       value={field.value ?? ''}
-                      placeholder={t('package-title-placeholder')}
+                      placeholder={t('package-title-placeholder', 'e.g., Standard - Solo, Standard - Group')}
                     />
                     <Form.Message>{fieldState.error?.message}</Form.Message>
                   </div>
@@ -943,7 +943,7 @@ const TourPricingOptionsFieldContent = ({
                       <Form.Label
                         className={fieldState.error ? 'text-destructive' : ''}
                       >
-                        {t('min-persons-required')}
+                        {t('min-persons-required', 'Min Persons *')}
                       </Form.Label>
                       <Input type="number" min="1" {...field} placeholder="1" />
                       <Form.Message>{fieldState.error?.message}</Form.Message>
@@ -959,7 +959,7 @@ const TourPricingOptionsFieldContent = ({
                       <Form.Label
                         className={fieldState.error ? 'text-destructive' : ''}
                       >
-                        {t('max-persons')}
+                        {t('max-persons', 'Max Persons')}
                       </Form.Label>
                       <Input
                         type="number"
@@ -968,7 +968,7 @@ const TourPricingOptionsFieldContent = ({
                         onChange={(e) =>
                           field.onChange(toOptionalNumber(e.target.value))
                         }
-                        placeholder={t('max-persons-placeholder')}
+                        placeholder={t('max-persons-placeholder', 'Leave empty for unlimited')}
                       />
                       <Form.Message>{fieldState.error?.message}</Form.Message>
                     </div>
@@ -985,7 +985,7 @@ const TourPricingOptionsFieldContent = ({
                   <Form.Label
                     className={fieldState.error ? 'text-destructive' : ''}
                   >
-                    {t('accommodation-type')}
+                    {t('accommodation-type', 'Accommodation Type')}
                     <span className="text-primary">{labelSuffix}</span>
                   </Form.Label>
                   <Input
@@ -994,7 +994,7 @@ const TourPricingOptionsFieldContent = ({
                     onChange={(e) =>
                       field.onChange(toOptionalString(e.target.value))
                     }
-                    placeholder={t('accommodation-type-placeholder')}
+                    placeholder={t('accommodation-type-placeholder', 'e.g., Hotel, Resort, etc.')}
                   />
                   <Form.Message>{fieldState.error?.message}</Form.Message>
                 </div>
@@ -1010,7 +1010,7 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('adult-price')}
+                      {t('adult-price', 'Adult Price')}
                       <span className="text-primary">{labelSuffix}</span>{' '}
                       <span className="text-destructive">*</span>
                     </Form.Label>
@@ -1044,7 +1044,7 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('child-price')}
+                      {t('child-price', 'Child Price')}
                       <span className="text-primary">{labelSuffix}</span>
                     </Form.Label>
                     <div className="relative">
@@ -1060,7 +1060,7 @@ const TourPricingOptionsFieldContent = ({
                         onChange={(e) =>
                           field.onChange(toOptionalNumber(e.target.value))
                         }
-                        placeholder={t('optional')}
+                        placeholder={t('optional', 'Optional')}
                         className="pl-7"
                       />
                     </div>
@@ -1077,7 +1077,7 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('infant-price')}
+                      {t('infant-price', 'Infant Price')}
                       <span className="text-primary">{labelSuffix}</span>
                     </Form.Label>
                     <div className="relative">
@@ -1093,7 +1093,7 @@ const TourPricingOptionsFieldContent = ({
                         onChange={(e) =>
                           field.onChange(toOptionalNumber(e.target.value))
                         }
-                        placeholder={t('optional')}
+                        placeholder={t('optional', 'Optional')}
                         className="pl-7"
                       />
                     </div>
@@ -1112,7 +1112,7 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('domestic-flight')}
+                      {t('domestic-flight', 'Domestic Flight')}
                     </Form.Label>
                     <div className="relative">
                       <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -1142,7 +1142,7 @@ const TourPricingOptionsFieldContent = ({
                     <Form.Label
                       className={fieldState.error ? 'text-destructive' : ''}
                     >
-                      {t('single-supplement')}
+                      {t('single-supplement', 'Single Supplement')}
                     </Form.Label>
                     <div className="relative">
                       <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -1173,7 +1173,7 @@ const TourPricingOptionsFieldContent = ({
                   <Form.Label
                     className={fieldState.error ? 'text-destructive' : ''}
                   >
-                    {t('note')}<span className="text-primary">{labelSuffix}</span>
+                    {t('note', 'Note')}<span className="text-primary">{labelSuffix}</span>
                   </Form.Label>
                   <Textarea
                     {...field}
@@ -1181,7 +1181,7 @@ const TourPricingOptionsFieldContent = ({
                     onChange={(e) =>
                       field.onChange(toOptionalString(e.target.value))
                     }
-                    placeholder={t('additional-info-placeholder')}
+                    placeholder={t('additional-info-placeholder', 'Additional information...')}
                   />
                   <Form.Message>{fieldState.error?.message}</Form.Message>
                 </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupAddSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupAddSheet.tsx
@@ -252,7 +252,7 @@ export const TourGroupAddSheet = ({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <Sheet.View className="w-[420px] sm:max-w-[420px] p-0">
           <Sheet.Header>
-            <Sheet.Title>{t('add-tour')}</Sheet.Title>
+            <Sheet.Title>{t('add-tour', 'Add tour')}</Sheet.Title>
           </Sheet.Header>
           <Sheet.Content className="flex items-center justify-center py-12">
             <Spinner />
@@ -265,8 +265,8 @@ export const TourGroupAddSheet = ({
   const handleSubmit = async (values: GroupTourAddFormValues) => {
     if (!branchId) {
       toast({
-        title: t('error'),
-        description: t('branch-required'),
+        title: t('error', 'Error'),
+        description: t('branch-required', 'Branch required'),
         variant: 'destructive',
       });
       return;
@@ -314,18 +314,18 @@ export const TourGroupAddSheet = ({
       },
       onCompleted: () => {
         toast({
-          title: t('success'),
+          title: t('success', 'Success'),
           variant: 'success',
-          description: t('tour-added-to-group-successfully'),
+          description: t('tour-added-to-group-successfully', 'Tour added to group successfully'),
         });
         onOpenChange(false);
         form.reset();
       },
       onError: (error: unknown) => {
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description:
-            error instanceof Error ? error.message : t('failed-to-add-tour'),
+            error instanceof Error ? error.message : t('failed-to-add-tour', 'Failed to add tour'),
           variant: 'destructive',
         });
       },
@@ -337,8 +337,8 @@ export const TourGroupAddSheet = ({
 
     if (!refValue?.trim()) {
       toast({
-        title: t('error'),
-        description: t('enter-ref-before-creating'),
+        title: t('error', 'Error'),
+        description: t('enter-ref-before-creating', 'Please enter the ref number in the main language before creating.'),
         variant: 'destructive',
       });
       setSelectedLang(resolvedPrimaryLanguage);
@@ -354,7 +354,7 @@ export const TourGroupAddSheet = ({
             className="flex flex-col h-full"
           >
             <Sheet.Header>
-              <Sheet.Title>{t('add-tour')}</Sheet.Title>
+              <Sheet.Title>{t('add-tour', 'Add tour')}</Sheet.Title>
               {allLanguages.length > 1 && (
                 <div className="flex items-center gap-2 ml-auto">
                   <TourFieldLanguageSwitch
@@ -375,11 +375,11 @@ export const TourGroupAddSheet = ({
                   render={({ field }) => (
                     <Form.Item>
                       <Form.Label>
-                        {t('ref-number-label')}{''}
+                        {t('ref-number-label', 'Ref number')}{''}
                         <span className="text-primary">{labelSuffix}</span>
                       </Form.Label>
                       <Form.Control>
-                        <Input placeholder={t('enter-ref-number')} {...field} />
+                        <Input placeholder={t('enter-ref-number', 'Enter ref number')} {...field} />
                       </Form.Control>
                       <Form.Message />
                     </Form.Item>
@@ -392,7 +392,7 @@ export const TourGroupAddSheet = ({
                   render={() => (
                     <Form.Item>
                       <Form.Label>
-                        {t('start-date')} <span className="text-destructive">*</span>
+                        {t('start-date', 'Start date')} <span className="text-destructive">*</span>
                       </Form.Label>
                       <Form.Control>
                         <RHFDatePicker
@@ -407,7 +407,7 @@ export const TourGroupAddSheet = ({
                 />
 
                 <Form.Item>
-                  <Form.Label>{t('end-date')}</Form.Label>
+                  <Form.Label>{t('end-date', 'End Date')}</Form.Label>
                   <Form.Control>
                     <Input
                       value={
@@ -415,7 +415,7 @@ export const TourGroupAddSheet = ({
                           ? dateFormatter.format(computedEndDate)
                           : ''
                       }
-                      placeholder={t('calculated-from-duration')}
+                      placeholder={t('calculated-from-duration', 'Calculated from duration')}
                       disabled
                       readOnly
                     />
@@ -431,10 +431,10 @@ export const TourGroupAddSheet = ({
                 disabled={loading}
                 onClick={() => onOpenChange(false)}
               >
-                {t('cancel')}
+                {t('cancel', 'Cancel')}
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? t('adding') : t('add-tour')}
+                {loading ? t('adding', 'Adding...') : t('add-tour', 'Add tour')}
               </Button>
             </Sheet.Footer>
           </form>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupList.tsx
@@ -174,10 +174,10 @@ function EmptyState({
         className="text-muted-foreground"
       />
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-grouped-tours-yet')}
+        {t('no-grouped-tours-yet', 'No grouped tours yet')}
       </h2>
       <p className="mb-4 text-md text-muted-foreground">
-        {t('no-grouped-tours-yet-desc')}
+        {t('no-grouped-tours-yet-desc', 'Tours with a group code will appear here.')}
       </p>
       <TourCreateSheet
         branchId={branchId}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupMoreCell.tsx
@@ -30,7 +30,7 @@ export const TourGroupMoreColumn = ({
           <Command.List>
             <Command.Item value="add-tour" onSelect={() => onAddTour?.(row)}>
               <IconPlus className="w-4 h-4" />
-              {t('add-tour')}
+              {t('add-tour', 'Add tour')}
             </Command.Item>
           </Command.List>
         </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourMoreCell.tsx
@@ -38,21 +38,21 @@ export const TourMoreColumn = ({
 
   const handleDelete = () => {
     confirm({
-      message: t('confirm-delete-tour'),
+      message: t('confirm-delete-tour', 'Are you sure you want to delete this tour?'),
       options: { confirmationValue: 'delete' },
     }).then(() => {
       removeTours({
         variables: { ids: [tour._id] },
         onCompleted: () => {
           toast({
-            title: t('success'),
+            title: t('success', 'Success'),
             variant: 'success',
-            description: t('tour-deleted-successfully'),
+            description: t('tour-deleted-successfully', 'Tour deleted successfully'),
           });
         },
         onError: (e) => {
           toast({
-            title: t('error'),
+            title: t('error', 'Error'),
             description: e.message,
             variant: 'destructive',
           });
@@ -71,15 +71,15 @@ export const TourMoreColumn = ({
           <Command.List>
             <Command.Item value="edit" onSelect={handleEdit}>
               <IconEdit className="w-4 h-4" />
-              {t('edit')}
+              {t('edit', 'Edit')}
             </Command.Item>
             <Command.Item value="duplicate" onSelect={handleDuplicate}>
               <IconCopy className="w-4 h-4" />
-              {t('duplicate')}
+              {t('duplicate', 'Duplicate')}
             </Command.Item>
             <Command.Item value="delete" onSelect={handleDelete}>
               <IconTrash className="w-4 h-4" />
-              {t('delete')}
+              {t('delete', 'Delete')}
             </Command.Item>
           </Command.List>
         </Command>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourRecordTable.tsx
@@ -171,10 +171,10 @@ function EmptyStateRow({
     <div className="flex flex-col items-center justify-center gap-3 p-6 w-full min-h-[80vh] text-center">
       <IconMapRoute size={64} stroke={1.5} className="text-muted-foreground" />
       <h2 className="text-lg font-semibold text-muted-foreground">
-        {t('no-tours-yet')}
+        {t('no-tours-yet', 'No tour yet')}
       </h2>
       <p className="max-w-sm text-sm text-muted-foreground">
-        {t('no-tours-yet-desc')}
+        {t('no-tours-yet-desc', 'Create your first tour to get started.')}
       </p>
       <TourCreateSheet
         branchId={branchId}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/ToursView.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/ToursView.tsx
@@ -30,7 +30,7 @@ export const ToursViewControl = ({ className }: ToursViewControlProps) => {
       <Popover.Trigger asChild>
         <Button variant="ghost" className={className}>
           <IconAdjustmentsHorizontal />
-          {t('view')}
+          {t('view', 'View')}
         </Button>
       </Popover.Trigger>
       <Popover.Content>
@@ -51,7 +51,7 @@ export const ToursViewControl = ({ className }: ToursViewControlProps) => {
               className="flex-col gap-0 h-11"
             >
               <IconTable className="size-5!" />
-              <span className="text-xs font-normal">{t('table-view')}</span>
+              <span className="text-xs font-normal">{t('table-view', 'Table')}</span>
             </Button>
           </ToggleGroup.Item>
           <ToggleGroup.Item value="calendar" asChild>
@@ -61,7 +61,7 @@ export const ToursViewControl = ({ className }: ToursViewControlProps) => {
               className="flex-col gap-0 h-11"
             >
               <IconCalendarMonth className="size-5!" />
-              <span className="text-xs font-normal">{t('calendar')}</span>
+              <span className="text-xs font-normal">{t('calendar', 'Calendar')}</span>
             </Button>
           </ToggleGroup.Item>
         </ToggleGroup>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/CustomizeTourPdfDialog.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/CustomizeTourPdfDialog.tsx
@@ -261,17 +261,17 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
           <section className="min-h-0 overflow-y-auto bg-background">
             <Dialog.Header className="px-6 py-6 border-b bg-muted/30">
               <Dialog.Title className="text-xl">
-                {t('customize-tour-pdf')}
+                {t('customize-tour-pdf', 'Customize Tour PDF')}
               </Dialog.Title>
               <Dialog.Description className="max-w-xl text-sm leading-6">
-                {t('customize-tour-pdf-desc')}
+                {t('customize-tour-pdf-desc', 'Control which tour sections appear and rename the built-in text used in the exported PDF.')}
               </Dialog.Description>
             </Dialog.Header>
 
             <div className="px-6 py-5 space-y-4">
               <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 <IconLayoutGrid size={14} />
-                {t('visible-sections')}
+                {t('visible-sections', 'Visible Sections')}
               </div>
 
               <div className="grid gap-3">
@@ -309,7 +309,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               <div className="pt-2">
                 <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <IconLayoutGrid size={14} />
-                  {t('attached-itinerary')}
+                  {t('attached-itinerary', 'Attached Itinerary')}
                 </div>
 
                 <div className="grid gap-3">
@@ -351,10 +351,10 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
             <div className="px-6 py-6 border-b bg-background/70 backdrop-blur">
               <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 <IconForms size={14} />
-                {t('static-text')}
+                {t('static-text', 'Static Text')}
               </div>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                {t('update-built-in-labels')}
+                {t('update-built-in-labels', 'Update the built-in labels used in the cover, overview, and pricing sections.')}
               </p>
             </div>
 
@@ -362,7 +362,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               <div className="px-4 py-4 border shadow-sm rounded-2xl border-border/60 bg-background">
                 <div className="mb-4 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <IconFileDescription size={14} />
-                  {t('tour-labels')}
+                  {t('tour-labels', 'Tour Labels')}
                 </div>
 
                 <div className="space-y-4">
@@ -388,7 +388,7 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
               <div className="px-4 py-4 border shadow-sm rounded-2xl border-border/60 bg-background">
                 <div className="mb-4 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <IconFileDescription size={14} />
-                  {t('itinerary-labels')}
+                  {t('itinerary-labels', 'Itinerary Labels')}
                 </div>
 
                 <div className="space-y-4">
@@ -413,17 +413,17 @@ export const CustomizeTourPdfDialog: React.FC<CustomizeTourPdfDialogProps> = ({
 
               <div className="px-4 py-4 border border-dashed rounded-2xl border-border/70 bg-background/70">
                 <p className="text-sm leading-6 text-muted-foreground">
-                  {t('preview-refreshes-auto')}
+                  {t('preview-refreshes-auto', 'Preview refreshes automatically when these values change. Use short labels for the cleanest PDF layout.')}
                 </p>
               </div>
             </div>
 
             <Dialog.Footer className="sticky bottom-0 px-6 py-4 border-t bg-background/95 backdrop-blur">
               <Button variant="outline" onClick={onReset}>
-                {t('reset-to-defaults')}
+                {t('reset-to-defaults', 'Reset to defaults')}
               </Button>
               <Button variant="outline" onClick={() => onOpenChange(false)}>
-                {t('close')}
+                {t('close', 'Close')}
               </Button>
             </Dialog.Footer>
           </aside>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/ExportPDFButton.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/pdf/ExportPDFButton.tsx
@@ -194,8 +194,8 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
     Boolean(previewBlob) && !previewLoading && !shouldWaitForResources;
   const previewStatusText =
     previewLoading || shouldWaitForResources
-      ? t('preparing-pdf-preview')
-      : t('preview-refreshes-after-edits');
+      ? t('preparing-pdf-preview', 'Preparing PDF preview...')
+      : t('preview-refreshes-after-edits', 'Preview refreshes automatically after edits and customization changes.');
 
   const revokePreviewUrl = useCallback(() => {
     if (previewObjectUrlRef.current) {
@@ -240,7 +240,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
   const generatePreview = useCallback(
     async (force = false) => {
       if (!localizedTour) {
-        setPreviewError(t('no-tour-data'));
+        setPreviewError(t('no-tour-data', 'No tour data available.'));
         return;
       }
 
@@ -270,8 +270,8 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
 
         if (totalImages > 0 && loadedImages < totalImages) {
           toast({
-            title: t('some-images-failed'),
-            description: t('some-images-failed-desc', { failed: totalImages - loadedImages, total: totalImages }),
+            title: t('some-images-failed', 'Some images failed to load'),
+            description: t('some-images-failed-desc', '{{failed}} of {{total}} image(s) could not be loaded. The preview may have missing images.', { failed: totalImages - loadedImages, total: totalImages }),
           });
         }
 
@@ -293,7 +293,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
         setPreviewError(
           error instanceof Error
             ? error.message
-            : t('failed-to-generate-preview'),
+            : t('failed-to-generate-preview', 'Failed to generate preview.'),
         );
       } finally {
         if (isMountedRef.current && requestId === previewRequestIdRef.current) {
@@ -324,8 +324,8 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
     triggerDownload(url, generateFilename(localizedTour.name));
 
     toast({
-      title: t('pdf-downloaded'),
-      description: t('pdf-downloaded-desc', { name: localizedTour.name || 'Tour' }),
+      title: t('pdf-downloaded', 'PDF downloaded'),
+      description: t('pdf-downloaded-desc', '"{{name}}" has been downloaded.', { name: localizedTour.name || 'Tour' }),
       variant: 'success',
     });
   }, [localizedTour, previewBlob, toast, triggerDownload]);
@@ -468,11 +468,11 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
           ]);
         } catch (error) {
           toast({
-            title: t('refresh-failed'),
+            title: t('refresh-failed', 'Refresh failed'),
             description:
               error instanceof Error
                 ? error.message
-                : t('failed-to-reload-tour'),
+                : t('failed-to-reload-tour', 'Failed to reload tour details.'),
             variant: 'destructive',
           });
         } finally {
@@ -544,7 +544,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
         onClick={() => handlePreviewOpenChange(true)}
       >
         <IconFileTypePdf size={16} />
-        {size !== 'icon' && t('preview-pdf')}
+        {size !== 'icon' && t('preview-pdf', 'Preview PDF')}
       </Button>
 
       <Dialog open={previewOpen} onOpenChange={handlePreviewOpenChange}>
@@ -560,9 +560,9 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
           </Dialog.Close>
 
           <Dialog.Header className="border-b px-6 py-4 pr-14 space-y-1">
-            <Dialog.Title>{t('tour-pdf-preview')}</Dialog.Title>
+            <Dialog.Title>{t('tour-pdf-preview', 'Tour PDF preview')}</Dialog.Title>
             <Dialog.Description>
-              {t('review-pdf-before-downloading')}
+              {t('review-pdf-before-downloading', 'Review the generated PDF before downloading it. You can also open the tour editor from here and refresh the preview.')}
             </Dialog.Description>
           </Dialog.Header>
 
@@ -571,7 +571,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
               <div className="flex h-full items-center justify-center">
                 <div className="flex items-center gap-3 text-sm text-muted-foreground">
                   <Spinner />
-                  {t('preparing-pdf-preview')}
+                  {t('preparing-pdf-preview', 'Preparing PDF preview...')}
                 </div>
               </div>
             ) : previewError ? (
@@ -581,18 +581,18 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
                 </p>
                 <Button variant="outline" onClick={handleRefreshPreview}>
                   <IconRefresh size={16} />
-                  {t('retry-preview')}
+                  {t('retry-preview', 'Retry preview')}
                 </Button>
               </div>
             ) : previewUrl ? (
               <iframe
-                title={t('tour-pdf-preview')}
+                title={t('tour-pdf-preview', 'Tour PDF preview')}
                 src={previewUrl}
                 className="h-full w-full border-0 bg-white"
               />
             ) : (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                {t('no-preview-available')}
+                {t('no-preview-available', 'No preview available yet.')}
               </div>
             )}
           </div>
@@ -607,7 +607,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
                 disabled={!localizedTour}
               >
                 <IconAdjustmentsHorizontal size={16} />
-                {t('customize')}
+                {t('customize', 'Customize')}
               </Button>
 
               <Button
@@ -616,7 +616,7 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
                 disabled={previewLoading || !localizedTour}
               >
                 {previewLoading ? <Spinner /> : <IconRefresh size={16} />}
-                {t('refresh')}
+                {t('refresh', 'Refresh')}
               </Button>
 
               <Button
@@ -625,12 +625,12 @@ export const ExportTourPDFButton: React.FC<ExportTourPDFButtonProps> = ({
                 disabled={!canEdit}
               >
                 <IconEdit size={16} />
-                {t('edit-tour-btn')}
+                {t('edit-tour-btn', 'Edit tour')}
               </Button>
 
               <Button onClick={handleDownload} disabled={!canDownload}>
                 <IconDownload size={16} />
-                {t('download-pdf')}
+                {t('download-pdf', 'Download PDF')}
               </Button>
             </div>
           </Dialog.Footer>

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/ActionMenu.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/ActionMenu.tsx
@@ -31,12 +31,12 @@ export const ActionMenu = ({
   const { t } = useTranslation('tourism');
   const dropdownItems: DropdownItem[] = [
     {
-      label: t('edit'),
+      label: t('edit', 'Edit'),
       icon: <IconEdit size={16} stroke={1.5} />,
       onClick: () => onEdit(),
     },
     {
-      label: duplicateLoading ? t('duplicating') : t('duplicate'),
+      label: duplicateLoading ? t('duplicating', 'Duplicating…') : t('duplicate', 'Duplicate'),
       icon: duplicateLoading ? (
         <Spinner className="w-4 h-4" />
       ) : (
@@ -46,7 +46,7 @@ export const ActionMenu = ({
       disabled: duplicateLoading,
     },
     {
-      label: t('delete'),
+      label: t('delete', 'Delete'),
       icon: <IconTrash size={16} stroke={1.5} />,
       onClick: () => onDelete(),
     },
@@ -60,7 +60,7 @@ export const ActionMenu = ({
           aria-label="Open action menu"
           aria-haspopup="true"
         >
-          {t('action')}
+          {t('action', 'Action')}
           <IconChevronDown size={18} stroke={2} />
         </button>
       </Popover.Trigger>

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/BranchCard.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/BranchCard.tsx
@@ -61,7 +61,7 @@ export const BranchCard = ({
       <div className="flex items-center justify-between px-3 py-2">
         <div className="min-w-0">
           <div className="text-sm font-semibold truncate">
-            {branch.name || t('unnamed-branch')}
+            {branch.name || t('unnamed-branch', 'Unnamed Branch')}
           </div>
         </div>
 
@@ -84,10 +84,10 @@ export const BranchCard = ({
         <div className="flex items-center min-w-0 gap-2">
           <IconCalendarPlus size={16} className="shrink-0" />
           <span className="text-xs font-medium truncate">
-            {t('created')}:{' '}
+            {t('created', 'Created')}:{' '}
             {branch.createdAt
               ? format(new Date(branch.createdAt), 'dd MMM yyyy')
-              : t('na')}
+              : t('na', 'N/A')}
           </span>
         </div>
 

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/BranchList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/BranchList.tsx
@@ -31,7 +31,7 @@ export const BranchList = () => {
     if (!branch) return;
 
     confirm({
-      message: t('confirm-duplicate-branch', { name: branchName }),
+      message: t('confirm-duplicate-branch', 'Are you sure you want to create a duplicate of "{{name}}"?', { name: branchName }),
       options: duplicateConfirmOptions,
     }).then(async () => {
       await handleDuplicateBranch(branch, refetch);
@@ -42,7 +42,7 @@ export const BranchList = () => {
     const branchName = list?.find((b) => b._id === branchId)?.name || '';
 
     confirm({
-      message: t('confirm-delete-branch', { name: branchName }),
+      message: t('confirm-delete-branch', 'Are you sure you want to permanently delete "{{name}}"?', { name: branchName }),
       options: deleteConfirmOptions,
     }).then(async () => {
       await handleDeleteBranch(branchId, refetch);

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/CreateTmsForm.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/CreateTmsForm.tsx
@@ -148,7 +148,7 @@ const CreateTmsForm = ({
     <Sheet.View className="h-full p-0 w-175 md:w-175 sm:max-w-175">
       {isEditMode ? (
         <Sheet.Header>
-          <Sheet.Title>{t('edit-tms')}</Sheet.Title>
+          <Sheet.Title>{t('edit-tms', 'Edit Tour Management System')}</Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
       ) : (

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/CreateTmsSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/CreateTmsSheet.tsx
@@ -21,7 +21,7 @@ export const TmsCreateSheet = () => {
       <Sheet.Trigger asChild>
         <Button>
           <IconPlus />
-          {t('create-tms')}
+          {t('create-tms', 'Create TMS')}
         </Button>
       </Sheet.Trigger>
       <CreateTmsForm onOpenChange={handleOpenChange} isOpen={open} />
@@ -33,7 +33,7 @@ export const TmsCreateSheetHeader = () => {
   const { t } = useTranslation('tourism');
   return (
     <Sheet.Header>
-      <Sheet.Title>{t('create-tms-full')}</Sheet.Title>
+      <Sheet.Title>{t('create-tms-full', 'Create Tour Management System')}</Sheet.Title>
       <Sheet.Close />
     </Sheet.Header>
   );

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/EmptyList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/EmptyList.tsx
@@ -17,11 +17,11 @@ export const EmptyList = () => {
 
         <div className="p-2 text-center">
           <h2 className="mb-2 text-lg font-semibold sm:mb-3 sm:text-xl text-foreground">
-            {t('tour-management-system')}
+            {t('tour-management-system', 'Tour management system')}
           </h2>
 
           <p className="px-1 sm:px-0 text-center text-muted-foreground text-xs sm:text-sm font-medium leading-[140%] font-inter pb-3 sm:pb-4">
-            {t('tms-empty-description')}
+            {t('tms-empty-description', 'A tour management system is software designed to help travel agencies and operators organize and manage tour-related activities. It helps streamline itinerary planning, booking, guide assignment, customer information, and travel schedules.')}
           </p>
 
           <TmsCreateSheet />

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/TmsFormFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/TmsFormFields.tsx
@@ -46,7 +46,7 @@ export const TourName = ({ control }: { control: Control<TmsFormType> }) => {
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('name')} <span className="text-destructive">*</span>
+            {t('name', 'Name')} <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Control>
             <Input className="h-8 rounded-md" {...field} />
@@ -97,7 +97,7 @@ export const MainLanguageSelect = ({
       name="mainLanguage"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('main-language')}</Form.Label>
+          <Form.Label>{t('main-language', 'Main language')}</Form.Label>
           <Form.Control>
             <MainLanguageSelectFormItem
               value={field.value}
@@ -129,15 +129,15 @@ const MainLanguageSelectFormItem = ({
     <Popover open={open} onOpenChange={setOpen}>
       <Combobox.Trigger className="w-full shadow-xs">
         <Combobox.Value
-          placeholder={t('select-main-language')}
+          placeholder={t('select-main-language', 'Select main language')}
           value={selected?.label}
         />
       </Combobox.Trigger>
       <Combobox.Content>
         <Command>
-          <Command.Input placeholder={t('search-languages')} />
+          <Command.Input placeholder={t('search-languages', 'Search languages...')} />
           <Command.List className="max-h-[300px] overflow-y-auto">
-            <Command.Empty>{t('no-language-found')}</Command.Empty>
+            <Command.Empty>{t('no-language-found', 'No language found')}</Command.Empty>
             {LANGUAGES.filter((language) =>
               options.includes(language.value),
             ).map((language) => (
@@ -169,7 +169,7 @@ export const SelectColor = ({ control }: { control: Control<TmsFormType> }) => {
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('main-color')} <span className="text-destructive">*</span>
+            {t('main-color', 'Main color')} <span className="text-destructive">*</span>
           </Form.Label>
 
           <Form.Control>
@@ -256,7 +256,7 @@ const ImageUploadField = ({
                       <div className="relative z-10 flex flex-col items-center justify-center gap-3">
                         <IconUpload size={20} />
                         <span className="text-xs text-muted-foreground">
-                          {t('max-size-file-type')}
+                          {t('max-size-file-type', 'Max size: 15MB, File type: PNG')}
                         </span>
                       </div>
                     )}
@@ -264,7 +264,7 @@ const ImageUploadField = ({
                       <div className="absolute inset-0 flex items-center justify-center transition-all duration-200 bg-black/0 group-hover:bg-black/20">
                         <div className="transition-opacity duration-200 opacity-0 group-hover:opacity-100">
                           <div className="px-2 py-1 text-xs font-medium text-black rounded-lg backdrop-blur-sm bg-white/90">
-                            {t('change')}
+                            {t('change', 'Change')}
                           </div>
                         </div>
                       </div>
@@ -313,8 +313,8 @@ export const LogoField = ({ control }: { control: Control<TmsFormType> }) => {
     <ImageUploadField
       control={control}
       name="logo"
-      label={t('logo')}
-      description={t('logo-description')}
+      label={t('logo', 'LOGO')}
+      description={t('logo-description', 'Image can be shown on the top of the post also')}
     />
   );
 };
@@ -329,8 +329,8 @@ export const FavIconField = ({
     <ImageUploadField
       control={control}
       name="favIcon"
-      label={t('fav-icon')}
-      description={t('fav-icon-description')}
+      label={t('fav-icon', 'FAV ICON')}
+      description={t('fav-icon-description', 'Fav icon can be shown on the top of the post also in')}
     />
   );
 };
@@ -348,10 +348,10 @@ export const GeneralManager = ({
       render={({ field }) => (
         <Form.Item>
           <Form.Label>
-            {t('general-managers')} <span className="text-destructive">*</span>
+            {t('general-managers', 'General Managers')} <span className="text-destructive">*</span>
           </Form.Label>
           <Form.Description>
-            {t('general-manager-description')}
+            {t('general-manager-description', 'General manager can be shown on the top of the post also in the list view')}
           </Form.Description>
           <Form.Control>
             <div className="w-full">
@@ -377,9 +377,9 @@ export const Manager = ({ control }: { control: Control<TmsFormType> }) => {
       name="managers"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('managers')}</Form.Label>
+          <Form.Label>{t('managers', 'Managers')}</Form.Label>
           <Form.Description>
-            {t('manager-description')}
+            {t('manager-description', 'Manager can be shown on the top of the post also in the list view')}
           </Form.Description>
           <Form.Control>
             <div className="w-full">
@@ -422,15 +422,15 @@ const LanguageSelectFormItem = ({
     <Popover open={open} onOpenChange={setOpen}>
       <Combobox.Trigger className="w-full shadow-xs">
         <Combobox.Value
-          placeholder={t('select-languages')}
+          placeholder={t('select-languages', 'Select languages')}
           value={selectedLabels.length ? selectedLabels.join(', ') : undefined}
         />
       </Combobox.Trigger>
       <Combobox.Content>
         <Command>
-          <Command.Input placeholder={t('search-languages')} />
+          <Command.Input placeholder={t('search-languages', 'Search languages...')} />
           <Command.List className="max-h-[300px] overflow-y-auto">
-            <Command.Empty>{t('no-language-found')}</Command.Empty>
+            <Command.Empty>{t('no-language-found', 'No language found')}</Command.Empty>
             {LANGUAGES.map((language) => (
               <Command.Item
                 key={language.value}
@@ -460,7 +460,7 @@ export const LanguageSelect = ({
       name="language"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('language')}</Form.Label>
+          <Form.Label>{t('language', 'Language')}</Form.Label>
           <Form.Control>
             <LanguageSelectFormItem
               value={
@@ -488,9 +488,9 @@ export const Payments = ({ control }: { control: Control<TmsFormType> }) => {
       name="payment"
       render={({ field }) => (
         <Form.Item>
-          <Form.Label>{t('payments')}</Form.Label>
+          <Form.Label>{t('payments', 'PAYMENTS')}</Form.Label>
           <Form.Description>
-            {t('select-payments-description')}
+            {t('select-payments-description', 'Select payments that you want to use')}
           </Form.Description>
           <div className="flex items-end justify-between gap-4">
             <Form.Control className="flex-1">
@@ -500,7 +500,7 @@ export const Payments = ({ control }: { control: Control<TmsFormType> }) => {
                 onValueChange={(value) => {
                   field.onChange(Array.isArray(value) ? value : []);
                 }}
-                placeholder={t('select-payments')}
+                placeholder={t('select-payments', 'Select payments')}
               />
             </Form.Control>
           </div>
@@ -526,8 +526,8 @@ export const Prepaid = ({ form }: { form: UseFormReturn<TmsFormType> }) => {
         render={({ field }) => (
           <Form.Item className="flex items-center justify-between gap-4">
             <div className="space-y-2">
-              <Form.Label className="cursor-pointer">{t('prepaid')}</Form.Label>
-              <Form.Description>{t('enable-prepaid-percentage')}</Form.Description>
+              <Form.Label className="cursor-pointer">{t('prepaid', 'Prepaid')}</Form.Label>
+              <Form.Description>{t('enable-prepaid-percentage', 'Enable prepaid percentage')}</Form.Description>
             </div>
             <Form.Control>
               <Switch
@@ -555,14 +555,14 @@ export const Prepaid = ({ form }: { form: UseFormReturn<TmsFormType> }) => {
           name="prepaidPercent"
           render={({ field }) => (
             <Form.Item className="mt-4">
-              <Form.Label>{t('prepaid-percent')}</Form.Label>
+              <Form.Label>{t('prepaid-percent', 'Prepaid Percent')}</Form.Label>
               <Form.Control>
                 <Input
                   type="number"
                   min="0"
                   max="100"
                   step="1"
-                  placeholder={t('enter-prepaid-percent')}
+                  placeholder={t('enter-prepaid-percent', 'Enter prepaid percent')}
                   value={field.value ?? ''}
                   onChange={(event) => {
                     const nextValue = event.target.value;
@@ -600,8 +600,8 @@ export const Token = ({ control }: { control: Control<TmsFormType> }) => {
       name="token"
       render={({ field }) => (
         <Form.Item className="py-3 border-y">
-          <Form.Label>{t('erxes-app-token')}</Form.Label>
-          <Form.Description>{t('erxes-app-token-desc')}</Form.Description>
+          <Form.Label>{t('erxes-app-token', 'Erxes app token')}</Form.Label>
+          <Form.Description>{t('erxes-app-token-desc', 'What is erxes app token ?')}</Form.Description>
           <Form.Control>
             <Input className="h-8 rounded-md" {...field} />
           </Form.Control>
@@ -631,11 +631,11 @@ export const OtherPayments = ({
     <div className="py-3">
       <div className="flex flex-col items-start self-stretch gap-2">
         <h2 className="self-stretch text-sm font-medium leading-tight text-primary">
-          {t('other-payments')}
+          {t('other-payments', 'Other Payments')}
         </h2>
 
         <p className="text-muted-foreground font-['Inter'] text-xs font-medium leading-[140%]">
-          {t('other-payments-desc')}
+          {t('other-payments-desc', 'Type is must latin, some default types: golomtCard, khaanCard, TDBCard')}
         </p>
       </div>
 
@@ -647,7 +647,7 @@ export const OtherPayments = ({
           type="button"
         >
           <IconPlus size={16} />
-          {t('add-payment-method')}
+          {t('add-payment-method', 'Add payment method')}
         </Button>
       </div>
 
@@ -660,7 +660,7 @@ export const OtherPayments = ({
                 name={`otherPayments.${index}.type`}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('type')}</Form.Label>
+                    <Form.Label>{t('type', 'Type')}</Form.Label>
                     <Form.Control>
                       <Input {...field} />
                     </Form.Control>
@@ -673,7 +673,7 @@ export const OtherPayments = ({
                 name={`otherPayments.${index}.title`}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('title')}</Form.Label>
+                    <Form.Label>{t('title', 'Title')}</Form.Label>
                     <Form.Control>
                       <Input {...field} />
                     </Form.Control>
@@ -686,7 +686,7 @@ export const OtherPayments = ({
                 name={`otherPayments.${index}.config`}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('config')}</Form.Label>
+                    <Form.Label>{t('config', 'Config')}</Form.Label>
                     <Form.Control>
                       <Input {...field} />
                     </Form.Control>

--- a/frontend/plugins/tourism_ui/src/modules/tms/components/TmsInformationFields.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/components/TmsInformationFields.tsx
@@ -177,15 +177,15 @@ export const TmsInformationFields = ({
         <div className="flex gap-2 items-center">
           <div className="flex h-5 px-2 justify-center items-center gap-1 rounded-[21px] bg-[rgba(79,70,229,0.10)] transition-all duration-300">
             <p className="text-primary leading-none text-[12px] font-semibold uppercase font-mono">
-              {t('step', { step: currentStep })}
+              {t('step', 'STEP {{step}}', { step: currentStep })}
             </p>
           </div>
           <p className="text-primary font-inter text-[14px] font-semibold leading-[140%] transition-all duration-300">
             {currentStep === 1
-              ? t('general-information')
+              ? t('general-information', 'General information')
               : currentStep === 2
-                ? t('permission')
-                : t('payments')}
+                ? t('permission', 'Permission')
+                : t('payments', 'PAYMENTS')}
           </p>
         </div>
         <div className="flex gap-2 items-center self-stretch">
@@ -204,10 +204,10 @@ export const TmsInformationFields = ({
         </div>
         <p className="self-stretch text-muted-foreground font-inter text-[13px] font-medium leading-[140%] transition-all duration-300">
           {currentStep === 1
-            ? t('setup-tms-information')
+            ? t('setup-tms-information', 'Set up your TMS information')
             : currentStep === 2
-              ? t('setup-permission')
-              : t('setup-payments')}
+              ? t('setup-permission', 'Setup your permission')
+              : t('setup-payments', 'Setup your payments')}
         </p>
       </div>
       <div className="overflow-hidden relative flex-1 min-h-0">
@@ -223,7 +223,7 @@ export const TmsInformationFields = ({
             onClick={handleCancel}
             className="transition-all duration-200 hover:scale-105"
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
         ) : (
           <Button
@@ -231,7 +231,7 @@ export const TmsInformationFields = ({
             onClick={handlePrevious}
             className="transition-all duration-200 hover:scale-105"
           >
-            {t('previous')}
+            {t('previous', 'Previous')}
           </Button>
         )}
         {currentStep < 3 ? (
@@ -239,7 +239,7 @@ export const TmsInformationFields = ({
             onClick={handleNext}
             className="transition-all duration-200 hover:scale-105"
           >
-            {t('next')}
+            {t('next', 'Next')}
           </Button>
         ) : (
           <Button
@@ -247,7 +247,7 @@ export const TmsInformationFields = ({
             disabled={isLoading}
             className="transition-all duration-200 hover:scale-105"
           >
-            {isLoading ? t('saving') : t('save')}
+            {isLoading ? t('saving', 'Saving...') : t('save', 'Save')}
           </Button>
         )}
       </div>

--- a/frontend/plugins/tourism_ui/src/modules/tms/hooks/BranchDuplicate.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/hooks/BranchDuplicate.ts
@@ -68,7 +68,7 @@ export const useBranchDuplicate = (options?: UseBranchDuplicateOptions) => {
         },
         onCompleted: async () => {
           toast({
-            title: t('branch-duplicated-successfully'),
+            title: t('branch-duplicated-successfully', 'Branch duplicated successfully'),
           });
           if (refetch) {
             await refetch();
@@ -77,8 +77,8 @@ export const useBranchDuplicate = (options?: UseBranchDuplicateOptions) => {
       });
     } catch (error) {
       toast({
-        title: t('failed-to-duplicate-branch'),
-        description: error?.message || t('unknown-error-occurred'),
+        title: t('failed-to-duplicate-branch', 'Failed to duplicate branch'),
+        description: error?.message || t('unknown-error-occurred', 'Unknown error occurred'),
         variant: 'destructive',
       });
       throw error;

--- a/frontend/plugins/tourism_ui/src/modules/tms/hooks/useBranchSubmit.ts
+++ b/frontend/plugins/tourism_ui/src/modules/tms/hooks/useBranchSubmit.ts
@@ -38,9 +38,9 @@ export function useBranchSubmit({
   const { editBranch, loading: editLoading } = useBranchEdit({
     onError: (error: unknown) => {
       const errorMessage =
-        error instanceof Error ? error.message : t('unknown-error-occurred');
+        error instanceof Error ? error.message : t('unknown-error-occurred', 'Unknown error occurred');
       toast({
-        title: t('error'),
+        title: t('error', 'Error'),
         description: errorMessage,
         variant: 'destructive',
       });
@@ -57,7 +57,7 @@ export function useBranchSubmit({
         await refetch();
       } catch (error) {
         toast({
-          title: t('warning'),
+          title: t('warning', 'Warning'),
           description: error instanceof Error ? error.message : String(error),
           variant: 'destructive',
         });
@@ -102,8 +102,8 @@ export function useBranchSubmit({
       },
       onCompleted: async () => {
         toast({
-          title: t('success'),
-          description: t('branch-updated-successfully'),
+          title: t('success', 'Success'),
+          description: t('branch-updated-successfully', 'Branch updated successfully'),
         });
         onOpenChange?.(false);
         onSuccess?.();
@@ -117,17 +117,17 @@ export function useBranchSubmit({
       variables,
       onError: (error: unknown) => {
         const errorMessage =
-          error instanceof Error ? error.message : t('unknown-error-occurred');
+          error instanceof Error ? error.message : t('unknown-error-occurred', 'Unknown error occurred');
         toast({
-          title: t('error'),
+          title: t('error', 'Error'),
           description: errorMessage,
           variant: 'destructive',
         });
       },
       onCompleted: async () => {
         toast({
-          title: t('success'),
-          description: t('branch-created-successfully'),
+          title: t('success', 'Success'),
+          description: t('branch-created-successfully', 'Branch created successfully'),
         });
         resetForm();
         form.reset(DEFAULT_TMS_FORM);

--- a/frontend/plugins/tourism_ui/src/pages/pms/IndexPage.tsx
+++ b/frontend/plugins/tourism_ui/src/pages/pms/IndexPage.tsx
@@ -18,7 +18,7 @@ export const IndexPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/pms">
                     <IconSandbox />
-                    {t('pms-index-breadcrumb')}
+                    {t('pms-index-breadcrumb', 'Property management system')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>

--- a/frontend/plugins/tourism_ui/src/pages/tms/BranchDetailIndexPage.tsx
+++ b/frontend/plugins/tourism_ui/src/pages/tms/BranchDetailIndexPage.tsx
@@ -135,7 +135,7 @@ export const BranchDetailIndexPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to={basePath}>
                     <IconBox />
-                    {t('tms-index-breadcrumb')}
+                    {t('tms-index-breadcrumb', 'Tour management system')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>
@@ -148,15 +148,15 @@ export const BranchDetailIndexPage = () => {
                     <Select.Value
                       placeholder={
                         listLoading
-                          ? t('loading-branches')
-                          : selectedBranch?.name || t('select-branch')
+                          ? t('loading-branches', 'Loading branches...')
+                          : selectedBranch?.name || t('select-branch', 'Select branch')
                       }
                     />
                   </Select.Trigger>
                   <Select.Content>
                     {list.map((branch) => (
                       <Select.Item key={branch._id} value={branch._id}>
-                        {branch.name || t('unnamed-branch')}
+                        {branch.name || t('unnamed-branch', 'Unnamed Branch')}
                       </Select.Item>
                     ))}
                   </Select.Content>
@@ -170,7 +170,7 @@ export const BranchDetailIndexPage = () => {
                   <Breadcrumb.Item>
                     <Select value={activeLang} onValueChange={onSelectLanguage}>
                       <Select.Trigger className="w-[180px]">
-                        <Select.Value placeholder={t('select-language')} />
+                        <Select.Value placeholder={t('select-language', 'Select language')} />
                       </Select.Trigger>
                       <Select.Content>
                         {availableLanguages.map((lang) => (

--- a/frontend/plugins/tourism_ui/src/pages/tms/IndexPage.tsx
+++ b/frontend/plugins/tourism_ui/src/pages/tms/IndexPage.tsx
@@ -18,7 +18,7 @@ export const IndexPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/tourism/tms">
                     <IconBox />
-                    {t('tms-index-breadcrumb')}
+                    {t('tms-index-breadcrumb', 'Tour management system')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of labels, placeholders, empty states, validation messages, confirmations, and toast notifications across tourism management screens.
  * Added clearer fallback text for missing translations, ensuring key actions and guidance remain understandable.
  * Refined several error messages, including website URL, validation, upload, and data-loading failures.
  * Improved selected-item count wording and pluralized category, customer, and itinerary messages.
  * Updated PDF preview and export status messages for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->