### PR TITLE
feat(core): add restore action for deleted products

### DIFF
--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -5,6 +5,7 @@ import { Row } from '@tanstack/table-core';
 import { Button, CommandBar, RecordTable, Separator, toast } from 'erxes-ui';
 import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
+import { ProductsRestore } from './restore/productRestore';
 import { ProductMerge } from './ProductMerge';
 
 const updateProductsTagCache = (
@@ -27,6 +28,10 @@ export const ProductCommandBar = () => {
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const productIds = selectedRows.map((row: Row<IProduct>) => row.original._id);
+
+  const deletedProductIds = selectedRows
+    .filter((row: Row<IProduct>) => row.original.status === 'deleted')
+    .map((row: Row<IProduct>) => row.original._id);
 
   const intersection = (arrays: string[][]): string[] => {
     if (arrays.length === 0) return [];
@@ -86,6 +91,12 @@ export const ProductCommandBar = () => {
         />
         <Separator.Inline />
         <ProductsDelete productIds={productIds} />
+        {deletedProductIds.length > 0 && (
+          <>
+            <Separator.Inline />
+            <ProductsRestore productIds={deletedProductIds} />
+          </>
+        )}
         <Separator.Inline />
         <Can action="productsCreate">
           <Button variant="secondary">

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
@@ -1,0 +1,62 @@
+import { ApolloError } from '@apollo/client';
+import { IconRestore } from '@tabler/icons-react';
+import { Button, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import { useCallback } from 'react';
+import { Can } from 'ui-modules';
+import { useRestoreProducts } from '@/products/product-detail/hooks/useRestoreProduct';
+
+export const ProductsRestore = ({ productIds }: { productIds: string[] }) => {
+  const { confirm } = useConfirm();
+  const { restoreProducts, loading } = useRestoreProducts();
+  const { table } = RecordTable.useRecordTable();
+  const { toast } = useToast();
+
+  const disabled = loading || !productIds?.length;
+
+  const handleClick = useCallback(async () => {
+    if (disabled) {
+      return;
+    }
+
+    try {
+      await confirm({
+        message: `Are you sure you want to restore the ${
+          productIds.length
+        } selected product${productIds.length === 1 ? '' : 's'}?`,
+      });
+
+      await restoreProducts(productIds, {
+        onCompleted: () => {
+          table.setRowSelection({});
+          toast({
+            title: 'Products restored successfully',
+            variant: 'success',
+          });
+        },
+        onError: (e: ApolloError) => {
+          toast({
+            title: 'Error',
+            description: e.message,
+            variant: 'destructive',
+          });
+        },
+      });
+    } catch {
+      // User cancelled the confirmation
+    }
+  }, [disabled, confirm, productIds, restoreProducts, toast, table]);
+
+  return (
+    <Can action="productsUpdate">
+      <Button
+        variant="secondary"
+        className="text-primary"
+        onClick={handleClick}
+        disabled={disabled}
+      >
+        <IconRestore />
+        Restore
+      </Button>
+    </Can>
+  );
+};

--- a/frontend/core-ui/src/modules/products/graphql/ProductsQueries.tsx
+++ b/frontend/core-ui/src/modules/products/graphql/ProductsQueries.tsx
@@ -53,6 +53,7 @@ const productsMain = gql`
         shortName
         uom
         unitPrice
+        status
         type
         vendor {
           _id

--- a/frontend/core-ui/src/modules/products/product-detail/hooks/useRestoreProduct.tsx
+++ b/frontend/core-ui/src/modules/products/product-detail/hooks/useRestoreProduct.tsx
@@ -1,0 +1,36 @@
+import { ApolloError, useApolloClient, useMutation } from '@apollo/client';
+import { productsMutations, productsQueries } from '@/products/graphql';
+
+export const useRestoreProducts = () => {
+  const client = useApolloClient();
+  const [_restoreProduct, { loading }] = useMutation(
+    productsMutations.productsEdit,
+  );
+
+  const restoreProducts = async (
+    productIds: string[],
+    callbacks?: {
+      onCompleted?: () => void;
+      onError?: (error: ApolloError) => void;
+    },
+  ) => {
+    try {
+
+      await Promise.all(
+        productIds.map((_id) => _restoreProduct({ variables: { _id } })),
+      );
+
+      client.cache.evict({ fieldName: 'productsMain' });
+      client.cache.gc();
+      await client.refetchQueries({
+        include: [productsQueries.productsMain],
+      });
+
+      callbacks?.onCompleted?.();
+    } catch (error) {
+      callbacks?.onError?.(error as ApolloError);
+    }
+  };
+
+  return { restoreProducts, loading };
+};

--- a/frontend/libs/ui-modules/src/modules/products/types/Product.ts
+++ b/frontend/libs/ui-modules/src/modules/products/types/Product.ts
@@ -26,6 +26,7 @@ export interface IProduct {
     | 'year';
   currency: CurrencyCode;
   remainder: any;
+  status?: 'active' | 'deleted';
 }
 export interface IBundleRuleItem {
   code: string;


### PR DESCRIPTION
## Summary by Sourcery

Add a bulk restore action for deleted products in the products command bar.

New Features:
- Expose product status in the products list and product type to support restore eligibility filtering.
- Introduce a ProductsRestore control in the product command bar to restore selected deleted products with confirmation and toast feedback.
- Add a useRestoreProducts hook that performs restore mutations, refreshes the products list cache, and integrates completion/error callbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to restore deleted products directly from the product command bar.
  - Added confirmation prompts and success or error notifications for restoration actions.
  - Restored products are refreshed automatically, and selected rows are cleared after success.
  - Product listings now identify whether products are active or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->