### PR TITLE
fix(frontline): use shared form collection names

### DIFF
--- a/backend/plugins/frontline_api/src/connectionResolvers.ts
+++ b/backend/plugins/frontline_api/src/connectionResolvers.ts
@@ -622,17 +622,17 @@ export const loadClasses = (
     loadConfigClass(models),
   );
   models.Fields = db.model<IFieldDocument, IFieldModel>(
-    'frontline_form_fields',
+    'form_fields',
     loadFieldClass(models, subdomain),
   );
   models.Forms = db.model<IFormDocument, IFormModel>(
-    'frontline_forms',
+    'forms',
     loadFormClass(models),
   );
   models.FormSubmissions = db.model<
     IFormSubmissionDocument,
     IFormSubmissionModel
-  >('frontline_form_submissions', loadFormSubmissionClass(models));
+  >('form_submissions', loadFormSubmissionClass(models));
 
   models.Article = db.model<IArticleDocument, IArticleModel>(
     'knowledgebase_articles',


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure frontline form models use the shared MongoDB collections for fields, forms, and submissions instead of plugin-specific collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form data handling to use the correct collections for fields, forms, and submissions.
  * Improved consistency when loading and accessing form-related data.
  * Existing behavior for other data types remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->