### PR TITLE
feat: add cpCompanies query

### DIFF
--- a/backend/core-api/src/modules/contacts/graphql/resolvers/queries/company.ts
+++ b/backend/core-api/src/modules/contacts/graphql/resolvers/queries/company.ts
@@ -1,17 +1,42 @@
 import {
   ICompanyDocument,
   ICompanyFilterQueryParams,
+  Resolver,
 } from 'erxes-api-shared/core-types';
 import { cursorPaginate } from 'erxes-api-shared/utils';
 import { FilterQuery } from 'mongoose';
 import { IContext } from '~/connectionResolvers';
 import { generateFilter } from '~/modules/contacts/utils';
 
-export const companyQueries = {
+export const companyQueries: Record<
+  string,
+  Resolver<undefined, unknown, IContext>
+> = {
   /**
    * Get companies
    */
   companies: async (
+    _parent: undefined,
+    params: ICompanyFilterQueryParams,
+    { models, subdomain }: IContext,
+  ) => {
+    const filter: FilterQuery<ICompanyDocument> = await generateFilter(
+      subdomain,
+      params,
+      models,
+    );
+
+    const { list, totalCount, pageInfo } =
+      await cursorPaginate<ICompanyDocument>({
+        model: models.Companies,
+        params,
+        query: filter,
+      });
+
+    return { list, totalCount, pageInfo };
+  },
+
+  cpCompanies: async (
     _parent: undefined,
     params: ICompanyFilterQueryParams,
     { models, subdomain }: IContext,
@@ -42,4 +67,8 @@ export const companyQueries = {
   ) => {
     return await models.Companies.findOne({ $or: [{ _id }, { code: _id }] });
   },
+};
+
+companyQueries.cpCompanies.wrapperConfig = {
+  forClientPortal: true,
 };

--- a/backend/core-api/src/modules/contacts/graphql/schemas/company.ts
+++ b/backend/core-api/src/modules/contacts/graphql/schemas/company.ts
@@ -82,6 +82,7 @@ const queryParams = `
 
 export const queries = `
   companies(${queryParams}): CompaniesListResponse
+  cpCompanies(${queryParams}): CompaniesListResponse
   companyDetail(_id: String!): Company
 `;
 


### PR DESCRIPTION
## Summary by Sourcery

Add a GraphQL query for fetching companies tailored for the client portal and type the companyQueries resolver map.

New Features:
- Introduce cpCompanies GraphQL query to retrieve paginated company lists for the client portal.

Enhancements:
- Define an explicit typed resolver map for companyQueries and configure cpCompanies as client-portal specific via wrapperConfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a client-portal company listing query with filtering and cursor-based pagination.
  * The new query returns company results in the same format as the existing company listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->