### PR TITLE
feat(team-member): add deactivate and resend invite bulk actions

### DIFF
--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/TeamMemberCommandbar.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/TeamMemberCommandbar.tsx
@@ -32,9 +32,7 @@ export const TeamMemberCommandBar = () => {
         </Can>
         <Separator.Inline />
         <TeamMemberAssignPermissions teamMemberIds={teamMemberIds} />
-        <Separator.Inline />
         <TeamMemberResendInvite teamMembers={teamMembers} />
-        <Separator.Inline />
         <TeamMemberDeactivate teamMembers={teamMembers} />
         <Separator.Inline />
         <TeamMemberDelete teamMemberIds={teamMemberIds} />

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/TeamMemberCommandbar.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/TeamMemberCommandbar.tsx
@@ -1,14 +1,18 @@
+import { IUser } from '@/settings/team-member/types';
 import { Row } from '@tanstack/table-core';
 import { CommandBar, RecordTable, Separator } from 'erxes-ui';
 import { TeamMemberDelete } from './delete/TeamMemberDelete';
 import { TeamMemberAssignPermissions } from './assign-permissions/TeamMemberAssignPermissions';
+import { TeamMemberDeactivate } from './deactivate/TeamMemberDeactivate';
+import { TeamMemberResendInvite } from './resend-invite/TeamMemberResendInvite';
 import { Can, Export } from 'ui-modules';
 
 export const TeamMemberCommandBar = () => {
   const { table } = RecordTable.useRecordTable();
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
-  const teamMemberIds = selectedRows.map((row: Row<any>) => row.original._id);
+  const teamMembers = selectedRows.map((row: Row<IUser>) => row.original);
+  const teamMemberIds = teamMembers.map(({ _id }) => _id);
 
   return (
     <CommandBar open={selectedRows.length > 0}>
@@ -28,6 +32,10 @@ export const TeamMemberCommandBar = () => {
         </Can>
         <Separator.Inline />
         <TeamMemberAssignPermissions teamMemberIds={teamMemberIds} />
+        <Separator.Inline />
+        <TeamMemberResendInvite teamMembers={teamMembers} />
+        <Separator.Inline />
+        <TeamMemberDeactivate teamMembers={teamMembers} />
         <Separator.Inline />
         <TeamMemberDelete teamMemberIds={teamMemberIds} />
       </CommandBar.Bar>

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
@@ -1,7 +1,14 @@
 import { useTeamMemberDeactivate } from '@/settings/team-member/hooks/useTeamMemberDeactivate';
 import { IUser } from '@/settings/team-member/types';
 import { IconToggleLeft } from '@tabler/icons-react';
-import { Button, RecordTable, Spinner, useConfirm, useToast } from 'erxes-ui';
+import {
+  Button,
+  RecordTable,
+  Separator,
+  Spinner,
+  useConfirm,
+  useToast,
+} from 'erxes-ui';
 import { useAtomValue } from 'jotai';
 import { Can, currentUserState } from 'ui-modules';
 
@@ -14,19 +21,23 @@ export const TeamMemberDeactivate = ({
   const { deactivateTeamMembers, loading } = useTeamMemberDeactivate();
   const { table } = RecordTable.useRecordTable();
   const { toast } = useToast();
-  const currentUser = useAtomValue(currentUserState);
+  const currentUserId = useAtomValue(currentUserState)?._id;
 
   // Only active members can be deactivated and the backend rejects the whole
-  // batch when it contains the requesting user.
-  const teamMemberIds = teamMembers
-    .filter(
-      (teamMember) =>
-        teamMember.isActive !== false && teamMember._id !== currentUser?._id,
-    )
-    .map((teamMember) => teamMember._id);
+  // batch when it contains the requesting user, so wait until the current user
+  // is loaded before allowing the action.
+  const teamMemberIds = currentUserId
+    ? teamMembers
+        .filter(
+          (teamMember) =>
+            teamMember.isActive !== false && teamMember._id !== currentUserId,
+        )
+        .map((teamMember) => teamMember._id)
+    : [];
 
   return (
     <Can action="teamMembersRemove">
+      <Separator.Inline />
       <Button
         variant="secondary"
         disabled={loading || teamMemberIds.length === 0}

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
@@ -1,0 +1,63 @@
+import { useTeamMemberDeactivate } from '@/settings/team-member/hooks/useTeamMemberDeactivate';
+import { IUser } from '@/settings/team-member/types';
+import { IconToggleLeft } from '@tabler/icons-react';
+import { Button, RecordTable, Spinner, useConfirm, useToast } from 'erxes-ui';
+import { useAtomValue } from 'jotai';
+import { Can, currentUserState } from 'ui-modules';
+
+export const TeamMemberDeactivate = ({
+  teamMembers,
+}: {
+  teamMembers: IUser[];
+}) => {
+  const { confirm } = useConfirm();
+  const { deactivateTeamMembers, loading } = useTeamMemberDeactivate();
+  const { table } = RecordTable.useRecordTable();
+  const { toast } = useToast();
+  const currentUser = useAtomValue(currentUserState);
+
+  // Only active members can be deactivated and the backend rejects the whole
+  // batch when it contains the requesting user.
+  const teamMemberIds = teamMembers
+    .filter(
+      (teamMember) =>
+        teamMember.isActive !== false && teamMember._id !== currentUser?._id,
+    )
+    .map((teamMember) => teamMember._id);
+
+  return (
+    <Can action="teamMembersRemove">
+      <Button
+        variant="secondary"
+        disabled={loading || teamMemberIds.length === 0}
+        onClick={() =>
+          confirm({
+            message: `Are you sure you want to deactivate the ${teamMemberIds.length} selected team member?`,
+          }).then(async () => {
+            try {
+              await deactivateTeamMembers(teamMemberIds);
+              table.setRowSelection({});
+              toast({
+                title: 'Success',
+                variant: 'success',
+                description: `${teamMemberIds.length} team member(s) deactivated successfully`,
+              });
+            } catch (error) {
+              toast({
+                title: 'Error',
+                description:
+                  error instanceof Error
+                    ? error.message
+                    : 'Something went wrong',
+                variant: 'destructive',
+              });
+            }
+          })
+        }
+      >
+        {loading ? <Spinner size="sm" /> : <IconToggleLeft />}
+        Deactivate
+      </Button>
+    </Can>
+  );
+};

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/deactivate/TeamMemberDeactivate.tsx
@@ -23,9 +23,6 @@ export const TeamMemberDeactivate = ({
   const { toast } = useToast();
   const currentUserId = useAtomValue(currentUserState)?._id;
 
-  // Only active members can be deactivated and the backend rejects the whole
-  // batch when it contains the requesting user, so wait until the current user
-  // is loaded before allowing the action.
   const teamMemberIds = currentUserId
     ? teamMembers
         .filter(

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
@@ -1,7 +1,7 @@
 import { useResendInvites } from '@/settings/team-member/hooks/useResendInvite';
 import { EStatus, IUser } from '@/settings/team-member/types';
 import { IconRefresh } from '@tabler/icons-react';
-import { Button, RecordTable, Spinner, useToast } from 'erxes-ui';
+import { Button, RecordTable, Separator, Spinner, useToast } from 'erxes-ui';
 import { Can } from 'ui-modules';
 
 export const TeamMemberResendInvite = ({
@@ -43,6 +43,7 @@ export const TeamMemberResendInvite = ({
 
   return (
     <Can action="teamMembersInvite">
+      <Separator.Inline />
       <Button
         variant="secondary"
         disabled={loading || pendingEmails.length === 0}

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
@@ -13,7 +13,6 @@ export const TeamMemberResendInvite = ({
   const { table } = RecordTable.useRecordTable();
   const { toast } = useToast();
 
-  // Invitations can only be resent to members who have not confirmed theirs yet.
   const pendingEmails = teamMembers
     .filter(({ status }) => status !== EStatus.Verified)
     .map(({ email }) => email);

--- a/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/team-member-command-bar/resend-invite/TeamMemberResendInvite.tsx
@@ -1,0 +1,56 @@
+import { useResendInvites } from '@/settings/team-member/hooks/useResendInvite';
+import { EStatus, IUser } from '@/settings/team-member/types';
+import { IconRefresh } from '@tabler/icons-react';
+import { Button, RecordTable, Spinner, useToast } from 'erxes-ui';
+import { Can } from 'ui-modules';
+
+export const TeamMemberResendInvite = ({
+  teamMembers,
+}: {
+  teamMembers: IUser[];
+}) => {
+  const { resendMany, loading } = useResendInvites();
+  const { table } = RecordTable.useRecordTable();
+  const { toast } = useToast();
+
+  // Invitations can only be resent to members who have not confirmed theirs yet.
+  const pendingEmails = teamMembers
+    .filter(({ status }) => status !== EStatus.Verified)
+    .map(({ email }) => email);
+
+  const handleResend = async () => {
+    const { sent, failed, firstError } = await resendMany(pendingEmails);
+
+    if (sent > 0) {
+      toast({
+        title: 'Success',
+        variant: 'success',
+        description: `${sent} invitation(s) has been resent`,
+      });
+      table.setRowSelection({});
+    }
+
+    if (failed > 0) {
+      toast({
+        title: 'Error',
+        variant: 'destructive',
+        description: `Failed to resend ${failed} invitation(s)${
+          firstError ? `: ${firstError}` : ''
+        }`,
+      });
+    }
+  };
+
+  return (
+    <Can action="teamMembersInvite">
+      <Button
+        variant="secondary"
+        disabled={loading || pendingEmails.length === 0}
+        onClick={handleResend}
+      >
+        {loading ? <Spinner size="sm" /> : <IconRefresh />}
+        Resend Invite
+      </Button>
+    </Can>
+  );
+};

--- a/frontend/core-ui/src/modules/settings/team-member/graphql/usersMutations.ts
+++ b/frontend/core-ui/src/modules/settings/team-member/graphql/usersMutations.ts
@@ -25,6 +25,12 @@ const TEAM_MEMBER_REMOVE = gql`
   }
 `;
 
+const USERS_DEACTIVATE_BATCH = gql`
+  mutation UsersDeactivateBatch($_ids: [String!]!) {
+    usersSetActiveStatusBatch(_ids: $_ids)
+  }
+`;
+
 const USERS_CONFIRM_INVITATION = gql`
   mutation usersConfirmInvitation(
     $token: String
@@ -120,6 +126,7 @@ const mutations = {
   USERS_INLINE_EDIT,
   USERS_RESET_PASSWORD,
   TEAM_MEMBER_REMOVE,
+  USERS_DEACTIVATE_BATCH,
 };
 
 export default mutations;

--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
@@ -5,13 +5,18 @@ type InviteResendResult = {
   usersResendInvitation: boolean;
 };
 
+type InviteResendVariables = {
+  email: string;
+};
+
 export const useResendInvite = () => {
-  const [mutate, { loading, error }] = useMutation<InviteResendResult>(
-    mutations.USERS_RESEND_INVITATION,
-  );
+  const [mutate, { loading, error }] = useMutation<
+    InviteResendResult,
+    InviteResendVariables
+  >(mutations.USERS_RESEND_INVITATION);
 
   const handleResend = (
-    options: MutationFunctionOptions<InviteResendResult, any>,
+    options: MutationFunctionOptions<InviteResendResult, InviteResendVariables>,
   ) => {
     mutate({
       ...options,
@@ -22,6 +27,36 @@ export const useResendInvite = () => {
   };
   return {
     resend: handleResend,
+    loading,
+    error,
+  };
+};
+
+export const useResendInvites = () => {
+  const [mutate, { loading, error }] = useMutation<
+    InviteResendResult,
+    InviteResendVariables
+  >(mutations.USERS_RESEND_INVITATION);
+
+  const handleResendMany = async (emails: string[]) => {
+    const results = await Promise.allSettled(
+      emails.map((email) => mutate({ variables: { email } })),
+    );
+
+    const rejected = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    const firstError: unknown = rejected[0]?.reason;
+
+    return {
+      sent: results.length - rejected.length,
+      failed: rejected.length,
+      firstError: firstError instanceof Error ? firstError.message : undefined,
+    };
+  };
+
+  return {
+    resendMany: handleResendMany,
     loading,
     error,
   };

--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
@@ -1,8 +1,10 @@
 import { mutations } from '@/settings/team-member/graphql';
 import { MutationFunctionOptions, useMutation } from '@apollo/client';
+import { useState } from 'react';
 
 type InviteResendResult = {
-  usersResendInvitation: boolean;
+  // The registration token of the reinvited user.
+  usersResendInvitation: string;
 };
 
 type InviteResendVariables = {
@@ -33,15 +35,26 @@ export const useResendInvite = () => {
 };
 
 export const useResendInvites = () => {
-  const [mutate, { loading, error }] = useMutation<
+  const [mutate, { error }] = useMutation<
     InviteResendResult,
     InviteResendVariables
   >(mutations.USERS_RESEND_INVITATION);
+  // Apollo only reports the state of the latest mutation, so the whole batch is
+  // tracked here instead.
+  const [loading, setLoading] = useState(false);
 
   const handleResendMany = async (emails: string[]) => {
+    setLoading(true);
+
     const results = await Promise.allSettled(
-      emails.map((email) => mutate({ variables: { email } })),
-    );
+      emails.map(async (email) => {
+        const { data } = await mutate({ variables: { email } });
+
+        if (!data?.usersResendInvitation) {
+          throw new Error('Invitation could not be resent');
+        }
+      }),
+    ).finally(() => setLoading(false));
 
     const rejected = results.filter(
       (result): result is PromiseRejectedResult => result.status === 'rejected',

--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useResendInvite.tsx
@@ -3,7 +3,6 @@ import { MutationFunctionOptions, useMutation } from '@apollo/client';
 import { useState } from 'react';
 
 type InviteResendResult = {
-  // The registration token of the reinvited user.
   usersResendInvitation: string;
 };
 
@@ -39,8 +38,6 @@ export const useResendInvites = () => {
     InviteResendResult,
     InviteResendVariables
   >(mutations.USERS_RESEND_INVITATION);
-  // Apollo only reports the state of the latest mutation, so the whole batch is
-  // tracked here instead.
   const [loading, setLoading] = useState(false);
 
   const handleResendMany = async (emails: string[]) => {

--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useTeamMemberDeactivate.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useTeamMemberDeactivate.tsx
@@ -1,10 +1,19 @@
 import { useMutation } from '@apollo/client';
 import { mutations } from '../graphql';
 
+type DeactivateTeamMembersResult = {
+  usersSetActiveStatusBatch: boolean;
+};
+
+type DeactivateTeamMembersVariables = {
+  _ids: string[];
+};
+
 export const useTeamMemberDeactivate = () => {
-  const [_deactivateTeamMembers, { loading }] = useMutation(
-    mutations.USERS_DEACTIVATE_BATCH,
-  );
+  const [_deactivateTeamMembers, { loading }] = useMutation<
+    DeactivateTeamMembersResult,
+    DeactivateTeamMembersVariables
+  >(mutations.USERS_DEACTIVATE_BATCH);
 
   const deactivateTeamMembers = (teamMemberIds: string[]) =>
     _deactivateTeamMembers({

--- a/frontend/core-ui/src/modules/settings/team-member/hooks/useTeamMemberDeactivate.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/hooks/useTeamMemberDeactivate.tsx
@@ -1,0 +1,16 @@
+import { useMutation } from '@apollo/client';
+import { mutations } from '../graphql';
+
+export const useTeamMemberDeactivate = () => {
+  const [_deactivateTeamMembers, { loading }] = useMutation(
+    mutations.USERS_DEACTIVATE_BATCH,
+  );
+
+  const deactivateTeamMembers = (teamMemberIds: string[]) =>
+    _deactivateTeamMembers({
+      variables: { _ids: teamMemberIds },
+      refetchQueries: ['Users'],
+    });
+
+  return { deactivateTeamMembers, loading };
+};


### PR DESCRIPTION
## What

Adds **Deactivate** and **Resend Invite** to the team member bulk action (command) bar, so both actions can be applied to a selection instead of one row at a time. They mirror the actions already available in the row more menu.

## Details

- **Deactivate** (`TeamMemberDeactivate`) reuses `usersSetActiveStatusBatch`. It filters out members that are already inactive and the requesting user, because the backend rejects the whole batch when it contains the current user. Asks for confirmation, then clears the row selection and refetches `Users`.
- **Resend Invite** (`TeamMemberResendInvite`) only targets members whose invitation is still pending (`status !== 'Verified'`), sends one `usersResendInvitation` per email and reports how many invitations were sent / failed. Disabled when the selection has no pending invitation.
- Both buttons are gated by the same permissions as the backend / row menu: `teamMembersRemove` and `teamMembersInvite`.
- `useResendInvite.tsx` gains a `useResendInvites` hook for the bulk case and its variables are now typed (`any` removed).

## Notes

The existing **Delete** bulk action also calls `usersSetActiveStatusBatch`, which only deactivates (there is no hard delete on the API). So Delete and the new Deactivate hit the same mutation — worth deciding separately whether Delete should be renamed or dropped.

## Test plan

- Settings → Team members: select several members, confirm **Deactivate** deactivates them and the list refreshes.
- Select a mix of pending and verified members: **Resend Invite** only resends for pending ones and the toast counts match.
- Select only verified members: **Resend Invite** is disabled; select only inactive members: **Deactivate** is disabled.

## Summary by Sourcery

Add bulk deactivate and resend invite actions to the team member command bar and supporting hooks and mutations.

New Features:
- Introduce bulk deactivate action for selected team members in the command bar.
- Introduce bulk resend invite action for selected team members whose invitations are still pending.

Enhancements:
- Add typed variables and a new useResendInvites hook to support sending multiple invite resends.
- Wire team member selection objects into the command bar to support actions that depend on full user data rather than just IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch invitation resend for selected team members, with success and error feedback.
  * Added batch deactivation for active team members, including confirmation and status notifications.
* **Bug Fixes**
  * Deactivation remains disabled until the current user is available, preventing invalid actions.
* **UI Improvements**
  * Updated command bar separators around team member actions.
* **Access Control**
  * Resend and deactivation actions remain available only to users with the required permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->