### PR TITLE
feat(payment_ui): add default values to i18n t() calls in payment plugin

### DIFF
--- a/frontend/plugins/payment_ui/src/modules/PaymentSettingsNavigation.tsx
+++ b/frontend/plugins/payment_ui/src/modules/PaymentSettingsNavigation.tsx
@@ -5,18 +5,18 @@ export const PaymentSettingsNavigation = () => {
   const { t } = useTranslation('payment');
   return (
     <Sidebar.Group>
-      <Sidebar.GroupLabel className="h-4">{t('payment')}</Sidebar.GroupLabel>
+      <Sidebar.GroupLabel className="h-4">{t('payment', 'Payment')}</Sidebar.GroupLabel>
       <Sidebar.GroupContent className="pt-1">
         <Sidebar.Menu>
           <SettingsNavigationMenuLinkItem
             pathPrefix="payment"
             path="/methods"
-            name={t('payment-method')}
+            name={t('payment-method', 'Payment')}
           />
           <SettingsNavigationMenuLinkItem
             pathPrefix="payment"
             path="invoices"
-            name={t('invoices')}
+            name={t('invoices', 'Invoices')}
           />
           <SettingsNavigationMenuLinkItem
             pathPrefix="payment"

--- a/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceColumns.tsx
+++ b/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceColumns.tsx
@@ -16,7 +16,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'invoiceNumber',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('invoice-number')} icon={IconAlignLeft} />;
+      return <RecordTable.InlineHead label={t('invoice-number', 'Invoice number')} icon={IconAlignLeft} />;
     },
     cell: ({ cell }) => {
       return (
@@ -32,7 +32,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'description',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('description')} icon={IconHash} />;
+      return <RecordTable.InlineHead label={t('description', 'description')} icon={IconHash} />;
     },
     cell: ({ cell }) => {
       return (
@@ -48,7 +48,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'amount',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('amount')} icon={IconHash} />;
+      return <RecordTable.InlineHead label={t('amount', 'amount')} icon={IconHash} />;
     },
     cell: ({ cell }) => {
       return (
@@ -63,7 +63,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'currency',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('currency')} icon={IconHash} />;
+      return <RecordTable.InlineHead label={t('currency', 'currency')} icon={IconHash} />;
     },
     cell: ({ cell }) => {
       return (
@@ -78,7 +78,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'status',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('status')} icon={IconHash} />;
+      return <RecordTable.InlineHead label={t('status', 'Status')} icon={IconHash} />;
     },
     cell: ({ cell }) => {
       return (
@@ -99,7 +99,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'scannedAt',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('scanned')} icon={IconQrcode} />;
+      return <RecordTable.InlineHead label={t('scanned', 'scanned')} icon={IconQrcode} />;
     },
     cell: ({ cell }) => {
       const { t } = useTranslation('payment');
@@ -113,7 +113,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
               </Badge>
             </RelativeDateDisplay>
           ) : (
-            <Badge variant="outline">{t('not-scanned')}</Badge>
+            <Badge variant="outline">{t('not-scanned', 'Not scanned')}</Badge>
           )}
         </RecordTableInlineCell>
       );
@@ -124,7 +124,7 @@ export const invoicesColumns: ColumnDef<IInvoice>[] = [
     accessorKey: 'createdAt',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('date-created')} icon={IconCalendarPlus} />;
+      return <RecordTable.InlineHead label={t('date-created', 'Date Created')} icon={IconCalendarPlus} />;
     },
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceFilterBar.tsx
+++ b/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceFilterBar.tsx
@@ -36,16 +36,16 @@ export const InvoiceFilterBar = () => {
             <Combobox.Content>
               <Filter.View>
                 <Command>
-                  <Filter.CommandInput placeholder={t('filter-invoices')} />
+                  <Filter.CommandInput placeholder={t('filter-invoices', 'Filter invoices...')} />
                   <Command.List className="p-1">
                     <Filter.SearchValueTrigger />
                     <Filter.Item value="status" active={!!status}>
                       <IconProgressCheck />
-                      {t('status')}
+                      {t('status', 'Status')}
                     </Filter.Item>
                     <Filter.Item value="kind" active={!!kind}>
                       <IconWallet />
-                      {t('kind')}
+                      {t('kind', 'Kind')}
                     </Filter.Item>
                   </Command.List>
                 </Command>
@@ -61,7 +61,7 @@ export const InvoiceFilterBar = () => {
 
           <Filter.Dialog>
             <Filter.View filterKey="searchValue" inDialog>
-              <Filter.DialogStringView filterKey="searchValue" label={t('search')} />
+              <Filter.DialogStringView filterKey="searchValue" label={t('search', 'Search')} />
             </Filter.View>
           </Filter.Dialog>
 
@@ -70,7 +70,7 @@ export const InvoiceFilterBar = () => {
           <Filter.BarItem queryKey="status">
             <Filter.BarName>
               <IconProgressCheck />
-              {t('status')}
+              {t('status', 'Status')}
             </Filter.BarName>
             <Popover>
               <Popover.Trigger asChild>
@@ -85,7 +85,7 @@ export const InvoiceFilterBar = () => {
           <Filter.BarItem queryKey="kind">
             <Filter.BarName>
               <IconWallet />
-              {t('kind')}
+              {t('kind', 'Kind')}
             </Filter.BarName>
             <Popover>
               <Popover.Trigger asChild>

--- a/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceKindFilter.tsx
+++ b/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceKindFilter.tsx
@@ -18,7 +18,7 @@ export const InvoiceKindFilter = () => {
           onSelect={() => setView('root')}
         >
           <IconChevronLeft className="w-3 h-3" />
-          {t('back')}
+          {t('back', 'Back')}
         </Command.Item>
         <Command.Separator />
         {Object.entries(PAYMENT_KINDS).map(([value, config]) => (

--- a/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceStatusFilter.tsx
+++ b/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceStatusFilter.tsx
@@ -28,7 +28,7 @@ export const InvoiceStatusFilter = () => {
           onSelect={() => setView('root')}
         >
           <IconChevronLeft className="w-3 h-3" />
-          {t('back')}
+          {t('back', 'Back')}
         </Command.Item>
         <Command.Separator />
         {STATUS_OPTIONS.map((opt) => (

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/KhanbankForm.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/KhanbankForm.tsx
@@ -79,7 +79,7 @@ const KhanbankForm: React.FC<Props> = ({ payment, form, Form }) => {
   return (
     <div className="grid grid-cols-2 gap-4 mt-4">
       <Form.Item>
-        <Form.Label>{t('name')} *</Form.Label>
+        <Form.Label>{t('name', 'Name')} *</Form.Label>
         <Form.Control>
           <Input
             {...register('name', {

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentAddSheet.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentAddSheet.tsx
@@ -10,7 +10,7 @@ export const PaymentAddSheet = () => {
   return (
     <Sheet onOpenChange={setOpen} open={open}>
       <Sheet.Trigger asChild>
-        <Button variant="outline">{t('add-payment')}</Button>
+        <Button variant="outline">{t('add-payment', 'Add Payment')}</Button>
       </Sheet.Trigger>
       <Sheet.View
         className="p-0"

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentColumns.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentColumns.tsx
@@ -50,7 +50,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
                 <Command.List>
                   <Command.Item value="edit" onSelect={() => setOpen(true)}>
                     <IconEdit className="w-4 h-4" />
-                    {t('edit')}
+                    {t('edit', 'Edit')}
                   </Command.Item>
 
                   <Command.Item
@@ -59,7 +59,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
                       removePayment({ variables: { _ids: [payment._id] } })
                     }
                   >
-                    <IconTrash /> {t('delete')}
+                    <IconTrash /> {t('delete', 'Delete')}
                   </Command.Item>
                 </Command.List>
               </Command>
@@ -82,7 +82,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
     accessorKey: 'kind',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('payment-method-label')} icon={IconSettings} />;
+      return <RecordTable.InlineHead label={t('payment-method-label', 'Payment Method')} icon={IconSettings} />;
     },
     cell: ({ cell }) => {
       const kind = cell.getValue() as string;
@@ -107,7 +107,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
     accessorKey: 'name',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('name')} icon={IconHash} />;
+      return <RecordTable.InlineHead label={t('name', 'Name')} icon={IconHash} />;
     },
     cell: ({ cell }) => {
       const payment = cell.row.original;
@@ -134,7 +134,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
     accessorKey: 'status',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('status')} icon={IconProgress} />;
+      return <RecordTable.InlineHead label={t('status', 'Status')} icon={IconProgress} />;
     },
     cell: ({ cell }) => {
       return (
@@ -149,7 +149,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
     accessorKey: 'credentials',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('credentials')} icon={IconKey} />;
+      return <RecordTable.InlineHead label={t('credentials', 'Credentials')} icon={IconKey} />;
     },
     cell: () => {
       return (
@@ -164,7 +164,7 @@ export const paymentColumns: ColumnDef<IPayment>[] = [
     accessorKey: 'createdAt',
     header: () => {
       const { t } = useTranslation('payment');
-      return <RecordTable.InlineHead label={t('created-at')} icon={IconCalendarPlus} />;
+      return <RecordTable.InlineHead label={t('created-at', 'Created At')} icon={IconCalendarPlus} />;
     },
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentEditSheet.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentEditSheet.tsx
@@ -18,7 +18,7 @@ export const PaymentEditSheet = ({
       <Sheet.Trigger asChild>
         <>
           <IconEdit className="w-4 h-4" />
-          {t('edit')}
+          {t('edit', 'Edit')}
         </>
       </Sheet.Trigger>
       <Sheet.View

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentForm.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentForm.tsx
@@ -268,13 +268,13 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
         })
           .then(() => {
             toast({
-              title: t('success'),
-              description: t('payment-method-updated'),
+              title: t('success', 'Success'),
+              description: t('payment-method-updated', 'Payment method updated successfully'),
             });
           })
           .catch((e) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e.message,
             });
           });
@@ -286,13 +286,13 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
         })
           .then(() => {
             toast({
-              title: t('success'),
-              description: t('payment-method-added'),
+              title: t('success', 'Success'),
+              description: t('payment-method-added', 'Payment method added successfully'),
             });
           })
           .catch((e) => {
             toast({
-              title: t('error'),
+              title: t('error', 'Error'),
               description: e.message,
             });
           });
@@ -330,7 +330,7 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
       >
         <Sheet.Header className="gap-3 border-b">
           <Sheet.Title>
-            {payment ? t('edit-payment') : t('add-payment')}
+            {payment ? t('edit-payment', 'Edit Payment') : t('add-payment', 'Add Payment')}
           </Sheet.Title>
           <Sheet.Close />
         </Sheet.Header>
@@ -353,7 +353,7 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
 
                   return (
                     <Form.Item>
-                      <Form.Label>{t('payment-method-label')} *</Form.Label>
+                      <Form.Label>{t('payment-method-label', 'Payment Method')} *</Form.Label>
                       <Popover
                         open={kindOpen}
                         onOpenChange={(open) => {
@@ -367,13 +367,13 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                         >
                           <Combobox.Value
                             value={selectedMethod?.name}
-                            placeholder={t('select-payment-method')}
+                            placeholder={t('select-payment-method', 'Select payment method')}
                           />
                         </Combobox.Trigger>
                         <Combobox.Content>
                           <Command shouldFilter={false}>
                             <Command.Input
-                              placeholder={t('search-payment-method')}
+                              placeholder={t('search-payment-method', 'Search payment method')}
                               value={kindSearch}
                               onValueChange={setKindSearch}
                             />
@@ -415,9 +415,9 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                 control={form.control}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('display-name')} *</Form.Label>
+                    <Form.Label>{t('display-name', 'Display Name')} *</Form.Label>
                     <Form.Control>
-                      <Input {...field} placeholder={t('enter-payment-name')} />
+                      <Input {...field} placeholder={t('enter-payment-name', 'Enter a name for this payment method')} />
                     </Form.Control>
                   </Form.Item>
                 )}
@@ -429,7 +429,7 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                 control={form.control}
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>{t('status')} *</Form.Label>
+                    <Form.Label>{t('status', 'Status')} *</Form.Label>
                     <Form.Control>
                       <Select
                         value={field.value}
@@ -442,7 +442,7 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                             <Select.Value
                               placeholder={
                                 <span className="font-medium text-muted-foreground text-sm text-center truncate">
-                                  {t('select-status')}
+                                  {t('select-status', 'Select status')}
                                 </span>
                               }
                             >
@@ -458,13 +458,13 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                               className="h-7 text-xs capitalize"
                               value="active"
                             >
-                              {t('active')}
+                              {t('active', 'Active')}
                             </Select.Item>
                             <Select.Item
                               className="h-7 text-xs capitalize"
                               value="inactive"
                             >
-                              {t('inactive')}
+                              {t('inactive', 'Inactive')}
                             </Select.Item>
                           </Select.Group>
                         </Select.Content>
@@ -481,9 +481,9 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
                   <Form.Item>
                     <div className="flex items-center justify-between gap-3">
                       <div className="space-y-0.5">
-                        <Form.Label>{t('send-email-after-payment')}</Form.Label>
+                        <Form.Label>{t('send-email-after-payment', 'Send email after successful payment')}</Form.Label>
                         <p className="text-xs text-muted-foreground">
-                          {t('send-email-description')}
+                          {t('send-email-description', 'Automatically send a QR ticket to the customer\'s email when payment is completed.')}
                         </p>
                       </div>
                       <Form.Control>
@@ -534,7 +534,7 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
             onClick={onCancel}
             disabled={isSubmitting}
           >
-            {t('cancel')}
+            {t('cancel', 'Cancel')}
           </Button>
           <Button
             type="submit"
@@ -542,10 +542,10 @@ const PaymentForm = ({ payment, onCancel }: Props) => {
             className="bg-primary hover:bg-primary/90 text-primary-foreground"
           >
             {isSubmitting
-              ? t('saving')
+              ? t('saving', 'Saving...')
               : payment
-                ? t('update-payment-method')
-                : t('save-payment-method')}
+                ? t('update-payment-method', 'Update Payment Method')
+                : t('save-payment-method', 'Save Payment Method')}
           </Button>
         </Sheet.Footer>
       </form>

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentsCommandBar.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/PaymentsCommandBar.tsx
@@ -38,7 +38,7 @@ export const PaymentsCommandBar = () => {
     <CommandBar open={table.getFilteredSelectedRowModel().rows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>
-          {t('selected', { count: table.getFilteredSelectedRowModel().rows.length })}
+          {t('selected', '{{count}} selected', { count: table.getFilteredSelectedRowModel().rows.length })}
         </CommandBar.Value>
         <Separator.Inline />
         <Button
@@ -47,7 +47,7 @@ export const PaymentsCommandBar = () => {
           onClick={handleDelete}
         >
           <IconTrash />
-          {t('delete')}
+          {t('delete', 'Delete')}
         </Button>
       </CommandBar.Bar>
     </CommandBar>

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/QuickQrForm.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/QuickQrForm.tsx
@@ -93,19 +93,19 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
         control={control}
         render={({ field }: any) => (
           <Form.Item>
-            <Form.Label>{t('type')} *</Form.Label>
+            <Form.Label>{t('type', 'Type')} *</Form.Label>
             <Form.Control>
               <Select
                 value={field.value}
                 onValueChange={field.onChange}
               >
                 <Select.Trigger>
-                  <Select.Value placeholder={t('select-type')} />
+                  <Select.Value placeholder={t('select-type', 'Select type')} />
                 </Select.Trigger>
                 <Select.Content>
                   <Select.Group>
-                    <Select.Item value="company">{t('mcc-company')}</Select.Item>
-                    <Select.Item value="person">{t('mcc-person')}</Select.Item>
+                    <Select.Item value="company">{t('mcc-company', 'Company')}</Select.Item>
+                    <Select.Item value="person">{t('mcc-person', 'Individual')}</Select.Item>
                   </Select.Group>
                 </Select.Content>
               </Select>
@@ -116,25 +116,25 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
 
       {type && (
         <>
-          {isCompany && renderItem('companyName', t('company-name'))}
-          {!isCompany && renderItem('firstName', t('first-name'))}
-          {!isCompany && renderItem('lastName', t('last-name'))}
+          {isCompany && renderItem('companyName', t('company-name', 'Company Name'))}
+          {!isCompany && renderItem('firstName', t('first-name', 'First Name'))}
+          {!isCompany && renderItem('lastName', t('last-name', 'Last Name'))}
 
-          {renderItem('registerNumber', t('register-number'))}
+          {renderItem('registerNumber', t('register-number', 'Register Number'))}
 
           <Form.Field
             name="mccCode"
             control={control}
             render={({ field }: any) => (
               <Form.Item>
-                <Form.Label>{t('mcc-code')} *</Form.Label>
+                <Form.Label>{t('mcc-code', 'MCC Code')} *</Form.Label>
                 <Form.Control>
                   <Select
                     value={field.value}
                     onValueChange={field.onChange}
                   >
                     <Select.Trigger>
-                      <Select.Value placeholder={t('select-mcc-code')} />
+                      <Select.Value placeholder={t('select-mcc-code', 'Select MCC Code')} />
                     </Select.Trigger>
                     <Select.Content>
                       <Select.Group>
@@ -156,14 +156,14 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
             control={control}
             render={({ field }: any) => (
               <Form.Item>
-                <Form.Label>{t('city')} *</Form.Label>
+                <Form.Label>{t('city', 'City')} *</Form.Label>
                 <Form.Control>
                   <Select
                     value={field.value}
                     onValueChange={field.onChange}
                   >
                     <Select.Trigger>
-                      <Select.Value placeholder={t('select-city')} />
+                      <Select.Value placeholder={t('select-city', 'Select city')} />
                     </Select.Trigger>
                     <Select.Content>
                       <Select.Group>
@@ -181,7 +181,7 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
           />
 
           <Form.Item>
-            <Form.Label>{t('district')} *</Form.Label>
+            <Form.Label>{t('district', 'District')} *</Form.Label>
             <SelectDistrict
               cityCode={watch('city')}
               value={watch('district')}
@@ -189,21 +189,21 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
             />
           </Form.Item>
 
-          {renderItem('businessName', t('business-name'))}
-          {renderItem('address', t('address'))}
-          {renderItem('phone', t('phone'))}
-          {renderItem('email', t('email'), true, 'email')}
-          {renderItem('bankAccount', t('account-number'))}
+          {renderItem('businessName', t('business-name', 'Business Name'))}
+          {renderItem('address', t('address', 'Address'))}
+          {renderItem('phone', t('phone', 'Phone'))}
+          {renderItem('email', t('email', 'Email'), true, 'email')}
+          {renderItem('bankAccount', t('account-number', 'Account Number'))}
 
           <Form.Item>
-            <Form.Label>{t('bank')} *</Form.Label>
+            <Form.Label>{t('bank', 'Bank')} *</Form.Label>
             <Form.Control>
               <Select
                 value={watch('bankCode')}
                 onValueChange={(value) => setValue('bankCode', value)}
               >
                 <Select.Trigger>
-                  <Select.Value placeholder={t('select-bank')} />
+                  <Select.Value placeholder={t('select-bank', 'Select bank')} />
                 </Select.Trigger>
                 <Select.Content>
                   <Select.Group>
@@ -218,8 +218,8 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
             </Form.Control>
           </Form.Item>
 
-          {renderItem('ibanNumber', t('iban-number'))}
-          {renderItem('bankAccountName', t('account-name'))}
+          {renderItem('ibanNumber', t('iban-number', 'IBAN Number'))}
+          {renderItem('bankAccountName', t('account-name', 'Account Name'))}
 
           {!payment && (
             <Form.Field
@@ -227,7 +227,7 @@ const QuickQrForm: React.FC<Props> = ({ payment, form, Form }) => {
               control={control}
               render={({ field }: any) => (
                 <Form.Item>
-                  <Form.Label>{t('is-flat')}</Form.Label>
+                  <Form.Label>{t('is-flat', 'Is flat')}</Form.Label>
                   <Form.Control>
                     <Switch
                       checked={field.value === true}

--- a/frontend/plugins/payment_ui/src/modules/settings/payment/components/SelectDistrict.tsx
+++ b/frontend/plugins/payment_ui/src/modules/settings/payment/components/SelectDistrict.tsx
@@ -23,7 +23,7 @@ const SelectDistrict = (props: Props) => {
   return (
     <Select onValueChange={onChange} value={value} disabled={!cityCode}>
       <Select.Trigger>
-        <Select.Value placeholder={t('select-district')} />
+        <Select.Value placeholder={t('select-district', 'Select district')} />
       </Select.Trigger>
       <Select.Content>
         <Select.Group>

--- a/frontend/plugins/payment_ui/src/pages/payment/InvoicesPage.tsx
+++ b/frontend/plugins/payment_ui/src/pages/payment/InvoicesPage.tsx
@@ -17,7 +17,7 @@ export const InvoicesPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/settings/payment">
                     <IconCurrencyDollar />
-                    {t('payment')}
+                    {t('payment', 'Payment')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>
@@ -28,7 +28,7 @@ export const InvoicesPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/settings/payment/invoices">
                     <IconInvoice />
-                    {t('invoices')}
+                    {t('invoices', 'Invoices')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>

--- a/frontend/plugins/payment_ui/src/pages/payment/PaymentSettingsPage.tsx
+++ b/frontend/plugins/payment_ui/src/pages/payment/PaymentSettingsPage.tsx
@@ -18,7 +18,7 @@ const PaymentSettingsPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/settings/payment">
                     <IconCurrencyDollar />
-                    {t('payment')}
+                    {t('payment', 'Payment')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>
@@ -29,7 +29,7 @@ const PaymentSettingsPage = () => {
                 <Button variant="ghost" asChild>
                   <Link to="/settings/payment/methods">
                     <IconSettings />
-                    {t('methods')}
+                    {t('methods', 'Methods')}
                   </Link>
                 </Button>
               </Breadcrumb.Item>

--- a/frontend/plugins/payment_ui/src/widgets/relation/modules/Invoice.tsx
+++ b/frontend/plugins/payment_ui/src/widgets/relation/modules/Invoice.tsx
@@ -31,7 +31,7 @@ export const Invoice = ({
         <div className="border border-dashed p-6 bg-background rounded-xl">
           <IconInvoice />
         </div>
-        <span className="text-sm">{t('no-invoices')}</span>
+        <span className="text-sm">{t('no-invoices', 'No invoices to display at the moment.')}</span>
       </div>
     );
   }
@@ -39,7 +39,7 @@ export const Invoice = ({
   return (
     <>
       <div className="h-11 px-4 flex items-center gap-2 flex-none bg-background justify-between">
-        <span className="font-medium text-primary">{t('invoices')}</span>
+        <span className="font-medium text-primary">{t('invoices', 'Invoices')}</span>
       </div>
       <Separator />
       <ScrollArea className="flex-auto">


### PR DESCRIPTION
## Summary by Sourcery

Add human-readable default English strings to all payment plugin i18n translation calls to improve fallback behavior and UX when translations are missing.

Enhancements:
- Provide explicit default labels and placeholders for payment and invoice forms, filters, navigation, and command bars in the payment UI.
- Ensure toast notifications and empty-state messages in payment flows have clear default English text for success, error, and no-data states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internationalization**
  * Added fallback text for payment navigation, breadcrumbs, invoices, filters, forms, actions, notifications, and empty states.
  * Payment settings and invoice screens now continue displaying clear English labels when translations are unavailable.
  * Improved fallback coverage across payment method, bank, QR, and district selection forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->