### PR TITLE
fix(content): reduce scheduled post worker database load

### DIFF
--- a/backend/erxes-api-shared/src/utils/saas/definition.ts
+++ b/backend/erxes-api-shared/src/utils/saas/definition.ts
@@ -70,6 +70,9 @@ export const saasOrganizationsSchema = new mongoose.Schema({
   cycleEnabled: { type: Boolean },
 });
 
+saasOrganizationsSchema.index({ subdomain: 1 }, { unique: true, sparse: true });
+saasOrganizationsSchema.index({ onboardedPlugins: 1 });
+
 export const saasInstallationSchema = new mongoose.Schema({
   createdAt: { type: Date, label: 'Created at', default: new Date() },
   userId: { type: String, label: 'Owner user' },

--- a/backend/plugins/content_api/package.json
+++ b/backend/plugins/content_api/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "tsx watch src/main.ts",
     "build": "tsc --project tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "start": "node -r tsconfig-paths/register dist/src/main.js"
+    "cleanup:scheduled-post-jobs": "tsx src/modules/cms/migrations/cleanupScheduledPostJobs.ts",
+    "migrate:scheduled-post-indexes": "tsx src/modules/cms/migrations/addScheduledPostIndexes.ts",
+    "start": "node -r tsconfig-paths/register dist/src/main.js",
+    "test": "tsx --test src/worker/*.spec.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/plugins/content_api/project.json
+++ b/backend/plugins/content_api/project.json
@@ -45,6 +45,15 @@
       }
     },
 
+    "test": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "options": {
+        "cwd": "backend/plugins/content_api",
+        "command": "pnpm test"
+      }
+    },
+
     "docker-build": {
       "dependsOn": ["build"],
       "command": "docker build -f backend/plugins/content_api/Dockerfile . -t erxes/erxes-next-content_api"

--- a/backend/plugins/content_api/src/main.ts
+++ b/backend/plugins/content_api/src/main.ts
@@ -21,7 +21,7 @@ startPlugin({
     return context;
   },
   onServerInit: async () => {
-    // await initMQWorkers(redis);
+    await initMQWorkers(redis);
   },
   meta: {
     permissions,

--- a/backend/plugins/content_api/src/modules/cms/db/definitions/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/db/definitions/posts.ts
@@ -74,6 +74,8 @@ postSchema.index(
 );
 
 postSchema.index({ webId: 1 });
+postSchema.index({ status: 1, scheduledDate: 1 });
+postSchema.index({ status: 1, autoArchiveDate: 1 });
 
 export const postCategorySchema = new Schema<IPostCategoryDocument>(
   {

--- a/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/mutations/posts.ts
@@ -18,6 +18,7 @@ import { CMS_POST_ACTIONS } from '~/meta/permissions';
 import { preparePdfAttachmentPages } from '@/cms/utils/pdfAttachments';
 import { assertCmsAccessByClientPortal } from '@/cms/utils/cms-access';
 import { sendPublishedPostNotification } from '@/cms/utils/notifications';
+import { syncPostScheduleSafely } from '~/worker/postScheduling';
 
 const getDefaultLanguage = async (
   models: IContext['models'],
@@ -130,6 +131,7 @@ export const postMutations: Record<string, Resolver> = {
     const post = await models.Posts.createPost(postInput);
 
     await saveTranslations(models, post._id, translations || []);
+    await syncPostScheduleSafely({ subdomain, currentPost: post });
 
     return post;
   },
@@ -205,6 +207,7 @@ export const postMutations: Record<string, Resolver> = {
     const post = await models.Posts.createPost(postInput);
 
     await saveTranslations(models, post._id, translations || []);
+    await syncPostScheduleSafely({ subdomain, currentPost: post });
 
     return post;
   },
@@ -280,6 +283,11 @@ export const postMutations: Record<string, Resolver> = {
           (translations || []) as TPostTranslationInput[]
         ).filter((t) => t?.language !== language);
         await saveTranslations(models, _id, remainingTranslations);
+        await syncPostScheduleSafely({
+          subdomain,
+          previousPost: existingPost,
+          currentPost: post,
+        });
 
         return post;
       }
@@ -296,12 +304,17 @@ export const postMutations: Record<string, Resolver> = {
     const post = await models.Posts.updatePost(_id, postInput);
 
     await saveTranslations(models, _id, translations || []);
+    await syncPostScheduleSafely({
+      subdomain,
+      previousPost: existingPost,
+      currentPost: post,
+    });
 
     return post;
   },
 
   cmsPostsRemove: async (_parent, args, context: IContext) => {
-    const { models } = context;
+    const { models, subdomain } = context;
     const { _id } = args;
     const post = await models.Posts.findOne({ _id }).lean();
 
@@ -320,11 +333,18 @@ export const postMutations: Record<string, Resolver> = {
     await models.Translations.deleteMany({
       $or: [{ objectId: _id }, { postId: _id }],
     });
-    return models.Posts.deleteOne({ _id });
+    const result = await models.Posts.deleteOne({ _id });
+
+    await syncPostScheduleSafely({
+      subdomain,
+      previousPost: post,
+    });
+
+    return result;
   },
 
   cmsPostsRemoveMany: async (_parent, args, context: IContext) => {
-    const { models } = context;
+    const { models, subdomain } = context;
     const { _ids } = args;
     const uniqueIds = [
       ...new Set((_ids || []).map((id: string) => String(id))),
@@ -351,6 +371,16 @@ export const postMutations: Record<string, Resolver> = {
       $or: [{ objectId: { $in: uniqueIds } }, { postId: { $in: uniqueIds } }],
     });
     const result = await models.Posts.deleteMany({ _id: { $in: uniqueIds } });
+
+    await Promise.all(
+      posts.map((post) =>
+        syncPostScheduleSafely({
+          subdomain,
+          previousPost: post,
+        }),
+      ),
+    );
+
     return { deletedCount: result.deletedCount };
   },
 
@@ -380,6 +410,12 @@ export const postMutations: Record<string, Resolver> = {
     });
 
     const updatedPost = await models.Posts.changeStatus(_id, status);
+
+    await syncPostScheduleSafely({
+      subdomain,
+      previousPost: post,
+      currentPost: updatedPost,
+    });
 
     return updatedPost;
   },

--- a/backend/plugins/content_api/src/modules/cms/migrations/addScheduledPostIndexes.ts
+++ b/backend/plugins/content_api/src/modules/cms/migrations/addScheduledPostIndexes.ts
@@ -1,0 +1,197 @@
+import * as dotenv from 'dotenv';
+import {
+  Collection,
+  Db,
+  Document,
+  IndexDescriptionInfo,
+  IndexDirection,
+  MongoClient,
+  ObjectId,
+} from 'mongodb';
+
+dotenv.config();
+
+const MONGO_URL =
+  process.env.MONGO_URL ||
+  'mongodb://localhost:27017/erxes?directConnection=true';
+const CORE_MONGO_URL = process.env.CORE_MONGO_URL;
+const VERSION = process.env.VERSION || 'os';
+const DB_NAME_TEMPLATE = process.env.DB_NAME || 'erxes_<organizationId>';
+
+type TOrganization = {
+  _id: ObjectId | string;
+  subdomain: string;
+};
+
+type TManagedIndex = {
+  key: Record<string, IndexDirection>;
+  name: string;
+};
+
+const POST_INDEXES: TManagedIndex[] = [
+  {
+    key: { status: 1, scheduledDate: 1 },
+    name: 'status_1_scheduledDate_1',
+  },
+  {
+    key: { status: 1, autoArchiveDate: 1 },
+    name: 'status_1_autoArchiveDate_1',
+  },
+];
+
+const hasKey = (
+  index: Pick<IndexDescriptionInfo, 'key'>,
+  expectedKey: Record<string, IndexDirection>,
+) => {
+  const actualKey = index.key;
+  const expectedEntries = Object.entries(expectedKey);
+
+  return (
+    Object.keys(actualKey).length === expectedEntries.length &&
+    expectedEntries.every(
+      ([field, direction]) => actualKey[field] === direction,
+    )
+  );
+};
+
+const ensurePostIndexes = async (database: Db) => {
+  const collections = await database
+    .listCollections({ name: 'cms_posts' }, { nameOnly: true })
+    .toArray();
+
+  if (collections.length === 0) {
+    return false;
+  }
+
+  const posts = database.collection('cms_posts');
+  const existingIndexes = await posts.listIndexes().toArray();
+
+  for (const index of POST_INDEXES) {
+    if (!existingIndexes.some((existing) => hasKey(existing, index.key))) {
+      await posts.createIndex(index.key, { name: index.name });
+    }
+  }
+
+  return true;
+};
+
+const ensureOrganizationIndexes = async (
+  organizations: Collection<Document>,
+) => {
+  const existingIndexes = await organizations.listIndexes().toArray();
+  const existingSubdomainIndex = existingIndexes.find((index) =>
+    hasKey(index, { subdomain: 1 }),
+  );
+
+  if (!existingSubdomainIndex?.unique) {
+    const duplicate = await organizations
+      .aggregate([
+        { $match: { subdomain: { $type: 'string' } } },
+        { $group: { _id: '$subdomain', count: { $sum: 1 } } },
+        { $match: { count: { $gt: 1 } } },
+        { $limit: 1 },
+      ])
+      .next();
+
+    if (duplicate) {
+      throw new Error(
+        `Cannot create unique organization subdomain index: duplicate "${duplicate._id}" exists`,
+      );
+    }
+
+    if (existingSubdomainIndex?.name) {
+      await organizations.dropIndex(existingSubdomainIndex.name);
+    }
+
+    await organizations.createIndex(
+      { subdomain: 1 },
+      { name: 'subdomain_1', unique: true, sparse: true },
+    );
+  }
+
+  if (
+    !existingIndexes.some((index) => hasKey(index, { onboardedPlugins: 1 }))
+  ) {
+    await organizations.createIndex(
+      { onboardedPlugins: 1 },
+      { name: 'onboardedPlugins_1' },
+    );
+  }
+};
+
+const migrateSaas = async (dataClient: MongoClient) => {
+  if (!CORE_MONGO_URL) {
+    throw new Error('CORE_MONGO_URL is required when VERSION=saas');
+  }
+
+  const coreClient = new MongoClient(CORE_MONGO_URL);
+
+  try {
+    await coreClient.connect();
+
+    const organizations = coreClient.db().collection('organizations');
+
+    await ensureOrganizationIndexes(organizations);
+
+    const contentOrganizations = await organizations
+      .find<TOrganization>(
+        {
+          onboardedPlugins: 'content',
+          subdomain: { $type: 'string' },
+        },
+        { projection: { _id: 1, subdomain: 1 } },
+      )
+      .toArray();
+
+    let indexedDatabases = 0;
+
+    for (const organization of contentOrganizations) {
+      const databaseName = DB_NAME_TEMPLATE.replace(
+        '<organizationId>',
+        String(organization._id),
+      );
+
+      if (await ensurePostIndexes(dataClient.db(databaseName))) {
+        indexedDatabases += 1;
+      }
+    }
+
+    console.log(
+      `Scheduled-post indexes ready for ${indexedDatabases} Content organization databases`,
+    );
+  } finally {
+    await coreClient.close();
+  }
+};
+
+/**
+ * Adds the scheduler indexes to OS or all SaaS Content tenant databases.
+ */
+export const addScheduledPostIndexes = async () => {
+  const dataClient = new MongoClient(MONGO_URL);
+
+  try {
+    await dataClient.connect();
+
+    if (VERSION === 'saas') {
+      await migrateSaas(dataClient);
+    } else {
+      const indexed = await ensurePostIndexes(dataClient.db());
+
+      console.log(
+        indexed
+          ? 'Scheduled-post indexes are ready'
+          : 'cms_posts does not exist; no post indexes were created',
+      );
+    }
+  } finally {
+    await dataClient.close();
+  }
+};
+
+addScheduledPostIndexes().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+
+  console.error(`Scheduled-post index migration failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/backend/plugins/content_api/src/modules/cms/migrations/cleanupScheduledPostJobs.ts
+++ b/backend/plugins/content_api/src/modules/cms/migrations/cleanupScheduledPostJobs.ts
@@ -1,0 +1,47 @@
+import { Queue } from 'bullmq';
+import { redis } from 'erxes-api-shared/utils';
+
+const CLEANUP_BATCH_SIZE = 1_000;
+
+type TFinishedJobState = 'completed' | 'failed';
+
+const cleanupState = async (
+  queue: Queue<unknown>,
+  state: TFinishedJobState,
+): Promise<number> => {
+  let cleanedCount = 0;
+  let cleanedJobIds: string[];
+
+  do {
+    cleanedJobIds = await queue.clean(0, CLEANUP_BATCH_SIZE, state);
+    cleanedCount += cleanedJobIds.length;
+  } while (cleanedJobIds.length === CLEANUP_BATCH_SIZE);
+
+  return cleanedCount;
+};
+
+/**
+ * Removes legacy completed and failed jobs retained before cleanup was enabled.
+ */
+export const cleanupScheduledPostJobs = async () => {
+  const queue = new Queue<unknown>('content-schedule', { connection: redis });
+
+  try {
+    const completedCount = await cleanupState(queue, 'completed');
+    const failedCount = await cleanupState(queue, 'failed');
+
+    console.log(
+      `Removed ${completedCount} completed and ${failedCount} failed content schedule jobs`,
+    );
+  } finally {
+    await queue.close();
+    await redis.quit();
+  }
+};
+
+cleanupScheduledPostJobs().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+
+  console.error(`Scheduled-post job cleanup failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/backend/plugins/content_api/src/worker/index.ts
+++ b/backend/plugins/content_api/src/worker/index.ts
@@ -1,12 +1,15 @@
 import { Queue } from 'bullmq';
 import { createMQWorkerWithListeners } from 'erxes-api-shared/utils';
 import {
-  processScheduledPosts,
+  processScheduledPostJob,
   scheduledPostsDispatcher,
 } from '~/worker/scheduledPosts';
 
 type TRedisConnection = Parameters<typeof createMQWorkerWithListeners>[3];
 
+/**
+ * Registers delayed post workers and the 15-minute reconciliation scheduler.
+ */
 export const initMQWorkers = async (redis: TRedisConnection) => {
   const scheduledPostsQueue = new Queue('content-scheduled-posts-check', {
     connection: redis,
@@ -19,7 +22,7 @@ export const initMQWorkers = async (redis: TRedisConnection) => {
   await scheduledPostsQueue.upsertJobScheduler(
     'content-scheduled-posts-check',
     {
-      pattern: '* * * * *',
+      pattern: '*/15 * * * *',
       tz: 'UTC',
     },
     {
@@ -32,18 +35,14 @@ export const initMQWorkers = async (redis: TRedisConnection) => {
     'scheduled-posts-check',
     scheduledPostsDispatcher,
     redis,
-    () => {
-      console.log('Worker for queue content-scheduled-posts-check is ready');
-    },
+    () => undefined,
   );
 
   createMQWorkerWithListeners(
     'content',
     'schedule',
-    processScheduledPosts,
+    processScheduledPostJob,
     redis,
-    () => {
-      console.log('Worker for queue content-schedule is ready');
-    },
+    () => undefined,
   );
 };

--- a/backend/plugins/content_api/src/worker/postScheduling.spec.ts
+++ b/backend/plugins/content_api/src/worker/postScheduling.spec.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { JobsOptions } from 'bullmq';
+
+import {
+  getPlannedPostJob,
+  syncPostScheduleWithQueue,
+  TPostScheduleJobData,
+  TSchedulablePost,
+} from '~/worker/postSchedulingPlan';
+
+class FakeJob {
+  public removed = false;
+
+  constructor(private readonly state: string) {}
+
+  public getState = async () => this.state;
+
+  public remove = async () => {
+    this.removed = true;
+  };
+}
+
+class FakeQueue {
+  public readonly jobs = new Map<string, FakeJob>();
+  public readonly added: Array<{
+    name: string;
+    data: TPostScheduleJobData;
+    options: JobsOptions;
+  }> = [];
+
+  public add = async (
+    name: string,
+    data: TPostScheduleJobData,
+    options: JobsOptions,
+  ) => {
+    this.added.push({ name, data, options });
+  };
+
+  public getJob = async (jobId: string) => this.jobs.get(jobId);
+}
+
+describe('post scheduling', () => {
+  const now = new Date('2026-07-23T00:00:00.000Z');
+
+  it('creates a delayed publish job with automatic cleanup', () => {
+    const dueAt = new Date('2026-07-23T00:05:00.000Z');
+    const job = getPlannedPostJob({
+      subdomain: 'acme',
+      post: {
+        _id: 'post-1',
+        status: 'scheduled',
+        scheduledDate: dueAt,
+      },
+      now,
+    });
+
+    assert.equal(job?.action, 'publish');
+    assert.equal(job?.options.delay, 300_000);
+    assert.equal(job?.options.removeOnComplete, true);
+    assert.equal(job?.options.removeOnFail, true);
+    assert.match(job?.options.jobId || '', /post-1-1784765100000$/);
+  });
+
+  it('does not touch the queue when scheduling fields are unchanged', async () => {
+    const queue = new FakeQueue();
+    const post: TSchedulablePost = {
+      _id: 'post-1',
+      status: 'scheduled',
+      scheduledDate: new Date('2026-07-23T00:05:00.000Z'),
+    };
+
+    await syncPostScheduleWithQueue({
+      subdomain: 'acme',
+      previousPost: post,
+      currentPost: { ...post, autoArchiveDate: undefined },
+      queue,
+      now,
+    });
+
+    assert.equal(queue.added.length, 0);
+  });
+
+  it('replaces the previous delayed job when the due date changes', async () => {
+    const queue = new FakeQueue();
+    const previousPost: TSchedulablePost = {
+      _id: 'post-1',
+      status: 'scheduled',
+      scheduledDate: new Date('2026-07-23T00:05:00.000Z'),
+    };
+    const currentPost = {
+      ...previousPost,
+      scheduledDate: new Date('2026-07-23T00:10:00.000Z'),
+    };
+    const previousJob = getPlannedPostJob({
+      subdomain: 'acme',
+      post: previousPost,
+      now,
+    });
+
+    assert.ok(previousJob);
+
+    const queuedJob = new FakeJob('delayed');
+    queue.jobs.set(previousJob.options.jobId, queuedJob);
+
+    await syncPostScheduleWithQueue({
+      subdomain: 'acme',
+      previousPost,
+      currentPost,
+      queue,
+      now,
+    });
+
+    assert.equal(queuedJob.removed, true);
+    assert.equal(queue.added.length, 1);
+    assert.equal(queue.added[0].name, 'publish');
+    assert.equal(queue.added[0].options.delay, 600_000);
+  });
+
+  it('keeps an active stale job while adding the replacement job', async () => {
+    const queue = new FakeQueue();
+    const previousPost: TSchedulablePost = {
+      _id: 'post-1',
+      status: 'scheduled',
+      scheduledDate: new Date('2026-07-23T00:05:00.000Z'),
+    };
+    const previousJob = getPlannedPostJob({
+      subdomain: 'acme',
+      post: previousPost,
+      now,
+    });
+
+    assert.ok(previousJob);
+
+    const activeJob = new FakeJob('active');
+    queue.jobs.set(previousJob.options.jobId, activeJob);
+
+    await syncPostScheduleWithQueue({
+      subdomain: 'acme',
+      previousPost,
+      currentPost: {
+        ...previousPost,
+        scheduledDate: new Date('2026-07-23T00:10:00.000Z'),
+      },
+      queue,
+      now,
+    });
+
+    assert.equal(activeJob.removed, false);
+    assert.equal(queue.added.length, 1);
+  });
+
+  it('adds an archive job when a scheduled post becomes published', async () => {
+    const queue = new FakeQueue();
+    const archiveAt = new Date('2026-07-24T00:00:00.000Z');
+
+    await syncPostScheduleWithQueue({
+      subdomain: 'acme',
+      previousPost: {
+        _id: 'post-1',
+        status: 'scheduled',
+        scheduledDate: now,
+        autoArchiveDate: archiveAt,
+      },
+      currentPost: {
+        _id: 'post-1',
+        status: 'published',
+        scheduledDate: now,
+        autoArchiveDate: archiveAt,
+      },
+      queue,
+      now,
+    });
+
+    assert.equal(queue.added.length, 1);
+    assert.equal(queue.added[0].name, 'archive');
+    assert.equal(queue.added[0].options.delay, 86_400_000);
+  });
+});

--- a/backend/plugins/content_api/src/worker/postScheduling.ts
+++ b/backend/plugins/content_api/src/worker/postScheduling.ts
@@ -1,0 +1,43 @@
+import { sendWorkerQueue } from 'erxes-api-shared/utils';
+
+import {
+  syncPostScheduleWithQueue,
+  TSchedulablePost,
+} from '~/worker/postSchedulingPlan';
+
+/**
+ * Synchronizes a post's delayed job through the shared Content schedule queue.
+ */
+export const syncPostSchedule = async ({
+  subdomain,
+  previousPost,
+  currentPost,
+}: {
+  subdomain: string;
+  previousPost?: TSchedulablePost | null;
+  currentPost?: TSchedulablePost | null;
+}) =>
+  syncPostScheduleWithQueue({
+    subdomain,
+    previousPost,
+    currentPost,
+    queue: sendWorkerQueue('content', 'schedule'),
+  });
+
+/**
+ * Preserves post writes when Redis is unavailable; reconciliation repairs them.
+ */
+export const syncPostScheduleSafely = async (
+  options: Parameters<typeof syncPostSchedule>[0],
+) => {
+  try {
+    await syncPostSchedule(options);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown queue error';
+
+    console.error(
+      `[content:schedule] Failed to synchronize post job: ${message}`,
+    );
+  }
+};

--- a/backend/plugins/content_api/src/worker/postSchedulingPlan.ts
+++ b/backend/plugins/content_api/src/worker/postSchedulingPlan.ts
@@ -1,0 +1,194 @@
+import type { JobsOptions } from 'bullmq';
+
+import type { IPost } from '@/cms/@types/posts';
+
+export type TPostScheduleAction = 'publish' | 'archive';
+
+export type TSchedulablePost = Pick<
+  IPost,
+  'status' | 'scheduledDate' | 'autoArchiveDate'
+> & {
+  _id: string;
+};
+
+export type TPostScheduleJobData = {
+  subdomain: string;
+  postId: string;
+  dueAt: string;
+};
+
+type TQueueJob = {
+  getState: () => Promise<string>;
+  remove: () => Promise<void>;
+};
+
+export type TScheduleQueue = {
+  add: (
+    name: string,
+    data: TPostScheduleJobData,
+    options: JobsOptions,
+  ) => Promise<unknown>;
+  getJob: (jobId: string) => Promise<TQueueJob | undefined>;
+};
+
+export type TPlannedPostJob = {
+  action: TPostScheduleAction;
+  data: TPostScheduleJobData;
+  options: JobsOptions & { jobId: string };
+};
+
+const getSubdomainKey = (subdomain: string) =>
+  Buffer.from(subdomain).toString('base64url');
+
+const getPostJobId = ({
+  action,
+  subdomain,
+  postId,
+  dueAt,
+}: {
+  action: TPostScheduleAction;
+  subdomain: string;
+  postId: string;
+  dueAt: Date;
+}) =>
+  `content-${action}-${getSubdomainKey(
+    subdomain,
+  )}-${postId}-${dueAt.getTime()}`;
+
+const toValidDate = (value?: Date) => {
+  if (!value) {
+    return;
+  }
+
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime()) ? undefined : date;
+};
+
+/**
+ * Builds the single delayed publish or archive job represented by a post.
+ */
+export const getPlannedPostJob = ({
+  subdomain,
+  post,
+  now = new Date(),
+}: {
+  subdomain: string;
+  post?: TSchedulablePost | null;
+  now?: Date;
+}): TPlannedPostJob | undefined => {
+  if (!post) {
+    return;
+  }
+
+  const isPublish = post.status === 'scheduled';
+  const isArchive = post.status === 'published';
+  const action = isPublish ? 'publish' : isArchive ? 'archive' : undefined;
+  const dueAt = toValidDate(
+    isPublish
+      ? post.scheduledDate
+      : isArchive
+      ? post.autoArchiveDate
+      : undefined,
+  );
+
+  if (!action || !dueAt) {
+    return;
+  }
+
+  const jobId = getPostJobId({
+    action,
+    subdomain,
+    postId: post._id,
+    dueAt,
+  });
+
+  return {
+    action,
+    data: {
+      subdomain,
+      postId: post._id,
+      dueAt: dueAt.toISOString(),
+    },
+    options: {
+      jobId,
+      delay: Math.max(dueAt.getTime() - now.getTime(), 0),
+      removeOnComplete: true,
+      removeOnFail: true,
+    },
+  };
+};
+
+/**
+ * Detects changes that require a delayed job to be added, replaced, or removed.
+ */
+export const hasPostScheduleChanged = (
+  previousPost?: TSchedulablePost | null,
+  currentPost?: TSchedulablePost | null,
+) => {
+  const getTime = (value?: Date) => toValidDate(value)?.getTime();
+
+  return (
+    previousPost?.status !== currentPost?.status ||
+    getTime(previousPost?.scheduledDate) !==
+      getTime(currentPost?.scheduledDate) ||
+    getTime(previousPost?.autoArchiveDate) !==
+      getTime(currentPost?.autoArchiveDate)
+  );
+};
+
+const removeJob = async (queue: TScheduleQueue, jobId: string) => {
+  const job = await queue.getJob(jobId);
+
+  if (!job || (await job.getState()) === 'active') {
+    return;
+  }
+
+  try {
+    await job.remove();
+  } catch (error) {
+    if ((await job.getState()) !== 'active') {
+      throw error;
+    }
+  }
+};
+
+/**
+ * Reconciles one post's previous and current scheduling state with BullMQ.
+ */
+export const syncPostScheduleWithQueue = async ({
+  subdomain,
+  previousPost,
+  currentPost,
+  queue,
+  now = new Date(),
+}: {
+  subdomain: string;
+  previousPost?: TSchedulablePost | null;
+  currentPost?: TSchedulablePost | null;
+  queue: TScheduleQueue;
+  now?: Date;
+}) => {
+  if (!hasPostScheduleChanged(previousPost, currentPost)) {
+    return;
+  }
+
+  const previousJob = getPlannedPostJob({
+    subdomain,
+    post: previousPost,
+    now,
+  });
+  const currentJob = getPlannedPostJob({
+    subdomain,
+    post: currentPost,
+    now,
+  });
+
+  if (previousJob && previousJob.options.jobId !== currentJob?.options.jobId) {
+    await removeJob(queue, previousJob.options.jobId);
+  }
+
+  if (currentJob && currentJob.options.jobId !== previousJob?.options.jobId) {
+    await queue.add(currentJob.action, currentJob.data, currentJob.options);
+  }
+};

--- a/backend/plugins/content_api/src/worker/postSchedulingPlan.ts
+++ b/backend/plugins/content_api/src/worker/postSchedulingPlan.ts
@@ -81,16 +81,18 @@ export const getPlannedPostJob = ({
     return;
   }
 
-  const isPublish = post.status === 'scheduled';
-  const isArchive = post.status === 'published';
-  const action = isPublish ? 'publish' : isArchive ? 'archive' : undefined;
-  const dueAt = toValidDate(
-    isPublish
-      ? post.scheduledDate
-      : isArchive
-      ? post.autoArchiveDate
-      : undefined,
-  );
+  let action: TPostScheduleAction | undefined;
+  let dueDate: Date | undefined;
+
+  if (post.status === 'scheduled') {
+    action = 'publish';
+    dueDate = post.scheduledDate;
+  } else if (post.status === 'published') {
+    action = 'archive';
+    dueDate = post.autoArchiveDate;
+  }
+
+  const dueAt = toValidDate(dueDate);
 
   if (!action || !dueAt) {
     return;

--- a/backend/plugins/content_api/src/worker/scheduledPosts.ts
+++ b/backend/plugins/content_api/src/worker/scheduledPosts.ts
@@ -1,10 +1,30 @@
 import { Job } from 'bullmq';
 import {
   getEnv,
-  getSaasOrganizations,
+  getSaasOrganizationsByFilter,
   sendWorkerQueue,
 } from 'erxes-api-shared/utils';
 import { generateModels } from '~/connectionResolvers';
+import { syncPostScheduleSafely } from '~/worker/postScheduling';
+import { TPostScheduleJobData } from '~/worker/postSchedulingPlan';
+
+type TReconciliationJobData = {
+  subdomain: string;
+};
+
+const RECONCILIATION_JOB_OPTIONS = {
+  removeOnComplete: true,
+  removeOnFail: true,
+};
+
+const getSubdomainKey = (subdomain: string) =>
+  Buffer.from(subdomain).toString('base64url');
+
+/**
+ * Returns the stable ID that prevents overlapping reconciliation per tenant.
+ */
+export const getReconciliationJobId = (subdomain: string) =>
+  `content-reconcile-${getSubdomainKey(subdomain)}`;
 
 /**
  * Scheduler tick handler: enqueues one scheduled-posts check per organization
@@ -15,15 +35,31 @@ export const scheduledPostsDispatcher = async () => {
   const scheduleQueue = sendWorkerQueue('content', 'schedule');
 
   if (VERSION && VERSION === 'saas') {
-    const orgs = await getSaasOrganizations();
+    const orgs: Array<{ subdomain: string }> =
+      await getSaasOrganizationsByFilter({
+        onboardedPlugins: 'content',
+        subdomain: { $type: 'string' },
+      });
 
-    await Promise.all(
-      orgs.map((org: { subdomain: string }) =>
-        scheduleQueue.add('schedule', { subdomain: org.subdomain }),
-      ),
-    );
+    for (const org of orgs) {
+      await scheduleQueue.add(
+        'reconcile',
+        { subdomain: org.subdomain },
+        {
+          ...RECONCILIATION_JOB_OPTIONS,
+          jobId: getReconciliationJobId(org.subdomain),
+        },
+      );
+    }
   } else {
-    await scheduleQueue.add('schedule', { subdomain: 'os' });
+    await scheduleQueue.add(
+      'reconcile',
+      { subdomain: 'os' },
+      {
+        ...RECONCILIATION_JOB_OPTIONS,
+        jobId: getReconciliationJobId('os'),
+      },
+    );
   }
 
   return 'success';
@@ -34,9 +70,7 @@ export const scheduledPostsDispatcher = async () => {
  * existing publishedDate) and archives published posts whose autoArchiveDate
  * has passed, for the organization named in the job data.
  */
-export const processScheduledPosts = async (job: Job) => {
-  const { subdomain } = job?.data ?? {};
-
+export const reconcileScheduledPosts = async (subdomain: string) => {
   const models = await generateModels(subdomain);
   const now = new Date();
 
@@ -63,9 +97,95 @@ export const processScheduledPosts = async (job: Job) => {
     { $set: { status: 'archived' } },
   );
 
-  if (publishResult.modifiedCount || archiveResult.modifiedCount) {
-    console.log(
-      `[content:schedule] org: ${subdomain}, published: ${publishResult.modifiedCount}, archived: ${archiveResult.modifiedCount}`,
-    );
+  return {
+    publishedCount: publishResult.modifiedCount,
+    archivedCount: archiveResult.modifiedCount,
+  };
+};
+
+const processDelayedPost = async (
+  action: 'publish' | 'archive',
+  { subdomain, postId, dueAt }: TPostScheduleJobData,
+) => {
+  const models = await generateModels(subdomain);
+  const expectedDate = new Date(dueAt);
+
+  if (Number.isNaN(expectedDate.getTime())) {
+    throw new Error('Scheduled post job has an invalid due date');
   }
+
+  if (action === 'publish') {
+    const publishedPost = await models.Posts.findOneAndUpdate(
+      {
+        _id: postId,
+        status: 'scheduled',
+        scheduledDate: expectedDate,
+      },
+      [
+        {
+          $set: {
+            status: 'published',
+            publishedDate: { $ifNull: ['$publishedDate', '$$NOW'] },
+          },
+        },
+      ],
+      { new: true },
+    );
+
+    if (publishedPost) {
+      await syncPostScheduleSafely({
+        subdomain,
+        previousPost: {
+          _id: publishedPost._id,
+          status: 'scheduled',
+          scheduledDate: expectedDate,
+          autoArchiveDate: publishedPost.autoArchiveDate,
+        },
+        currentPost: publishedPost,
+      });
+    }
+
+    return;
+  }
+
+  await models.Posts.updateOne(
+    {
+      _id: postId,
+      status: 'published',
+      autoArchiveDate: expectedDate,
+    },
+    { $set: { status: 'archived' } },
+  );
+};
+
+const isPostScheduleJobData = (
+  data: TReconciliationJobData | TPostScheduleJobData,
+): data is TPostScheduleJobData =>
+  'postId' in data && typeof data.postId === 'string' && 'dueAt' in data;
+
+/**
+ * Routes reconciliation and delayed post jobs to their specialized processors.
+ */
+export const processScheduledPostJob = async (
+  job: Job<TReconciliationJobData | TPostScheduleJobData>,
+) => {
+  if (job.name === 'reconcile') {
+    return reconcileScheduledPosts(job.data.subdomain);
+  }
+
+  if (job.name === 'schedule') {
+    // Jobs queued by the old per-minute poll are intentionally not replayed.
+    job.opts.removeOnComplete = true;
+    return 'Skipped legacy per-minute reconciliation job';
+  }
+
+  if (job.name === 'publish' || job.name === 'archive') {
+    if (!isPostScheduleJobData(job.data)) {
+      throw new Error(`Content ${job.name} job is missing post data`);
+    }
+
+    return processDelayedPost(job.name, job.data);
+  }
+
+  throw new Error(`Unsupported content schedule job: ${job.name}`);
 };

--- a/backend/plugins/content_api/src/worker/scheduledPosts.ts
+++ b/backend/plugins/content_api/src/worker/scheduledPosts.ts
@@ -111,7 +111,7 @@ const processDelayedPost = async (
   const expectedDate = new Date(dueAt);
 
   if (Number.isNaN(expectedDate.getTime())) {
-    throw new Error('Scheduled post job has an invalid due date');
+    throw new TypeError('Scheduled post job has an invalid due date');
   }
 
   if (action === 'publish') {


### PR DESCRIPTION
## Summary
- replace per-minute all-tenant scans with delayed post jobs and 15-minute reconciliation
- add MongoDB indexes and filter reconciliation to organizations using Content
- deduplicate per-organization BullMQ jobs, remove completed/failed jobs, and provide cleanup commands

## Root cause
The scheduled-post worker dispatched two unindexed `updateMany` scans for every SaaS organization every minute and retained per-organization jobs in Redis.

## Impact
- reconciliation polling frequency falls by at least 93.3% (from every minute to every 15 minutes)
- organizations without Content are excluded
- normal scheduled publish/archive transitions use delayed jobs and indexed per-post updates
- deterministic job IDs prevent duplicate pending reconciliation jobs

## Deployment
Run the MongoDB index migration before rollout:

```bash
pnpm nx run content_api:migrate:scheduled-post-indexes
```

Clean up legacy completed/failed scheduled-post jobs around or after rollout:

```bash
pnpm nx run content_api:cleanup:scheduled-post-jobs
```

## Validation
- `pnpm nx test content_api --skip-nx-cache` — 5 tests passing
- `pnpm nx lint content_api` — passes with existing warnings only
- `pnpm nx build erxes-api-shared` — passes
- `pnpm nx build content_api --skip-nx-cache` — passes
- changed-file ESLint and repository rule checks — pass