### PR TITLE
fix(sales): archived pipelines and deactivated members with realtime sync

### DIFF
--- a/backend/core-api/src/apollo/subscription.ts
+++ b/backend/core-api/src/apollo/subscription.ts
@@ -5,6 +5,7 @@ export default {
             notificationRead(userId: String): JSON
             notificationArchived(userId: String): JSON
             activityLogInserted(userId: String, targetId: String): ActivityLog
+            userStatusChanged(_id: String!): User
 		`,
   generateResolvers: (graphqlPubsub) => {
     return {
@@ -60,6 +61,11 @@ export default {
             `activityLogInserted:${subdomain}:${userId}`,
           );
         },
+      },
+      userStatusChanged: {
+        resolve: (payload) => payload.userStatusChanged,
+        subscribe: (_, { _id }, { subdomain }) =>
+          graphqlPubsub.asyncIterator(`userStatusChanged:${subdomain}:${_id}`),
       },
     };
   },

--- a/backend/core-api/src/apollo/subscription.ts
+++ b/backend/core-api/src/apollo/subscription.ts
@@ -5,7 +5,7 @@ export default {
             notificationRead(userId: String): JSON
             notificationArchived(userId: String): JSON
             activityLogInserted(userId: String, targetId: String): ActivityLog
-            userStatusChanged(_id: String!): User
+            userStatusChanged(_id: String): User
 		`,
   generateResolvers: (graphqlPubsub) => {
     return {
@@ -65,7 +65,11 @@ export default {
       userStatusChanged: {
         resolve: (payload) => payload.userStatusChanged,
         subscribe: (_, { _id }, { subdomain }) =>
-          graphqlPubsub.asyncIterator(`userStatusChanged:${subdomain}:${_id}`),
+          graphqlPubsub.asyncIterator(
+            _id
+              ? `userStatusChanged:${subdomain}:${_id}`
+              : `userStatusChanged:${subdomain}`,
+          ),
       },
     };
   },

--- a/backend/core-api/src/modules/organization/team-member/graphql/mutations.ts
+++ b/backend/core-api/src/modules/organization/team-member/graphql/mutations.ts
@@ -11,6 +11,7 @@ import {
   getPlugin,
   getPlugins,
   getSaasOrganizationDetail,
+  graphqlPubsub,
 } from 'erxes-api-shared/utils';
 import { IContext, IModels } from '~/connectionResolvers';
 import { saveValidatedToken } from '~/modules/auth/utils';
@@ -245,7 +246,7 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
   async usersSetActiveStatus(
     _parent: undefined,
     { _id }: { _id: string },
-    { user, models, checkPermission }: IContext,
+    { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('teamMembersRemove');
 
@@ -255,13 +256,17 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
 
     const updatedUser = await models.Users.setUserActiveOrInactive(_id);
 
+    await graphqlPubsub.publish(`userStatusChanged:${subdomain}:${_id}`, {
+      userStatusChanged: updatedUser,
+    });
+
     return updatedUser;
   },
 
   async usersSetActiveStatusBatch(
     _parent: undefined,
     { _ids }: { _ids: string[] },
-    { user, models, checkPermission }: IContext,
+    { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('teamMembersRemove');
 
@@ -275,7 +280,11 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
       const targetUser = await models.Users.findOne({ _id });
 
       if (targetUser && targetUser.isActive !== false) {
-        await models.Users.setUserActiveOrInactive(_id);
+        const updatedUser = await models.Users.setUserActiveOrInactive(_id);
+
+        await graphqlPubsub.publish(`userStatusChanged:${subdomain}:${_id}`, {
+          userStatusChanged: updatedUser,
+        });
       }
     }
 

--- a/backend/core-api/src/modules/organization/team-member/graphql/mutations.ts
+++ b/backend/core-api/src/modules/organization/team-member/graphql/mutations.ts
@@ -23,6 +23,19 @@ export interface IUsersEdit extends IUser {
   _id: string;
 }
 
+const publishUserStatusChanged = (
+  subdomain: string,
+  userId: string,
+  updatedUser: IUser,
+) => {
+  const payload = { userStatusChanged: updatedUser };
+
+  return Promise.all([
+    graphqlPubsub.publish(`userStatusChanged:${subdomain}:${userId}`, payload),
+    graphqlPubsub.publish(`userStatusChanged:${subdomain}`, payload),
+  ]);
+};
+
 const validatePermissionGroupIds = async (
   models: IModels,
   permissionGroupIds: string[],
@@ -256,9 +269,7 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
 
     const updatedUser = await models.Users.setUserActiveOrInactive(_id);
 
-    await graphqlPubsub.publish(`userStatusChanged:${subdomain}:${_id}`, {
-      userStatusChanged: updatedUser,
-    });
+    await publishUserStatusChanged(subdomain, _id, updatedUser);
 
     return updatedUser;
   },
@@ -282,9 +293,7 @@ export const userMutations: Record<string, Resolver<any, any, IContext>> = {
       if (targetUser && targetUser.isActive !== false) {
         const updatedUser = await models.Users.setUserActiveOrInactive(_id);
 
-        await graphqlPubsub.publish(`userStatusChanged:${subdomain}:${_id}`, {
-          userStatusChanged: updatedUser,
-        });
+        await publishUserStatusChanged(subdomain, _id, updatedUser);
       }
     }
 

--- a/backend/plugins/sales_api/src/apollo/subscription.ts
+++ b/backend/plugins/sales_api/src/apollo/subscription.ts
@@ -10,6 +10,7 @@ export default {
     salesDealListChanged(pipelineId: String!, userId: String, filter: IDealFilter): DealSubscription
     salesProductsDataChanged(_id: String!): DealProductsDataChangeResponse
     salesPipelinesChanged(_id: String!): SalesPipelineChangeResponse
+    salesPipelineListChanged: SalesPipelineChangeResponse
     salesChecklistsChanged(contentType: String!, contentTypeId: String!): SalesChecklist
     salesChecklistDetailChanged(_id: String!): SalesChecklist
 
@@ -86,6 +87,11 @@ export default {
         resolve: (payload) => payload.salesPipelinesChanged,
         subscribe: (_, { _id }) =>
           graphqlPubsub.asyncIterator(`salesPipelinesChanged:${_id}`),
+      },
+      salesPipelineListChanged: {
+        resolve: (payload) => payload.salesPipelineListChanged,
+        subscribe: () =>
+          graphqlPubsub.asyncIterator('salesPipelineListChanged'),
       },
       salesChecklistsChanged: {
         resolve: (payload) => payload.salesChecklistsChanged,

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/pipelines.ts
@@ -1,5 +1,5 @@
 import { IOrderInput } from 'erxes-api-shared/core-types';
-import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { graphqlPubsub, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import {
   IPipeline,
@@ -127,10 +127,25 @@ export const pipelineMutations = {
    */
   async salesPipelinesArchive(
     _root,
-    { _id, status }: { _id: string; status: string },
-    { models }: IContext,
+    { _id }: { _id: string },
+    { models, user }: IContext,
   ) {
-    return await models.Pipelines.archivePipeline(_id, status);
+    await models.Pipelines.archivePipeline(_id, user._id);
+
+    const pipeline = await models.Pipelines.getPipeline(_id);
+
+    await graphqlPubsub.publish('salesPipelineListChanged', {
+      salesPipelineListChanged: {
+        _id,
+        action: 'statusChanged',
+        data: {
+          boardId: pipeline.boardId,
+          status: pipeline.status,
+        },
+      },
+    });
+
+    return true;
   },
 
   /**

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/pipelines.ts
@@ -1,7 +1,29 @@
 import { ICursorPaginateParams, Resolver } from 'erxes-api-shared/core-types';
-import { cursorPaginate, sendTRPCMessage } from 'erxes-api-shared/utils';
+import {
+  cursorPaginate,
+  cursorPaginateAggregation,
+  sendTRPCMessage,
+} from 'erxes-api-shared/utils';
+import type { FilterQuery, PipelineStage } from 'mongoose';
+
 import { IContext } from '~/connectionResolvers';
 import { IPipelineDocument } from '~/modules/sales/@types';
+import { SALES_STATUSES } from '~/modules/sales/constants';
+
+// Keep legacy pipelines without a status in the active group and cursor.
+const PIPELINE_STATUS_RANK_STAGE: PipelineStage = {
+  $addFields: {
+    statusRank: {
+      $cond: [{ $eq: ['$status', SALES_STATUSES.ARCHIVED] }, 1, 0],
+    },
+  },
+};
+
+const PIPELINES_ORDER_BY = {
+  statusRank: 1,
+  createdAt: -1,
+  _id: 1,
+} as const;
 
 export const pipelineQueries: Record<string, Resolver> = {
   /**
@@ -17,11 +39,10 @@ export const pipelineQueries: Record<string, Resolver> = {
   ) {
     const { boardId, isAll } = params;
 
-    const query: any =
+    const query: FilterQuery<IPipelineDocument> =
       user.isOwner || isAll
         ? {}
         : {
-            status: { $ne: 'archived' },
             $or: [
               { visibility: 'public' },
               {
@@ -38,6 +59,11 @@ export const pipelineQueries: Record<string, Resolver> = {
             ],
           };
 
+    // Owners may see private pipelines; only management callers see archived ones.
+    if (!isAll) {
+      query.status = { $ne: SALES_STATUSES.ARCHIVED };
+    }
+
     if (!user.isOwner && !isAll) {
       const userDetail = await sendTRPCMessage({
         subdomain,
@@ -53,7 +79,7 @@ export const pipelineQueries: Record<string, Resolver> = {
       const departmentIds = userDetail?.departmentIds || [];
 
       if (Object.keys(query) && departmentIds.length > 0) {
-        query.$or.push({
+        query.$or?.push({
           $and: [
             { visibility: 'private' },
             { departmentIds: { $in: departmentIds } },
@@ -67,14 +93,16 @@ export const pipelineQueries: Record<string, Resolver> = {
     }
 
     const { list, totalCount, pageInfo } =
-      await cursorPaginate<IPipelineDocument>({
+      await cursorPaginateAggregation<IPipelineDocument>({
         model: models.Pipelines,
+        pipeline: [{ $match: query }, PIPELINE_STATUS_RANK_STAGE],
         params: {
           ...params,
-          orderBy: { createdAt: -1 },
+          orderBy: PIPELINES_ORDER_BY,
           limit: params.limit || 20,
         },
-        query: query,
+        // Cursor dates are encoded as ISO strings.
+        formatter: { createdAt: 'date' },
       });
 
     return { list, totalCount, pageInfo };

--- a/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
@@ -138,22 +138,27 @@ const MemberInlineEffectComponent = ({
     skip,
     fetchPolicy: 'cache-and-network',
   });
-  useSubscription(USER_STATUS_CHANGED, {
+  const { data: statusChangedData } = useSubscription<{
+    userStatusChanged?: IUser;
+  }>(USER_STATUS_CHANGED, {
     variables: { _id: memberId },
     skip,
   });
+  const statusChangedUser = statusChangedData?.userStatusChanged;
+  const resolvedUser =
+    statusChangedUser?._id === memberId ? statusChangedUser : userDetail;
 
   useEffect(() => {
     if (!updateMembers) return;
 
-    if (userDetail?.isActive === false) {
+    if (resolvedUser?.isActive === false) {
       onActiveChange(memberId, false);
       updateMembers((prev) => prev.filter(({ _id }) => _id !== memberId));
-    } else if (userDetail) {
+    } else if (resolvedUser) {
       onActiveChange(memberId, true);
       updateMembers((prev) => {
         if (prev.some((m) => m._id === memberId)) return prev;
-        return [...prev, { ...userDetail, _id: memberId }];
+        return [...prev, { ...resolvedUser, _id: memberId }];
       });
     }
     if (currentUser?._id === memberId) {
@@ -163,7 +168,7 @@ const MemberInlineEffectComponent = ({
         return [currentUser, ...prev];
       });
     }
-  }, [userDetail, currentUser, memberId, onActiveChange, updateMembers]);
+  }, [resolvedUser, currentUser, memberId, onActiveChange, updateMembers]);
 
   return null;
 };

--- a/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
@@ -1,3 +1,5 @@
+import { useSubscription } from '@apollo/client';
+import { IconUserCancel } from '@tabler/icons-react';
 import {
   Avatar,
   AvatarProps,
@@ -7,17 +9,18 @@ import {
   isUndefinedOrNull,
   readImage,
 } from 'erxes-ui';
+import { useAtomValue } from 'jotai';
+import { useCallback, useEffect, useState } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import { currentUserState } from 'ui-modules/states';
+
 import {
   MembersInlineContext,
   useMembersInlineContext,
-} from '../contexts/MembersInlineContext';
-import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-
-import { IUser } from '../types/TeamMembers';
-import { IconUserCancel } from '@tabler/icons-react';
-import { currentUserState } from 'ui-modules/states';
-import { useAtomValue } from 'jotai';
-import { useMemberInline } from '../hooks';
+} from 'ui-modules/modules/team-members/contexts/MembersInlineContext';
+import { USER_STATUS_CHANGED } from 'ui-modules/modules/team-members/graphql/subscriptions/userStatusChanged';
+import { useMemberInline } from 'ui-modules/modules/team-members/hooks';
+import { IUser } from 'ui-modules/modules/team-members/types/TeamMembers';
 
 export const MembersInlineRoot = ({
   members,
@@ -60,7 +63,7 @@ export const MembersInlineProvider = ({
   size,
   allowUnassigned,
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
   memberIds?: string[];
   members?: IUser[];
   placeholder?: string;
@@ -69,11 +72,33 @@ export const MembersInlineProvider = ({
   allowUnassigned?: boolean;
 }) => {
   const [_members, _setMembers] = useState<IUser[]>(members || []);
+  const [inactiveMemberIds, setInactiveMemberIds] = useState<string[]>([]);
+  const currentMembers = members || _members;
+  const activeMembers = currentMembers.filter(
+    ({ _id, isActive }) =>
+      isActive !== false && !inactiveMemberIds.includes(_id),
+  );
+  const handleMemberActiveChange = useCallback(
+    (memberId: string, isActive: boolean) => {
+      setInactiveMemberIds((currentIds) => {
+        if (isActive) {
+          return currentIds.includes(memberId)
+            ? currentIds.filter((id) => id !== memberId)
+            : currentIds;
+        }
+
+        return currentIds.includes(memberId)
+          ? currentIds
+          : [...currentIds, memberId];
+      });
+    },
+    [],
+  );
 
   return (
     <MembersInlineContext.Provider
       value={{
-        members: members || _members,
+        members: activeMembers,
         loading: false,
         memberIds: memberIds,
         placeholder: isUndefinedOrNull(placeholder)
@@ -85,42 +110,60 @@ export const MembersInlineProvider = ({
       }}
     >
       <Tooltip.Provider>{children}</Tooltip.Provider>
-      {memberIds
-        ?.filter((id) => !members?.some((member) => member._id === id))
-        .map((memberId) => (
-          <MemberInlineEffectComponent key={memberId} memberId={memberId} />
-        ))}
+      {memberIds?.map((memberId) => (
+        <MemberInlineEffectComponent
+          key={memberId}
+          memberId={memberId}
+          onActiveChange={handleMemberActiveChange}
+        />
+      ))}
     </MembersInlineContext.Provider>
   );
 };
 
-const MemberInlineEffectComponent = ({ memberId }: { memberId: string }) => {
+const MemberInlineEffectComponent = ({
+  memberId,
+  onActiveChange,
+}: {
+  memberId: string;
+  onActiveChange: (memberId: string, isActive: boolean) => void;
+}) => {
   const currentUser = useAtomValue(currentUserState) as IUser;
   const { updateMembers } = useMembersInlineContext();
+  const skip = !memberId || memberId === currentUser?._id;
   const { userDetail } = useMemberInline({
     variables: {
       _id: memberId,
     },
-    skip: !memberId || memberId === currentUser?._id,
+    skip,
+    fetchPolicy: 'cache-and-network',
+  });
+  useSubscription(USER_STATUS_CHANGED, {
+    variables: { _id: memberId },
+    skip,
   });
 
   useEffect(() => {
     if (!updateMembers) return;
 
-    if (userDetail) {
+    if (userDetail?.isActive === false) {
+      onActiveChange(memberId, false);
+      updateMembers((prev) => prev.filter(({ _id }) => _id !== memberId));
+    } else if (userDetail) {
+      onActiveChange(memberId, true);
       updateMembers((prev) => {
         if (prev.some((m) => m._id === memberId)) return prev;
         return [...prev, { ...userDetail, _id: memberId }];
       });
     }
     if (currentUser?._id === memberId) {
+      onActiveChange(memberId, true);
       updateMembers((prev) => {
         if (prev.some((m) => m._id === memberId)) return prev;
         return [currentUser, ...prev];
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userDetail, currentUser, updateMembers]);
+  }, [userDetail, currentUser, memberId, onActiveChange, updateMembers]);
 
   return null;
 };

--- a/frontend/libs/ui-modules/src/modules/team-members/components/SelectMember.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/SelectMember.tsx
@@ -1,3 +1,4 @@
+import { useSubscription } from '@apollo/client';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import {
   AvatarProps,
@@ -20,6 +21,7 @@ import {
   SelectMemberContext,
   useSelectMemberContext,
 } from '../contexts/SelectMemberContext';
+import { USER_STATUS_CHANGED } from '../graphql/subscriptions/userStatusChanged';
 import { IUser } from '../types/TeamMembers';
 import { MembersInline } from './MembersInline';
 
@@ -153,6 +155,7 @@ const SelectMemberNoAssigneeItem = () => {
 
 const SelectMemberContent = () => {
   const [search, setSearch] = useState('');
+  const [inactiveMemberIds, setInactiveMemberIds] = useState<string[]>([]);
   const [debouncedSearch] = useDebounce(search, 500);
   const { memberIds, members, allowUnassigned } = useSelectMemberContext();
   const { users, loading, handleFetchMore, totalCount, error } = useUsers({
@@ -160,9 +163,26 @@ const SelectMemberContent = () => {
       searchValue: debouncedSearch,
     },
   });
+  useSubscription<{ userStatusChanged?: IUser }>(USER_STATUS_CHANGED, {
+    onData: ({ data }) => {
+      const statusChangedUser = data.data?.userStatusChanged;
 
+      if (!statusChangedUser) return;
+
+      setInactiveMemberIds((currentIds) =>
+        statusChangedUser.isActive === false
+          ? [...new Set([...currentIds, statusChangedUser._id])]
+          : currentIds.filter((id) => id !== statusChangedUser._id),
+      );
+    },
+  });
+
+  const activeMembers = members.filter(
+    ({ _id, isActive }) =>
+      isActive !== false && !inactiveMemberIds.includes(_id),
+  );
   const filteredMembers = search
-    ? members.filter((member) => {
+    ? activeMembers.filter((member) => {
         const q = search.toLowerCase();
         const fullName = `${member.details?.firstName || ''} ${
           member.details?.lastName || ''
@@ -174,7 +194,7 @@ const SelectMemberContent = () => {
           (member.username || '').toLowerCase().includes(q)
         );
       })
-    : members;
+    : activeMembers;
 
   return (
     <Command shouldFilter={false}>
@@ -200,7 +220,9 @@ const SelectMemberContent = () => {
         {!loading &&
           users
             .filter(
-              (user) => !memberIds.find((memberId) => memberId === user._id),
+              (user) =>
+                !inactiveMemberIds.includes(user._id) &&
+                !memberIds.find((memberId) => memberId === user._id),
             )
             .map((user) => (
               <SelectMemberCommandItem key={user._id} user={user} />
@@ -383,7 +405,9 @@ export const SelectMemberFormItem = ({
     <SelectMemberProvider
       onValueChange={(value) => {
         onValueChange?.(value);
-        props.mode !== 'multiple' && setOpen(false);
+        if (props.mode !== 'multiple') {
+          setOpen(false);
+        }
       }}
       {...props}
     >
@@ -427,12 +451,15 @@ export const SelectMemberDetail = ({
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           {!value ? (
-            <Combobox.TriggerBase className="font-medium">
-              Add Owner <IconPlus />
+            <Combobox.TriggerBase className={cn('font-medium', className)}>
+              {placeholder || 'Add Owner'} <IconPlus />
             </Combobox.TriggerBase>
           ) : (
-            <Button variant="ghost" className="w-full inline-flex">
-              <SelectMemberValue size={size} />
+            <Button
+              variant="ghost"
+              className={cn('w-full inline-flex', className)}
+            >
+              <SelectMemberValue size={size} placeholder={placeholder} />
             </Button>
           )}
         </Popover.Trigger>

--- a/frontend/libs/ui-modules/src/modules/team-members/components/SelectMember.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/SelectMember.tsx
@@ -222,7 +222,7 @@ const SelectMemberContent = () => {
             .filter(
               (user) =>
                 !inactiveMemberIds.includes(user._id) &&
-                !memberIds.find((memberId) => memberId === user._id),
+                !memberIds.some((memberId) => memberId === user._id),
             )
             .map((user) => (
               <SelectMemberCommandItem key={user._id} user={user} />

--- a/frontend/libs/ui-modules/src/modules/team-members/graphql/queries/userQueries.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/graphql/queries/userQueries.ts
@@ -78,6 +78,7 @@ export const GET_ASSIGNED_MEMBER = gql`
   query AssignedMember($_id: String) {
     userDetail(_id: $_id) {
       _id
+      isActive
       details {
         avatar
         fullName

--- a/frontend/libs/ui-modules/src/modules/team-members/graphql/queries/userQueries.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/graphql/queries/userQueries.ts
@@ -21,6 +21,7 @@ export const GET_USERS = gql`
       list {
         _id
         email
+        isActive
         details {
           avatar
           fullName

--- a/frontend/libs/ui-modules/src/modules/team-members/graphql/subscriptions/userStatusChanged.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/graphql/subscriptions/userStatusChanged.ts
@@ -1,10 +1,16 @@
 import { gql } from '@apollo/client';
 
 export const USER_STATUS_CHANGED = gql`
-  subscription UserStatusChanged($_id: String!) {
+  subscription UserStatusChanged($_id: String) {
     userStatusChanged(_id: $_id) {
       _id
       isActive
+      email
+      username
+      details {
+        avatar
+        fullName
+      }
     }
   }
 `;

--- a/frontend/libs/ui-modules/src/modules/team-members/graphql/subscriptions/userStatusChanged.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/graphql/subscriptions/userStatusChanged.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const USER_STATUS_CHANGED = gql`
+  subscription UserStatusChanged($_id: String!) {
+    userStatusChanged(_id: $_id) {
+      _id
+      isActive
+    }
+  }
+`;

--- a/frontend/libs/ui-modules/src/modules/team-members/hooks/useUsers.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/hooks/useUsers.tsx
@@ -20,6 +20,7 @@ export const useUsers = (
   const { data, loading, fetchMore, error } = useQuery<
     ICursorListResponse<IUser>
   >(GET_USERS, {
+    fetchPolicy: 'cache-and-network',
     ...options,
     variables: {
       limit: USERS_LIMIT,
@@ -55,7 +56,7 @@ export const useUsers = (
   };
 
   return {
-    users: list,
+    users: list.filter(({ isActive }) => isActive !== false),
     loading,
     handleFetchMore,
     error,

--- a/frontend/libs/ui-modules/src/modules/team-members/hooks/useUsers.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/hooks/useUsers.tsx
@@ -1,13 +1,16 @@
+import { OperationVariables, QueryHookOptions, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   ICursorListResponse,
   mergeCursorData,
   validateFetchMore,
 } from 'erxes-ui';
-import { GET_ASSIGNED_MEMBER, GET_USERS } from '../graphql/queries/userQueries';
-import { OperationVariables, QueryHookOptions, useQuery } from '@apollo/client';
 
-import { IUser } from '../types/TeamMembers';
+import {
+  GET_ASSIGNED_MEMBER,
+  GET_USERS,
+} from 'ui-modules/modules/team-members/graphql/queries/userQueries';
+import { IUser } from 'ui-modules/modules/team-members/types/TeamMembers';
 
 const USERS_LIMIT = 30;
 
@@ -63,7 +66,13 @@ export const useUsers = (
 
 export const useAssignedMember = (options?: OperationVariables) => {
   const { data, loading, error } = useQuery(GET_ASSIGNED_MEMBER, options);
-  return { details: data?.userDetail?.details, loading, error };
+  const userDetail = data?.userDetail;
+
+  return {
+    details: userDetail?.isActive === false ? undefined : userDetail?.details,
+    loading,
+    error,
+  };
 };
 
 export interface IUserInlineData {

--- a/frontend/libs/ui-modules/src/modules/team-members/types/TeamMembers.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/types/TeamMembers.ts
@@ -5,6 +5,7 @@ export interface IUser {
   email?: string;
   username?: string;
   isOwner?: boolean;
+  isActive?: boolean;
   configs?: any;
   isOnboarded: boolean;
   details?: {

--- a/frontend/plugins/sales_ui/src/modules/SalesSubNavigation.tsx
+++ b/frontend/plugins/sales_ui/src/modules/SalesSubNavigation.tsx
@@ -1,3 +1,4 @@
+import { IconDotsVertical, IconLink, IconSettings } from '@tabler/icons-react';
 import {
   Button,
   Collapsible,
@@ -10,14 +11,13 @@ import {
   useQueryState,
   useToast,
 } from 'erxes-ui';
-import { IconDotsVertical, IconLink, IconSettings } from '@tabler/icons-react';
+import { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { IBoard } from '@/deals/types/boards';
-import { useBoards } from '~/modules/deals/boards/hooks/useBoards';
-import { useEffect, useMemo } from 'react';
 import { usePipelines } from '@/deals/boards/hooks/usePipelines';
-import { useTranslation } from 'react-i18next';
+import { useBoards } from '~/modules/deals/boards/hooks/useBoards';
 
 function LoadingSkeleton() {
   return (
@@ -100,8 +100,11 @@ const Pipelines = () => {
 
   const currentBoardPipelines = useMemo(
     () =>
-      pipelines?.filter((pipeline) => pipeline.boardId === selectedBoardId) ||
-      [],
+      pipelines?.filter(
+        (pipeline) =>
+          pipeline.boardId === selectedBoardId &&
+          pipeline.status !== 'archived',
+      ) || [],
     [pipelines, selectedBoardId],
   );
   const hasStalePipelines =
@@ -215,7 +218,7 @@ const ActionsMenu = () => {
       <DropdownMenu.Content side="right" align="start" className="w-60 min-w-0">
         <DropdownMenu.Item
           className="cursor-pointer"
-          onSelect={(e) => {
+          onSelect={() => {
             navigate(`/settings/deals`);
           }}
         >
@@ -223,7 +226,7 @@ const ActionsMenu = () => {
           {t('manage-board-pipelines')}
         </DropdownMenu.Item>
         <DropdownMenu.Item
-          onSelect={(e) => {
+          onSelect={() => {
             handleCopyLink();
           }}
           className="cursor-pointer"

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/usePipelines.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/usePipelines.tsx
@@ -1,4 +1,21 @@
 import {
+  MutationHookOptions,
+  QueryHookOptions,
+  useApolloClient,
+  useMutation,
+  useQuery,
+  useSubscription,
+} from '@apollo/client';
+import {
+  EnumCursorDirection,
+  ICursorListResponse,
+  toast,
+  useQueryState,
+  useToast,
+} from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+import {
   ADD_PIPELINE,
   ARCHIVE_PIPELINE,
   COPY_PIPELINE,
@@ -7,32 +24,65 @@ import {
   UPDATE_PIPELINE_ORDER,
 } from '@/deals/graphql/mutations/PipelinesMutations';
 import {
-  EnumCursorDirection,
-  ICursorListResponse,
-  toast,
-  useQueryState,
-  useToast,
-} from 'erxes-ui';
-import {
-  GET_PIPELINES,
   GET_PIPELINE_DETAIL,
+  GET_PIPELINES,
 } from '@/deals/graphql/queries/PipelinesQueries';
-import {
-  MutationHookOptions,
-  QueryHookOptions,
-  useMutation,
-  useQuery,
-  useApolloClient,
-} from '@apollo/client';
-
+import { PIPELINE_LIST_CHANGED } from '@/deals/graphql/subscriptions/pipelineListChange';
 import { IPipeline } from '@/deals/types/pipelines';
-import { useTranslation } from 'react-i18next';
 
 const PIPELINES_PER_PAGE = 20;
+
+interface IPipelineArchiveData {
+  salesPipelinesArchive: boolean;
+}
+
+interface IPipelineArchiveVariables {
+  _id: string;
+}
+
+interface IPipelineListChangedData {
+  salesPipelineListChanged: {
+    _id: string;
+    action: string;
+    data: {
+      status?: string;
+    };
+  };
+}
 
 export const usePipelines = (
   options?: QueryHookOptions<ICursorListResponse<IPipeline>>,
 ) => {
+  useSubscription<IPipelineListChangedData>(PIPELINE_LIST_CHANGED, {
+    skip: options?.skip,
+    onData: ({ client, data: result }) => {
+      const event = result.data?.salesPipelineListChanged;
+      const status = event?.data?.status;
+
+      if (event?.action !== 'statusChanged' || !event._id || !status) {
+        return;
+      }
+
+      const pipelineCacheId = client.cache.identify({
+        __typename: 'SalesPipeline',
+        _id: event._id,
+      });
+
+      if (pipelineCacheId) {
+        client.cache.modify({
+          id: pipelineCacheId,
+          fields: {
+            status: () => status,
+          },
+        });
+      }
+
+      void client.refetchQueries({
+        include: ['SalesPipelines'],
+      });
+    },
+  });
+
   const { data, loading, error, fetchMore } = useQuery<
     ICursorListResponse<IPipeline>
   >(GET_PIPELINES, {
@@ -47,6 +97,9 @@ export const usePipelines = (
     totalCount = 0,
     pageInfo,
   } = data?.salesPipelines || {};
+  const visiblePipelines = options?.variables?.isAll
+    ? pipelines
+    : pipelines?.filter(({ status }) => status !== 'archived');
 
   const handleFetchMore = () => {
     if (totalCount <= (pipelines?.length || 0)) return;
@@ -73,7 +126,14 @@ export const usePipelines = (
     });
   };
 
-  return { pipelines, loading, error, handleFetchMore, pageInfo, totalCount };
+  return {
+    pipelines: visiblePipelines,
+    loading,
+    error,
+    handleFetchMore,
+    pageInfo,
+    totalCount,
+  };
 };
 
 export const usePipelineRemove = (
@@ -179,13 +239,40 @@ export const usePipelineEdit = () => {
 };
 
 export const usePipelineArchive = (
-  options?: MutationHookOptions<{ salesPipelines: IPipeline[] }>,
+  options?: MutationHookOptions<
+    IPipelineArchiveData,
+    IPipelineArchiveVariables
+  >,
 ) => {
   const { t } = useTranslation('sales');
-  const [archivePipeline, { loading, error }] = useMutation(ARCHIVE_PIPELINE, {
+  const [archivePipeline, { loading, error }] = useMutation<
+    IPipelineArchiveData,
+    IPipelineArchiveVariables
+  >(ARCHIVE_PIPELINE, {
     ...options,
+    optimisticResponse: {
+      salesPipelinesArchive: true,
+    },
     variables: {
       ...options?.variables,
+    },
+    update: (cache, _result, { variables }) => {
+      if (!variables?._id) return;
+
+      const pipelineCacheId = cache.identify({
+        __typename: 'SalesPipeline',
+        _id: variables._id,
+      });
+
+      if (!pipelineCacheId) return;
+
+      cache.modify({
+        id: pipelineCacheId,
+        fields: {
+          status: (currentStatus: string) =>
+            currentStatus === 'active' ? 'archived' : 'active',
+        },
+      });
     },
     refetchQueries: ['SalesPipelines'],
     awaitRefetchQueries: true,
@@ -299,7 +386,9 @@ export const usePipelinesBulkRemove = () => {
 
       const failures = results.filter((result) => result.status === 'rejected');
       if (failures.length > 0) {
-        throw new Error(t('failed-to-delete-pipelines', { count: failures.length }));
+        throw new Error(
+          t('failed-to-delete-pipelines', { count: failures.length }),
+        );
       }
 
       // Single refetch after all operations complete

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealsQuery.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealsQuery.tsx
@@ -1,3 +1,4 @@
+import { QueryHookOptions, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   ICursorListResponse,
@@ -7,31 +8,35 @@ import {
   useQueryState,
   validateFetchMore,
 } from 'erxes-ui';
-import { QueryHookOptions, useQuery } from '@apollo/client';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-
-import { DEAL_LIST_CHANGED } from '@/deals/graphql/subscriptions/dealListChange';
-import { GET_DEALS } from '@/deals/graphql/queries/DealsQueries';
-import { IDeal } from '@/deals/types/deals';
 import { currentUserState } from 'ui-modules';
+
+import { GET_DEALS } from '@/deals/graphql/queries/DealsQueries';
+import { DEAL_LIST_CHANGED } from '@/deals/graphql/subscriptions/dealListChange';
 import { dealTotalCountAtom } from '@/deals/states/dealsTotalCountState';
 import { dealsViewAtom } from '@/deals/states/dealsViewState';
+import { IDeal } from '@/deals/types/deals';
 
 interface IDealChanged {
   salesDealListChanged: {
     action: string;
-    deal: IDeal;
+    deal?: IDeal | null;
   };
 }
+
+const withResolvedFieldsOnly = (deal: IDeal): Partial<IDeal> =>
+  Object.fromEntries(
+    Object.entries(deal).filter(([, value]) => value !== null),
+  ) as Partial<IDeal>;
 
 export const useDeals = (
   options?: QueryHookOptions<ICursorListResponse<IDeal>>,
   pipelineId?: string,
 ) => {
   const { t } = useTranslation('sales');
-  const { data, loading, fetchMore, subscribeToMore } = useQuery<
+  const { data, loading, fetchMore, refetch, subscribeToMore } = useQuery<
     ICursorListResponse<IDeal>
   >(GET_DEALS, {
     ...options,
@@ -54,21 +59,27 @@ export const useDeals = (
 
   const { list: deals, pageInfo, totalCount } = data?.deals || {};
 
-  const subscriptionVars = useMemo(
-    () => ({
-      pipelineId: lastPipelineId,
-      userId: currentUser?._id,
-      filter: options?.variables,
-    }),
-    [lastPipelineId, currentUser?._id, options?.variables],
-  );
+  const filterVariables = options?.variables;
+
+  const subscriptionKey = JSON.stringify({
+    pipelineId: lastPipelineId,
+    userId: currentUser?._id,
+    filter: filterVariables ?? {},
+  });
+
+  const filterVariablesRef = useRef(filterVariables);
+  filterVariablesRef.current = filterVariables;
 
   useEffect(() => {
-    if (!currentUser?._id) return;
+    if (!currentUser?._id || !lastPipelineId) return;
 
     const unsubscribe = subscribeToMore<IDealChanged>({
       document: DEAL_LIST_CHANGED,
-      variables: subscriptionVars,
+      variables: {
+        pipelineId: lastPipelineId,
+        userId: currentUser._id,
+        filter: filterVariablesRef.current,
+      },
 
       updateQuery: (prev, { subscriptionData }) => {
         if (!prev || !subscriptionData.data) return prev;
@@ -76,26 +87,27 @@ export const useDeals = (
 
         const { action, deal } = subscriptionData.data.salesDealListChanged;
         const currentList = prev.deals.list;
+        const changedDeal = deal ? withResolvedFieldsOnly(deal) : {};
 
         let updatedList = currentList;
-        let added = false;
         let removed = false;
 
         if (action === 'add') {
+          if (!deal) return prev;
+
           const exists = currentList.some(
             (item: IDeal) => item._id === deal._id,
           );
           if (!exists) {
-            const merged = [...currentList, deal];
-            merged.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-            updatedList = merged;
-            added = true;
+            void refetch();
           }
         }
 
         if (action === 'edit') {
+          if (!deal) return prev;
+
           updatedList = currentList.map((item: IDeal) =>
-            item._id === deal._id ? { ...item, ...deal } : item,
+            item._id === deal._id ? { ...item, ...changedDeal } : item,
           );
           updatedList.sort(
             (a: IDeal, b: IDeal) => (a.order ?? 0) - (b.order ?? 0),
@@ -109,9 +121,7 @@ export const useDeals = (
           );
         }
         let nextTotalCount = prev.deals.totalCount;
-        if (added) {
-          nextTotalCount = prev.deals.totalCount + 1;
-        } else if (removed) {
+        if (removed) {
           nextTotalCount = prev.deals.totalCount - 1;
         }
 
@@ -128,7 +138,13 @@ export const useDeals = (
     });
 
     return unsubscribe;
-  }, [currentUser?._id, subscribeToMore, subscriptionVars]);
+  }, [
+    currentUser?._id,
+    lastPipelineId,
+    refetch,
+    subscribeToMore,
+    subscriptionKey,
+  ]);
 
   const handleFetchMore = ({
     direction,

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealsQuery.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealsQuery.tsx
@@ -1,4 +1,3 @@
-import { QueryHookOptions, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   ICursorListResponse,
@@ -8,35 +7,31 @@ import {
   useQueryState,
   validateFetchMore,
 } from 'erxes-ui';
+import { QueryHookOptions, useQuery } from '@apollo/client';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { currentUserState } from 'ui-modules';
 
-import { GET_DEALS } from '@/deals/graphql/queries/DealsQueries';
 import { DEAL_LIST_CHANGED } from '@/deals/graphql/subscriptions/dealListChange';
+import { GET_DEALS } from '@/deals/graphql/queries/DealsQueries';
+import { IDeal } from '@/deals/types/deals';
+import { currentUserState } from 'ui-modules';
 import { dealTotalCountAtom } from '@/deals/states/dealsTotalCountState';
 import { dealsViewAtom } from '@/deals/states/dealsViewState';
-import { IDeal } from '@/deals/types/deals';
 
 interface IDealChanged {
   salesDealListChanged: {
     action: string;
-    deal?: IDeal | null;
+    deal: IDeal;
   };
 }
-
-const withResolvedFieldsOnly = (deal: IDeal): Partial<IDeal> =>
-  Object.fromEntries(
-    Object.entries(deal).filter(([, value]) => value !== null),
-  ) as Partial<IDeal>;
 
 export const useDeals = (
   options?: QueryHookOptions<ICursorListResponse<IDeal>>,
   pipelineId?: string,
 ) => {
   const { t } = useTranslation('sales');
-  const { data, loading, fetchMore, refetch, subscribeToMore } = useQuery<
+  const { data, loading, fetchMore, subscribeToMore } = useQuery<
     ICursorListResponse<IDeal>
   >(GET_DEALS, {
     ...options,
@@ -59,27 +54,21 @@ export const useDeals = (
 
   const { list: deals, pageInfo, totalCount } = data?.deals || {};
 
-  const filterVariables = options?.variables;
-
-  const subscriptionKey = JSON.stringify({
-    pipelineId: lastPipelineId,
-    userId: currentUser?._id,
-    filter: filterVariables ?? {},
-  });
-
-  const filterVariablesRef = useRef(filterVariables);
-  filterVariablesRef.current = filterVariables;
+  const subscriptionVars = useMemo(
+    () => ({
+      pipelineId: lastPipelineId,
+      userId: currentUser?._id,
+      filter: options?.variables,
+    }),
+    [lastPipelineId, currentUser?._id, options?.variables],
+  );
 
   useEffect(() => {
-    if (!currentUser?._id || !lastPipelineId) return;
+    if (!currentUser?._id) return;
 
     const unsubscribe = subscribeToMore<IDealChanged>({
       document: DEAL_LIST_CHANGED,
-      variables: {
-        pipelineId: lastPipelineId,
-        userId: currentUser._id,
-        filter: filterVariablesRef.current,
-      },
+      variables: subscriptionVars,
 
       updateQuery: (prev, { subscriptionData }) => {
         if (!prev || !subscriptionData.data) return prev;
@@ -87,27 +76,26 @@ export const useDeals = (
 
         const { action, deal } = subscriptionData.data.salesDealListChanged;
         const currentList = prev.deals.list;
-        const changedDeal = deal ? withResolvedFieldsOnly(deal) : {};
 
         let updatedList = currentList;
+        let added = false;
         let removed = false;
 
         if (action === 'add') {
-          if (!deal) return prev;
-
           const exists = currentList.some(
             (item: IDeal) => item._id === deal._id,
           );
           if (!exists) {
-            void refetch();
+            const merged = [...currentList, deal];
+            merged.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+            updatedList = merged;
+            added = true;
           }
         }
 
         if (action === 'edit') {
-          if (!deal) return prev;
-
           updatedList = currentList.map((item: IDeal) =>
-            item._id === deal._id ? { ...item, ...changedDeal } : item,
+            item._id === deal._id ? { ...item, ...deal } : item,
           );
           updatedList.sort(
             (a: IDeal, b: IDeal) => (a.order ?? 0) - (b.order ?? 0),
@@ -121,7 +109,9 @@ export const useDeals = (
           );
         }
         let nextTotalCount = prev.deals.totalCount;
-        if (removed) {
+        if (added) {
+          nextTotalCount = prev.deals.totalCount + 1;
+        } else if (removed) {
           nextTotalCount = prev.deals.totalCount - 1;
         }
 
@@ -138,13 +128,7 @@ export const useDeals = (
     });
 
     return unsubscribe;
-  }, [
-    currentUser?._id,
-    lastPipelineId,
-    refetch,
-    subscribeToMore,
-    subscriptionKey,
-  ]);
+  }, [currentUser?._id, subscribeToMore, subscriptionVars]);
 
   const handleFetchMore = ({
     direction,

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/BoardsQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/BoardsQueries.ts
@@ -79,4 +79,3 @@ export const GET_BOARD_LOGS = gql`
     salesBoardLogs(action: $action, content: $content, contentId: $contentId)
   }
 `;
-

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/subscriptions/pipelineListChange.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/subscriptions/pipelineListChange.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export const PIPELINE_LIST_CHANGED = gql`
+  subscription salesPipelineListChanged {
+    salesPipelineListChanged {
+      _id
+      action
+      data
+    }
+  }
+`;

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineList.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineList.tsx
@@ -1,10 +1,9 @@
 import { Accordion, Sidebar } from 'erxes-ui';
-
-import { IPipeline } from '@/deals/types/pipelines';
 import { Link } from 'react-router-dom';
-import { PipelineListLoading } from '@/deals/components/loading/PipelineListLoading';
-import { useBoardDetail } from '@/deals/boards/hooks/useBoards';
 import { useTranslation } from 'react-i18next';
+
+import { useBoardDetail } from '@/deals/boards/hooks/useBoards';
+import { PipelineListLoading } from '@/deals/components/loading/PipelineListLoading';
 
 export const PipelineList = ({
   boardId,
@@ -13,6 +12,7 @@ export const PipelineList = ({
   boardId: string;
   pipelineId: string;
 }) => {
+  const { t } = useTranslation('sales');
   const { boardDetail, loading } = useBoardDetail({
     variables: {
       _id: boardId,
@@ -23,8 +23,7 @@ export const PipelineList = ({
     return <PipelineListLoading />;
   }
 
-  const pipelines = boardDetail?.pipelines || ([] as IPipeline[]);
-  const { t } = useTranslation('sales');
+  const pipelines = boardDetail?.pipelines || [];
 
   return (
     <>

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
@@ -1,4 +1,16 @@
 import {
+  IconArchive,
+  IconArrowBack,
+  IconCalendarTime,
+  IconCopy,
+  IconEdit,
+  IconSandbox,
+  IconSettings,
+  IconTrash,
+  IconUser,
+} from '@tabler/icons-react';
+import { Cell, ColumnDef } from '@tanstack/react-table';
+import {
   Badge,
   Combobox,
   Command,
@@ -13,18 +25,12 @@ import {
   useMultiQueryState,
   useQueryState,
 } from 'erxes-ui';
-import { Cell, ColumnDef } from '@tanstack/react-table';
-import {
-  IconArchive,
-  IconArrowBack,
-  IconCalendarTime,
-  IconCopy,
-  IconEdit,
-  IconSandbox,
-  IconSettings,
-  IconTrash,
-  IconUser,
-} from '@tabler/icons-react';
+import { TFunction } from 'i18next';
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
 import {
   usePipelineArchive,
   usePipelineCopy,
@@ -32,12 +38,8 @@ import {
   usePipelineRemove,
   usePipelines,
 } from '@/deals/boards/hooks/usePipelines';
+import { PipelineCommandBar } from '@/deals/pipelines/components/PipelineCommandBar';
 import { IPipeline } from '@/deals/types/pipelines';
-import { PipelineCommandBar } from './PipelineCommandBar';
-import React from 'react';
-import { useNavigate } from 'react-router';
-import { useTranslation } from 'react-i18next';
-import { TFunction } from 'i18next';
 
 export const PipelineMoreColumnCell = ({
   cell,
@@ -56,7 +58,7 @@ export const PipelineMoreColumnCell = ({
   const { archivePipeline } = usePipelineArchive();
   const { _id, status } = cell.row.original;
   const { t } = useTranslation('sales');
-  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const runAction = (action: () => void) => {
     setMenuOpen(false);
@@ -186,6 +188,58 @@ export const PipelineMoreColumnCell = ({
   );
 };
 
+const PipelineNameColumnCell = ({
+  cell,
+}: {
+  cell: Cell<IPipeline & { hasChildren: boolean; type?: string }, unknown>;
+}) => {
+  const { pipelineEdit, loading } = usePipelineEdit();
+  const { _id, name, type } = cell.row.original;
+  const [open, setOpen] = useState(false);
+  const [editedName, setEditedName] = useState(name);
+
+  const onSave = () => {
+    if (name !== editedName) {
+      pipelineEdit({
+        variables: {
+          id: _id,
+          type,
+          name: editedName,
+        },
+      });
+    }
+  };
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setEditedName(event.currentTarget.value);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (!isOpen) {
+          onSave();
+        }
+      }}
+    >
+      <RecordTableInlineCell.Trigger>
+        <RecordTableTree.Trigger
+          order=""
+          name={cell.getValue() as string}
+          hasChildren={cell.row.original.hasChildren}
+        >
+          {cell.getValue() as string}
+        </RecordTableTree.Trigger>
+      </RecordTableInlineCell.Trigger>
+      <RecordTableInlineCell.Content>
+        <Input value={editedName} onChange={onChange} disabled={loading} />
+      </RecordTableInlineCell.Content>
+    </Popover>
+  );
+};
+
 export const pipelinesColumns: (
   t: TFunction,
 ) => ColumnDef<IPipeline & { hasChildren: boolean; type?: string }>[] = (t) => [
@@ -201,57 +255,7 @@ export const pipelinesColumns: (
     id: 'name',
     header: () => t('name'),
     accessorKey: 'name',
-    cell: ({ cell }) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const { pipelineEdit, loading } = usePipelineEdit();
-      const { _id, name, type } = cell.row.original;
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const [open, setOpen] = React.useState<boolean>(false);
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const [_name, setName] = React.useState<string>(name);
-
-      const onSave = () => {
-        if (name !== _name) {
-          pipelineEdit({
-            variables: {
-              id: _id,
-              type: type,
-              name: _name,
-            },
-          });
-        }
-      };
-
-      const onChange = (el: React.ChangeEvent<HTMLInputElement>) => {
-        setName(el.currentTarget.value);
-      };
-
-      return (
-        <Popover
-          open={open}
-          onOpenChange={(open) => {
-            setOpen(open);
-            if (!open) {
-              onSave();
-            }
-          }}
-        >
-          <RecordTableInlineCell.Trigger>
-            <RecordTableTree.Trigger
-              // order={cell.row.original.order || ''}
-              order=""
-              name={cell.getValue() as string}
-              hasChildren={cell.row.original.hasChildren}
-            >
-              {cell.getValue() as string}
-            </RecordTableTree.Trigger>
-          </RecordTableInlineCell.Trigger>
-          <RecordTableInlineCell.Content>
-            <Input value={_name} onChange={onChange} disabled={loading} />
-          </RecordTableInlineCell.Content>
-        </Popover>
-      );
-    },
+    cell: PipelineNameColumnCell,
     size: 300,
   },
   {
@@ -322,6 +326,7 @@ const PipelineRecordTable = () => {
         type: contentType || '',
         searchValue: searchValue ?? undefined,
         boardId: queries.activeBoardId || '',
+        isAll: true,
       },
     });
 


### PR DESCRIPTION
## Changes

### 1. ui-modules — Deactivated members

- Added `isActive` to the `AssignedMember` query.
- Deactivated users are removed from `MembersInline`, including users already present in local or supplied state.
- Existing selections and details for active users remain unchanged.

### 2. Sales — Archived pipeline lists

- Standard pipeline queries exclude archived pipelines.
- The settings management table shows archived pipelines when using `isAll: true`.
- Active pipelines appear first, followed by archived pipelines, using stable cursor ordering.
- An archived pipeline disappears from active navigation immediately without a page refresh.

### 3. Sales — Pipeline archive realtime updates

- Archiving or restoring a pipeline immediately updates the Apollo cache in the current window.
- The backend publishes a `salesPipelineListChanged` event.
- Other browser and incognito sessions receive the event, update their cache, and refetch the pipeline query.

### 4. Code quality

- Normalized external and internal import groups across the touched Sales and ui-modules files.
- Replaced `any` in the pipeline query filter with a Mongoose `FilterQuery` type.
- Replaced hooks inside a table render callback with a proper React cell component.
- Removed obsolete hook-rule suppression comments.

## Verification

- [x] Deactivated members are hidden, including members already loaded in state
- [x] Archived pipelines are shown in the settings table
- [x] Archived pipelines disappear from active navigation immediately
- [x] Archive and restore updates appear in other browser/incognito sessions in realtime
- [x] Focused ESLint passes for all files changed in the review fix
- [x] `sales_ui`, `sales_api`, and `core-ui` builds pass