### PR TITLE
feat(pos): add clear session utility for login page

### DIFF
--- a/apps/posclient-front/lib/utils.ts
+++ b/apps/posclient-front/lib/utils.ts
@@ -89,6 +89,22 @@ export const resetLocal = () => {
   })
 }
 
+// Removes the specified cookie by expiring it immediately.
+const deleteCookie = (name: string) => {
+  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+}
+
+// Clears authentication/session data and refreshes the page.
+export const clearAllSessionData = () => {
+  deleteCookie("auth-token")
+  deleteCookie("pos-auth-token")
+
+  resetLocal()
+  sessionStorage.clear()
+
+  window.location.reload()
+}
+
 export function hexToHsl(hex: string) {
   // Remove the '#' symbol from the hex code
   hex = hex.replace("#", "")

--- a/apps/posclient-front/lib/utils.ts
+++ b/apps/posclient-front/lib/utils.ts
@@ -89,16 +89,9 @@ export const resetLocal = () => {
   })
 }
 
-// Removes the specified cookie by expiring it immediately.
-const deleteCookie = (name: string) => {
-  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
-}
-
-// Clears authentication/session data and refreshes the page.
+// Clears remaining client-side storage and refreshes the page.
+// Auth cookies are HttpOnly, so they must be cleared via the logout mutation first.
 export const clearAllSessionData = () => {
-  deleteCookie("auth-token")
-  deleteCookie("pos-auth-token")
-
   resetLocal()
   sessionStorage.clear()
 

--- a/apps/posclient-front/modules/auth/LoginPage.tsx
+++ b/apps/posclient-front/modules/auth/LoginPage.tsx
@@ -1,10 +1,12 @@
+import ClearSessionButton from "@/modules/auth/components/clearSessionButton"
 import Logo from "@/modules/auth/components/logo"
 import LoginContainer from "@/modules/auth/login"
 
 const Login = () => {
   return (
     <div className="flex h-screen items-center justify-center bg-neutral-100 md:p-10">
-      <div className="flex h-full w-full items-center justify-center md:rounded-3xl bg-white shadow-xl">
+      <div className="relative flex h-full w-full items-center justify-center md:rounded-3xl bg-white shadow-xl">
+        <ClearSessionButton />
         <div className="mx-auto w-full max-w-sm">
           <div className="mb-5 flex w-full justify-center rounded-lg border py-3">
             <Logo />

--- a/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
+++ b/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useMutation } from "@apollo/client"
 import { Trash2 } from "lucide-react"
 
 import { clearAllSessionData } from "@/lib/utils"
@@ -11,7 +12,19 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import mutations from "../graphql/mutations"
+import { onError } from "@/components/ui/use-toast"
+
 const ClearSessionButton = () => {
+  const [logout, { loading }] = useMutation(mutations.logout, {
+    onError({ message }) {
+      onError(message)
+    },
+    onCompleted() {
+      clearAllSessionData()
+    },
+  })
+
   return (
     <TooltipProvider>
       <Tooltip>
@@ -20,7 +33,8 @@ const ClearSessionButton = () => {
             type="button"
             variant="ghost"
             size="icon"
-            onClick={clearAllSessionData}
+            loading={loading}
+            onClick={() => logout()}
             aria-label="Clear session & refresh"
             className="absolute right-4 top-4 border-none bg-transparent text-muted-foreground shadow-none hover:bg-gray-100 hover:text-foreground"
           >

--- a/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
+++ b/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+
+import { clearAllSessionData } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const ClearSessionButton = () => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={clearAllSessionData}
+            aria-label="Clear session & refresh"
+            className="absolute right-4 top-4 border-none bg-transparent text-muted-foreground shadow-none hover:bg-gray-100 hover:text-foreground"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear session & refresh</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export default ClearSessionButton

--- a/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
+++ b/apps/posclient-front/modules/auth/components/clearSessionButton.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMutation } from "@apollo/client"
-import { Trash2 } from "lucide-react"
+import { Paintbrush } from "lucide-react"
 
 import { clearAllSessionData } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -34,11 +34,12 @@ const ClearSessionButton = () => {
             variant="ghost"
             size="icon"
             loading={loading}
+            iconOnly
             onClick={() => logout()}
             aria-label="Clear session & refresh"
-            className="absolute right-4 top-4 border-none bg-transparent text-muted-foreground shadow-none hover:bg-gray-100 hover:text-foreground"
+            className="absolute bg-transparent border-none shadow-none right-4 top-4 text-muted-foreground hover:bg-gray-100 hover:text-foreground"
           >
-            <Trash2 className="h-4 w-4" />
+            <Paintbrush className="w-4 h-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Clear session & refresh</TooltipContent>

--- a/apps/posclient-front/modules/auth/components/logout.tsx
+++ b/apps/posclient-front/modules/auth/components/logout.tsx
@@ -1,26 +1,20 @@
-import { gql, useMutation } from "@apollo/client"
+import { useMutation } from "@apollo/client"
 import { LogOutIcon } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 
+import mutations from "../graphql/mutations"
 import queries from "../graphql/queries"
 import { onError } from '@/components/ui/use-toast'
 
 const Logout = () => {
-  const [logout, { loading }] = useMutation(
-    gql`
-      mutation {
-        posLogout
-      }
-    `,
-    {
-      onError({ message }) {
-        onError(message)
-      },
-      refetchQueries: [queries.posCurrentUser],
-    }
-  )
+  const [logout, { loading }] = useMutation(mutations.logout, {
+    onError({ message }) {
+      onError(message)
+    },
+    refetchQueries: [queries.posCurrentUser],
+  })
   return (
     <DropdownMenuItem asChild onClick={() => logout()}>
       <Button

--- a/apps/posclient-front/modules/auth/graphql/mutations.ts
+++ b/apps/posclient-front/modules/auth/graphql/mutations.ts
@@ -20,10 +20,17 @@ const chooseConfig = gql`
   }
 `
 
+const logout = gql`
+  mutation {
+    posLogout
+  }
+`
+
 const mutations = {
   login,
   configsFetch,
   chooseConfig,
+  logout,
 }
 
 export default mutations


### PR DESCRIPTION
## Summary by Sourcery

Add a utility to clear all POS client session and authentication data and expose it via a clear-session action on the login page.

New Features:
- Introduce a clearAllSessionData helper that removes auth cookies, clears storage, and reloads the page.
- Add a ClearSessionButton component to trigger session clearing from the login screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Clear session & refresh”** button to the login page, with tooltip and loading feedback.
  * Clears persisted client session data, wipes session storage, and forces a full page refresh.
* **Bug Fixes**
  * Updated logout to use the shared, centrally defined logout GraphQL mutation consistently (including existing error handling and user refetch behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->