### PR TITLE
feat(frontline): instagram integration

### DIFF
--- a/backend/plugins/frontline_api/src/apollo/resolvers/resolvers.ts
+++ b/backend/plugins/frontline_api/src/apollo/resolvers/resolvers.ts
@@ -1,5 +1,6 @@
 import inboxResolvers from '@/inbox/graphql/resolvers/customResolvers';
 import integrationFacebookResolvers from '@/integrations/facebook/graphql/resolvers/customResolvers';
+import integrationInstagramResolvers from '@/integrations/instagram/graphql/resolvers/customResolvers';
 import { Channel } from '@/channel/graphql/resolvers/customResolvers/channel';
 import { ChannelMember } from '@/channel/graphql/resolvers/customResolvers/member';
 import { Pipeline } from '@/ticket/graphql/resolvers/customResolvers/pipeline';
@@ -17,6 +18,7 @@ import KnowledgeBaseTopic from '@/knowledgebase/graphql/resolvers/customResolver
 export const customResolvers = {
   ...inboxResolvers,
   ...integrationFacebookResolvers,
+  ...integrationInstagramResolvers,
   Channel,
   ChannelMember,
   Pipeline,

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/customResolvers/integration.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/customResolvers/integration.ts
@@ -189,7 +189,7 @@ export default {
 
       if (!igIntegration) return null;
 
-      const instagramPageId = igIntegration.instagramPageIds?.[0];
+      const instagramPageId = igIntegration.instagramPageId;
       if (!instagramPageId) return null;
 
       const account = await models.InstagramAccounts.findOne({

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/@types/bots.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/@types/bots.ts
@@ -1,7 +1,7 @@
 import { Document } from 'mongoose';
 
 export interface IInstagramPersistentMenus {
-  _id: number;
+  _id: string;
   text: string;
   type: string;
   link?: string;

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/@types/integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/@types/integrations.ts
@@ -6,7 +6,7 @@ export interface IInstagramIntegration {
   emailScope?: string;
   erxesApiId: string;
   facebookPageId?: string;
-  instagramPageIds?: string[];
+  instagramPageId?: string;
   facebookPageTokensMap?: { [key: string]: string };
   email: string;
   expiration?: string;

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/db/definitions/bots.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/db/definitions/bots.ts
@@ -2,7 +2,7 @@ import { mongooseStringRandomId, schemaWrapper } from 'erxes-api-shared/utils';
 import { Schema } from 'mongoose';
 
 const persistentMenuSchema = new Schema({
-  _id: { type: Number },
+  _id: { type: String },
   text: { type: String },
   type: { type: String },
   link: { type: String, optional: true },

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/db/models/Bots.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/db/models/Bots.ts
@@ -1,7 +1,7 @@
 import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import {
-  getPageAccessToken,
+  getPageTokenByInstagramId,
   graphRequest,
 } from '@/integrations/instagram/utils';
 import { IInstagramBotDocument } from '@/integrations/instagram/@types/bots';
@@ -64,10 +64,18 @@ export const loadInstagramBotClass = (models: IModels) => {
         throw new Error('Something went wrong');
       }
 
+      // `me/messenger_profile` must be called with the Facebook Page token that
+      // owns this Instagram account — `account.token` is a user token and makes
+      // Graph API reject the request with "Object with ID 'me' does not exist".
+      const pageAccessToken = await getPageTokenByInstagramId(
+        doc.pageId,
+        account.token,
+      );
+
       const bot = await models.InstagramBots.create({
         ...doc,
         uid: account.uid,
-        token: account.token,
+        token: pageAccessToken,
       });
 
       try {
@@ -102,7 +110,8 @@ export const loadInstagramBotClass = (models: IModels) => {
           throw new Error('Not found account');
         }
 
-        const pageAccessToken = await getPageAccessToken(
+
+        const pageAccessToken = await getPageTokenByInstagramId(
           bot.pageId,
           relatedAccount.token,
         );
@@ -210,11 +219,11 @@ export const loadInstagramBotClass = (models: IModels) => {
       for (const { _id, type, text, link } of persistentMenus || []) {
         if (text) {
           if (type === 'link' && link) {
+
             generatedPersistentMenus.push({
               type: 'web_url',
               title: text,
               url: link,
-              webview_height_ratio: 'full',
             });
           } else {
             generatedPersistentMenus.push({
@@ -240,12 +249,11 @@ export const loadInstagramBotClass = (models: IModels) => {
         });
       }
 
+
       const doc: any = {
-        get_started: { payload: JSON.stringify({ botId: botId }) },
         persistent_menu: [
           {
             locale: 'default',
-            composer_input_disabled: false,
             call_to_actions: [
               {
                 type: 'postback',
@@ -257,16 +265,13 @@ export const loadInstagramBotClass = (models: IModels) => {
           },
         ],
       };
-      if (greetText) {
-        doc.greeting = [
-          {
-            locale: 'default',
-            text: greetText,
-          },
-        ];
-      }
 
-      await graphRequest.post('me/messenger_profile', pageAccessToken, doc);
+
+      await graphRequest.post(
+        'me/messenger_profile?platform=instagram',
+        pageAccessToken,
+        doc,
+      );
 
       return { status: 'success' };
     }
@@ -276,9 +281,14 @@ export const loadInstagramBotClass = (models: IModels) => {
 
       if (bot?.token) {
         try {
-          await graphRequest.delete('me/messenger_profile', bot.token, {
-            fields: ['get_started', 'persistent_menu', 'greeting'],
-          });
+
+          await graphRequest.delete(
+            'me/messenger_profile?platform=instagram',
+            bot.token,
+            {
+              fields: ['persistent_menu'],
+            },
+          );
         } catch (e) {
           // log but don't throw — DB cleanup should still proceed
           debugError(`Failed to remove Instagram messenger profile: ${e.message}`);

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
@@ -403,9 +403,10 @@ export const instagramQueries = {
 
     const allPosts = await Promise.all(
       fetchedIntegrations.map(async (integration) => {
-        const { instagramPageIds, facebookPageTokensMap } = integration;
+        const { instagramPageId, facebookPageId, facebookPageTokensMap } =
+          integration;
 
-        if (!instagramPageIds || instagramPageIds.length === 0) {
+        if (!instagramPageId) {
           return [];
         }
 
@@ -427,18 +428,21 @@ export const instagramQueries = {
           return fetchPagesPostsList(pageId, accessToken, limit);
         };
 
-        const posts = await Promise.all(
-          instagramPageIds.map(async (pageId) => {
-            const accessToken = facebookPageTokensMap[pageId];
-            if (!accessToken) {
-              debugInstagram(`Access token missing for page ID: ${pageId}`);
-              return [];
-            }
-            return fetchPagePostsWithRateLimiting(pageId, accessToken, limit);
-          }),
+        const accessToken = facebookPageId
+          ? facebookPageTokensMap[facebookPageId]
+          : undefined;
+        if (!accessToken) {
+          debugInstagram(`Access token missing for page ID: ${instagramPageId}`);
+          return [];
+        }
+
+        const posts = await fetchPagePostsWithRateLimiting(
+          instagramPageId,
+          accessToken,
+          limit,
         );
 
-        return posts.flat();
+        return posts;
       }),
     );
 

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/helpers.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/helpers.ts
@@ -69,7 +69,7 @@ export const removeIntegration = async (
       );
     }
 
-    integrationRemoveBy = { igPageId: integration.instagramPageIds?.[0] };
+    integrationRemoveBy = { igPageId: integration.instagramPageId };
 
     const conversationIds =
       await models.InstagramConversations.find(selector).distinct('_id');
@@ -197,8 +197,8 @@ export const repairIntegrations = async (
       method: 'POST',
       body: JSON.stringify({
         domain,
-        instagramPageId: integration.instagramPageIds?.[0],
-        igPageId: integration.instagramPageIds?.[0],
+        instagramPageId: integration.instagramPageId,
+        igPageId: integration.instagramPageId,
       }),
       headers: { 'Content-Type': 'application/json' },
     });

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/messages/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/meta/automation/messages/utils.ts
@@ -248,10 +248,10 @@ export const sendMessage = async (
   );
 
   try {
-    // Send the actual message
+
     return await sendReply(
       models,
-      `${recipientId}/messages`,
+      'me/messages',
       {
         recipient: { id: senderId },
         message,
@@ -298,7 +298,7 @@ async function trySendTypingOn(
   try {
     await sendReply(
       models,
-      `${recipientId}/messages`,
+      'me/messages',
       {
         recipient: { id: senderId },
         sender_action: 'typing_on',

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/middleware/loginMiddleware.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/middleware/loginMiddleware.ts
@@ -19,7 +19,7 @@ export const loginMiddleware = async (req, res) => {
   const INSTAGRAM_PERMISSIONS = await getConfig(
     models,
     'INSTAGRAM_PERMISSIONS',
-    'pages_messaging,pages_manage_engagement,pages_manage_metadata,pages_read_user_content',
+    'pages_show_list,pages_messaging,pages_manage_metadata,pages_read_engagement,pages_manage_engagement,pages_read_user_content,business_management',
   );
 
   const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/utils.ts
@@ -143,7 +143,14 @@ export const subscribePage = async (
   pageToken,
 ): Promise<{ success: true } | any> => {
   return graphRequest.post(`${pageId}/subscribed_apps`, pageToken, {
-    subscribed_fields: ['messages'],
+    // `messaging_postbacks` is required to receive persistent-menu / Get Started
+    // / button taps — without it those postback events are never delivered and
+    // the bot never triggers. `messaging_referrals` covers ad/referral entries.
+    subscribed_fields: [
+      'messages',
+      'messaging_postbacks',
+      'messaging_referrals',
+    ],
   });
 };
 
@@ -157,6 +164,27 @@ export const getPageAccessToken = async (
   );
   return response.access_token;
 };
+export const getPageTokenByInstagramId = async (
+  instagramAccountId: string,
+  userAccessToken: string,
+): Promise<string> => {
+  const response: any = await graphRequest.get(
+    '/me/accounts?fields=instagram_business_account,access_token',
+    userAccessToken,
+  );
+
+  const page = (response?.data || []).find(
+    (item: any) => item?.instagram_business_account?.id === instagramAccountId,
+  );
+
+  if (!page?.access_token) {
+    throw new Error(
+      `Could not find a Facebook Page access token for Instagram account ${instagramAccountId}`,
+    );
+  }
+
+  return page.access_token;
+};
 
 export const getPageAccessTokenInstagram = async (
   pageId: string,
@@ -168,7 +196,6 @@ export const getPageAccessTokenInstagram = async (
       userAccessToken,
     );
 
-    // Handle cases where the Page is linked to an Instagram Business Account
     if (response.instagram_business_account) {
       return {
         type: 'IGUser',

--- a/frontend/plugins/frontline_ui/src/modules/integrations/instagram/components/IgPostTrigger.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/instagram/components/IgPostTrigger.tsx
@@ -26,11 +26,15 @@ export const IgPostTrigger = ({ erxesApiId }: { erxesApiId: string }) => {
           <IconBrowserShare />
           {loading ? (
             <Skeleton className="h-4 w-16" />
-          ) : (
+          ) : sanitized ? (
             <span
               className="flex-auto max-w-32 truncate"
               dangerouslySetInnerHTML={{ __html: sanitized }}
             />
+          ) : (
+            <span className="flex-auto max-w-32 truncate">
+              {t('view-post')}
+            </span>
           )}
         </Button>
       </Popover.Trigger>

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/components/AutomationBotSheetForm.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/components/AutomationBotSheetForm.tsx
@@ -1,14 +1,17 @@
 import { IconPlus } from '@tabler/icons-react';
 import { Button, cn, Sheet, useQueryState } from 'erxes-ui';
-import { useAtomValue } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { useEffect } from 'react';
 import { AutomationBotForm } from '~/widgets/automations/modules/instagram/components/bots/components/AutomationBotForm';
-import { isOpenInstagramBotSecondarySheet } from '~/widgets/automations/modules/instagram/components/bots/states/instagramBotStates';
+import {
+  isOpenInstagramBotSecondarySheet,
+  isOpenInstagramBotSheet,
+} from '~/widgets/automations/modules/instagram/components/bots/states/instagramBotStates';
 
 export const AutomationBotSheetForm = () => {
   const [instagramBotId, setInstagramBotId] =
     useQueryState<string>('instagramBotId');
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setOpen] = useAtom(isOpenInstagramBotSheet);
   const isOpenSecondarySheet = useAtomValue(isOpenInstagramBotSecondarySheet);
 
   useEffect(() => {

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/components/automationInstagramBotsColumns.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/components/automationInstagramBotsColumns.tsx
@@ -13,9 +13,77 @@ import {
 } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import {
+  INSTAGRAM_BOTS_LIST,
+  INSTAGRAM_BOTS_TOTAL_COUNT,
+} from '@/integrations/instagram/graphql/queries/instagramBots';
+import {
   REMOVE_INSTAGRAM_BOT,
   REPAIR_INSTAGRAM_BOT,
 } from '~/widgets/automations/modules/instagram/components/bots/graphql/automationBotsMutations';
+
+const INSTAGRAM_BOTS_REFETCH_QUERIES = [
+  { query: INSTAGRAM_BOTS_LIST },
+  { query: INSTAGRAM_BOTS_TOTAL_COUNT },
+];
+
+const BotActionsCell = ({ _id }: { _id?: string }) => {
+  const { t } = useTranslation('frontline');
+  const [, setInstagramBotId] = useQueryState('instagramBotId');
+
+  const [repairBot, { loading: loadingRepair }] = useMutation(
+    REPAIR_INSTAGRAM_BOT,
+    {
+      variables: { _id },
+      onCompleted: () => toast({ title: t('repaired-successfully') }),
+      onError: (error) =>
+        toast({
+          title: t('something-went-wrong'),
+          description: error.message,
+          variant: 'destructive',
+        }),
+    },
+  );
+
+  const [removeBot, { loading: loadingRemove }] = useMutation(
+    REMOVE_INSTAGRAM_BOT,
+    {
+      variables: { _id },
+      refetchQueries: INSTAGRAM_BOTS_REFETCH_QUERIES,
+      awaitRefetchQueries: true,
+      onCompleted: () => toast({ title: t('removed-successfully') }),
+      onError: (error) =>
+        toast({
+          title: t('something-went-wrong'),
+          description: error.message,
+          variant: 'destructive',
+        }),
+    },
+  );
+
+  return (
+    <div className="flex items-center justify-center gap-1 [&>button]:px-2">
+      <Button variant="ghost" onClick={() => setInstagramBotId(_id ?? null)}>
+        <IconEdit />
+      </Button>
+
+      <Button
+        disabled={loadingRepair}
+        variant="ghost"
+        onClick={() => repairBot()}
+      >
+        {loadingRepair ? <Spinner /> : <IconRefresh />}
+      </Button>
+
+      <Button
+        disabled={loadingRemove}
+        variant="ghost"
+        onClick={() => removeBot()}
+      >
+        {loadingRemove ? <Spinner /> : <IconX />}
+      </Button>
+    </div>
+  );
+};
 
 export const automationInstagramBotsColumns: ColumnDef<IInstagramBot>[] = [
   {
@@ -62,61 +130,6 @@ export const automationInstagramBotsColumns: ColumnDef<IInstagramBot>[] = [
   {
     id: 'action-group',
     header: () => <RecordTable.InlineHead label="Actions" />,
-    cell: ({ cell }) => {
-      const { t } = useTranslation('frontline');
-      const { _id } = cell.row.original || {};
-      const [_, setInstagramBotId] = useQueryState('instagramBotId');
-      const [repairBot, { loading: loadingRepair }] = useMutation(
-        REPAIR_INSTAGRAM_BOT,
-        {
-          variables: { _id },
-          onCompleted: () => toast({ title: t('repaired-successfully') }),
-          onError: (error) =>
-            toast({
-              title: t('something-went-wrong'),
-              description: error.message,
-              variant: 'destructive',
-            }),
-        },
-      );
-
-      const [removeBot, { loading: loadingRemove }] = useMutation(
-        REMOVE_INSTAGRAM_BOT,
-        {
-          variables: { _id },
-          onCompleted: () => toast({ title: t('removed-successfully') }),
-          onError: (error) =>
-            toast({
-              title: t('something-went-wrong'),
-              description: error.message,
-              variant: 'destructive',
-            }),
-        },
-      );
-
-      return (
-        <div className="flex items-center justify-center gap-1 [&>button]:px-2">
-          <Button variant="ghost" onClick={() => setInstagramBotId(_id)}>
-            <IconEdit />
-          </Button>
-
-          <Button
-            disabled={loadingRepair}
-            variant="ghost"
-            onClick={() => repairBot()}
-          >
-            {loadingRepair ? <Spinner /> : <IconRefresh />}
-          </Button>
-
-          <Button
-            disabled={loadingRemove}
-            variant="ghost"
-            onClick={() => removeBot()}
-          >
-            {loadingRemove ? <Spinner /> : <IconX />}
-          </Button>
-        </div>
-      );
-    },
+    cell: ({ cell }) => <BotActionsCell _id={cell.row.original?._id} />,
   },
 ];

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/graphql/automationBotsMutations.ts
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/graphql/automationBotsMutations.ts
@@ -4,7 +4,7 @@ const INSTAGRAM_BOT_PARAMS = `
   $name: String,
   $accountId: String,
   $pageId: String,
-  $persistentMenus: [BotPersistentMenuInput],
+  $persistentMenus: [InstagramBotPersistentMenuInput],
   $greetText: String,
   $tag: String,
   $isEnabledBackBtn: Boolean,

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/hooks/useInstagramBotForm.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/hooks/useInstagramBotForm.tsx
@@ -1,4 +1,8 @@
-import { INSTAGRAM_BOT_DETAIL } from '@/integrations/instagram/graphql/queries/instagramBots';
+import {
+  INSTAGRAM_BOTS_LIST,
+  INSTAGRAM_BOTS_TOTAL_COUNT,
+  INSTAGRAM_BOT_DETAIL,
+} from '@/integrations/instagram/graphql/queries/instagramBots';
 import { resetInstagramAddStateAtom } from '@/integrations/instagram/states/instagramStates';
 import { useMutation, useQuery } from '@apollo/client';
 import { toast, useQueryState } from 'erxes-ui';
@@ -11,12 +15,19 @@ import {
   UPDATE_INSTAGRAM_BOT,
 } from '~/widgets/automations/modules/instagram/components/bots/graphql/automationBotsMutations';
 import { instagramBotFormSchema } from '~/widgets/automations/modules/instagram/components/bots/states/instagramBotForm';
+import {
+  isOpenInstagramBotSecondarySheet,
+  isOpenInstagramBotSheet,
+} from '~/widgets/automations/modules/instagram/components/bots/states/instagramBotStates';
 import { InstagramBotDetailQueryResponse } from '~/widgets/automations/modules/instagram/components/bots/types/instagramBotTypes';
 
 export const useInstagramBotSave = () => {
   const { t } = useTranslation('frontline');
-  const [instagramBotId] = useQueryState<string>('instagramBotId');
+  const [instagramBotId, setInstagramBotId] =
+    useQueryState<string>('instagramBotId');
   const resetForm = useSetAtom(resetInstagramAddStateAtom);
+  const setOpenSheet = useSetAtom(isOpenInstagramBotSheet);
+  const setOpenSecondarySheet = useSetAtom(isOpenInstagramBotSecondarySheet);
 
   const [save, { loading: onSaveloading }] = useMutation(
     instagramBotId ? UPDATE_INSTAGRAM_BOT : ADD_INSTAGRAM_BOT,
@@ -29,10 +40,20 @@ export const useInstagramBotSave = () => {
     };
     save({
       variables,
+      refetchQueries: [
+        { query: INSTAGRAM_BOTS_LIST },
+        { query: INSTAGRAM_BOTS_TOTAL_COUNT },
+      ],
+      awaitRefetchQueries: true,
       onCompleted: () => {
         toast({
           title: t('save-successful'),
         });
+
+        setOpenSecondarySheet(false);
+        setOpenSheet(false);
+        setInstagramBotId(null);
+        resetForm();
       },
       onError: (error) => {
         toast({
@@ -42,8 +63,6 @@ export const useInstagramBotSave = () => {
         });
       },
     });
-
-    resetForm();
   };
 
   return {

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/states/instagramBotStates.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/instagram/components/bots/states/instagramBotStates.tsx
@@ -1,3 +1,4 @@
 import { atom } from 'jotai';
 
+export const isOpenInstagramBotSheet = atom<boolean>(false);
 export const isOpenInstagramBotSecondarySheet = atom<boolean>(false);


### PR DESCRIPTION
## Summary by Sourcery

Migrate Instagram integrations from supporting multiple page IDs to a single page ID and align related backend and frontend logic.

Bug Fixes:
- Ensure Instagram access tokens and page IDs are correctly resolved when fetching posts for an integration.
- Fallback to a generic 'view-post' label when no sanitized post title is available in the Instagram post trigger UI.

Enhancements:
- Simplify Instagram integration types and queries to use a single instagramPageId instead of an array of IDs.
- Align integration repair and removal helpers and inbox custom resolvers with the new single-page Instagram integration model.
- Expand default Instagram login permissions to include additional required Facebook page and business management scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Instagram connection permissions to enable additional page and business capabilities.
  * Improved Instagram event subscriptions to better support persistent-menu and related postbacks.

* **Bug Fixes**
  * Instagram post trigger now shows a loading placeholder and, when content is missing, reliably falls back to the “View post” label.
  * More accurate Instagram page targeting for post retrieval and bot token handling, improving integration behavior.

* **UI Improvements**
  * Instagram automation bot sheets and bot action controls were refined for smoother open/close behavior and updated refresh after changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->