### PR TITLE
feat(facebook): page post publishing + app-token machine access

### DIFF
--- a/backend/gateway/src/middlewares/userMiddleware.ts
+++ b/backend/gateway/src/middlewares/userMiddleware.ts
@@ -185,6 +185,20 @@ export default async function userMiddleware(
         { _id: appInDb._id },
         { $set: { lastUsedAt: new Date() } },
       );
+
+      // Forward the app as an authenticated system principal so plugin
+      // resolvers behind login/permission wrappers accept machine calls.
+      // Mirrors the JWT path's setUserHeader below; without this a valid
+      // app token authenticates the request but every wrapped mutation
+      // still fails "Login required".
+      if (!req.user) {
+        req.user = {
+          _id: `app:${appInDb._id}`,
+          username: appInDb.name,
+          isOwner: appInDb.allowAllPermission === true,
+        } as any;
+        setUserHeader(req.headers, req.user);
+      }
     } catch (e) {
       console.error(e);
       debugAuth(req, 'app-token-error', {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
@@ -4,7 +4,11 @@ import {
   updateConfigs,
 } from '@/integrations/facebook/helpers';
 import { IReplyParams } from '@/integrations/facebook/@types/utils';
-import { sendReply } from '@/integrations/facebook/utils';
+import {
+  createPagePost,
+  getPostDetails,
+  sendReply,
+} from '@/integrations/facebook/utils';
 import { sendNotifications } from '@/inbox/graphql/resolvers/mutations/conversations';
 import { TCreateBotInputDoc } from '../../db/models/Bots';
 export const facebookMutations = {
@@ -105,6 +109,48 @@ export const facebookMutations = {
     } catch (e) {
       throw new Error(e.message);
     }
+  },
+  // Publish a post to a connected Facebook page. The page token must carry
+  // pages_manage_posts (granted at OAuth time via FACEBOOK_PERMISSIONS).
+  async facebookCreatePost(
+    _root,
+    {
+      erxesApiId,
+      pageId,
+      message,
+      link,
+    }: { erxesApiId: string; pageId: string; message: string; link?: string },
+    { models }: IContext,
+  ) {
+    const integration = await models.FacebookIntegrations.findOne({
+      erxesApiId,
+    });
+
+    if (!integration) {
+      throw new Error('Integration not found');
+    }
+
+    if (!(integration.facebookPageIds || []).includes(pageId)) {
+      throw new Error('Page is not connected to this integration');
+    }
+
+    const response = await createPagePost(
+      pageId,
+      integration.facebookPageTokensMap || {},
+      message,
+      link,
+    );
+
+    const details = await getPostDetails(
+      pageId,
+      integration.facebookPageTokensMap || {},
+      response.id,
+    );
+
+    return {
+      postId: response.id,
+      permalinkUrl: details ? details.permalink_url : null,
+    };
   },
   async facebookMessengerAddBot(_root, args, { models, user }: IContext) {
     return await models.FacebookBots.addBot(args, {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/schema/facebook.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/schema/facebook.ts
@@ -175,6 +175,7 @@ export const mutations = `
   facebookUpdateConfigs(configsMap: JSON!): JSON
   facebookRepair(_id: String!): JSON
   facebookReplyToComment(conversationId: String, commentId: String, content: String): FacebookComment
+  facebookCreatePost(erxesApiId: String!, pageId: String!, message: String!, link: String): JSON
   facebookMessengerAddBot(${commonBotMutationParams}):FacebookMessengerBot
   facebookMessengerUpdateBot(_id:String,${commonBotMutationParams}):FacebookMessengerBot
   facebookMessengerRemoveBot(_id:String):JSON

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
@@ -19,7 +19,7 @@ export const loginMiddleware = async (req, res) => {
   const FACEBOOK_PERMISSIONS = await getConfig(
     models,
     'FACEBOOK_PERMISSIONS',
-    'pages_messaging,pages_manage_ads,pages_manage_engagement,pages_manage_metadata,pages_read_user_content,business_management',
+    'pages_messaging,pages_manage_ads,pages_manage_engagement,pages_manage_metadata,pages_read_user_content,business_management,pages_manage_posts',
   );
 
   const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
@@ -67,6 +67,42 @@ export const getPostDetails = async (
   }
 };
 
+export const createPagePost = async (
+  pageId: string,
+  pageTokens: { [key: string]: string },
+  message: string,
+  link?: string,
+): Promise<{ id: string }> => {
+  let pageAccessToken;
+
+  try {
+    pageAccessToken = getPageAccessTokenFromMap(pageId, pageTokens);
+  } catch (e) {
+    debugError(`Error occurred while getting page access token: ${e.message}`);
+    throw new Error('Page access token not found');
+  }
+
+  const doc: { message: string; link?: string } = { message };
+
+  if (link) {
+    doc.link = link;
+  }
+
+  try {
+    // Requires the pages_manage_posts permission on the page token.
+    const response: any = await graphRequest.post(
+      `${pageId}/feed`,
+      pageAccessToken,
+      doc,
+    );
+
+    return response;
+  } catch (e) {
+    debugError(`Error occurred while creating facebook post: ${e.message}`);
+    throw new Error(e.message);
+  }
+};
+
 export const createAWS = async (subdomain: string) => {
   const {
     AWS_FORCE_PATH_STYLE,


### PR DESCRIPTION
- frontline: facebookCreatePost mutation (validates page ownership, returns postId + permalinkUrl)
- frontline: createPagePost helper (POST {pageId}/feed)
- frontline: request pages_manage_posts in the default OAuth scope
- gateway: forward a validated erxes-app-token as an authenticated principal so machine callers can invoke protected mutations (previously always 'Login required')

## Summary by Sourcery

Add support for publishing posts to connected Facebook pages and allow machine callers authenticated via app tokens to access login-protected mutations.

New Features:
- Introduce facebookCreatePost GraphQL mutation to publish posts to a validated Facebook page and return postId and permalinkUrl.
- Add createPagePost helper to create posts on a Facebook page via the Graph API.

Enhancements:
- Extend default Facebook OAuth permissions to include pages_manage_posts so page tokens can publish posts.
- Treat validated erxes app tokens as authenticated principals in the gateway so plugin resolvers behind login and permission checks accept machine calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create Facebook Page posts with text and optional links.
  * Facebook post responses now include the post ID and permalink when available.
  * Added support for the required Facebook Page posting permission.

* **Bug Fixes**
  * App-token authenticated requests are now recognized correctly by downstream access and login checks.
  * Improved validation and error handling for unavailable Facebook integrations, pages, or access credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->