### PR TITLE
feat(core):favorite tooltip ,unfavorite from sidebar

### DIFF
--- a/frontend/core-ui/src/modules/navigation/components/SidebarNavigationFavorites.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/SidebarNavigationFavorites.tsx
@@ -1,7 +1,9 @@
-import { NavigationMenuGroup, NavigationMenuLinkItem } from 'erxes-ui';
+import { NavigationMenuGroup, NavigationMenuLinkItem, Sidebar } from 'erxes-ui';
 import { useFavorites } from '../hooks/useFavorites';
 import { MyInboxNavigationItem } from '@/notification/components/MyInboxNavigationItem';
 import { useTranslation } from 'react-i18next';
+import { IconX } from '@tabler/icons-react';
+import { useToggleFavorite } from 'ui-modules';
 
 export function SidebarNavigationFavorites() {
   const { t } = useTranslation('common', { keyPrefix: 'sidebar' });
@@ -19,17 +21,66 @@ export function SidebarNavigationFavorites() {
 
 export function SidebarNavigationFavoritesItem({
   name,
+  breadcrumb,
   icon,
   path,
 }: {
   name: string;
+  breadcrumb: string[];
   icon?: React.ElementType;
   path: string;
 }) {
-  const Icon = icon || (() => <span />);
+  const Icon = icon;
   const pathWithoutUi = path.replace('_ui', '');
+  const { toggleFavorite } = useToggleFavorite({ path, breadcrumb });
+  const sidebarLabel =
+    breadcrumb.length > 1 ? breadcrumb.slice(1).join(' / ') : name;
+
+  const handleRemove = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void toggleFavorite();
+  };
 
   return (
-    <NavigationMenuLinkItem name={name} icon={Icon} path={pathWithoutUi} />
+    <NavigationMenuLinkItem
+      name={name}
+      icon={Icon}
+      path={pathWithoutUi}
+      label={
+        <span className="min-w-0 flex-1 truncate text-muted-foreground">
+          {sidebarLabel}
+        </span>
+      }
+      action={
+        <Sidebar.MenuAction
+          aria-label={name}
+          className="size-4! text-muted-foreground hover:text-foreground"
+          onClick={handleRemove}
+          showOnHover
+        >
+          <IconX className="size-3!" />
+        </Sidebar.MenuAction>
+      }
+      tooltipVisibility="always"
+      tooltip={{
+        align: 'start',
+        className:
+          'max-w-80 border bg-background px-3 py-2 text-foreground shadow-md',
+        children: (
+          <div className="flex items-start gap-2">
+            {!!Icon && <Icon className="mt-0.5 size-4 shrink-0" />}
+            <div className="min-w-0">
+              <div className="font-medium">{breadcrumb[0]}</div>
+              {breadcrumb.length > 1 && (
+                <div className="mt-0.5 text-muted-foreground">
+                  {breadcrumb.slice(1).join(' / ')}
+                </div>
+              )}
+            </div>
+          </div>
+        ),
+      }}
+    />
   );
 }

--- a/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/useFavorites.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@apollo/client';
 import { GET_FAVORITES } from '@/navigation/graphql/queries/getFavorites';
 import { usePluginsModules } from '@/navigation/hooks/usePluginsModules';
+import { getFavoriteLabels } from '@/navigation/utils/getFavoriteLabels';
 import { useAtomValue } from 'jotai';
 import { currentUserState } from 'ui-modules';
 import { IconComponent } from 'erxes-ui';
@@ -22,6 +23,7 @@ interface Favorite {
 
 interface FavoriteModule {
   name: string;
+  breadcrumb: string[];
   icon?: ElementType;
   path: string;
 }
@@ -181,9 +183,18 @@ export function useFavorites(): FavoriteModule[] {
       return acc;
     }
 
+    const { breadcrumb, name } = getFavoriteLabels(
+      favorite.breadcrumb,
+      favorite.path,
+    );
+
     acc.push({
-      name: favorite.breadcrumb?.join(' / ') || favorite.path,
-      icon: resolveFavoriteIcon(favorite.icon) || allowedPaths.get(allowedPath) || IconStar,
+      name,
+      breadcrumb,
+      icon:
+        resolveFavoriteIcon(favorite.icon) ||
+        allowedPaths.get(allowedPath) ||
+        IconStar,
       path: favorite.path,
     });
 

--- a/frontend/core-ui/src/modules/navigation/utils/getFavoriteLabels.ts
+++ b/frontend/core-ui/src/modules/navigation/utils/getFavoriteLabels.ts
@@ -1,0 +1,21 @@
+interface FavoriteLabels {
+  breadcrumb: string[];
+  contextLabel: string;
+  name: string;
+  primaryLabel: string;
+}
+
+export function getFavoriteLabels(
+  breadcrumb: string[] | undefined,
+  fallback: string,
+): FavoriteLabels {
+  const resolvedBreadcrumb = breadcrumb?.length ? breadcrumb : [fallback];
+  const [primaryLabel = fallback, ...contextLabels] = resolvedBreadcrumb;
+
+  return {
+    breadcrumb: resolvedBreadcrumb,
+    contextLabel: contextLabels.join(' / '),
+    name: resolvedBreadcrumb.join(' / '),
+    primaryLabel,
+  };
+}

--- a/frontend/libs/erxes-ui/src/components/sidebar.tsx
+++ b/frontend/libs/erxes-ui/src/components/sidebar.tsx
@@ -467,7 +467,7 @@ SidebarSeparator.displayName = 'SidebarSeparator';
 const SidebarContent = React.forwardRef<
   React.ElementRef<typeof ScrollArea>,
   React.ComponentProps<typeof ScrollArea>
->(({ className, ...props }, ref) => {
+>(({ className, viewportClassName, ...props }, ref) => {
   return (
     <ScrollArea
       ref={ref}
@@ -475,6 +475,10 @@ const SidebarContent = React.forwardRef<
       className={cn(
         'flex min-h-0 flex-1 flex-col gap-2 group-data-[collapsible=icon]:overflow-hidden',
         className,
+      )}
+      viewportClassName={cn(
+        'min-w-0 [&>div]:block! [&>div]:min-w-0',
+        viewportClassName,
       )}
       {...props}
     />
@@ -584,7 +588,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = 'SidebarMenuItem';
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded p-2 text-left font-medium outline-hidden transition-[width,height,padding] hover:bg-accent focus-visible:ring-2 active:bg-accent disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary/10 data-[active=true]:text-primary [&>svg]:data-[active=true]:text-primary data-[state=open]:hover:bg-accent data-[state=active]:bg-primary/10 data-[state=active]:text-primary group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full min-w-0 max-w-full items-center gap-2 overflow-hidden rounded p-2 text-left font-medium outline-hidden transition-[width,height,padding] hover:bg-accent focus-visible:ring-2 active:bg-accent disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary/10 data-[active=true]:text-primary [&>svg]:data-[active=true]:text-primary data-[state=open]:hover:bg-accent data-[state=active]:bg-primary/10 data-[state=active]:text-primary group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -611,6 +615,7 @@ const SidebarMenuButton = React.forwardRef<
     asChild?: boolean;
     isActive?: boolean;
     tooltip?: string | React.ComponentProps<typeof Tooltip.Content>;
+    tooltipVisibility?: 'collapsed' | 'always';
   } & VariantProps<typeof sidebarMenuButtonVariants>
 >(
   (
@@ -620,6 +625,7 @@ const SidebarMenuButton = React.forwardRef<
       variant = 'default',
       size = 'default',
       tooltip,
+      tooltipVisibility = 'collapsed',
       className,
       ...props
     },
@@ -655,7 +661,10 @@ const SidebarMenuButton = React.forwardRef<
         <Tooltip.Content
           side="right"
           align="center"
-          hidden={state !== 'collapsed' || isMobile}
+          hidden={
+            isMobile ||
+            (tooltipVisibility === 'collapsed' && state !== 'collapsed')
+          }
           {...tooltip}
         />
       </Tooltip>

--- a/frontend/libs/erxes-ui/src/modules/navigation-menu/components/NavigationMenu.tsx
+++ b/frontend/libs/erxes-ui/src/modules/navigation-menu/components/NavigationMenu.tsx
@@ -13,6 +13,8 @@ export const NavigationMenuLinkItem = forwardRef<
     path: string;
     pathPrefix?: string;
     isActive?: boolean;
+    label?: React.ReactNode;
+    action?: React.ReactNode;
   }
 >(
   (
@@ -24,6 +26,8 @@ export const NavigationMenuLinkItem = forwardRef<
       children,
       className,
       isActive: isActiveProp,
+      label,
+      action,
       ...props
     },
     ref,
@@ -56,10 +60,15 @@ export const NavigationMenuLinkItem = forwardRef<
                 )}
               />
             )}
-            <span className="capitalize">{name}</span>
+            {label || (
+              <span className="min-w-0 flex-1 truncate capitalize">
+                {name}
+              </span>
+            )}
             {children}
           </Link>
         </Sidebar.MenuButton>
+        {action}
       </Sidebar.MenuItem>
     );
   },


### PR DESCRIPTION
## Summary by Sourcery

Enhance sidebar favorites to show detailed tooltips and support unfavoriting directly from the sidebar, while improving layout handling in the sidebar and navigation menu components.

New Features:
- Add always-visible, rich tooltips for sidebar favorite items based on structured breadcrumb labels.
- Allow users to remove favorites directly from sidebar navigation entries via a contextual action button.

Enhancements:
- Introduce a getFavoriteLabels utility to normalize breadcrumb-based labels for favorite items.
- Extend NavigationMenuLinkItem to support custom labels and action slots for more flexible menu rendering.
- Improve Sidebar content and menu button layout to better handle truncation and collapsed states, including configurable tooltip visibility.