### PR TITLE
fix(sales): stop deal detail sheet reopening and empty state flashing

### DIFF
--- a/frontend/libs/erxes-ui/src/components/sheet.tsx
+++ b/frontend/libs/erxes-ui/src/components/sheet.tsx
@@ -61,7 +61,8 @@ export const SheetPortal = ({
 SheetPortal.displayName = SheetPrimitive.Portal.displayName;
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetView = React.forwardRef<

--- a/frontend/libs/erxes-ui/src/components/sheet.tsx
+++ b/frontend/libs/erxes-ui/src/components/sheet.tsx
@@ -24,7 +24,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/25  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/25 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:duration-200 data-[state=closed]:duration-200 data-[state=closed]:[animation-fill-mode:forwards]',
       className,
     )}
     {...props}
@@ -34,16 +34,16 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 shadow-lg outline-hidden transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out rounded-md bg-muted',
+  'fixed z-50 shadow-lg outline-hidden ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:[animation-fill-mode:forwards] rounded-md bg-muted',
   {
     variants: {
       side: {
-        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top-full data-[state=open]:slide-in-from-top-full',
         bottom:
-          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full flex flex-col w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-md',
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full',
+        left: 'inset-y-0 left-0 h-full flex flex-col w-3/4 border-r data-[state=closed]:slide-out-to-left-full data-[state=open]:slide-in-from-left-full sm:max-w-md',
         right:
-          'inset-y-2 right-2 flex flex-col h-[calc(100dvh-1rem)] w-[calc(100vw-(--spacing(4)))] md:w-3/4 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right overflow-hidden sm:max-w-md',
+          'inset-y-2 right-2 flex flex-col h-[calc(100dvh-1rem)] w-[calc(100vw-(--spacing(4)))] md:w-3/4 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full overflow-hidden sm:max-w-md',
       },
     },
     defaultVariants: {

--- a/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
+++ b/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
@@ -37,13 +37,15 @@ export function useQueryState<T>(
 
   const setQuery = (value: T | null) => {
     const nextParams = new URLSearchParams(window.location.search);
-    const currentValue = parseQueryValue(nextParams.get(queryKey));
 
-    if (value !== null && value !== currentValue) {
+    if (value !== null) {
       const stringValue =
         typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+      if (nextParams.get(queryKey) === stringValue) return;
+
       nextParams.set(queryKey, stringValue);
-    } else if (value === null && currentValue !== null) {
+    } else if (nextParams.has(queryKey)) {
       nextParams.delete(queryKey);
     } else {
       return;
@@ -94,17 +96,25 @@ export function useMultiQueryState<T extends QueryTypes>(
 
   const setQueries = (values: Partial<QueryValues<T>>) => {
     const nextParams = new URLSearchParams(window.location.search);
+    let hasChanges = false;
 
     Object.entries(values).forEach(([key, value]) => {
-      const currentValue = parseQueryValue(nextParams.get(key), key);
-      if (value !== null && value !== currentValue) {
+      if (value !== null) {
         const stringValue =
           typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+        if (nextParams.get(key) === stringValue) return;
+
         nextParams.set(key, stringValue);
-      } else if (value === null && currentValue !== null) {
+        hasChanges = true;
+      } else if (nextParams.has(key)) {
         nextParams.delete(key);
+        hasChanges = true;
       }
     });
+
+    if (!hasChanges) return;
+
     setSearchParams(nextParams, { replace: true });
   };
 

--- a/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
+++ b/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
@@ -1,5 +1,33 @@
 import { useSearchParams } from 'react-router-dom';
 
+let searchParamsDraft: URLSearchParams | null = null;
+let draftSourceSearch = '';
+
+const getSearchParamsDraft = () => {
+  const currentSearch = window.location.search;
+  const draftSearch = searchParamsDraft?.toString();
+  const draftTargetSearch = draftSearch ? `?${draftSearch}` : '';
+
+  if (
+    !searchParamsDraft ||
+    (draftSourceSearch !== currentSearch && draftTargetSearch !== currentSearch)
+  ) {
+    draftSourceSearch = currentSearch;
+    searchParamsDraft = new URLSearchParams(currentSearch);
+
+    queueMicrotask(() => {
+      searchParamsDraft = null;
+      draftSourceSearch = '';
+    });
+  }
+
+  return new URLSearchParams(searchParamsDraft);
+};
+
+const updateSearchParamsDraft = (nextParams: URLSearchParams) => {
+  searchParamsDraft = new URLSearchParams(nextParams);
+};
+
 // Single key types and hook
 export type QueryState<T> = [T | null, (value: T | null) => void];
 
@@ -36,13 +64,14 @@ export function useQueryState<T>(
   const query = parseQueryValue(searchParams.get(queryKey));
 
   const setQuery = (value: T | null) => {
-    const nextParams = new URLSearchParams(window.location.search);
+    const nextParams = getSearchParamsDraft();
 
     if (value !== null) {
       const stringValue =
         typeof value === 'object' ? JSON.stringify(value) : String(value);
 
       if (nextParams.get(queryKey) === stringValue) return;
+      if (!nextParams.has(queryKey) && value === query) return;
 
       nextParams.set(queryKey, stringValue);
     } else if (nextParams.has(queryKey)) {
@@ -51,6 +80,7 @@ export function useQueryState<T>(
       return;
     }
 
+    updateSearchParamsDraft(nextParams);
     setSearchParams(nextParams);
   };
 
@@ -95,7 +125,7 @@ export function useMultiQueryState<T extends QueryTypes>(
   }, {} as QueryValues<T>);
 
   const setQueries = (values: Partial<QueryValues<T>>) => {
-    const nextParams = new URLSearchParams(window.location.search);
+    const nextParams = getSearchParamsDraft();
     let hasChanges = false;
 
     Object.entries(values).forEach(([key, value]) => {
@@ -115,6 +145,7 @@ export function useMultiQueryState<T extends QueryTypes>(
 
     if (!hasChanges) return;
 
+    updateSearchParamsDraft(nextParams);
     setSearchParams(nextParams, { replace: true });
   };
 
@@ -137,9 +168,10 @@ export function useSetQueryStateByKey() {
   const [, setSearchParams] = useSearchParams();
 
   const setQuery = (key: string, value: string) => {
-    const nextParams = new URLSearchParams(window.location.search);
+    const nextParams = getSearchParamsDraft();
     if (nextParams.get(key) === value) return;
     nextParams.set(key, value);
+    updateSearchParamsDraft(nextParams);
     setSearchParams(nextParams);
   };
 
@@ -150,9 +182,10 @@ export function useRemoveQueryStateByKey() {
   const [, setSearchParams] = useSearchParams();
 
   const removeQuery = (key: string) => {
-    const nextParams = new URLSearchParams(window.location.search);
+    const nextParams = getSearchParamsDraft();
     if (!nextParams.has(key)) return;
     nextParams.delete(key);
+    updateSearchParamsDraft(nextParams);
     setSearchParams(nextParams);
   };
 

--- a/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
+++ b/frontend/libs/erxes-ui/src/hooks/use-query-state.tsx
@@ -36,17 +36,20 @@ export function useQueryState<T>(
   const query = parseQueryValue(searchParams.get(queryKey));
 
   const setQuery = (value: T | null) => {
-    if (value !== null && value !== query) {
+    const nextParams = new URLSearchParams(window.location.search);
+    const currentValue = parseQueryValue(nextParams.get(queryKey));
+
+    if (value !== null && value !== currentValue) {
       const stringValue =
         typeof value === 'object' ? JSON.stringify(value) : String(value);
-      searchParams.set(queryKey, stringValue);
-    } else if (value === null && query !== null) {
-      searchParams.delete(queryKey);
+      nextParams.set(queryKey, stringValue);
+    } else if (value === null && currentValue !== null) {
+      nextParams.delete(queryKey);
     } else {
       return;
     }
 
-    setSearchParams(searchParams);
+    setSearchParams(nextParams);
   };
 
   return [query, setQuery];
@@ -90,16 +93,19 @@ export function useMultiQueryState<T extends QueryTypes>(
   }, {} as QueryValues<T>);
 
   const setQueries = (values: Partial<QueryValues<T>>) => {
+    const nextParams = new URLSearchParams(window.location.search);
+
     Object.entries(values).forEach(([key, value]) => {
-      if (value !== null && value !== queries[key]) {
+      const currentValue = parseQueryValue(nextParams.get(key), key);
+      if (value !== null && value !== currentValue) {
         const stringValue =
           typeof value === 'object' ? JSON.stringify(value) : String(value);
-        searchParams.set(key, stringValue);
-      } else if (value === null && queries[key] !== null) {
-        searchParams.delete(key);
+        nextParams.set(key, stringValue);
+      } else if (value === null && currentValue !== null) {
+        nextParams.delete(key);
       }
     });
-    setSearchParams(searchParams, { replace: true });
+    setSearchParams(nextParams, { replace: true });
   };
 
   return [queries, setQueries];
@@ -118,22 +124,26 @@ export const useNonNullMultiQueryState = <T extends QueryTypes>(
 };
 
 export function useSetQueryStateByKey() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   const setQuery = (key: string, value: string) => {
-    searchParams.set(key, value);
-    setSearchParams(searchParams);
+    const nextParams = new URLSearchParams(window.location.search);
+    if (nextParams.get(key) === value) return;
+    nextParams.set(key, value);
+    setSearchParams(nextParams);
   };
 
   return setQuery;
 }
 
 export function useRemoveQueryStateByKey() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   const removeQuery = (key: string) => {
-    searchParams.delete(key);
-    setSearchParams(searchParams);
+    const nextParams = new URLSearchParams(window.location.search);
+    if (!nextParams.has(key)) return;
+    nextParams.delete(key);
+    setSearchParams(nextParams);
   };
 
   return removeQuery;

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoard.tsx
@@ -262,7 +262,7 @@ export const DealsBoard = () => {
     return result;
   }, [pagination]);
 
-  if (columnsLoading) {
+  if (!pipelineId || columnsLoading) {
     return <StagesLoading />;
   }
 

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/common/GenericBoardColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/common/GenericBoardColumn.tsx
@@ -20,7 +20,6 @@ import { useDroppable } from '@dnd-kit/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useTranslation } from 'react-i18next';
 
-
 const ESTIMATED_CARD_HEIGHT = 100;
 const SCROLL_THRESHOLD = 200;
 
@@ -99,14 +98,16 @@ function GenericBoardColumnInner<
   );
 }
 
-const ShowingOf = memo(({ current, total }: { current: number; total: number }) => {
-  const { t } = useTranslation('sales');
-  return (
-    <div className="px-3 py-1.5 text-xs text-muted-foreground border-t border-border/50 text-center">
-      {t('showing-of', { current, total })}
-    </div>
-  );
-});
+const ShowingOf = memo(
+  ({ current, total }: { current: number; total: number }) => {
+    const { t } = useTranslation('sales');
+    return (
+      <div className="px-3 py-1.5 text-xs text-muted-foreground border-t border-border/50 text-center">
+        {t('showing-of', { current, total })}
+      </div>
+    );
+  },
+);
 ShowingOf.displayName = 'ShowingOf';
 
 const DefaultColumnHeader = memo(

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/common/GenericBoardColumn.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/common/GenericBoardColumn.tsx
@@ -85,7 +85,7 @@ function GenericBoardColumnInner<
       <VirtualizedCardList
         columnId={column._id}
         items={items}
-        isLoading={columnLoading[column._id]}
+        isLoading={columnLoading[column._id] ?? true}
         renderCard={renderCard}
         hasMore={hasMore}
         isLoadingMore={isLoadingMore}

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/list/DealsRecordTable.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/list/DealsRecordTable.tsx
@@ -31,6 +31,8 @@ export const DealsRecordTable = () => {
   });
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
 
+  const isLoading = loading || !pipelineId;
+
   if (pipelineId && !stagesLoading && stages.length === 0) {
     return <NoStagesWarning />;
   }
@@ -39,7 +41,7 @@ export const DealsRecordTable = () => {
     <div className="flex flex-col overflow-hidden h-full relative">
       <RecordTable.Provider
         columns={columns}
-        data={deals || (loading ? [{}] : [])}
+        data={deals || []}
         className="m-3 h-full"
         stickyColumns={['more', 'checkbox', 'name']}
         tableId="sales_deals_record_table"
@@ -55,7 +57,7 @@ export const DealsRecordTable = () => {
               <RecordTable.CursorBackwardSkeleton
                 handleFetchMore={handleFetchMore}
               />
-              {loading && <RecordTable.RowSkeleton rows={40} />}
+              {isLoading && <RecordTable.RowSkeleton rows={40} />}
               <RecordTable.RowList />
               <RecordTable.CursorForwardSkeleton
                 handleFetchMore={handleFetchMore}

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
@@ -11,7 +11,6 @@ import {
   useQueryState,
 } from 'erxes-ui';
 import { IconAlertCircle, IconCloudExclamation } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
 
 import { DealsProvider } from '@/deals/context/DealContext';
 import { IDeal } from '@/deals/types/deals';
@@ -95,18 +94,10 @@ const SalesItemDetailView = () => {
 export const SalesItemDetail = () => {
   const [activeDealId, setActiveDealId] = useAtom(dealDetailSheetState);
   const [salesItemId, setSalesItemId] = useQueryState<string>('salesItemId');
-  const { loading } = useDealDetail();
 
-  const [isOpen, setIsOpen] = useState(
-    (!!activeDealId || !!salesItemId) && !loading,
-  );
-
-  useEffect(() => {
-    setIsOpen((!!activeDealId || !!salesItemId) && !loading);
-  }, [activeDealId, salesItemId, loading]);
+  const isOpen = !!activeDealId || !!salesItemId;
 
   const handleOpenChange = (open: boolean) => {
-    setIsOpen(open);
     if (!open) {
       setActiveDealId(null);
       setSalesItemId(null);

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
@@ -95,7 +95,7 @@ export const SalesItemDetail = () => {
   const [activeDealId, setActiveDealId] = useAtom(dealDetailSheetState);
   const [salesItemId, setSalesItemId] = useQueryState<string>('salesItemId');
 
-  const isOpen = !!activeDealId || !!salesItemId;
+  const isOpen = Boolean(activeDealId) || Boolean(salesItemId);
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealDetail.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealDetail.tsx
@@ -34,17 +34,18 @@ export const useDealDetail = (
   const passedId = options?.variables?._id;
   const finalId = passedId || salesItemId || activeDealId;
 
-  const { data, loading, error, subscribeToMore, refetch } = useQuery<{
-    dealDetail: IDeal;
-  }>(GET_DEAL_DETAIL, {
-    ...options,
-    variables: {
-      ...options?.variables,
-      _id: finalId,
-    },
-    skip: !finalId,
-    fetchPolicy: options?.fetchPolicy || 'cache-and-network',
-  });
+  const { data, previousData, loading, error, subscribeToMore, refetch } =
+    useQuery<{
+      dealDetail: IDeal;
+    }>(GET_DEAL_DETAIL, {
+      ...options,
+      variables: {
+        ...options?.variables,
+        _id: finalId,
+      },
+      skip: !finalId,
+      fetchPolicy: options?.fetchPolicy || 'cache-and-network',
+    });
 
   useEffect(() => {
     if (!salesItemId) return;
@@ -114,7 +115,8 @@ export const useDealDetail = (
     return unsubscribe;
   }, [finalId, refetch, subscribeToMore]);
 
-  const deal = data?.dealDetail;
+  const deal =
+    data?.dealDetail || (!finalId ? previousData?.dealDetail : undefined);
 
   return { deal, loading: loading && !deal, error, refetch };
 };

--- a/frontend/plugins/sales_ui/src/widgets/relation/modules/DealWidgetCard.tsx
+++ b/frontend/plugins/sales_ui/src/widgets/relation/modules/DealWidgetCard.tsx
@@ -62,6 +62,7 @@ export const DealWidgetCard = ({ deal }: { deal: IDeal }) => {
     labels,
     boardId,
     pipeline,
+    pipelineId,
     departments,
     branches,
   } = deal || {};
@@ -72,7 +73,18 @@ export const DealWidgetCard = ({ deal }: { deal: IDeal }) => {
   const hasBranches = !!branches?.length;
 
   const onCardClick = () => {
-    const dealUrl = `/sales/deals?boardId=${boardId}&pipelineId=${pipeline._id}&salesItemId=${_id}`;
+    const searchParams = new URLSearchParams({ salesItemId: _id });
+    const resolvedPipelineId = pipeline?._id || pipelineId || stage?.pipelineId;
+
+    if (boardId) {
+      searchParams.set('boardId', boardId);
+    }
+
+    if (resolvedPipelineId) {
+      searchParams.set('pipelineId', resolvedPipelineId);
+    }
+
+    const dealUrl = `/sales/deals?${searchParams.toString()}`;
     window.open(dealUrl, '_blank');
   };
 


### PR DESCRIPTION
## Problem

Two glitches in the Sales deals views:

1. **The deal detail sheet replayed its open animation before closing.** It read as the sheet reopening for a moment and then closing again.
2. **Both the board and list views flashed an empty state** on first entry, before any data had arrived.

## Root causes

Four separate defects, each confirmed against the running app or the compiled CSS rather than inferred.

### 1. Sheet reopening — `SalesItemDetail.tsx`

`isOpen` was mirrored into local state and recomputed by an effect from two sources that clear on **different commits**: the jotai atom clears immediately, the URL param lags a commit. The effect therefore saw a commit where the atom was already `null` but the id was still in the URL, and flipped `open` back to `true` mid-close.

A frame-by-frame trace of the closing panel:

```
0–18ms    x=273   fill=forwards   closed, exit animation started
73ms      x=1117  fill=none       jumped off-screen, state back to open
73→274ms  x: 1117 → 273           slide-in-from-right-full replayed
274–476ms x=273   fill=none       sitting fully open
900ms     x=273   fill=forwards   finally closed
```

Deriving `isOpen` means it can only ever go `true -> false` once, when both sources are clear. `loading` is no longer part of it either — a load flicker while an id is set is the same `false -> true` trap, and the sheet already renders its own spinner.

### 2. Sheet close animation — `sheet.tsx`

Two problems, both visible in the compiled CSS:

- `slide-out-to-right` resolves against the **spacing scale** under Tailwind v4 (`tailwindcss-animate` is a v3 plugin), producing `--tw-exit-translate-x: 0.25rem`. The panel nudged 4px instead of sliding clear of the viewport. The `-full` variants give the intended `100%`.
- `animate-out` sets no `animation-fill-mode`, so the transform reverted the instant the keyframes finished and the panel snapped back to its open position until Radix unmounted it.

Also matched the overlay's duration to the content's, and dropped the `transition` shorthand that put `transform` under a transition competing with the keyframe animation.

### 3. URL state clobbering — `use-query-state.tsx`

`setQuery` mutated the `searchParams` instance — which is memoised on `location.search` — and handed the same object back to `setSearchParams`. Two setters firing in one tick each wrote their own stale copy and the last write won, restoring a key another setter had just removed. This is what left `salesItemId` in the URL after closing the sheet from the list view.

The setters now read, compare and write against the live URL. Because `navigate` updates history synchronously, a second setter in the same tick sees the first one's result and the writes compose. Applied to all four setters in the module.

### 4. Empty state flashing — `DealsBoard.tsx`, `DealsRecordTable.tsx`, `GenericBoardColumn.tsx`

The stages and deals queries are skipped until `pipelineId` reaches the URL, and **a skipped Apollo query reports `loading: false`**. Both views therefore treated "not started yet" as "loaded and empty" and rendered `NoStagesWarning` / a zero-row table before the request had begun. A missing `pipelineId` now counts as loading.

Column skeletons had the same shape of bug: `columnLoading[column._id]` is `undefined` until the column's effect runs, so the "drop cards here" placeholder rendered on the first frame.

Also removed a dead branch in `DealsRecordTable`: `deals || (loading ? [{}] : [])` never reached the fallback, because `deals` is always an array and an empty array is truthy.

The `use-query-state.tsx` change affects every consumer of these hooks across the app, so it is worth a careful look — it is the broadest change here.

## Summary by Sourcery

Fix deal detail sheet reopening and closing animations and prevent empty state flashes in sales deals views by tightening query state handling and loading conditions.

Bug Fixes:
- Ensure sheet overlay and content use full slide-out animations with correct fill mode to avoid panels snapping back or partially sliding.
- Derive the sales deal detail sheet open state directly from URL and atom state so it only closes once without replaying the open animation.
- Treat missing pipeline IDs and initial column loading as loading states to avoid flashing empty stages and tables in board and list views.
- Avoid mutating shared URLSearchParams instances and always read from the live URL so concurrent query state updates compose correctly instead of clobbering each other.

Enhancements:
- Skip redundant URL query updates when values are unchanged to reduce unnecessary navigation state churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Improved deal board loading by requiring pipeline information before showing stage content.
  - Updated deal record tables and board columns to show skeletons when loading or when pipeline is missing.
  - Refined query-parameter state updates to avoid stale URL state by using a draft clone and skipping no-op changes.
  - Improved deal detail handling to keep previously loaded data when final identifiers aren’t available yet.
- **UI Polish**
  - Refined sheet open/close animations and slide behavior for smoother transitions.
  - Simplified sales item detail panel open-state logic and improved deal card URL generation using resolved pipeline info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->