### PR TITLE
refactor(frontline): sync ticket detail sheet with url

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
@@ -3,7 +3,7 @@ import { SelectDateTicket } from '@/ticket/components/ticket-selects/SelectDateT
 import { SelectPriorityTicket } from '@/ticket/components/ticket-selects/SelectPriorityTicket';
 import { SelectStatusTicket } from '@/ticket/components/ticket-selects/SelectStatusTicket';
 import { allTicketsMapState } from '@/ticket/states/allTicketsMapState';
-import { ticketDetailSheetState } from '@/ticket/states/ticketDetailSheetState';
+import { useTicketDetailSheet } from '@/ticket/hooks/useTicketDetailSheet';
 import { ticketCountByBoardAtom } from '@/ticket/states/ticketsTotalCountState';
 import { IconCalendarEventFilled } from '@tabler/icons-react';
 import { format } from 'date-fns';
@@ -23,7 +23,7 @@ export const ticketBoardItemAtom = atom(
 export const TicketCard = ({ id, column }: BoardCardProps) => {
   const { t } = useTranslation('frontline');
   const ticket = useAtomValue(ticketBoardItemAtom)(id);
-  const setActiveTicket = useSetAtom(ticketDetailSheetState);
+  const [, setActiveTicket] = useTicketDetailSheet();
   const setTicketCountByBoard = useSetAtom(ticketCountByBoardAtom);
 
   if (!ticket) {

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsColumn.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsColumn.tsx
@@ -5,7 +5,7 @@ import { SelectPipeline } from '@/ticket/components/ticket-selects/SelectPipelin
 import { SelectPriorityTicket } from '@/ticket/components/ticket-selects/SelectPriorityTicket';
 import { SelectStatusTicket } from '@/ticket/components/ticket-selects/SelectStatusTicket';
 import { useUpdateTicket } from '@/ticket/hooks/useUpdateTicket';
-import { ticketDetailSheetState } from '@/ticket/states/ticketDetailSheetState';
+import { useTicketDetailSheet } from '@/ticket/hooks/useTicketDetailSheet';
 import { ITicket, TicketHotKeyScope } from '@/ticket/types';
 import {
   IconAlertSquareRounded,
@@ -23,7 +23,6 @@ import {
   RecordTableInlineCell,
   Tooltip,
 } from 'erxes-ui';
-import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ticketsMoreColumn } from './TicketsMoreColumn';
@@ -45,7 +44,7 @@ export const useTicketsColumns = (): ColumnDef<ITicket>[] => {
         const name = cell.getValue() as string;
         const [value, setValue] = useState(name);
         const { updateTicket } = useUpdateTicket();
-        const setActiveTicket = useSetAtom(ticketDetailSheetState);
+        const [, setActiveTicket] = useTicketDetailSheet();
 
         const handleUpdate = () => {
           if (value !== name) {

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsColumn.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsColumn.tsx
@@ -14,7 +14,7 @@ import {
   IconProgressCheck,
   IconUser,
 } from '@tabler/icons-react';
-import { ColumnDef } from '@tanstack/table-core';
+import { CellContext, ColumnDef } from '@tanstack/table-core';
 import clsx from 'clsx';
 import {
   Input,
@@ -26,6 +26,58 @@ import {
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ticketsMoreColumn } from './TicketsMoreColumn';
+
+const TicketNameCell = ({ cell }: CellContext<ITicket, unknown>) => {
+  const name = cell.getValue() as string;
+  const [value, setValue] = useState(name);
+  const { updateTicket } = useUpdateTicket();
+  const [, setActiveTicket] = useTicketDetailSheet();
+
+  const handleUpdate = () => {
+    if (value !== name) {
+      updateTicket({
+        variables: { _id: cell.row.original._id, name: value },
+      });
+    }
+  };
+
+  return (
+    <PopoverScoped
+      closeOnEnter
+      onOpenChange={(open) => {
+        if (!open) {
+          handleUpdate();
+        }
+      }}
+      scope={clsx(
+        TicketHotKeyScope.TicketTableCell,
+        cell.row.original._id,
+        'Name',
+      )}
+    >
+      <RecordTableInlineCell.Trigger>
+        <RecordTableInlineCell.Anchor
+          onClick={() => setActiveTicket(cell.row.original._id)}
+        >
+          {name}
+        </RecordTableInlineCell.Anchor>
+      </RecordTableInlineCell.Trigger>
+      <RecordTableInlineCell.Content className="min-w-72">
+        <Input
+          value={value || ''}
+          onChange={(e) => setValue(e.target.value)}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleUpdate();
+            }
+          }}
+        />
+      </RecordTableInlineCell.Content>
+    </PopoverScoped>
+  );
+};
 
 export const useTicketsColumns = (): ColumnDef<ITicket>[] => {
   const { t } = useTranslation('frontline');
@@ -40,57 +92,7 @@ export const useTicketsColumns = (): ColumnDef<ITicket>[] => {
       header: () => (
         <RecordTable.InlineHead label={t('name')} icon={IconLabelFilled} />
       ),
-      cell: ({ cell }) => {
-        const name = cell.getValue() as string;
-        const [value, setValue] = useState(name);
-        const { updateTicket } = useUpdateTicket();
-        const [, setActiveTicket] = useTicketDetailSheet();
-
-        const handleUpdate = () => {
-          if (value !== name) {
-            updateTicket({
-              variables: { _id: cell.row.original._id, name: value },
-            });
-          }
-        };
-
-        return (
-          <PopoverScoped
-            closeOnEnter
-            onOpenChange={(open) => {
-              if (!open) {
-                handleUpdate();
-              }
-            }}
-            scope={clsx(
-              TicketHotKeyScope.TicketTableCell,
-              cell.row.original._id,
-              'Name',
-            )}
-          >
-            <RecordTableInlineCell.Trigger>
-              <RecordTableInlineCell.Anchor
-                onClick={() => setActiveTicket(cell.row.original._id)}
-              >
-                {name}
-              </RecordTableInlineCell.Anchor>
-            </RecordTableInlineCell.Trigger>
-            <RecordTableInlineCell.Content className="min-w-72">
-              <Input
-                value={value || ''}
-                onChange={(e) => setValue(e.target.value)}
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    handleUpdate();
-                  }
-                }}
-              />
-            </RecordTableInlineCell.Content>
-          </PopoverScoped>
-        );
-      },
+      cell: TicketNameCell,
       size: 240,
     },
 

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsMoreColumn.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsMoreColumn.tsx
@@ -1,9 +1,8 @@
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
 import { Combobox, Command, Popover, RecordTable, useConfirm, useToast } from 'erxes-ui';
-import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { ticketDetailSheetState } from '../states/ticketDetailSheetState';
+import { useTicketDetailSheet } from '../hooks/useTicketDetailSheet';
 import { ITicket } from '../types';
 
 import { useTicketRemove } from '../hooks/useRemoveTicket';
@@ -14,7 +13,7 @@ export const TicketsMoreColumnCell = ({
   cell: Cell<ITicket, unknown>;
 }) => {
   const { t } = useTranslation('frontline');
-  const [, setActiveTicket] = useAtom(ticketDetailSheetState);
+  const [, setActiveTicket] = useTicketDetailSheet();
   const { _id } = cell.row.original;
   const { confirm } = useConfirm();
   const { toast } = useToast();

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketDetailSheet.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketDetailSheet.tsx
@@ -1,6 +1,6 @@
 import { TicketDetails } from '@/ticket/components/ticket-detail/TicketDetails';
 import { useGetTicket } from '@/ticket/hooks/useGetTicket';
-import { ticketDetailSheetState } from '@/ticket/states/ticketDetailSheetState';
+import { useTicketDetailSheet } from '@/ticket/hooks/useTicketDetailSheet';
 import {
   FocusSheet,
   ScrollArea,
@@ -9,7 +9,6 @@ import {
   Empty,
   Sheet,
 } from 'erxes-ui';
-import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { FieldsInDetail, RelationWidgetSideTabs } from 'ui-modules';
 import { TicketSidebar } from './TicketSidebar';
@@ -22,7 +21,7 @@ export const TicketDetailSheet = ({
   hideRelationWidgetSideTabs?: boolean;
 }) => {
   const { t } = useTranslation('frontline');
-  const [activeTicket, setActiveTicket] = useAtom(ticketDetailSheetState);
+  const [activeTicket, setActiveTicket] = useTicketDetailSheet();
   const { ticket, loading, error } = useGetTicket({
     variables: { _id: activeTicket },
     skip: !activeTicket,

--- a/frontend/plugins/frontline_ui/src/modules/ticket/constants/index.ts
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/constants/index.ts
@@ -1,1 +1,2 @@
 export const TICKETS_CURSOR_SESSION_KEY = 'tickets_cursor_session_key';
+export const TICKETS_DETAIL_QUERY_KEY = 'ticketId';

--- a/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useRemoveTicket.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useRemoveTicket.tsx
@@ -1,8 +1,7 @@
 import { useMutation } from '@apollo/client';
-import { useAtom } from 'jotai';
 import { GET_TICKETS } from '../graphql/queries/getTickets';
 import { REMOVE_TICKET } from '../graphql/mutations/removeTicket';
-import { ticketDetailSheetState } from '../states/ticketDetailSheetState';
+import { useTicketDetailSheet } from './useTicketDetailSheet';
 import {
   markTicketsRemoved,
   unmarkTicketsRemoved,
@@ -12,7 +11,7 @@ import { useRemoveTicketsFromView } from './useRemoveTicketsFromView';
 export const useTicketRemove = () => {
   const [_removeTicket, { loading }] = useMutation(REMOVE_TICKET);
   const { removeTicketsFromView } = useRemoveTicketsFromView();
-  const [activeTicket, setActiveTicket] = useAtom(ticketDetailSheetState);
+  const [activeTicket, setActiveTicket] = useTicketDetailSheet();
   const removeTicket = async (ticketIds: string[]) => {
     markTicketsRemoved(ticketIds);
 

--- a/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useTicketDetailSheet.ts
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/hooks/useTicketDetailSheet.ts
@@ -1,0 +1,5 @@
+import { TICKETS_DETAIL_QUERY_KEY } from '@/ticket/constants';
+import { useQueryState } from 'erxes-ui';
+
+export const useTicketDetailSheet = () =>
+  useQueryState<string>(TICKETS_DETAIL_QUERY_KEY);

--- a/frontend/plugins/frontline_ui/src/modules/ticket/states/ticketDetailSheetState.ts
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/states/ticketDetailSheetState.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const ticketDetailSheetState = atom<string | null>(null);

--- a/frontend/plugins/frontline_ui/src/widgets/relations/modules/ticket/TicketWidgetCard.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/relations/modules/ticket/TicketWidgetCard.tsx
@@ -2,12 +2,11 @@ import { SelectDateTicket } from '@/ticket/components/ticket-selects/SelectDateT
 import { SelectAssigneeTicket } from '@/ticket/components/ticket-selects/SelectAssigneeTicket';
 import { SelectStatusTicket } from '@/ticket/components/ticket-selects/SelectStatusTicket';
 import { SelectPriorityTicket } from '@/ticket/components/ticket-selects/SelectPriorityTicket';
-import { ticketDetailSheetState } from '@/ticket/states/ticketDetailSheetState';
+import { useTicketDetailSheet } from '@/ticket/hooks/useTicketDetailSheet';
 import { ITicket } from '@/ticket/types';
 import { IconCalendarEventFilled } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import { Button, Card, Separator } from 'erxes-ui';
-import { useAtom } from 'jotai';
 import { lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,7 +32,7 @@ export const TicketWidgetCard = ({ ticket }: { ticket: ITicket }) => {
     pipelineId,
     createdAt,
   } = ticket || {};
-  const [activeTicket, setActiveTicket] = useAtom(ticketDetailSheetState);
+  const [activeTicket, setActiveTicket] = useTicketDetailSheet();
 
   return (
     <>


### PR DESCRIPTION
Move ticket detail sheet state from jotai atom to ?ticketId query param, same as task detail sheet. Fixes reload/copy-link and the existing dead ?ticketId links in automation result and report list.

## Summary by Sourcery

Synchronize ticket detail sheet state with the URL query parameter and remove the Jotai-based atom implementation.

Enhancements:
- Introduce a reusable useTicketDetailSheet hook backed by a ticketId query parameter.
- Update ticket components and hooks to consume the new URL-based ticket detail sheet state instead of Jotai atoms.

Chores:
- Remove the obsolete ticketDetailSheetState atom and its usages.
- Add a ticket detail query key constant to the ticket module constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ticket detail panels now open and close using URL query state for more consistent navigation and state handling.
  * Ticket details are accessed more uniformly across ticket cards, lists, widgets, and related actions.
  * The ticket name inline editor keeps active-ticket behavior consistent while updating tickets on confirm.
* **Bug Fixes**
  * Removing a ticket now reliably closes the detail panel when that ticket was active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->