### PR TITLE
fix(sales): correct deal card assignee selection

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/item/Footer.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/item/Footer.tsx
@@ -40,9 +40,6 @@ export const ItemFooter = ({
         mode="multiple"
         value={assignedUsers.map((user) => user?._id) || ['']}
         id={id}
-        teamIds={
-          assignedUsers ? assignedUsers.map((user) => user._id) : undefined
-        }
       />
     </div>
   );

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
@@ -51,7 +51,9 @@ const SelectAssigneeValue = ({
     );
   }
 
-  return <SelectMember.Value placeholder={placeholder || t('select-assignee')} />;
+  return (
+    <SelectMember.Value placeholder={placeholder || t('select-assignee')} />
+  );
 };
 
 const SelectTeamMemberContent = ({

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
@@ -207,7 +207,8 @@ const SelectAssigneeDealRoot = ({
       editDeals({
         variables: {
           _id: id,
-          assignedUserIds: [value],
+          assignedUserIds:
+            value === null ? [] : Array.isArray(value) ? value : [value],
         },
       });
     }
@@ -229,9 +230,7 @@ const SelectAssigneeDealRoot = ({
       allowUnassigned
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
-        <SelectTriggerOperation
-          variant={variant === 'card' ? 'default' : variant}
-        >
+        <SelectTriggerOperation variant={variant === 'card' ? 'icon' : variant}>
           <SelectAssigneeValue variant={variant} />
         </SelectTriggerOperation>
         <SelectOperationContent variant={variant}>

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
@@ -204,11 +204,18 @@ const SelectAssigneeDealRoot = ({
 
   const handleValueChange = (value: string | string[] | null) => {
     if (id) {
+      let assignedUserIds: string[] = [];
+
+      if (Array.isArray(value)) {
+        assignedUserIds = value;
+      } else if (value !== null) {
+        assignedUserIds = [value];
+      }
+
       editDeals({
         variables: {
           _id: id,
-          assignedUserIds:
-            value === null ? [] : Array.isArray(value) ? value : [value],
+          assignedUserIds,
         },
       });
     }


### PR DESCRIPTION
## Summary

- fix deal card assignee updates for single, multiple, and unassigned values
- use the icon trigger variant on deal cards
- remove the incorrect team filter derived from assigned user IDs

## Testing

- `git diff --check`
- `pnpm nx lint sales_ui` *(could not complete because Nx project graph computation stalled after the daemon failed)*

## Summary by Sourcery

Fix deal card assignee handling and align the assignee selector trigger style on deal cards.

Bug Fixes:
- Correct deal assignee updates to support single, multiple, and unassigned values by mapping null to an empty list and arrays directly to assigned user IDs.
- Remove the incorrect team filter on deal cards that was derived from assigned user IDs.

Enhancements:
- Use the icon trigger variant for the assignee selector on deal cards instead of the default trigger when in card mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deal assignee selection to correctly handle multiple users with proper value mapping.
  * Ensured clearing assignees reliably removes all assignments and resets the control state.
  * Updated the deal card assignee selector to use a more compact icon-style trigger for better fit on smaller displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->