### PR TITLE
revert(mongolian): remove chunked product sync

### DIFF
--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/hooks/useSyncProduct.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/hooks/useSyncProduct.tsx
@@ -4,45 +4,6 @@ import { useToast } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { ProductItem, ProductStatus } from '../types/productItem';
 
-
-const CHUNK_SIZE = 1000;
-
-const getProductKey = (item: ProductItem): string | undefined =>
-  item._id || item.id;
-
-const toSyncPayload = (item: ProductItem) => ({
-  id: getProductKey(item),
-  code: item.code,
-  name: item.name,
-  barcodes: item.barcodes,
-  unit_price: item.unit_price,
-  category_code: item.category_code,
-  measure_unit_code: item.measure_unit_code,
-  vat_type_code: item.vat_type_code,
-  ratio_measure_unit: item.ratio_measure_unit,
-  sub_measure_unit_code: item.sub_measure_unit_code,
-  category: item.category,
-  group: item.group,
-  brand_code: item.brand_code,
-  sub_measure_unit: item.sub_measure_unit,
-  united_code: item.united_code,
-  measure_unit: item.measure_unit,
-  brand: item.brand,
-  vat_type: item.vat_type,
-  nickname: item.nickname,
-  group_code: item.group_code,
-  is_deleted: item.is_deleted || false,
-  is_service: item.is_service || false,
-});
-
-const chunkArray = <T,>(items: T[], size: number): T[][] => {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
-};
-
 export const useSyncProduct = () => {
   const [mutate, { loading, error }] = useMutation(syncProductsMutation);
   const { toast } = useToast();
@@ -75,53 +36,64 @@ export const useSyncProduct = () => {
 
     try {
       const action = selectedFilter.toUpperCase();
-      const syncedIds = new Set<string>();
-      let failed = false;
 
-      for (const chunkItems of chunkArray(productsToSync, CHUNK_SIZE)) {
-        try {
-          const response = await mutate({
-            variables: { action, products: chunkItems.map(toSyncPayload) },
-          });
-
-          if (response.data?.toSyncProducts) {
-            for (const item of chunkItems) {
-              const key = getProductKey(item);
-              if (key) syncedIds.add(key);
-            }
-          }
-        } catch (chunkError: any) {
-
-          failed = true;
+      const response = await mutate({
+        variables: {
+          action,
+          products: productsToSync.map((item) => ({
+            id: item._id || item.id,
+            code: item.code,
+            name: item.name,
+            barcodes: item.barcodes,
+            unit_price: item.unit_price,
+            category_code: item.category_code,
+            measure_unit_code: item.measure_unit_code,
+            vat_type_code: item.vat_type_code,
+            ratio_measure_unit: item.ratio_measure_unit,
+            sub_measure_unit_code: item.sub_measure_unit_code,
+            category: item.category,
+            group: item.group,
+            brand_code: item.brand_code,
+            sub_measure_unit: item.sub_measure_unit,
+            united_code: item.united_code,
+            measure_unit: item.measure_unit,
+            brand: item.brand,
+            vat_type: item.vat_type,
+            nickname: item.nickname,
+            group_code: item.group_code,
+            is_deleted: item.is_deleted || false,
+            is_service: item.is_service || false,
+          })),
+        },
+        onError: (error) => {
           toast({
             title: t('error'),
-            description: chunkError?.message || t('sync-products-error'),
+            description: error.message,
             variant: 'destructive',
           });
-          break;
-        }
-      }
+        },
+      });
 
-      if (syncedIds.size > 0) {
+      if (response.data?.toSyncProducts) {
         const updatedProducts = toCheckProducts.map((item) => {
-          const key = getProductKey(item);
+          const wasSynced = productsToSync.some(
+            (syncedItem) =>
+              (syncedItem._id && syncedItem._id === item._id) ||
+              (syncedItem.id && syncedItem.id === item.id),
+          );
 
-          if (key && syncedIds.has(key) && item.status === selectedFilter) {
+          if (wasSynced && item.status === selectedFilter) {
             return { ...item, isSynced: true };
           }
           return item;
         });
 
         toast({
-          title: failed ? t('warning') : t('success'),
-          description: t('products-synced', { count: syncedIds.size }),
+          title: t('success'),
+          description: t('products-synced', { count: productsToSync.length }),
         });
 
         return updatedProducts;
-      }
-
-      if (failed) {
-        return toCheckProducts;
       }
     } catch (err) {
       console.error('Sync products error:', err);


### PR DESCRIPTION
## Summary by Sourcery

Simplify product sync for Erkhet integration by reverting chunked requests to a single bulk mutation call and updating sync status handling.

Enhancements:
- Remove chunked product sync logic in favor of a single bulk mutation call for all selected products.
- Update synced product detection to compare products directly from the current sync batch instead of using generated keys.
- Standardize error handling by leveraging the mutation onError callback and simplifying toast messaging for sync results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product synchronization by processing the selected products in a single operation.
  * Added clearer error notifications when synchronization fails.
  * Updated synchronization status and success messaging after completion.
  * Removed partial-failure handling that could leave synchronization results inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->