### PR TITLE
fix: improve form select tab navigation

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/select-operation/components/SelectOperation.tsx
+++ b/frontend/libs/erxes-ui/src/modules/select-operation/components/SelectOperation.tsx
@@ -3,6 +3,65 @@ import { Badge, Button, Combobox, Form, Popover } from 'erxes-ui/components';
 import { Filter } from 'erxes-ui/modules/filter';
 import { RecordTableInlineCell } from 'erxes-ui/modules/record-table';
 
+const FORM_CONTROL_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[contenteditable="true"]',
+  '[tabindex]',
+].join(',');
+
+const getFocusableFormControls = (form: HTMLFormElement) =>
+  Array.from(form.querySelectorAll<HTMLElement>(FORM_CONTROL_SELECTOR)).filter(
+    (element) =>
+      element.tabIndex >= 0 &&
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.getClientRects().length > 0,
+  );
+
+const getPopoverTrigger = (content: HTMLElement) => {
+  if (!content.id) {
+    return;
+  }
+
+  return Array.from(
+    content.ownerDocument.querySelectorAll<HTMLElement>('[aria-controls]'),
+  ).find((element) => element.getAttribute('aria-controls') === content.id);
+};
+
+const handleFormContentTab = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  if (event.key !== 'Tab' || event.defaultPrevented) {
+    return;
+  }
+
+  const trigger = getPopoverTrigger(event.currentTarget);
+  const form = trigger?.closest('form');
+
+  if (!trigger || !form) {
+    return;
+  }
+
+  const controls = getFocusableFormControls(form);
+  const triggerIndex = controls.indexOf(trigger);
+
+  if (triggerIndex === -1) {
+    return;
+  }
+
+  const nextControl = controls[triggerIndex + (event.shiftKey ? -1 : 1)];
+
+  if (!nextControl) {
+    return;
+  }
+
+  event.preventDefault();
+  trigger.click();
+  requestAnimationFrame(() => nextControl.focus());
+};
+
 export enum SelectTriggerVariant {
   TABLE = 'table',
   CARD = 'card',
@@ -98,6 +157,9 @@ export const SelectOperationContent = ({
     <Combobox.Content
       sideOffset={variant === SelectTriggerVariant.CARD ? 4 : 8}
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={
+        variant === SelectTriggerVariant.FORM ? handleFormContentTab : undefined
+      }
     >
       {children}
     </Combobox.Content>

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/AddCardForm.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/AddCardForm.tsx
@@ -8,6 +8,7 @@ import { useDealsAdd } from '@/deals/cards/hooks/useDeals';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
 
 export function AddCardForm({
   onCloseSheet,
@@ -31,6 +32,10 @@ export function AddCardForm({
     },
   });
   const { addDeals, loading } = useDealsAdd();
+
+  useEffect(() => {
+    form.setFocus('name');
+  }, [form]);
 
   const onSubmit = (data: SalesFormType) => {
     addDeals({


### PR DESCRIPTION
## Summary by Sourcery

Improve keyboard tab navigation behavior for form-based select popovers and enhance initial focus handling in the deals add card form.

New Features:
- Add keyboard Tab handling within form select popover content to move focus between form controls while closing the popover as needed.

Enhancements:
- Automatically focus the name field when the deals add card form mounts to streamline data entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation within form-based popovers, including smoother Tab and Shift+Tab focus movement.
  * Automatically focuses the name field when opening the Add Card form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->