### PR TITLE
feat(record-table): improve bulk selection and actions

### DIFF
--- a/backend/gateway/src/locales/en/product.json
+++ b/backend/gateway/src/locales/en/product.json
@@ -280,5 +280,17 @@
     "similarity-saved": "Similarity saved",
     "similarity-removed": "Similarity removed",
     "check-required-fields": "Please fill in the required fields"
+  },
+  "bulk": {
+    "change-category": "Change category",
+    "category-changed_one": "{{count}} product moved to the new category",
+    "category-changed_other": "{{count}} products moved to the new category",
+    "category-change-failed_one": "{{count}} product could not be moved",
+    "category-change-failed_other": "{{count}} products could not be moved",
+    "deleted-skipped_one": "{{count}} deleted product was skipped",
+    "deleted-skipped_other": "{{count}} deleted products were skipped",
+    "no-movable-products": "Deleted products cannot be moved to another category",
+    "confirm-change-category_one": "Move the {{count}} selected product to this category? Its current category will be replaced.",
+    "confirm-change-category_other": "Move the {{count}} selected products to this category? Their current categories will be replaced."
   }
 }

--- a/backend/gateway/src/locales/mn/product.json
+++ b/backend/gateway/src/locales/mn/product.json
@@ -278,5 +278,17 @@
     "similarity-saved": "Ижил төстэй хадгалагдлаа",
     "similarity-removed": "Ижил төстэй устгагдлаа",
     "check-required-fields": "Шаардлагатай талбаруудыг бөглөнө үү"
+  },
+  "bulk": {
+    "change-category": "Ангилал солих",
+    "category-changed_one": "{{count}} бүтээгдэхүүнийг шинэ ангилалд шилжүүллээ",
+    "category-changed_other": "{{count}} бүтээгдэхүүнийг шинэ ангилалд шилжүүллээ",
+    "category-change-failed_one": "{{count}} бүтээгдэхүүнийг шилжүүлж чадсангүй",
+    "category-change-failed_other": "{{count}} бүтээгдэхүүнийг шилжүүлж чадсангүй",
+    "deleted-skipped_one": "Устгасан {{count}} бүтээгдэхүүнийг алгаслаа",
+    "deleted-skipped_other": "Устгасан {{count}} бүтээгдэхүүнийг алгаслаа",
+    "no-movable-products": "Устгасан бүтээгдэхүүнийг өөр ангилалд шилжүүлэх боломжгүй",
+    "confirm-change-category_one": "Сонгосон {{count}} бүтээгдэхүүнийг энэ ангилалд шилжүүлэх үү? Одоогийн ангиллыг нь орлуулна.",
+    "confirm-change-category_other": "Сонгосон {{count}} бүтээгдэхүүнийг энэ ангилалд шилжүүлэх үү? Одоогийн ангиллыг нь орлуулна."
   }
 }

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -7,6 +7,7 @@ import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
 import { ProductsRestore } from './restore/productRestore';
 import { ProductMerge } from './ProductMerge';
+import { ProductsChangeCategory } from './ProductsChangeCategory';
 
 const updateProductsTagCache = (
   cache: ApolloCache<unknown>,
@@ -71,6 +72,14 @@ export const ProductCommandBar = () => {
                   });
                 },
               })}
+            />
+          </>
+        </Can>
+        <Can action="productsUpdate">
+          <>
+            <Separator.Inline />
+            <ProductsChangeCategory
+              products={selectedRows.map((row: Row<IProduct>) => row.original)}
             />
           </>
         </Can>

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
@@ -1,0 +1,150 @@
+import { IconCategory } from '@tabler/icons-react';
+import { useApolloClient } from '@apollo/client';
+import { Button, Popover, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IProduct, SelectCategory } from 'ui-modules';
+
+import { useProductsEdit } from '@/products/hooks/useProductsEdit';
+
+export const ProductsChangeCategory = ({
+  products,
+}: {
+  products: IProduct[];
+}) => {
+  const { t } = useTranslation('product');
+  const { toast } = useToast();
+  const { confirm } = useConfirm();
+  const { table } = RecordTable.useRecordTable();
+  const { productsEdit } = useProductsEdit();
+  const client = useApolloClient();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // productsEdit forces status back to 'active', so moving a soft-deleted
+  // product would silently restore it. Leave those out of the batch.
+  const movableProducts = products.filter(
+    (product) => product.status !== 'deleted',
+  );
+  const skippedCount = products.length - movableProducts.length;
+
+  const handleSelect = async (value: string | string[]) => {
+    const categoryId = Array.isArray(value) ? value[0] : value;
+
+    if (!categoryId || loading) {
+      return;
+    }
+
+    setOpen(false);
+
+    if (!movableProducts.length) {
+      toast({
+        title: t('bulk.no-movable-products', {
+          defaultValue: 'Deleted products cannot be moved to another category',
+        }),
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      // Moving is not reversible: once overwritten, there is no record of which
+      // category each product came from.
+      await confirm({
+        message: t('bulk.confirm-change-category', {
+          count: movableProducts.length,
+          defaultValue_one:
+            'Move the {{count}} selected product to this category? Its current category will be replaced.',
+          defaultValue_other:
+            'Move the {{count}} selected products to this category? Their current categories will be replaced.',
+        }),
+      });
+    } catch {
+      // User cancelled the confirmation
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const results = await Promise.allSettled(
+        movableProducts.map((product) =>
+          productsEdit({ variables: { _id: product._id, categoryId } }),
+        ),
+      );
+
+      const failedCount = results.filter(
+        (result) => result.status === 'rejected',
+      ).length;
+      const movedCount = results.length - failedCount;
+
+      const notes = [
+        failedCount > 0 &&
+          t('bulk.category-change-failed', {
+            count: failedCount,
+            defaultValue_one: '{{count}} product could not be moved',
+            defaultValue_other: '{{count}} products could not be moved',
+          }),
+        skippedCount > 0 &&
+          t('bulk.deleted-skipped', {
+            count: skippedCount,
+            defaultValue_one: '{{count}} deleted product was skipped',
+            defaultValue_other: '{{count}} deleted products were skipped',
+          }),
+      ].filter(Boolean) as string[];
+
+      if (movedCount === 0) {
+        toast({
+          title: t('bulk.category-change-failed', {
+            count: failedCount,
+            defaultValue_one: '{{count}} product could not be moved',
+            defaultValue_other: '{{count}} products could not be moved',
+          }),
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      toast({
+        title: t('bulk.category-changed', {
+          count: movedCount,
+          defaultValue_one: '{{count}} product moved to the new category',
+          defaultValue_other: '{{count}} products moved to the new category',
+        }),
+        description: notes.length ? notes.join(' · ') : undefined,
+        variant: 'success',
+      });
+
+      table.setRowSelection({});
+      client.refetchQueries({ include: ['ProductsMain'] });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button variant="secondary" disabled={loading || !products.length}>
+          <IconCategory />
+          {t('bulk.change-category', { defaultValue: 'Change category' })}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        className="p-0 w-96"
+        align="end"
+        side="top"
+        sideOffset={10}
+      >
+        <SelectCategory.Provider
+          mode="single"
+          value=""
+          onValueChange={handleSelect}
+        >
+          <SelectCategory.Content />
+        </SelectCategory.Provider>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/frontend/core-ui/src/modules/products/hooks/useProductsEdit.tsx
+++ b/frontend/core-ui/src/modules/products/hooks/useProductsEdit.tsx
@@ -7,12 +7,11 @@ export const useProductsEdit = () => {
     productsMutations.productsEdit,
   );
 
-  const mutate = ({ variables, ...options }: MutationHookOptions) => {
+  const mutate = ({ variables, ...options }: MutationHookOptions) =>
     productsEdit({
       ...options,
       variables,
     });
-  };
 
   return { productsEdit: mutate, loading };
 };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -1,34 +1,52 @@
 import { Checkbox } from 'erxes-ui/components/checkbox';
-import { ColumnDef, Row } from '@tanstack/react-table';
+import { ColumnDef, Row, Table } from '@tanstack/react-table';
 
-// A pointer drag is a single global interaction, so this transient state lives
-// at module scope rather than being threaded through the table context.
 const dragSelection = {
-  active: false,
+  owner: null as Table<any> | null,
   selecting: false,
-  suppressClickOn: null as string | null,
+  suppressClickOn: null as { table: Table<any>; rowId: string } | null,
+  previousUserSelect: '',
 };
+
+const DRAG_END_EVENTS = ['pointerup', 'pointercancel', 'blur'] as const;
 
 const endDragSelection = () => {
-  dragSelection.active = false;
-  document.body.style.userSelect = '';
+  dragSelection.owner = null;
+  document.body.style.userSelect = dragSelection.previousUserSelect;
+  DRAG_END_EVENTS.forEach((event) =>
+    window.removeEventListener(event, endDragSelection),
+  );
 };
 
-const startDragSelection = (selecting: boolean, rowId: string) => {
-  dragSelection.active = true;
+const startDragSelection = (
+  selecting: boolean,
+  row: Row<any>,
+  table: Table<any>,
+) => {
+  if (dragSelection.owner) {
+    endDragSelection();
+  }
+
+  dragSelection.owner = table;
   dragSelection.selecting = selecting;
-  dragSelection.suppressClickOn = rowId;
-  // Shift + drag would otherwise paint a text selection across the rows.
+  dragSelection.suppressClickOn = { table, rowId: row.id };
+  dragSelection.previousUserSelect = document.body.style.userSelect;
   document.body.style.userSelect = 'none';
-  window.addEventListener('pointerup', endDragSelection, { once: true });
+  DRAG_END_EVENTS.forEach((event) =>
+    window.addEventListener(event, endDragSelection),
+  );
 };
 
-const CheckboxCell = ({ row }: { row: Row<any> }) => (
+const CheckboxCell = ({
+  row,
+  table,
+}: {
+  row: Row<any>;
+  table: Table<any>;
+}) => (
   <div
     className="flex items-center justify-center size-full"
     onPointerDown={(event) => {
-      // A fresh press always precedes that element's click, so this also clears
-      // a suppression left dangling by a drag that ended on another row.
       dragSelection.suppressClickOn = null;
 
       if (!event.shiftKey || event.button !== 0) {
@@ -37,21 +55,20 @@ const CheckboxCell = ({ row }: { row: Row<any> }) => (
 
       event.preventDefault();
       const selecting = !row.getIsSelected();
-      startDragSelection(selecting, row.id);
+      startDragSelection(selecting, row, table);
       row.toggleSelected(selecting);
     }}
     onPointerEnter={(event) => {
-      // event.buttons guards against a drag left dangling by a missed pointerup.
-      if (!dragSelection.active || event.buttons !== 1) {
+      if (dragSelection.owner !== table || event.buttons !== 1) {
         return;
       }
 
       row.toggleSelected(dragSelection.selecting);
     }}
     onClickCapture={(event) => {
-      // pointerdown already applied the change; swallow the click that Radix
-      // would otherwise turn into a second toggle of the row we started on.
-      if (dragSelection.suppressClickOn !== row.id) {
+      const suppressed = dragSelection.suppressClickOn;
+
+      if (suppressed?.table !== table || suppressed.rowId !== row.id) {
         return;
       }
 
@@ -85,5 +102,5 @@ export const checkboxColumn: ColumnDef<any> = {
     );
   },
   size: 33,
-  cell: ({ row }) => <CheckboxCell row={row} />,
+  cell: ({ row, table }) => <CheckboxCell row={row} table={table} />,
 };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -1,5 +1,71 @@
 import { Checkbox } from 'erxes-ui/components/checkbox';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, Row } from '@tanstack/react-table';
+
+// A pointer drag is a single global interaction, so this transient state lives
+// at module scope rather than being threaded through the table context.
+const dragSelection = {
+  active: false,
+  selecting: false,
+  suppressClickOn: null as string | null,
+};
+
+const endDragSelection = () => {
+  dragSelection.active = false;
+  document.body.style.userSelect = '';
+};
+
+const startDragSelection = (selecting: boolean, rowId: string) => {
+  dragSelection.active = true;
+  dragSelection.selecting = selecting;
+  dragSelection.suppressClickOn = rowId;
+  // Shift + drag would otherwise paint a text selection across the rows.
+  document.body.style.userSelect = 'none';
+  window.addEventListener('pointerup', endDragSelection, { once: true });
+};
+
+const CheckboxCell = ({ row }: { row: Row<any> }) => (
+  <div
+    className="flex items-center justify-center size-full"
+    onPointerDown={(event) => {
+      // A fresh press always precedes that element's click, so this also clears
+      // a suppression left dangling by a drag that ended on another row.
+      dragSelection.suppressClickOn = null;
+
+      if (!event.shiftKey || event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+      const selecting = !row.getIsSelected();
+      startDragSelection(selecting, row.id);
+      row.toggleSelected(selecting);
+    }}
+    onPointerEnter={(event) => {
+      // event.buttons guards against a drag left dangling by a missed pointerup.
+      if (!dragSelection.active || event.buttons !== 1) {
+        return;
+      }
+
+      row.toggleSelected(dragSelection.selecting);
+    }}
+    onClickCapture={(event) => {
+      // pointerdown already applied the change; swallow the click that Radix
+      // would otherwise turn into a second toggle of the row we started on.
+      if (dragSelection.suppressClickOn !== row.id) {
+        return;
+      }
+
+      dragSelection.suppressClickOn = null;
+      event.preventDefault();
+      event.stopPropagation();
+    }}
+  >
+    <Checkbox
+      checked={row.getIsSelected()}
+      onCheckedChange={(value) => row.toggleSelected(!!value)}
+    />
+  </div>
+);
 
 export const checkboxColumn: ColumnDef<any> = {
   accessorKey: 'checkbox',
@@ -19,12 +85,5 @@ export const checkboxColumn: ColumnDef<any> = {
     );
   },
   size: 33,
-  cell: ({ row }) => (
-    <div className="flex items-center justify-center">
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-      />
-    </div>
-  ),
+  cell: ({ row }) => <CheckboxCell row={row} />,
 };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -5,14 +5,13 @@ const dragSelection = {
   owner: null as Table<any> | null,
   selecting: false,
   suppressClickOn: null as { table: Table<any>; rowId: string } | null,
-  previousUserSelect: '',
 };
 
 const DRAG_END_EVENTS = ['pointerup', 'pointercancel', 'blur'] as const;
 
 const endDragSelection = () => {
   dragSelection.owner = null;
-  document.body.style.userSelect = dragSelection.previousUserSelect;
+  document.body.style.userSelect = '';
   DRAG_END_EVENTS.forEach((event) =>
     window.removeEventListener(event, endDragSelection),
   );
@@ -23,14 +22,9 @@ const startDragSelection = (
   row: Row<any>,
   table: Table<any>,
 ) => {
-  if (dragSelection.owner) {
-    endDragSelection();
-  }
-
   dragSelection.owner = table;
   dragSelection.selecting = selecting;
   dragSelection.suppressClickOn = { table, rowId: row.id };
-  dragSelection.previousUserSelect = document.body.style.userSelect;
   document.body.style.userSelect = 'none';
   DRAG_END_EVENTS.forEach((event) =>
     window.addEventListener(event, endDragSelection),

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -37,13 +37,7 @@ const startDragSelection = (
   );
 };
 
-const CheckboxCell = ({
-  row,
-  table,
-}: {
-  row: Row<any>;
-  table: Table<any>;
-}) => (
+const CheckboxCell = ({ row, table }: { row: Row<any>; table: Table<any> }) => (
   <div
     className="flex items-center justify-center size-full"
     onPointerDown={(event) => {


### PR DESCRIPTION
## Summary by Sourcery

Add a bulk category change action to the products command bar for selected records, with confirmation, status-aware handling, and feedback, integrating with existing edit mutations and table selection.

New Features:
- Introduce a bulk "Change category" action in the product command bar that updates the category of all selected non-deleted products.
- Provide user confirmation and success/error toasts for bulk category changes, including handling of skipped deleted products.

Enhancements:
- Simplify the products edit hook interface by returning the mutation function directly.
- Reset table row selection and refresh the main products list after successful bulk category changes.

Documentation:
- Add new product locale strings to support bulk category change messaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk category changes for selected products.
  * Added category selection, confirmation, progress feedback, and success or failure notifications.
  * Deleted products are skipped automatically, with clear messaging when changes are unavailable.
  * The action is available only to authorized users.
  * Added shift-drag support for selecting multiple product rows.
  * Product selections refresh after successful category changes.

* **Localization**
  * Added English and Mongolian translations for bulk category change messages, including singular and plural variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->