### PR TITLE
feat(clientportal): add cpDepartments query

### DIFF
--- a/backend/core-api/src/modules/organization/structure/graphql/resolvers/queries/deparments.ts
+++ b/backend/core-api/src/modules/organization/structure/graphql/resolvers/queries/deparments.ts
@@ -5,7 +5,7 @@ import {
 import { cursorPaginate } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import { generateFilters } from './utils';
-
+import { STRUCTURE_STATUSES } from 'erxes-api-shared/core-modules';
 export const deparmentQueries = {
   async departments(
     _parent: undefined,
@@ -54,5 +54,48 @@ export const deparmentQueries = {
 
   async departmentDetail(_parent: undefined, { _id }, { models }: IContext) {
     return models.Departments.getDepartment({ _id });
+  },
+
+  async cpDepartments(
+    _root,
+    params,
+    { models }: IContext,
+  ) {
+    const filter: any = {
+      status: { $ne: STRUCTURE_STATUSES.DELETED },
+    };
+
+    if (params?.ids?.length) {
+      filter._id = {
+        [params.excludeIds ? '$nin' : '$in']: params.ids,
+      };
+    }
+
+    if (params?.status) {
+      filter.status = params.status;
+    }
+
+    if (params?.onlyFirstLevel) {
+      filter.parentId = { $in: [null, ''] };
+    }
+
+    if (params?.parentId) {
+      filter.parentId = params.parentId;
+    }
+
+    if (params?.searchValue) {
+      const regex = {
+        $regex: `.*${params.searchValue.trim()}.*`,
+        $options: 'i',
+      };
+
+      filter.$or = [
+        { title: regex },
+        { description: regex },
+        { code: regex },
+      ];
+    }
+
+    return models.Departments.find(filter).sort({ order: 1 });
   },
 };

--- a/backend/core-api/src/modules/organization/structure/graphql/resolvers/queries/deparments.ts
+++ b/backend/core-api/src/modules/organization/structure/graphql/resolvers/queries/deparments.ts
@@ -1,12 +1,13 @@
 import {
   ICursorPaginateParams,
   IListParams,
+  Resolver,
 } from 'erxes-api-shared/core-types';
 import { cursorPaginate } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import { generateFilters } from './utils';
 import { STRUCTURE_STATUSES } from 'erxes-api-shared/core-modules';
-export const deparmentQueries = {
+export const deparmentQueries: Record<string, Resolver> = {
   async departments(
     _parent: undefined,
     params: any,

--- a/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
+++ b/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
@@ -48,4 +48,5 @@ export const queries = `
     departments(${commonParams},withoutUserFilter:Boolean): [Department]
     departmentsMain(${commonParams},withoutUserFilter:Boolean): DepartmentsListResponse
     departmentDetail(_id: String!): Department
+    cpDepartments(${commonParams},withoutUserFilter:Boolean): [Department]
 `;


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose a cpDepartments GraphQL query for retrieving filtered department lists for the client portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new GraphQL query to retrieve departments with flexible filtering.
  * Supports filtering by department IDs (include/exclude), status, and parent/first-level scope.
  * Added case-insensitive search across department title, description, and code.
  * Results are returned sorted by the configured department order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->