### PR TITLE
fix(frontline): null-guard inbox conversation subscription updateQuery

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -93,18 +93,25 @@ export const useConversations = (
         userId,
       },
       updateQuery: (prev, { subscriptionData }) => {
-        if (subscriptionData.data) {
-          setNewMessagesCount((prev) => prev + 1);
-          const incomingConversationId =
-            subscriptionData.data.conversationClientMessageInserted.conversationId;
-          if (incomingConversationId !== activeConversationRef.current?._id) {
-            playNotificationSound();
-          }
-        }
-        if (!subscriptionData.data || !prev) return prev;
+        // Subscription payloads can be null (Sentry ERXES-UI-C4 / #8774) and the
+        // conversations query cache may not be populated yet when the first event
+        // arrives (Sentry ERXES-UI-C2 / #8771). Guard both before reading fields.
         const newMessage =
-          subscriptionData.data.conversationClientMessageInserted;
-        const conversationId = newMessage?.conversationId;
+          subscriptionData.data?.conversationClientMessageInserted;
+        if (!newMessage || !prev) {
+          return prev;
+        }
+
+        setNewMessagesCount((count) => count + 1);
+        if (newMessage.conversationId !== activeConversationRef.current?._id) {
+          playNotificationSound();
+        }
+
+        if (!prev.conversations?.list) {
+          return prev;
+        }
+
+        const conversationId = newMessage.conversationId;
         const index = prev.conversations.list.findIndex(
           (conversation) => conversation._id === conversationId,
         );
@@ -113,14 +120,15 @@ export const useConversations = (
           // New conversation not yet in list — refetch to load the full entry
           setTimeout(() => refetchRef.current(), 0);
           return prev;
-        } else {
-          list.splice(index, 1, {
-            ...list[index],
-            readUserIds: list[index].readUserIds?.filter((id) => id !== userId),
-            status: ConversationStatus.OPEN,
-            content: newMessage.content,
-          });
         }
+
+        list.splice(index, 1, {
+          ...list[index],
+          readUserIds: list[index].readUserIds?.filter((id) => id !== userId),
+          status: ConversationStatus.OPEN,
+          content: newMessage.content,
+        });
+
         return { ...prev, conversations: { ...prev.conversations, list } };
       },
     });

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -108,6 +108,8 @@ export const useConversations = (
         }
 
         if (!prev.conversations?.list) {
+          // Cache not ready yet — refetch once it can populate (#8771)
+          setTimeout(() => refetchRef.current(), 0);
           return prev;
         }
 


### PR DESCRIPTION
## Summary
- Fixes #8083 (`TypeError: Cannot read properties of undefined (reading 'list')`) and Fixes #8774 (`TypeError: Cannot read properties of null (reading 'conversationId')`) in the frontline inbox conversation list subscription handler.
- Note: #8771 was consolidated into #8083 as a duplicate.
- Root cause: `useConversations` `subscribeToMore` `updateQuery` read `conversationClientMessageInserted.conversationId` and `prev.conversations.list` without guarding null/undefined payloads or an unpopulated Apollo cache.
- Fix: early-return when the subscription message is null/missing or `prev.conversations.list` is unavailable, then proceed with the existing unread/content update path.

## What / Why / How
- **What:** Null-safety guards in `frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx`.
- **Why:** Production Sentry crashes (ERXES-UI-C4 / ERXES-UI-C2) when a client-message subscription fires with a null payload or before the conversations query cache is ready.
- **How:** Read `subscriptionData.data?.conversationClientMessageInserted` once; return `prev` if the message or cache list is missing; otherwise keep existing notification + list splice behavior.

## Testing
- [x] Manual code-path review of the subscription `updateQuery` for null payload and missing `conversations.list`
- [ ] Full `pnpm nx build frontline_ui` not run locally (monorepo deps not installed in this environment); expecting CI `ci-ui-frontline` to validate

## Test plan
- [ ] Open inbox with an active subscription
- [ ] Confirm no console TypeError when a subscription event arrives before conversations cache is populated
- [ ] Confirm null `conversationClientMessageInserted` payloads no longer crash the UI
- [ ] Confirm existing conversations still move to top / mark unread / update content on real client messages

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for real-time inbox updates when subscription payloads or cached conversations are missing or not yet ready.
  * Prevented incorrect unread count changes and ensured notification sounds only play for newly received conversations different from the currently open one.
  * Automatically refreshes conversation lists when the incoming conversation isn’t present in the current cache.
  * Keeps conversation preview content and status consistent when new messages arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->