### PR TITLE
fix(sales): keep pipeline stages saveable after removing a stage

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
@@ -79,10 +79,15 @@ export const PipelineStages = ({ form, stagesLoading }: Props) => {
             }}
             renderItem={({
               value,
-              index,
               ...sortableProps
             }: PipelineStageRenderItemProps) => {
-              if (index === undefined) {
+              // Sortable can still render a removed stage, so resolve the index
+              // by id instead of trusting its own order.
+              const stageIndex = fields.findIndex(
+                (field) => field.id === value,
+              );
+
+              if (stageIndex === -1) {
                 return null;
               }
 
@@ -91,10 +96,10 @@ export const PipelineStages = ({ form, stagesLoading }: Props) => {
                   {...sortableProps}
                   key={String(value)}
                   value={value}
-                  index={index}
+                  index={stageIndex}
                   control={control}
-                  stage={fields[index]}
-                  onRemoveStage={() => remove(index)}
+                  stage={fields[stageIndex]}
+                  onRemoveStage={() => remove(stageIndex)}
                 />
               );
             }}

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSubmit.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSubmit.ts
@@ -60,6 +60,10 @@ const findFirstFormError = (errors: FieldErrors<TPipelineForm>) => {
   return undefined;
 };
 
+// A stage without an id was never rendered, so it cannot be fixed by the user.
+const removeGhostStages = (stages: TPipelineForm['stages']) =>
+  (stages || []).filter((stage) => Boolean(stage?._id));
+
 const removeEmptyPaymentTypes = (paymentTypes: TPipelineForm['paymentTypes']) =>
   (paymentTypes || []).filter((paymentType) =>
     [
@@ -145,6 +149,13 @@ export const usePipelineFormSubmit = ({
         methods.setValue('paymentTypes', populatedPaymentTypes, {
           shouldDirty: true,
         });
+      }
+
+      const stages = methods.getValues('stages');
+      const populatedStages = removeGhostStages(stages);
+
+      if (populatedStages.length !== (stages || []).length) {
+        methods.setValue('stages', populatedStages, { shouldDirty: true });
       }
 
       void methods.handleSubmit(submitHandler, onInvalid)(event);


### PR DESCRIPTION
## Problem

Editing a sales pipeline could no longer be saved: submitting showed a `Required` toast on the **Stages** tab, but no stage row in the form had a visible error to fix.

## Cause

`Sortable` keeps its own copy of the item ids and only syncs them in an effect, so it runs one render after the field array changed. When a stage is removed, that render calls `renderItem` with an index that no longer exists, `fields[index]` is `undefined`, and `PipelineStageItem` registers `stages.<index>.{name,probability,status,visibility}` for it. The result is a stage entry in form state with no `_id`.

`_id` is the first key of the stage schema, so zod reports its default `Required` message for that invisible entry, `onInvalid` maps the `stages` field to the Stages tab, and the pipeline can never be saved.

## Fix

- `PipelineStages` resolves the stage index from the field array id (`fields.findIndex((field) => field.id === value)`) instead of the order `Sortable` reports, and renders nothing when the id is gone. This also stops a reorder from writing into a neighbouring stage's fields.
- `usePipelineFormSubmit` drops stage entries without an `_id` before validation, the same way empty payment types are already dropped, so a stale entry cannot block saving.

## Test plan

- Settings → Sales → Deals → edit a pipeline → Stages: remove a stage, then Update. Saves instead of failing with `Required`.
- Drag stages to reorder, rename one, then Update: the edited values land on the right stages.
- Add a stage, remove it again, then Update.

## Summary by Sourcery

Ensure sales pipeline stages can be saved and reordered safely after stage removal by preventing ghost stages from being registered or validated.

Bug Fixes:
- Prevent removed pipeline stages from leaving invisible, invalid stage entries in form state that block saving with a generic Required error.

Enhancements:
- Make PipelineStages resolve stage indices by field id and skip rendering for removed stages to avoid writing into neighboring stage fields.
- Filter out non-rendered pipeline stages without an id before validation so they no longer interfere with form submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipeline stage ordering and removal behavior during editing.
  * Prevented deleted or unavailable stages from appearing in the pipeline editor.
  * Automatically removes incomplete stages before pipeline changes are submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->