### PR TITLE
feat(operation): sync task detail sheet URL with address bar

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/task/components/TaskBoardCard.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TaskBoardCard.tsx
@@ -7,7 +7,7 @@ import { SelectStatusTask } from '@/task/components/task-selects/SelectStatusTas
 import { SelectTaskPriority } from '@/task/components/task-selects/SelectTaskPriority';
 import { SelectTeamTask } from '@/task/components/task-selects/SelectTeamTask';
 import { allTasksMapState } from '@/task/components/TasksBoard';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { taskCountByBoardAtom } from '@/task/states/tasksTotalCountState';
 import { IconCalendarEventFilled } from '@tabler/icons-react';
 import { format } from 'date-fns';
@@ -33,7 +33,7 @@ export const TaskBoardCard = ({ id, column }: BoardCardProps) => {
     _id,
     createdAt,
   } = useAtomValue(taskBoardItemAtom)(id);
-  const setActiveTask = useSetAtom(taskDetailSheetState);
+  const [, setActiveTask] = useTaskDetailSheet();
   const setTaskCountByBoard = useSetAtom(taskCountByBoardAtom);
 
   return (

--- a/frontend/plugins/operation_ui/src/modules/task/components/TaskDetailSheet.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TaskDetailSheet.tsx
@@ -1,14 +1,13 @@
 import { TaskDetails } from '@/task/components/detail/TaskDetails';
 import { useGetTask } from '@/task/hooks/useGetTask';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { IconArrowsDiagonal } from '@tabler/icons-react';
 import { Button, Separator, Sheet, TextOverflowTooltip } from 'erxes-ui';
-import { useAtom } from 'jotai';
 import { Link, useParams } from 'react-router-dom';
 import { TaskDetailActions } from './task-actions/TaskDetailActions';
 
 export const TaskDetailSheet = () => {
-  const [activeTask, setActiveTask] = useAtom(taskDetailSheetState);
+  const [activeTask, setActiveTask] = useTaskDetailSheet();
 
   return (
     <Sheet open={!!activeTask} onOpenChange={() => setActiveTask(null)}>
@@ -31,7 +30,7 @@ export const TaskDetailSheet = () => {
 
 export const TaskDetailSheetHeader = () => {
   const { teamId, projectId } = useParams();
-  const [activeTask, setActiveTask] = useAtom(taskDetailSheetState);
+  const [activeTask, setActiveTask] = useTaskDetailSheet();
   const { task } = useGetTask({ variables: { _id: activeTask } });
 
   const url =

--- a/frontend/plugins/operation_ui/src/modules/task/components/TasksColumn.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TasksColumn.tsx
@@ -9,7 +9,7 @@ import { SelectStatusTask } from '@/task/components/task-selects/SelectStatusTas
 import { SelectTaskPriority } from '@/task/components/task-selects/SelectTaskPriority';
 import { SelectTeamTask } from '@/task/components/task-selects/SelectTeamTask';
 import { useUpdateTask } from '@/task/hooks/useUpdateTask';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { ITask } from '@/task/types';
 import { ITeam } from '@/team/types';
 import {
@@ -31,7 +31,6 @@ import {
   RecordTable,
   RecordTableInlineCell,
 } from 'erxes-ui';
-import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 import { SelectMilestone } from './task-selects/SelectMilestone';
 import { TagsSelect } from 'ui-modules';
@@ -57,7 +56,7 @@ export const tasksColumns = (
         const name = cell.getValue() as string;
         const [value, setValue] = useState(name);
         const { updateTask } = useUpdateTask();
-        const setActiveTask = useSetAtom(taskDetailSheetState);
+        const [, setActiveTask] = useTaskDetailSheet();
 
         const handleUpdate = () => {
           if (value !== name) {

--- a/frontend/plugins/operation_ui/src/modules/task/components/TasksMoreColumn.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/TasksMoreColumn.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { ITask } from '@/task/types';
 import { IconEdit } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import { Combobox, Command, Popover, RecordTable } from 'erxes-ui';
-import { useSetAtom } from 'jotai';
 
 export const TasksMoreColumnCell = ({
   cell,
@@ -12,7 +11,7 @@ export const TasksMoreColumnCell = ({
   cell: Cell<ITask, unknown>;
 }) => {
   const { t } = useTranslation('operation');
-  const setActiveTask = useSetAtom(taskDetailSheetState);
+  const [, setActiveTask] = useTaskDetailSheet();
   const { _id } = cell.row.original;
 
   const handleEdit = (taskId: string) => {

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-actions/MakeACopy.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-actions/MakeACopy.tsx
@@ -3,7 +3,7 @@ import {
   taskCreateDefaultValuesState,
   taskCreateSheetState,
 } from '@/task/states/taskCreateSheetState';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { ITask, TAddTask } from '@/task/types';
 import { IconCopy } from '@tabler/icons-react';
 import { Command, useToast } from 'erxes-ui';
@@ -18,7 +18,7 @@ type MakeACopyTriggerProps = {
 const useMakeACopy = () => {
   const setTaskCreateSheet = useSetAtom(taskCreateSheetState);
   const setTaskCreateDefaultValues = useSetAtom(taskCreateDefaultValuesState);
-  const setTaskDetailSheet = useSetAtom(taskDetailSheetState);
+  const [, setTaskDetailSheet] = useTaskDetailSheet();
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-actions/TaskDetailActions.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-actions/TaskDetailActions.tsx
@@ -15,8 +15,7 @@ import { CopyTaskTrigger, CopyTaskCommandBarItem } from './CopyTask';
 import { useGetTask } from '@/task/hooks/useGetTask';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRemoveTask } from '@/task/hooks/useRemoveTask';
-import { useSetAtom } from 'jotai';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 
 export const TaskDetailActions = ({ taskId }: { taskId: string }) => {
   const { t } = useTranslation('operation');
@@ -26,7 +25,7 @@ export const TaskDetailActions = ({ taskId }: { taskId: string }) => {
   const { teamId } = useParams();
   const { removeTask } = useRemoveTask();
   const navigate = useNavigate();
-  const setActiveTask = useSetAtom(taskDetailSheetState);
+  const [, setActiveTask] = useTaskDetailSheet();
 
   return (
     <Popover

--- a/frontend/plugins/operation_ui/src/modules/task/constants.ts
+++ b/frontend/plugins/operation_ui/src/modules/task/constants.ts
@@ -1,1 +1,2 @@
 export const TASKS_CURSOR_SESSION_KEY = 'tasks_cursor_session_key';
+export const TASK_DETAIL_QUERY_KEY = 'task_id';

--- a/frontend/plugins/operation_ui/src/modules/task/hooks/useTaskDetailSheet.ts
+++ b/frontend/plugins/operation_ui/src/modules/task/hooks/useTaskDetailSheet.ts
@@ -1,0 +1,8 @@
+import { TASK_DETAIL_QUERY_KEY } from '@/task/constants';
+import { useQueryState } from 'erxes-ui';
+
+// The URL is the single source of truth for the task detail sheet: it is open
+// exactly when `?task_id=` is present. Browser back/forward and copied links
+// work for free, with no manual history bookkeeping.
+export const useTaskDetailSheet = () =>
+  useQueryState<string>(TASK_DETAIL_QUERY_KEY);

--- a/frontend/plugins/operation_ui/src/modules/task/states/taskDetailSheetState.ts
+++ b/frontend/plugins/operation_ui/src/modules/task/states/taskDetailSheetState.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const taskDetailSheetState = atom<string | null>(null);

--- a/frontend/plugins/operation_ui/src/modules/triage/hooks/useConvertTriage.ts
+++ b/frontend/plugins/operation_ui/src/modules/triage/hooks/useConvertTriage.ts
@@ -5,15 +5,14 @@ import { CONVERT_TRIAGE_TO_TASK } from '../graphql/mutations/convertTriage';
 
 import { GET_TRIAGES } from '@/triage/graphql/queries/getTriages';
 
-import { useSetAtom } from 'jotai';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { GET_TRIAGE } from '@/triage/graphql/queries/getTriage';
 
 export const useConvertTriage = () => {
   const { t } = useTranslation('operation');
   const { toast } = useToast();
 
-  const setActiveTask = useSetAtom(taskDetailSheetState);
+  const [, setActiveTask] = useTaskDetailSheet();
 
   const [convertTriageToTaskMutation, { loading, error }] = useMutation(
     CONVERT_TRIAGE_TO_TASK,

--- a/frontend/plugins/operation_ui/src/widgets/relation/modules/TaskWidgetCard.tsx
+++ b/frontend/plugins/operation_ui/src/widgets/relation/modules/TaskWidgetCard.tsx
@@ -5,12 +5,11 @@ import { SelectProject } from '@/task/components/task-selects/SelectProjectTask'
 import { SelectStatusTask } from '@/task/components/task-selects/SelectStatusTask';
 import { SelectTaskPriority } from '@/task/components/task-selects/SelectTaskPriority';
 import { SelectTeamTask } from '@/task/components/task-selects/SelectTeamTask';
-import { taskDetailSheetState } from '@/task/states/taskDetailSheetState';
+import { useTaskDetailSheet } from '@/task/hooks/useTaskDetailSheet';
 import { ITask } from '@/task/types';
 import { IconCalendarEventFilled } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import { Button, Card, Separator } from 'erxes-ui';
-import { useAtom } from 'jotai';
 import { lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -36,7 +35,7 @@ export const TaskWidgetCard = ({ task }: { task: ITask }) => {
     status,
     createdAt,
   } = task || {};
-  const [activeTask, setActiveTask] = useAtom(taskDetailSheetState);
+  const [activeTask, setActiveTask] = useTaskDetailSheet();
 
   return (
     <>


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add a hook to mirror the active task detail sheet to a task-specific URL using history.pushState without triggering a full page navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task detail sheets now synchronize with the browser URL.
  * Opening a task detail updates the URL; closing returns to the task list view.
  * Browser back/forward navigation now correctly closes and reopens the task detail sheet.
* **Refactor**
  * Updated task detail sheet activation to use a dedicated hook across task board cards, columns, actions, widgets, and conversion flows.
* **Chores**
  * Added a shared query key constant for the URL-driven task detail state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->