### PR TITLE
fix(sales): truncate long board and pipeline names in breadcrumb

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/components/breadcrumb/SalesBreadCrumb.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/breadcrumb/SalesBreadCrumb.tsx
@@ -1,4 +1,10 @@
-import { Breadcrumb, Button, Separator, Skeleton } from 'erxes-ui';
+import {
+  Breadcrumb,
+  Button,
+  Separator,
+  Skeleton,
+  TextOverflowTooltip,
+} from 'erxes-ui';
 import { IconCards, IconLayoutCards } from '@tabler/icons-react';
 
 import { useBoardDetail } from '@/deals/boards/hooks/useBoards';
@@ -36,11 +42,14 @@ export const SalesBreadCrumb = ({
     <>
       {boardDetail && (
         <>
-          <Breadcrumb.Item>
-            <Button variant="ghost" asChild>
+          <Breadcrumb.Item className="min-w-0">
+            <Button variant="ghost" asChild className="min-w-0">
               <span className="flex items-center gap-1">
                 <IconLayoutCards />
-                {boardDetail?.name}
+                <TextOverflowTooltip
+                  value={boardDetail.name}
+                  className="min-w-0"
+                />
               </span>
             </Button>
           </Breadcrumb.Item>
@@ -49,16 +58,19 @@ export const SalesBreadCrumb = ({
       )}
 
       {pipelineDetail && (
-        <Breadcrumb.Item>
-          <Button variant="ghost" asChild>
+        <Breadcrumb.Item className="min-w-0">
+          <Button variant="ghost" asChild className="min-w-0">
             <span className="flex items-center gap-1">
               <IconCards />
-              {pipelineDetail?.name}
+              <TextOverflowTooltip
+                value={pipelineDetail.name}
+                className="min-w-0"
+              />
             </span>
           </Button>
         </Breadcrumb.Item>
       )}
-      <Breadcrumb.Item className="ml-1">
+      <Breadcrumb.Item className="ml-1 shrink-0">
         <FavoriteToggleIconButton
           breadcrumb={breadcrumb}
           icon="IconBriefcase"

--- a/frontend/plugins/sales_ui/src/modules/deals/components/breadcrumb/SalesBreadCrumb.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/breadcrumb/SalesBreadCrumb.tsx
@@ -42,7 +42,7 @@ export const SalesBreadCrumb = ({
     <>
       {boardDetail && (
         <>
-          <Breadcrumb.Item className="min-w-0">
+          <Breadcrumb.Item className="min-w-32">
             <Button variant="ghost" asChild className="min-w-0">
               <span className="flex items-center gap-1">
                 <IconLayoutCards />
@@ -58,7 +58,7 @@ export const SalesBreadCrumb = ({
       )}
 
       {pipelineDetail && (
-        <Breadcrumb.Item className="min-w-0">
+        <Breadcrumb.Item className="min-w-32">
           <Button variant="ghost" asChild className="min-w-0">
             <span className="flex items-center gap-1">
               <IconCards />

--- a/frontend/plugins/sales_ui/src/modules/deals/components/commonSearch.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/commonSearch.tsx
@@ -52,7 +52,7 @@ export const CommonDealSearch = () => {
   return (
     <Popover open={showDropdown}>
       <Popover.Anchor asChild>
-        <div className="relative w-72">
+        <div className="relative w-64">
           <IconSearch className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             className="h-8 pl-8"

--- a/frontend/plugins/sales_ui/src/pages/SalesIndexPage.tsx
+++ b/frontend/plugins/sales_ui/src/pages/SalesIndexPage.tsx
@@ -34,14 +34,14 @@ export const SalesIndexPage = () => {
     <div className="flex h-full overflow-hidden w-full">
       <div className="flex flex-col h-full w-full overflow-hidden">
         <PageHeader>
-          <PageHeader.Start>
-            <Breadcrumb>
-              <Breadcrumb.List className="gap-1">
-                <Breadcrumb.Item>
+          <PageHeader.Start className="flex-1 min-w-0">
+            <Breadcrumb className="min-w-0">
+              <Breadcrumb.List className="gap-1 flex-nowrap min-w-0">
+                <Breadcrumb.Item className="shrink-0">
                   <Button variant="ghost" asChild>
                     <Link to="/sales/deal">
                       <IconSandbox />
-                      {t('sales-pipeline')}
+                      {t('sales-pipeline', 'Sales Pipeline')}
                     </Link>
                   </Button>
                 </Breadcrumb.Item>
@@ -52,14 +52,14 @@ export const SalesIndexPage = () => {
               </Breadcrumb.List>
             </Breadcrumb>
           </PageHeader.Start>
-          <PageHeader.End>
+          <PageHeader.End className="flex-none">
             <CommonDealSearch />
             <Button variant="ghost" asChild>
               <Link
                 to={`/settings/sales/deals?${settingsSearchParams.toString()}`}
               >
                 <IconSettings />
-                {t('go-to-settings')}
+                {t('go-to-settings', 'Go to Settings')}
               </Link>
             </Button>
           </PageHeader.End>

--- a/frontend/plugins/sales_ui/src/pages/SalesIndexPage.tsx
+++ b/frontend/plugins/sales_ui/src/pages/SalesIndexPage.tsx
@@ -34,7 +34,7 @@ export const SalesIndexPage = () => {
     <div className="flex h-full overflow-hidden w-full">
       <div className="flex flex-col h-full w-full overflow-hidden">
         <PageHeader>
-          <PageHeader.Start className="flex-1 min-w-0">
+          <PageHeader.Start className="flex-auto min-w-0">
             <Breadcrumb className="min-w-0">
               <Breadcrumb.List className="gap-1 flex-nowrap min-w-0">
                 <Breadcrumb.Item className="shrink-0">
@@ -52,7 +52,7 @@ export const SalesIndexPage = () => {
               </Breadcrumb.List>
             </Breadcrumb>
           </PageHeader.Start>
-          <PageHeader.End className="flex-none">
+          <PageHeader.End>
             <CommonDealSearch />
             <Button variant="ghost" asChild>
               <Link


### PR DESCRIPTION
## Summary by Sourcery

Improve sales breadcrumbs and page header layout to better handle long board and pipeline names and ensure readable labels.

Enhancements:
- Truncate long board and pipeline names in the sales breadcrumb using a tooltip for overflow text.
- Adjust breadcrumb and page header flex layout to prevent overflow and ensure responsive behavior.
- Provide default translation fallbacks for sales pipeline and settings breadcrumb labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved breadcrumb layout so long board and pipeline names truncate cleanly and display in tooltips.
  * Updated header and breadcrumb sizing/behavior for more reliable display across screen sizes.
  * Added translation fallback labels for “Sales Pipeline” and “Go to Settings”.
  * Adjusted the sales search popover input width to better fit the dropdown layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->