### PR TITLE
feat(core): standardize relation widget names

### DIFF
--- a/frontend/core-ui/src/modules/widgets/components/FormWidgets.tsx
+++ b/frontend/core-ui/src/modules/widgets/components/FormWidgets.tsx
@@ -1,6 +1,6 @@
 import { FieldValues, UseFormReturn } from 'react-hook-form';
 import { FocusSheet } from 'erxes-ui';
-import { toFormWidgetForm } from 'ui-modules';
+import { getRelationWidgetLabel, toFormWidgetForm } from 'ui-modules';
 import { RenderPluginsComponent } from '~/plugins/components/RenderPluginsComponent';
 import { useFormWidgetsModules } from '../hooks/useFormWidgets';
 
@@ -45,7 +45,7 @@ export const FormWidgetSideTabs = <T extends FieldValues>({
             key={`${module.pluginName}:${module.name}`}
             value={module.name}
             Icon={module.icon}
-            label={module.name.charAt(0).toUpperCase() + module.name.slice(1)}
+            label={getRelationWidgetLabel(module)}
           />
         ))}
       </FocusSheet.SideTabsList>

--- a/frontend/core-ui/src/modules/widgets/constants/core-relations.ts
+++ b/frontend/core-ui/src/modules/widgets/constants/core-relations.ts
@@ -5,10 +5,12 @@ export const CORE_RELATIONS = [
     pluginName: 'core',
     name: 'customer',
     icon: IconUser,
+    label: 'Customers',
   },
   {
     pluginName: 'core',
     name: 'company',
     icon: IconBuilding,
+    label: 'Companies',
   },
 ];

--- a/frontend/core-ui/src/modules/widgets/hooks/useRelationWidgets.tsx
+++ b/frontend/core-ui/src/modules/widgets/hooks/useRelationWidgets.tsx
@@ -26,6 +26,7 @@ export const useRelationWidgetsModules = (): IRelationModules[] => {
       pluginName: plugin.name,
       icon: module.icon as Icon,
       name: module.name,
+      label: module.label,
     }));
   });
 

--- a/frontend/libs/erxes-ui/src/types/UIConfig.ts
+++ b/frontend/libs/erxes-ui/src/types/UIConfig.ts
@@ -38,6 +38,7 @@ export type IUIConfig = {
     relationWidgets?: {
       name: string;
       icon?: React.ElementType;
+      label?: string;
     }[];
     customerDetailWidgets?: {
       name: string;

--- a/frontend/libs/ui-modules/src/modules/widget/components/RelationWidgetSideTabs.tsx
+++ b/frontend/libs/ui-modules/src/modules/widget/components/RelationWidgetSideTabs.tsx
@@ -3,7 +3,7 @@ import {
   useRelationWidget,
   WidgetAccessProp,
 } from '../widget-provider/context/widgetContext';
-import { resolveAccess } from '../utils';
+import { getRelationWidgetLabel, resolveAccess } from '../utils';
 
 export const RelationWidgetSideTabs = ({
   contentId,
@@ -52,7 +52,7 @@ export const RelationWidgetSideTabs = ({
             key={module.name}
             value={module.name}
             Icon={module.icon}
-            label={module.name.charAt(0).toUpperCase() + module.name.slice(1)}
+            label={getRelationWidgetLabel(module)}
           />
         ))}
       </FocusSheet.SideTabsList>

--- a/frontend/libs/ui-modules/src/modules/widget/index.ts
+++ b/frontend/libs/ui-modules/src/modules/widget/index.ts
@@ -1,4 +1,5 @@
 export * from './components/RelationWidgetSideTabs';
+export * from './utils';
 export * from './widget-provider/context/widgetContext';
 export * from './widget-provider/context/formWidget';
 export * from './hooks';

--- a/frontend/libs/ui-modules/src/modules/widget/utils.ts
+++ b/frontend/libs/ui-modules/src/modules/widget/utils.ts
@@ -1,5 +1,11 @@
 import { WidgetAccessProp } from './widget-provider/context/widgetContext';
 
+export const getRelationWidgetLabel = (module: {
+  name: string;
+  label?: string;
+}): string =>
+  module.label || module.name.charAt(0).toUpperCase() + module.name.slice(1);
+
 export const resolveAccess = (
   access: WidgetAccessProp,
   moduleName: string,

--- a/frontend/libs/ui-modules/src/modules/widget/widget-provider/context/widgetContext.tsx
+++ b/frontend/libs/ui-modules/src/modules/widget/widget-provider/context/widgetContext.tsx
@@ -20,6 +20,7 @@ export interface IRelationModules {
   name: string;
   pluginName: string;
   icon: Icon;
+  label?: string;
 }
 
 export const RelationWidgetContext = createContext<{

--- a/frontend/plugins/frontline_ui/src/config.tsx
+++ b/frontend/plugins/frontline_ui/src/config.tsx
@@ -67,10 +67,12 @@ export const CONFIG: IUIConfig = {
       {
         name: 'conversation',
         icon: IconMail,
+        label: 'Conversations',
       },
       {
         name: 'ticket',
         icon: IconTicket,
+        label: 'Tickets',
       },
     ],
     propertyInputs: {

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationSideWidget.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationSideWidget.tsx
@@ -1,5 +1,5 @@
 import { SideMenu, useSideMenuContext } from 'erxes-ui';
-import { useRelationWidget } from 'ui-modules';
+import { getRelationWidgetLabel, useRelationWidget } from 'ui-modules';
 import { useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { sideWidgetOpenState } from '@/inbox/states/sideWidgetOpenState';
@@ -49,7 +49,7 @@ export const ConversationSideWidget = ({
             <SideMenu.Trigger
               key={module.name}
               value={module.name}
-              label={module.name}
+              label={getRelationWidgetLabel(module)}
               Icon={module.icon}
             />
           );

--- a/frontend/plugins/frontline_ui/src/widgets/relations/TicketSideWidgets.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/relations/TicketSideWidgets.tsx
@@ -1,5 +1,5 @@
 import { SideMenu } from 'erxes-ui';
-import { useRelationWidget } from 'ui-modules';
+import { getRelationWidgetLabel, useRelationWidget } from 'ui-modules';
 
 export const TicketSideWidgets = ({ contentId }: { contentId: string }) => {
   const { relationWidgetsModules, RelationWidget } = useRelationWidget({
@@ -28,7 +28,7 @@ export const TicketSideWidgets = ({ contentId }: { contentId: string }) => {
             <SideMenu.Trigger
               key={module.name}
               value={module.name}
-              label={module.name}
+              label={getRelationWidgetLabel(module)}
               Icon={module.icon}
             />
           );

--- a/frontend/plugins/operation_ui/src/modules/triage/components/TriageSideWidgets.tsx
+++ b/frontend/plugins/operation_ui/src/modules/triage/components/TriageSideWidgets.tsx
@@ -1,5 +1,5 @@
 import { SideMenu } from 'erxes-ui';
-import { getRelationWidgetLabel, useRelationWidget } from 'ui-modules';
+import { useRelationWidget } from 'ui-modules';
 
 export const TriageSideWidgets = ({ contentId }: { contentId: string }) => {
   const { relationWidgetsModules, RelationWidget } = useRelationWidget({
@@ -28,7 +28,7 @@ export const TriageSideWidgets = ({ contentId }: { contentId: string }) => {
             <SideMenu.Trigger
               key={module.name}
               value={module.name}
-              label={getRelationWidgetLabel(module)}
+              label={module.name}
               Icon={module.icon}
             />
           );

--- a/frontend/plugins/operation_ui/src/modules/triage/components/TriageSideWidgets.tsx
+++ b/frontend/plugins/operation_ui/src/modules/triage/components/TriageSideWidgets.tsx
@@ -1,5 +1,5 @@
 import { SideMenu } from 'erxes-ui';
-import { useRelationWidget } from 'ui-modules';
+import { getRelationWidgetLabel, useRelationWidget } from 'ui-modules';
 
 export const TriageSideWidgets = ({ contentId }: { contentId: string }) => {
   const { relationWidgetsModules, RelationWidget } = useRelationWidget({
@@ -28,7 +28,7 @@ export const TriageSideWidgets = ({ contentId }: { contentId: string }) => {
             <SideMenu.Trigger
               key={module.name}
               value={module.name}
-              label={module.name}
+              label={getRelationWidgetLabel(module)}
               Icon={module.icon}
             />
           );

--- a/frontend/plugins/operation_ui/src/widgets/relation/TaskSideWidgets.tsx
+++ b/frontend/plugins/operation_ui/src/widgets/relation/TaskSideWidgets.tsx
@@ -1,5 +1,5 @@
 import { SideMenu } from 'erxes-ui';
-import { useRelationWidget } from 'ui-modules';
+import { getRelationWidgetLabel, useRelationWidget } from 'ui-modules';
 
 export const TaskSideWidgets = ({ contentId }: { contentId: string }) => {
   const { relationWidgetsModules, RelationWidget } = useRelationWidget({
@@ -28,7 +28,7 @@ export const TaskSideWidgets = ({ contentId }: { contentId: string }) => {
             <SideMenu.Trigger
               key={module.name}
               value={module.name}
-              label={module.name}
+              label={getRelationWidgetLabel(module)}
               Icon={module.icon}
             />
           );

--- a/frontend/plugins/sales_ui/src/config.tsx
+++ b/frontend/plugins/sales_ui/src/config.tsx
@@ -84,6 +84,7 @@ export const CONFIG: IUIConfig = {
       {
         name: 'posOrders',
         icon: IconReceipt,
+        label: 'POS orders',
       },
     ],
     propertyInputs: {


### PR DESCRIPTION
Widget tab names were computed in six places with two different implementations - two capitalized module.name, four rendered it raw. The same widget therefore read as "Customer" on detail sheets but "customer" in the inbox and on task detail.

Add an optional label to IRelationModules and UIConfig.relationWidgets[], and route every render site through getRelationWidgetLabel(), which falls back to the capitalized name so modules without a label keep their current rendering. Set labels for the widgets whose identifier did not read well: Customers, Companies, Conversations, Tickets, POS orders.

Internal name identifiers are untouched, so hiddenModules filters, the CoreWidgets switch, access-map keys and tab values all keep working.

## Summary by Sourcery

Standardize relation widget display labels across core UI and plugins while keeping internal identifiers unchanged.

New Features:
- Introduce an optional label property on relation widget module definitions and UI configuration to control displayed names independently of internal identifiers.

Enhancements:
- Add a shared getRelationWidgetLabel helper and route all relation widget tab and side menu renderers through it for consistent capitalization and labeling.
- Expose widget utilities, including the new label helper, from the ui-modules widget index for reuse across the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Relation widget side tabs now display configured, human-readable labels.
  - Added custom labels for tickets, conversations, POS orders, customers, and companies.
  - Widgets without a custom label continue using a formatted default label.
  - Label handling is now consistent across inbox, task, triage, and other relation widget views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->