### PR TITLE
feat(mongolian,loyalty): add record table column selector

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableColumnSelector.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableColumnSelector.tsx
@@ -50,7 +50,7 @@ const SortableColumnItem = ({
   column,
   isLastVisible,
 }: {
-  column: Column<any, unknown>;
+  column: Column<unknown, unknown>;
   isLastVisible: boolean;
 }) => {
   const isPinned = !!column.getIsPinned();

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableColumnSelector.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableColumnSelector.tsx
@@ -46,7 +46,13 @@ const getColumnLabel = (column: Column<any, unknown>): string => {
   return column.id;
 };
 
-const SortableColumnItem = ({ column }: { column: Column<any, unknown> }) => {
+const SortableColumnItem = ({
+  column,
+  isLastVisible,
+}: {
+  column: Column<any, unknown>;
+  isLastVisible: boolean;
+}) => {
   const isPinned = !!column.getIsPinned();
   const {
     attributes,
@@ -83,6 +89,10 @@ const SortableColumnItem = ({ column }: { column: Column<any, unknown> }) => {
       <Checkbox
         id={`col-visibility-${column.id}`}
         checked={column.getIsVisible()}
+        disabled={isLastVisible}
+        title={
+          isLastVisible ? 'At least one column must stay visible' : undefined
+        }
         onCheckedChange={(checked) => column.toggleVisibility(!!checked)}
       />
 
@@ -117,7 +127,7 @@ export const RecordTableColumnSelector = ({
   children?: React.ReactElement;
   align?: 'start' | 'center' | 'end';
 }) => {
-  const { table } = useRecordTable();
+  const { table, columnSelectorOpen, setColumnSelectorOpen } = useRecordTable();
 
   const columns = table
     .getAllLeafColumns()
@@ -146,10 +156,15 @@ export const RecordTableColumnSelector = ({
     }
   };
 
+  const visibleColumns = columns.filter((col) => col.getIsVisible());
+
   if (columns.length === 0) return null;
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={columnSelectorOpen}
+      onOpenChange={setColumnSelectorOpen}
+    >
       <DropdownMenu.Trigger asChild>
         {children ?? (
           <Button variant="ghost" className="h-full w-full rounded-none px-0">
@@ -172,7 +187,14 @@ export const RecordTableColumnSelector = ({
             strategy={verticalListSortingStrategy}
           >
             {columns.map((column) => (
-              <SortableColumnItem key={column.id} column={column} />
+              <SortableColumnItem
+                key={column.id}
+                column={column}
+                isLastVisible={
+                  visibleColumns.length === 1 &&
+                  visibleColumns[0].id === column.id
+                }
+              />
             ))}
           </SortableContext>
         </DndContext>

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHead.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHead.tsx
@@ -30,6 +30,7 @@ export const recordTableHeadVariants = cva(
 export const RecordTableHead = ({
   header,
   children,
+  className,
   ...props
 }: React.ComponentProps<'th'> & {
   header: Header<any, unknown>;
@@ -51,9 +52,10 @@ export const RecordTableHead = ({
             column.getIsPinned() === 'left'
               ? 'left'
               : column.getIsPinned() === 'right'
-              ? 'right'
-              : null,
+                ? 'right'
+                : null,
         }),
+        className,
       )}
       style={{
         width: `var(--header-${column.id}-width)`,

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHeader.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHeader.tsx
@@ -13,7 +13,7 @@ import { useRecordTable } from './RecordTableProvider';
 
 const SELECTOR_WIDTH = 32;
 
-const resolveSelectorSlot = (visibleHeaders: Header<any, unknown>[]) => {
+const resolveSelectorSlot = (visibleHeaders: Header<unknown, unknown>[]) => {
   let offset = 0;
 
   for (const header of visibleHeaders) {

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHeader.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableHeader.tsx
@@ -2,13 +2,32 @@ import {
   horizontalListSortingStrategy,
   SortableContext,
 } from '@dnd-kit/sortable';
-import { flexRender } from '@tanstack/react-table';
+import { flexRender, Header } from '@tanstack/react-table';
 
 import { Table } from 'erxes-ui/components';
+import { isStructuralColumn } from 'erxes-ui/modules/record-table/utils/columnUtils';
 
 import { RecordTableHead } from './RecordTableHead';
 import { RecordTableColumnSelector } from './RecordTableColumnSelector';
 import { useRecordTable } from './RecordTableProvider';
+
+const SELECTOR_WIDTH = 32;
+
+const resolveSelectorSlot = (visibleHeaders: Header<any, unknown>[]) => {
+  let offset = 0;
+
+  for (const header of visibleHeaders) {
+    const tooNarrow = header.getSize() < SELECTOR_WIDTH * 2;
+
+    if (!isStructuralColumn(header.column.id) && !tooNarrow) {
+      return { offset, coveredId: header.id };
+    }
+
+    offset += header.getSize();
+  }
+
+  return { offset: 0, coveredId: visibleHeaders[0]?.id };
+};
 
 export const RecordTableHeader = ({
   showColumnSelector = false,
@@ -19,9 +38,11 @@ export const RecordTableHeader = ({
   return (
     <Table.Header>
       {table.getHeaderGroups().map((headerGroup) => {
-        const firstHeaderId = headerGroup.headers.find(
+        const visibleHeaders = headerGroup.headers.filter(
           (header) => !header.isPlaceholder,
-        )?.id;
+        );
+        const { offset, coveredId } = resolveSelectorSlot(visibleHeaders);
+        const anchorId = visibleHeaders[0]?.id;
 
         return (
           <Table.Row key={headerGroup.id}>
@@ -36,20 +57,27 @@ export const RecordTableHeader = ({
                       header.column.columnDef.header,
                       header.getContext(),
                     );
-                const hasColumnSelector =
-                  showColumnSelector && header.id === firstHeaderId;
+                const isAnchor = showColumnSelector && header.id === anchorId;
+                const isCovered = showColumnSelector && header.id === coveredId;
 
                 return (
-                  <RecordTableHead header={header} key={header.id}>
-                    {hasColumnSelector ? (
-                      <>
-                        <div className="pl-8">{headerContent}</div>
-                        <div className="absolute left-0 top-0 z-20 h-full w-8 border-r bg-sidebar">
-                          <RecordTableColumnSelector />
-                        </div>
-                      </>
+                  <RecordTableHead
+                    header={header}
+                    key={header.id}
+                    className={isAnchor ? 'z-4' : undefined}
+                  >
+                    {isCovered ? (
+                      <div className="pl-8">{headerContent}</div>
                     ) : (
                       headerContent
+                    )}
+                    {isAnchor && (
+                      <div
+                        className="absolute top-0 z-20 h-full w-8 border-r bg-sidebar"
+                        style={{ left: `${offset}px` }}
+                      >
+                        <RecordTableColumnSelector />
+                      </div>
                     )}
                   </RecordTableHead>
                 );

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableProvider.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableProvider.tsx
@@ -4,6 +4,8 @@ import {
   HTMLAttributes,
   type ReactNode,
   useContext,
+  useMemo,
+  useRef,
   useState,
   useEffect,
 } from 'react';
@@ -25,6 +27,7 @@ import {
 import RecordTableContainer from 'erxes-ui/modules/record-table/components/RecordTableContainer';
 import { RecordTableDnDProvider } from 'erxes-ui/modules/record-table/components/RecordTableDnDProvider';
 import { IRecordTableContext } from 'erxes-ui/modules/record-table/types/recordTableTypes';
+import { isStructuralColumn } from 'erxes-ui/modules/record-table/utils/columnUtils';
 import { useTablePreferences } from '../hooks/useTablePreferences';
 
 const RecordTableContext = createContext<IRecordTableContext | null>(null);
@@ -65,6 +68,7 @@ export const RecordTableProvider = forwardRef<
     },
     ref,
   ) => {
+    const [columnSelectorOpen, setColumnSelectorOpen] = useState(false);
     const [sorting, setSorting] = useState<SortingState>([]);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -84,11 +88,46 @@ export const RecordTableProvider = forwardRef<
     const [colPinning, setColPinning] = useState<ColumnPinningState>(
       () => columnPinning || { left: stickyColumns ?? [] },
     );
+    const stickyKey = (stickyColumns ?? []).join(',');
+    const isPinningTouched = useRef(false);
     useEffect(() => {
-      if (!columnPinning) {
-        setColPinning((prev) => ({ ...prev, left: stickyColumns ?? [] }));
-      }
-    }, [columnPinning, stickyColumns]);
+      if (columnPinning || isPinningTouched.current) return;
+      setColPinning((prev) => ({
+        ...prev,
+        left: stickyKey ? stickyKey.split(',') : [],
+      }));
+    }, [columnPinning, stickyKey]);
+
+    const columnIdsKey = columns.map((column) => column.id || '').join(',');
+    useEffect(() => {
+      setColumnOrder((prev) => {
+        const ids = columnIdsKey.split(',').filter(Boolean);
+        const known = prev.filter((id) => ids.includes(id));
+
+        if (known.length === prev.length && known.length === ids.length) {
+          return prev;
+        }
+
+        return [...known, ...ids.filter((id) => !known.includes(id))];
+      });
+    }, [columnIdsKey]);
+
+    const structuralKey = columns
+      .map((column) => column.id)
+      .filter(
+        (id): id is string => typeof id === 'string' && isStructuralColumn(id),
+      )
+      .join(',');
+    const pinning = useMemo<ColumnPinningState>(() => {
+      const left = colPinning.left ?? [];
+      const structural = (structuralKey ? structuralKey.split(',') : []).filter(
+        (id) => !left.includes(id),
+      );
+
+      if (!left.length || !structural.length) return colPinning;
+
+      return { ...colPinning, left: [...structural, ...left] };
+    }, [colPinning, structuralKey]);
     const table = useReactTable({
       data,
       columns,
@@ -100,7 +139,7 @@ export const RecordTableProvider = forwardRef<
         columnOrder: colOrder,
         columnSizing: colSizing,
         columnVisibility: colVisibility,
-        columnPinning: colPinning,
+        columnPinning: pinning,
         sorting,
         columnFilters,
         rowSelection,
@@ -109,7 +148,10 @@ export const RecordTableProvider = forwardRef<
       onColumnOrderChange: setColumnOrder,
       onColumnSizingChange: setColSizing,
       onColumnVisibilityChange: setColVisibility,
-      onColumnPinningChange: setColPinning,
+      onColumnPinningChange: (updater) => {
+        isPinningTouched.current = true;
+        setColPinning(updater);
+      },
       onSortingChange: setSorting,
       onColumnFiltersChange: setColumnFilters,
       onRowSelectionChange: setRowSelection,
@@ -137,6 +179,8 @@ export const RecordTableProvider = forwardRef<
       <RecordTableContext.Provider
         value={{
           table,
+          columnSelectorOpen,
+          setColumnSelectorOpen,
         }}
       >
         <RecordTableDnDProvider setColumnOrder={setColumnOrder}>

--- a/frontend/libs/erxes-ui/src/modules/record-table/types/recordTableTypes.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/types/recordTableTypes.ts
@@ -3,4 +3,6 @@ import { Table } from '@tanstack/react-table';
 export interface IRecordTableContext {
   table: Table<any>;
   handleReachedBottom?: () => void;
+  columnSelectorOpen: boolean;
+  setColumnSelectorOpen: (open: boolean) => void;
 }

--- a/frontend/plugins/loyalty_ui/AGENTS.md
+++ b/frontend/plugins/loyalty_ui/AGENTS.md
@@ -75,23 +75,6 @@ round-trip the typed fields. The legacy flat block was removed from `GeneralInfo
 Verified with `npx tsc --noEmit` (0 errors). The loyalty_api contract + engine
 landed earlier (see backend AGENTS.md).
 
----
-
-## Record tables
-
-Every list in this plugin (coupons, vouchers, lotteries, scores, agents,
-pricing) uses `RecordTable` with the same column shape: a `more` utility column
-first, then `RecordTable.checkboxColumn`, then the data columns.
-
-- The `more` column's `header` is `<RecordTable.ColumnSelector />` and its `cell`
-  is the feature's own row menu.
-- `more`, `checkbox`, and `select` are utility columns: excluded from the
-  selector list, never hidden or reordered through it. When a table has a `more`
-  column it must lead both the column array and `stickyColumns`.
-- Pass a unique `tableId` to `RecordTable.Provider` so column visibility, order,
-  pinning, and sizing persist. Prefix ids with `loyalty` and never reuse one
-  across two tables, or they share stored preferences.
-
 ## Validation
 
 `pnpm nx lint loyalty_ui` · `pnpm nx build loyalty_ui` ·

--- a/frontend/plugins/loyalty_ui/AGENTS.md
+++ b/frontend/plugins/loyalty_ui/AGENTS.md
@@ -75,6 +75,23 @@ round-trip the typed fields. The legacy flat block was removed from `GeneralInfo
 Verified with `npx tsc --noEmit` (0 errors). The loyalty_api contract + engine
 landed earlier (see backend AGENTS.md).
 
+---
+
+## Record tables
+
+Every list in this plugin (coupons, vouchers, lotteries, scores, agents,
+pricing) uses `RecordTable` with the same column shape: a `more` utility column
+first, then `RecordTable.checkboxColumn`, then the data columns.
+
+- The `more` column's `header` is `<RecordTable.ColumnSelector />` and its `cell`
+  is the feature's own row menu.
+- `more`, `checkbox`, and `select` are utility columns: excluded from the
+  selector list, never hidden or reordered through it. When a table has a `more`
+  column it must lead both the column array and `stickyColumns`.
+- Pass a unique `tableId` to `RecordTable.Provider` so column visibility, order,
+  pinning, and sizing persist. Prefix ids with `loyalty` and never reuse one
+  across two tables, or they share stored preferences.
+
 ## Validation
 
 `pnpm nx lint loyalty_ui` · `pnpm nx build loyalty_ui` ·

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
@@ -35,6 +35,7 @@ export const pricingColumns = (
 ): ColumnDef<IPricing>[] => [
   {
     id: 'more',
+    header: () => <RecordTable.ColumnSelector />,
     cell: (cell) => <PricingMoreCell {...cell} />,
     size: 33,
   },
@@ -63,7 +64,9 @@ export const pricingColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => <RecordTable.InlineHead label={t('status')} icon={IconHash} />,
+    header: () => (
+      <RecordTable.InlineHead label={t('status')} icon={IconHash} />
+    ),
     cell: ({ cell }) => {
       const status = cell.getValue() as string;
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingColumns.tsx
@@ -35,7 +35,6 @@ export const pricingColumns = (
 ): ColumnDef<IPricing>[] => [
   {
     id: 'more',
-    header: () => <RecordTable.ColumnSelector />,
     cell: (cell) => <PricingMoreCell {...cell} />,
     size: 33,
   },
@@ -64,9 +63,7 @@ export const pricingColumns = (
   {
     id: 'status',
     accessorKey: 'status',
-    header: () => (
-      <RecordTable.InlineHead label={t('status')} icon={IconHash} />
-    ),
+    header: () => <RecordTable.InlineHead label={t('status')} icon={IconHash} />,
     cell: ({ cell }) => {
       const status = cell.getValue() as string;
       return (

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
@@ -37,7 +37,6 @@ export function PricingRecordTable() {
       data={pricing || []}
       columns={pricingColumns(t)}
       stickyColumns={['more', 'checkbox', 'name']}
-      tableId="loyalty_pricing_record_table"
       className="m-3"
     >
       <RecordTable.Scroll>

--- a/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
+++ b/frontend/plugins/loyalty_ui/src/modules/pricing/components/PricingRecordTable.tsx
@@ -37,6 +37,7 @@ export function PricingRecordTable() {
       data={pricing || []}
       columns={pricingColumns(t)}
       stickyColumns={['more', 'checkbox', 'name']}
+      tableId="loyalty_pricing_record_table"
       className="m-3"
     >
       <RecordTable.Scroll>

--- a/frontend/plugins/mongolian_ui/AGENTS.md
+++ b/frontend/plugins/mongolian_ui/AGENTS.md
@@ -1,0 +1,145 @@
+# mongolian_ui Rules
+
+## Architecture
+
+- This plugin is the Module Federation remote `mongolian_ui`.
+- Dev server port is `3007` from `project.json`.
+- Public exposes are `./config`, `./mongolian`, `./mongolianSettings`,
+  `./widgets`, and `./floatingWidget` in `module-federation.config.ts`.
+- `./mongolian` points to `src/modules/MongolianMain.tsx`; routes are mounted
+  under `/mongolian`.
+- `./mongolianSettings` points to `src/modules/MongolianSettings.tsx`; settings
+  routes are mounted under the core settings shell.
+- `src/config.tsx` declares the navigation groups and the `mongolian/*` module
+  paths. Every path there must resolve to a route in `MongolianMain.tsx` or
+  `MongolianSettings.tsx`.
+- Main routes: `/mongolian/put-response/*` (put responses, by-date,
+  duplicated), `/mongolian/sync-erkhet/*` (history, deals, products, category,
+  pos-order), `/mongolian/msdynamic/*` (sync-history, synced-orders, customers,
+  products, categories, prices, pos-order-detail).
+- Settings routes: `ebarimt/*`, `msdynamic/*`, `product-places/*`,
+  `sync-erkhet/*`, `exchange-rates/*`.
+- Feature internals belong under `src/modules/<integration>`: `ebarimt`,
+  `erkhet-sync`, `msdynamic`, `productplaces`, `exchangeRates`.
+- Each integration keeps settings under its own `settings` folder and shared
+  pieces under its own `shared` or `components` folder — never in another
+  integration's tree.
+- Route-level composition lives in `src/pages`; MS Dynamic pages are nested in
+  `src/pages/msdynamic`.
+- `src/widgets` is for plugin widget exports, not general shared UI.
+- Keep hooks, GraphQL documents, states, constants, and types near the feature
+  they support.
+
+## UI Conventions
+
+- Use `erxes-ui` and `ui-modules` components before creating new primitives; do
+  not import Radix directly.
+- Use `@tabler/icons-react` for icons.
+- Use `RecordTable` for every list page, with `RecordTable.CursorProvider` where
+  the query is cursor-paginated.
+- Keep table columns, command bars, filters, selects, and empty states in
+  separate files like the nearby integrations already do.
+- Column headers go through the integration's local `HeaderCell` wrapper where
+  one exists, otherwise `RecordTable.InlineHead`. `HeaderCell` receives a
+  translation key and calls `t()` itself.
+- `more`, `checkbox`, and `select` are utility columns. When a table has a `more`
+  column it must be the first entry of the column array and the first entry of
+  `stickyColumns`.
+- A table that offers column visibility, reordering, or pinning must pass a
+  unique `tableId` to `RecordTable.Provider`; without it the shared preference
+  storage is disabled. Prefix ids with `mongolian_` and never reuse one.
+- All user-facing strings go through `useTranslation('mongolian')`.
+- Provide loading, empty, success, and error states; every button needs a
+  working handler.
+- Do not introduce a new visual style, spacing system, UI library, or icon
+  library.
+
+## Data and GraphQL
+
+- Use Apollo Client hooks already used in this plugin.
+- GraphQL operations live in the feature's `graphql` folder when one exists.
+- Name operations with the integration or module prefix plus the purpose, and
+  keep the name unique repository-wide.
+- Search the integration's `graphql` folder before adding an operation; eBarimt
+  and Erkhet share several config queries through `mnConfigs`.
+- For cursor lists, follow the `useRecordTableCursor`, `validateFetchMore`, and
+  `RecordTable.CursorProvider` pattern already used by put responses and sync
+  history.
+- After create, update, or delete, update the Apollo cache or refetch so the
+  table never needs a manual refresh.
+- Do not change backend eBarimt, Erkhet, or MS Dynamic contracts from this
+  frontend plugin unless explicitly requested.
+
+## State and Routing
+
+- Add routes in `MongolianMain.tsx` or `MongolianSettings.tsx` with lazy imports
+  and `Suspense`, then mirror the path in `src/config.tsx`.
+- Use Jotai only for state shared across sibling components, such as the detail
+  atoms and to-sync selection atoms each integration already defines.
+- Prefer URL query state (`useQueryState`) for filters, detail sheets, and table
+  controls, matching nearby list pages.
+- Use React Hook Form with Zod for config and settings forms.
+- Keep hooks single-purpose and avoid hidden side effects.
+
+## Good References
+
+- Route entry:
+  `src/modules/MongolianMain.tsx`
+
+- Settings entry:
+  `src/modules/MongolianSettings.tsx`
+
+- Cursor-paginated record table:
+  `src/modules/ebarimt/put-response/components/PutResponseRecordTable.tsx`
+
+- Table with `more` menu, checkbox column, and command bar:
+  `src/modules/ebarimt/settings/product-group/components/ProductGroupTable.tsx`
+
+- Sync-check table with bulk selection:
+  `src/modules/erkhet-sync/check-synced-deals/components/CheckSyncedDealsRecordTable.tsx`
+
+- Sync history table with detail sheet:
+  `src/modules/msdynamic/msdynamic-sync-history/components/MSDynamicSyncHistoryRecordTable.tsx`
+
+## Forbidden
+
+- Do not modify backend contracts for a frontend-only task.
+- Do not import from another plugin or from an internal path inside a shared
+  package.
+- Do not share components, atoms, or GraphQL documents across integrations by
+  reaching into another integration's folder; move them to a shared folder
+  first.
+- Do not add new UI, table, form, routing, state, icon, or date libraries.
+- Do not move Module Federation exposes without updating all host references.
+- Do not put feature-specific components in `src/widgets`.
+- Do not hard-code Mongolian or English strings in components.
+
+## Before Coding
+
+1. Search for a similar implementation in the same integration
+2. Reuse nearby patterns
+3. Confirm the route exists in both the router and `src/config.tsx`
+4. Check whether GraphQL operations already exist
+5. Keep changes minimal and scoped to the feature
+
+## Validation
+
+- For documentation-only edits, verify referenced paths exist.
+- For code changes, run `pnpm nx lint mongolian_ui` and
+  `pnpm nx build mongolian_ui`.
+- Run `pnpm nx test mongolian_ui` when tests, test setup, or tested behavior
+  were touched.
+- Fix TypeScript, lint, build, and Sonar warnings introduced by the change.
+
+## Common Mistakes
+
+- Using stale paths copied from another integration or plugin.
+- Adding a route without adding the matching entry to `src/config.tsx`.
+- Reusing a `tableId` across two tables, which makes them share stored column
+  preferences.
+- Placing a `more` column after the checkbox column, or leaving it out of
+  `stickyColumns`.
+- Passing an already-translated string to `HeaderCell`, which expects a key.
+- Building a list with plain `Table` when `RecordTable` cursor behavior is
+  expected.
+- Changing backend schema or API assumptions from the UI layer.

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/components/PutResponseMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/components/PutResponseMoreColumn.tsx
@@ -24,6 +24,7 @@ export const PutResponseMoreColumnCell = ({
 
 export const putResponseMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: PutResponseMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/components/PutResponseRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/components/PutResponseRecordTable.tsx
@@ -17,6 +17,7 @@ export const PutResponseRecordTable = () => {
       data={putResponses || []}
       className="m-3"
       stickyColumns={['more', 'name']}
+      tableId="mongolian_ebarimt_put_response_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -41,7 +42,10 @@ export const PutResponseRecordTable = () => {
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="flex flex-col items-center justify-center text-center">
               <div className="mb-6">
-                <IconShoppingCartX size={48} className="text-muted-foreground" />
+                <IconShoppingCartX
+                  size={48}
+                  className="text-muted-foreground"
+                />
               </div>
               <h3 className="text-lg font-semibold">{t('no-put-response')}</h3>
               <p className="mt-1 text-sm text-muted-foreground">

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-by-date/components/ByDateMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-by-date/components/ByDateMoreColumn.tsx
@@ -24,6 +24,7 @@ export const ByDateMoreColumnCell = ({
 
 export const byDateMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: ByDateMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-by-date/components/ByDateRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-by-date/components/ByDateRecordTable.tsx
@@ -17,6 +17,7 @@ export const ByDateRecordTable = () => {
       data={byDate || []}
       className="m-3"
       stickyColumns={['more']}
+      tableId="mongolian_ebarimt_put_response_by_date_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-duplicated/components/DuplicatedMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-duplicated/components/DuplicatedMoreColumn.tsx
@@ -24,6 +24,7 @@ export const DuplicatedMoreColumnCell = ({
 
 export const duplicatedMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: DuplicatedMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-duplicated/components/DuplicatedRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/put-response/put-responses-duplicated/components/DuplicatedRecordTable.tsx
@@ -18,6 +18,7 @@ export const DuplicatedRecordTable = () => {
       data={putResponsesDuplicated || []}
       className="m-3"
       stickyColumns={['more']}
+      tableId="mongolian_ebarimt_put_response_duplicated_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/pos-in-ebarimt-config/components/PosInEBarimtConfigTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/pos-in-ebarimt-config/components/PosInEBarimtConfigTable.tsx
@@ -124,7 +124,9 @@ const usePosInEbarimtColumns = (): ColumnDef<IPosInEbarimtConfigRow>[] => {
     {
       id: 'title',
       accessorKey: 'title',
-      header: () => <RecordTable.InlineHead label={t('title')} icon={IconCode} />,
+      header: () => (
+        <RecordTable.InlineHead label={t('title')} icon={IconCode} />
+      ),
       cell: ({ cell }) => <PosInEBarimtConfigTitleCell cell={cell} />,
       size: 200,
     },
@@ -142,7 +144,9 @@ const usePosInEbarimtColumns = (): ColumnDef<IPosInEbarimtConfigRow>[] => {
     {
       id: 'posNo',
       accessorKey: 'posNo',
-      header: () => <RecordTable.InlineHead label={t('pos-no')} icon={IconCode} />,
+      header: () => (
+        <RecordTable.InlineHead label={t('pos-no')} icon={IconCode} />
+      ),
       cell: ({ cell }) => (
         <RecordTableInlineCell>
           <TextOverflowTooltip value={cell.getValue() as string} />
@@ -172,7 +176,12 @@ export const PosInEBarimtConfigTable = () => {
   const posInEbarimtColumns = usePosInEbarimtColumns();
 
   return (
-    <RecordTable.Provider columns={posInEbarimtColumns} data={rows}>
+    <RecordTable.Provider
+      columns={posInEbarimtColumns}
+      data={rows}
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_ebarimt_pos_in_ebarimt_config_record_table"
+    >
       <RecordTable.Scroll>
         <RecordTable>
           <RecordTable.Header />

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-group/components/ProductGroupTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-group/components/ProductGroupTable.tsx
@@ -60,7 +60,12 @@ export const ProductGroupTable = () => {
   const isInitialLoading = loading && productGroupRows.length === 0;
 
   return (
-    <RecordTable.Provider columns={memoizedColumns} data={productGroupRows}>
+    <RecordTable.Provider
+      columns={memoizedColumns}
+      data={productGroupRows}
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_ebarimt_product_group_record_table"
+    >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
         hasNextPage={hasNextPage}
@@ -84,9 +89,7 @@ export const ProductGroupTable = () => {
             <Spinner />
           </div>
         )}
-        {!loading && totalCount === 0 && (
-          <ProductGroupEmptyState />
-        )}
+        {!loading && totalCount === 0 && <ProductGroupEmptyState />}
       </RecordTable.CursorProvider>
       <ProductGroupRowsCommandbar />
     </RecordTable.Provider>
@@ -185,6 +188,7 @@ ProductGroupRowMoreColumnCell.displayName = 'ProductGroupRowMoreColumnCell';
 
 const productGroupRowMoreColumn: ColumnDef<IProductGroup> = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: ({ cell }) => <ProductGroupRowMoreColumnCell cell={cell} />,
   size: 33,
 };
@@ -206,7 +210,9 @@ export const useProductGroupsColumns = (): ColumnDef<IProductGroup>[] => {
     {
       id: 'subProductId',
       accessorKey: 'subProductId',
-      header: () => <RecordTable.InlineHead icon={IconTag} label={t('sub-product')} />,
+      header: () => (
+        <RecordTable.InlineHead icon={IconTag} label={t('sub-product')} />
+      ),
       cell: ({ cell }) => <ProductGroupSubProductCell cell={cell} />,
       size: 250,
     },
@@ -214,7 +220,10 @@ export const useProductGroupsColumns = (): ColumnDef<IProductGroup>[] => {
       id: 'sortNum',
       accessorKey: 'sortNum',
       header: () => (
-        <RecordTable.InlineHead icon={IconSortAscending} label={t('sort-number')} />
+        <RecordTable.InlineHead
+          icon={IconSortAscending}
+          label={t('sort-number')}
+        />
       ),
       cell: ({ cell }) => (
         <RecordTableInlineCell>
@@ -242,7 +251,9 @@ export const useProductGroupsColumns = (): ColumnDef<IProductGroup>[] => {
       ),
       cell: ({ cell }) => (
         <RecordTableInlineCell>
-          <TextOverflowTooltip value={cell.getValue() ? t('active') : t('inactive')} />
+          <TextOverflowTooltip
+            value={cell.getValue() ? t('active') : t('inactive')}
+          />
         </RecordTableInlineCell>
       ),
     },

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/components/ProductRulesOnTaxTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/product-rules-on-tax/components/ProductRulesOnTaxTable.tsx
@@ -55,6 +55,8 @@ export const ProductRulesOnTaxTable = () => {
     <RecordTable.Provider
       columns={productRulesOnTaxColumns}
       data={productRulesOnTaxRows || []}
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_ebarimt_product_rules_on_tax_record_table"
     >
       <RecordTable.Scroll>
         <RecordTable>
@@ -119,7 +121,9 @@ export const ProductRulesOnTaxRowMoreColumnCell = ({
     confirm({
       message: t('delete-this-rule-confirm'),
       options: { okLabel: t('delete'), cancelLabel: t('cancel') },
-    }).then(() => removeProductRulesOnTax({ variables: { ids: [cell.row.original._id] } }));
+    }).then(() =>
+      removeProductRulesOnTax({ variables: { ids: [cell.row.original._id] } }),
+    );
   };
 
   return (
@@ -145,78 +149,92 @@ export const ProductRulesOnTaxRowMoreColumnCell = ({
 
 export const productRulesOnTaxRowMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: ProductRulesOnTaxRowMoreColumnCell,
   size: 33,
 };
 
-export const useProductRulesOnTaxColumns = (): ColumnDef<IProductRulesOnTax>[] => {
-  const { t } = useTranslation('mongolian');
-  return [
-    productRulesOnTaxRowMoreColumn,
-    RecordTable.checkboxColumn as ColumnDef<IProductRulesOnTax>,
-    {
-      id: 'title',
-      accessorKey: 'title',
-      header: () => <RecordTable.InlineHead label={t('title')} icon={IconCode} />,
-      cell: ({ cell }) => <ProductRulesOnTaxTitleCell cell={cell} />,
-      size: 150,
-    },
-    {
-      id: 'kind',
-      accessorKey: 'kind',
-      header: () => <RecordTable.InlineHead label={t('kind')} icon={IconTag} />,
-      cell: ({ cell }) => {
-        return (
-          <RecordTableInlineCell>
-            <TextOverflowTooltip value={cell.getValue() as string} />
-          </RecordTableInlineCell>
-        );
+export const useProductRulesOnTaxColumns =
+  (): ColumnDef<IProductRulesOnTax>[] => {
+    const { t } = useTranslation('mongolian');
+    return [
+      productRulesOnTaxRowMoreColumn,
+      RecordTable.checkboxColumn as ColumnDef<IProductRulesOnTax>,
+      {
+        id: 'title',
+        accessorKey: 'title',
+        header: () => (
+          <RecordTable.InlineHead label={t('title')} icon={IconCode} />
+        ),
+        cell: ({ cell }) => <ProductRulesOnTaxTitleCell cell={cell} />,
+        size: 150,
       },
-      size: 100,
-    },
-    {
-      id: 'taxType',
-      accessorKey: 'taxType',
-      header: () => (
-        <RecordTable.InlineHead label={t('tax-type')} icon={IconReceipt} />
-      ),
-      cell: ({ cell }) => {
-        return (
-          <RecordTableInlineCell>
-            <TextOverflowTooltip value={cell.getValue() as string} />
-          </RecordTableInlineCell>
-        );
+      {
+        id: 'kind',
+        accessorKey: 'kind',
+        header: () => (
+          <RecordTable.InlineHead label={t('kind')} icon={IconTag} />
+        ),
+        cell: ({ cell }) => {
+          return (
+            <RecordTableInlineCell>
+              <TextOverflowTooltip value={cell.getValue() as string} />
+            </RecordTableInlineCell>
+          );
+        },
+        size: 100,
       },
-    },
-    {
-      id: 'taxCode',
-      accessorKey: 'taxCode',
-      header: () => <RecordTable.InlineHead label={t('tax-code')} icon={IconCode} />,
-      cell: ({ row, cell }) => {
-        return (
-          <RecordTableInlineCell>
-            <TextOverflowTooltip value={TAX_TYPES[row.original.taxType]?.options.find(opt => opt.value === cell.getValue() as string)?.label} />
-          </RecordTableInlineCell>
-        );
+      {
+        id: 'taxType',
+        accessorKey: 'taxType',
+        header: () => (
+          <RecordTable.InlineHead label={t('tax-type')} icon={IconReceipt} />
+        ),
+        cell: ({ cell }) => {
+          return (
+            <RecordTableInlineCell>
+              <TextOverflowTooltip value={cell.getValue() as string} />
+            </RecordTableInlineCell>
+          );
+        },
       },
-      size: 150,
-    },
-    {
-      id: 'taxPercent',
-      accessorKey: 'taxPercent',
-      header: () => (
-        <RecordTable.InlineHead label={t('percent')} icon={IconPercentage} />
-      ),
-      cell: ({ cell }) => {
-        const value = cell.getValue() as string | number | null | undefined;
-        return (
-          <RecordTableInlineCell>
-            {value !== null && value !== undefined ? String(value) : ''}
-          </RecordTableInlineCell>
-        );
+      {
+        id: 'taxCode',
+        accessorKey: 'taxCode',
+        header: () => (
+          <RecordTable.InlineHead label={t('tax-code')} icon={IconCode} />
+        ),
+        cell: ({ row, cell }) => {
+          return (
+            <RecordTableInlineCell>
+              <TextOverflowTooltip
+                value={
+                  TAX_TYPES[row.original.taxType]?.options.find(
+                    (opt) => opt.value === (cell.getValue() as string),
+                  )?.label
+                }
+              />
+            </RecordTableInlineCell>
+          );
+        },
+        size: 150,
       },
-    },
-  ];
-};
+      {
+        id: 'taxPercent',
+        accessorKey: 'taxPercent',
+        header: () => (
+          <RecordTable.InlineHead label={t('percent')} icon={IconPercentage} />
+        ),
+        cell: ({ cell }) => {
+          const value = cell.getValue() as string | number | null | undefined;
+          return (
+            <RecordTableInlineCell>
+              {value !== null && value !== undefined ? String(value) : ''}
+            </RecordTableInlineCell>
+          );
+        },
+      },
+    ];
+  };
 
 export const productRulesOnTaxColumns: ColumnDef<IProductRulesOnTax>[] = [];

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/stage-in-ebarimt-config/components/StageInEBarimtConfigTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/stage-in-ebarimt-config/components/StageInEBarimtConfigTable.tsx
@@ -112,6 +112,7 @@ const StageInEBarimtConfigMoreCell = ({
 
 const moreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: StageInEBarimtConfigMoreCell,
   size: 33,
 };
@@ -124,7 +125,9 @@ const useStageInEbarimtColumns = (): ColumnDef<IStageInEbarimtConfigRow>[] => {
     {
       id: 'title',
       accessorKey: 'title',
-      header: () => <RecordTable.InlineHead label={t('title')} icon={IconCode} />,
+      header: () => (
+        <RecordTable.InlineHead label={t('title')} icon={IconCode} />
+      ),
       cell: ({ cell }) => <StageInEBarimtConfigTitleCell cell={cell} />,
       size: 200,
     },
@@ -144,7 +147,9 @@ const useStageInEbarimtColumns = (): ColumnDef<IStageInEbarimtConfigRow>[] => {
     {
       id: 'posNo',
       accessorKey: 'posNo',
-      header: () => <RecordTable.InlineHead label={t('pos-no')} icon={IconCode} />,
+      header: () => (
+        <RecordTable.InlineHead label={t('pos-no')} icon={IconCode} />
+      ),
       cell: ({ cell }) => (
         <RecordTableInlineCell>
           <TextOverflowTooltip value={cell.getValue() as string} />
@@ -169,7 +174,10 @@ const useStageInEbarimtColumns = (): ColumnDef<IStageInEbarimtConfigRow>[] => {
       id: 'hasCitytax',
       accessorKey: 'hasCitytax',
       header: () => (
-        <RecordTable.InlineHead label={t('has-citytax')} icon={IconToggleLeft} />
+        <RecordTable.InlineHead
+          label={t('has-citytax')}
+          icon={IconToggleLeft}
+        />
       ),
       cell: ({ cell }) => (
         <RecordTableInlineCell>
@@ -187,7 +195,12 @@ export const StageInEBarimtConfigTable = () => {
   const columns = useStageInEbarimtColumns();
 
   return (
-    <RecordTable.Provider columns={columns} data={rows}>
+    <RecordTable.Provider
+      columns={columns}
+      data={rows}
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_ebarimt_stage_in_ebarimt_config_record_table"
+    >
       <RecordTable.Scroll>
         <RecordTable>
           <RecordTable.Header />

--- a/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/stage-in-return-ebarimt-config/components/ReturnEBarimtConfigTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/ebarimt/settings/stage-in-return-ebarimt-config/components/ReturnEBarimtConfigTable.tsx
@@ -10,7 +10,13 @@ import {
   Command,
 } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
-import { IconClipboardList, IconCode, IconEdit, IconToggleLeft, IconTrash } from '@tabler/icons-react';
+import {
+  IconClipboardList,
+  IconCode,
+  IconEdit,
+  IconToggleLeft,
+  IconTrash,
+} from '@tabler/icons-react';
 import { useSetAtom } from 'jotai';
 import { useQuery } from '@apollo/client';
 import { GET_MN_CONFIGS } from '@/ebarimt/settings/stage-in-return-ebarimt-config/graphql/queries/mnConfigs';
@@ -147,7 +153,9 @@ const returnEbarimtColumns: ColumnDef<IReturnEbarimtConfigRow>[] = [
     accessorKey: 'hasVat',
     header: () => {
       const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead label={t('has-vat')} icon={IconToggleLeft} />;
+      return (
+        <RecordTable.InlineHead label={t('has-vat')} icon={IconToggleLeft} />
+      );
     },
     cell: ({ cell }) => {
       const { t } = useTranslation('mongolian');
@@ -164,7 +172,12 @@ const returnEbarimtColumns: ColumnDef<IReturnEbarimtConfigRow>[] = [
     accessorKey: 'hasCitytax',
     header: () => {
       const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead label={t('has-citytax')} icon={IconToggleLeft} />;
+      return (
+        <RecordTable.InlineHead
+          label={t('has-citytax')}
+          icon={IconToggleLeft}
+        />
+      );
     },
     cell: ({ cell }) => {
       const { t } = useTranslation('mongolian');
@@ -183,7 +196,12 @@ export const ReturnEBarimtConfigTable = () => {
   const { rows, loading } = useReturnEbarimtConfigRows();
 
   return (
-    <RecordTable.Provider columns={returnEbarimtColumns} data={rows}>
+    <RecordTable.Provider
+      columns={returnEbarimtColumns}
+      data={rows}
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_ebarimt_return_ebarimt_config_record_table"
+    >
       <RecordTable.Scroll>
         <RecordTable>
           <RecordTable.Header />

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-category/components/CheckCategoryRecordTable.tsx
@@ -24,6 +24,7 @@ export const CheckCategoryRecordTable = () => {
       data={filteredCategories || []}
       className="m-3"
       stickyColumns={['more', 'checkbox', 'createdAt']}
+      tableId="mongolian_erkhet_check_category_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-pos-orders/components/CheckPosOrdersRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-pos-orders/components/CheckPosOrdersRecordTable.tsx
@@ -20,6 +20,7 @@ export const CheckPosOrdersRecordTable = () => {
       data={checkPosOrders || []}
       className="m-3"
       stickyColumns={['checkbox', 'toSync', 'createdAt']}
+      tableId="mongolian_erkhet_check_pos_orders_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -28,7 +29,7 @@ export const CheckPosOrdersRecordTable = () => {
         sessionKey={CHECK_POS_ORDERS_CURSOR_SESSION_KEY}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
               handleFetchMore={handleFetchMore}

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-products/components/CheckProductRecordTable.tsx
@@ -19,6 +19,7 @@ export const CheckProductRecordTable = () => {
       data={filteredProducts || []}
       className="m-3"
       stickyColumns={['more', 'checkbox', 'createdAt']}
+      tableId="mongolian_erkhet_check_products_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -27,7 +28,7 @@ export const CheckProductRecordTable = () => {
         sessionKey={CHECK_PRODUCTS_CURSOR_SESSION_KEY}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
               handleFetchMore={checkProduct}

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-synced-deals/components/CheckSyncedDealsRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/check-synced-deals/components/CheckSyncedDealsRecordTable.tsx
@@ -19,6 +19,7 @@ export const CheckSyncedDealsRecordTable = () => {
       data={Deals || []}
       className="m-3"
       stickyColumns={['checkbox', 'toSync', 'createdAt']}
+      tableId="mongolian_erkhet_check_synced_deals_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -27,7 +28,7 @@ export const CheckSyncedDealsRecordTable = () => {
         sessionKey={CHECK_SYNCED_DEALS_CURSOR_SESSION_KEY}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
               handleFetchMore={handleFetchMore}

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pipeline-remainder-config/components/PipelineRemainderConfigColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pipeline-remainder-config/components/PipelineRemainderConfigColumns.tsx
@@ -1,84 +1,44 @@
-import { IconAlignLeft, IconAt, IconLayoutKanban } from '@tabler/icons-react';
-import { CellContext, ColumnDef } from '@tanstack/react-table';
-import { RecordTable, RecordTableInlineCell } from 'erxes-ui';
-import { useTranslation } from 'react-i18next';
-import { checkboxColumn } from 'erxes-ui/modules/record-table/components/CheckboxColumn';
+import { IconAt, IconLayoutKanban } from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+import { TFunction } from 'i18next';
 import { AddPipelineRemainderConfig } from '../types';
 import { TRemainderConfigRow } from '../hooks/usePipelineRemainderConfigs';
 import { PipelineRemainderConfigEditSheet } from './PipelineRemainderConfigEditSheet';
-import { ErkhetConfigTitleCell, ErkhetConfigMoreCell } from '../../shared/components/ErkhetConfigColumnCells';
+import {
+  buildErkhetConfigBaseColumns,
+  erkhetConfigTextColumn,
+} from '../../shared/components/ErkhetConfigColumns';
 
 export const buildRemainderConfigColumns = (
+  t: TFunction,
   onEdit: (id: string, data: AddPipelineRemainderConfig) => Promise<void>,
   onDelete: (id: string) => void,
   editLoading: boolean,
 ): ColumnDef<TRemainderConfigRow>[] => [
-  {
-    id: 'more',
-    cell: (cell: CellContext<TRemainderConfigRow, unknown>) => (
-      <ErkhetConfigMoreCell
-        cell={cell}
-        onDelete={onDelete}
-        editLoading={editLoading}
-        renderEditSheet={(open, onOpenChange) => (
-          <PipelineRemainderConfigEditSheet
-            config={cell.row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
+  ...buildErkhetConfigBaseColumns<TRemainderConfigRow>({
+    t,
+    onDelete,
+    editLoading,
+    renderEditSheet: (config, open, onOpenChange) => (
+      <PipelineRemainderConfigEditSheet
+        config={config}
+        open={open}
+        onOpenChange={onOpenChange}
+        onSubmit={onEdit}
+        loading={editLoading}
       />
     ),
-    size: 33,
-  },
-  checkboxColumn as ColumnDef<TRemainderConfigRow>,
-  {
-    id: 'title',
-    accessorKey: 'title',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAlignLeft} label={t('title')} />;
-    },
-    cell: ({ row }) => (
-      <ErkhetConfigTitleCell
-        config={row.original}
-        renderEditSheet={(open, onOpenChange) => (
-          <PipelineRemainderConfigEditSheet
-            config={row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
-      />
-    ),
-    size: 200,
-  },
-  {
+  }),
+  erkhetConfigTextColumn<TRemainderConfigRow>({
+    t,
     id: 'account',
-    accessorKey: 'account',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAt} label={t('account')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>{(cell.getValue() as string) || '—'}</RecordTableInlineCell>
-    ),
-    size: 200,
-  },
-  {
+    icon: IconAt,
+    labelKey: 'account',
+  }),
+  erkhetConfigTextColumn<TRemainderConfigRow>({
+    t,
     id: 'location',
-    accessorKey: 'location',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconLayoutKanban} label={t('location')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>{(cell.getValue() as string) || '—'}</RecordTableInlineCell>
-    ),
-    size: 200,
-  },
+    icon: IconLayoutKanban,
+    labelKey: 'location',
+  }),
 ];

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pipeline-remainder-config/components/PipelineRemainderConfigRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pipeline-remainder-config/components/PipelineRemainderConfigRecordTable.tsx
@@ -24,9 +24,15 @@ export const PipelineRemainderConfigRecordTable = ({
   return (
     <ErkhetConfigRecordTable
       configs={configs}
-      columns={buildRemainderConfigColumns(onEdit, onDelete, editLoading)}
+      columns={buildRemainderConfigColumns(t, onEdit, onDelete, editLoading)}
+      tableId="mongolian_erkhet_pipeline_remainder_config_record_table"
       emptyDescription={t('create-first-remainder-config')}
-      commandBar={<PipelineRemainderConfigCommandBar onDeleteMany={onDeleteMany} loading={editLoading} />}
+      commandBar={
+        <PipelineRemainderConfigCommandBar
+          onDeleteMany={onDeleteMany}
+          loading={editLoading}
+        />
+      }
     />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pos-order-erkhet-config/components/PosOrderErkhetConfig.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/pos-order-erkhet-config/components/PosOrderErkhetConfig.tsx
@@ -580,6 +580,7 @@ export const PosOrderErkhetConfigRecordTable = ({
     <ErkhetConfigRecordTable
       configs={configs}
       columns={buildColumns({ editLoading, onDelete, onEdit, poss })}
+      tableId="mongolian_erkhet_pos_order_config_record_table"
       emptyDescription={t('create-first-pos-order-erkhet-config')}
       commandBar={
         <ErkhetConfigCommandBar

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/shared/components/ErkhetConfigColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/shared/components/ErkhetConfigColumns.tsx
@@ -1,0 +1,94 @@
+import { Icon, IconAlignLeft } from '@tabler/icons-react';
+import { CellContext, ColumnDef } from '@tanstack/react-table';
+import { RecordTable, RecordTableInlineCell } from 'erxes-ui';
+import { TFunction } from 'i18next';
+import { ReactNode } from 'react';
+import {
+  ErkhetConfigMoreCell,
+  ErkhetConfigTitleCell,
+} from './ErkhetConfigColumnCells';
+
+type TErkhetConfigRow = { _id: string; title?: string };
+
+export type RenderErkhetConfigEditSheet<TRow> = (
+  config: TRow,
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+) => ReactNode;
+
+interface ErkhetConfigColumnsArgs<TRow> {
+  t: TFunction;
+  onDelete: (id: string) => void;
+  editLoading: boolean;
+  renderEditSheet: RenderErkhetConfigEditSheet<TRow>;
+}
+
+export const buildErkhetConfigBaseColumns = <TRow extends TErkhetConfigRow>({
+  t,
+  onDelete,
+  editLoading,
+  renderEditSheet,
+}: ErkhetConfigColumnsArgs<TRow>): ColumnDef<TRow>[] => [
+  {
+    id: 'more',
+    cell: (cell: CellContext<TRow, unknown>) => (
+      <ErkhetConfigMoreCell
+        cell={cell}
+        onDelete={onDelete}
+        editLoading={editLoading}
+        renderEditSheet={(open, onOpenChange) =>
+          renderEditSheet(cell.row.original, open, onOpenChange)
+        }
+      />
+    ),
+    size: 33,
+  },
+  RecordTable.checkboxColumn as ColumnDef<TRow>,
+  {
+    id: 'title',
+    accessorKey: 'title',
+    header: () => (
+      <RecordTable.InlineHead icon={IconAlignLeft} label={t('title')} />
+    ),
+    cell: ({ row }) => (
+      <ErkhetConfigTitleCell
+        config={row.original}
+        renderEditSheet={(open, onOpenChange) =>
+          renderEditSheet(row.original, open, onOpenChange)
+        }
+      />
+    ),
+    size: 200,
+  },
+];
+
+interface ErkhetConfigTextColumnArgs<TRow> {
+  t: TFunction;
+  id: Extract<keyof TRow, string>;
+  icon: Icon;
+  labelKey: string;
+  size?: number;
+  format?: (value: string) => string;
+}
+
+export const erkhetConfigTextColumn = <TRow extends TErkhetConfigRow>({
+  t,
+  id,
+  icon,
+  labelKey,
+  size = 200,
+  format,
+}: ErkhetConfigTextColumnArgs<TRow>): ColumnDef<TRow> => ({
+  id,
+  accessorKey: id,
+  header: () => <RecordTable.InlineHead icon={icon} label={t(labelKey)} />,
+  cell: ({ cell }) => {
+    const value = (cell.getValue() as string) || '';
+    return (
+      <RecordTableInlineCell>
+        {format ? format(value) : value || '—'}
+      </RecordTableInlineCell>
+    );
+  },
+  size,
+});

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/shared/components/ErkhetConfigRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/shared/components/ErkhetConfigRecordTable.tsx
@@ -9,6 +9,7 @@ interface Props<T extends object> {
   columns: ColumnDef<T>[];
   emptyDescription: string;
   commandBar: ReactNode;
+  tableId: string;
 }
 
 export const ErkhetConfigRecordTable = <T extends object>({
@@ -16,6 +17,7 @@ export const ErkhetConfigRecordTable = <T extends object>({
   columns,
   emptyDescription,
   commandBar,
+  tableId,
 }: Props<T>) => {
   const { t } = useTranslation('mongolian');
   return (
@@ -23,6 +25,8 @@ export const ErkhetConfigRecordTable = <T extends object>({
       columns={columns}
       data={configs}
       className="m-3"
+      stickyColumns={['more', 'checkbox']}
+      tableId={tableId}
       tableOptions={{ enableRowSelection: true } as any}
     >
       <RecordTable>

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-config/components/StageInErkhetConfigColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-config/components/StageInErkhetConfigColumns.tsx
@@ -1,105 +1,51 @@
-import { IconAlignLeft, IconAt, IconLayoutKanban } from '@tabler/icons-react';
-import { CellContext, ColumnDef } from '@tanstack/react-table';
-import { RecordTable, RecordTableInlineCell } from 'erxes-ui';
-import { useTranslation } from 'react-i18next';
-import { checkboxColumn } from 'erxes-ui/modules/record-table/components/CheckboxColumn';
+import { IconAt, IconLayoutKanban } from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+import { TFunction } from 'i18next';
 import { TErkhetConfig } from '../types';
 import { TStageInErkhetConfigRow } from '../hooks/useStageInErkhetConfigs';
 import { StageInErkhetConfigEditSheet } from './StageInErkhetConfigEditSheet';
 import {
-  ErkhetConfigTitleCell,
-  ErkhetConfigMoreCell,
-} from '../../shared/components/ErkhetConfigColumnCells';
+  buildErkhetConfigBaseColumns,
+  erkhetConfigTextColumn,
+} from '../../shared/components/ErkhetConfigColumns';
 
 export const buildStageInErkhetConfigColumns = (
+  t: TFunction,
   onEdit: (id: string, data: TErkhetConfig) => Promise<void>,
   onDelete: (id: string) => void,
   editLoading: boolean,
 ): ColumnDef<TStageInErkhetConfigRow>[] => [
-  {
-    id: 'more',
-    cell: (cell: CellContext<TStageInErkhetConfigRow, unknown>) => (
-      <ErkhetConfigMoreCell
-        cell={cell}
-        onDelete={onDelete}
-        editLoading={editLoading}
-        renderEditSheet={(open, onOpenChange) => (
-          <StageInErkhetConfigEditSheet
-            config={cell.row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
+  ...buildErkhetConfigBaseColumns<TStageInErkhetConfigRow>({
+    t,
+    onDelete,
+    editLoading,
+    renderEditSheet: (config, open, onOpenChange) => (
+      <StageInErkhetConfigEditSheet
+        config={config}
+        open={open}
+        onOpenChange={onOpenChange}
+        onSubmit={onEdit}
+        loading={editLoading}
       />
     ),
-    size: 33,
-  },
-  checkboxColumn as ColumnDef<TStageInErkhetConfigRow>,
-  {
-    id: 'title',
-    accessorKey: 'title',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAlignLeft} label={t('title')} />;
-    },
-    cell: ({ row }) => (
-      <ErkhetConfigTitleCell
-        config={row.original}
-        renderEditSheet={(open, onOpenChange) => (
-          <StageInErkhetConfigEditSheet
-            config={row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
-      />
-    ),
-    size: 200,
-  },
-  {
+  }),
+  erkhetConfigTextColumn<TStageInErkhetConfigRow>({
+    t,
     id: 'userEmail',
-    accessorKey: 'userEmail',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAt} label={t('user-email')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
-    size: 200,
-  },
-  {
+    icon: IconAt,
+    labelKey: 'user-email',
+  }),
+  erkhetConfigTextColumn<TStageInErkhetConfigRow>({
+    t,
     id: 'responseField',
-    accessorKey: 'responseField',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconLayoutKanban} label={t('response-field')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
-    size: 200,
-  },
-  {
+    icon: IconLayoutKanban,
+    labelKey: 'response-field',
+  }),
+  erkhetConfigTextColumn<TStageInErkhetConfigRow>({
+    t,
     id: 'defaultPay',
-    accessorKey: 'defaultPay',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconLayoutKanban} label={t('default-pay')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
+    icon: IconLayoutKanban,
+    labelKey: 'default-pay',
     size: 150,
-  },
+  }),
 ];

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-config/components/StageInErkhetConfigRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-config/components/StageInErkhetConfigRecordTable.tsx
@@ -24,9 +24,20 @@ export const StageInErkhetConfigRecordTable = ({
   return (
     <ErkhetConfigRecordTable
       configs={configs}
-      columns={buildStageInErkhetConfigColumns(onEdit, onDelete, editLoading)}
+      columns={buildStageInErkhetConfigColumns(
+        t,
+        onEdit,
+        onDelete,
+        editLoading,
+      )}
+      tableId="mongolian_erkhet_stage_in_erkhet_config_record_table"
       emptyDescription={t('create-first-stage-in-erkhet-config')}
-      commandBar={<StageInErkhetConfigCommandBar onDeleteMany={onDeleteMany} loading={editLoading} />}
+      commandBar={
+        <StageInErkhetConfigCommandBar
+          onDeleteMany={onDeleteMany}
+          loading={editLoading}
+        />
+      }
     />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/components/MovementConfigColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/components/MovementConfigColumns.tsx
@@ -1,111 +1,51 @@
-import {
-  IconAlignLeft,
-  IconAt,
-  IconLayoutKanban,
-  IconUser,
-} from '@tabler/icons-react';
-import { CellContext, ColumnDef } from '@tanstack/react-table';
-import { RecordTable, RecordTableInlineCell } from 'erxes-ui';
-import { checkboxColumn } from 'erxes-ui/modules/record-table/components/CheckboxColumn';
-import { useTranslation } from 'react-i18next';
-import { TMovementErkhetConfig } from '../types';
+import { IconAt, IconLayoutKanban, IconUser } from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+import { TFunction } from 'i18next';
+import { TMovementConfigRow, TMovementErkhetConfig } from '../types';
 import { MovementConfigEditSheet } from './MovementConfigEditSheet';
 import {
-  ErkhetConfigTitleCell,
-  ErkhetConfigMoreCell,
-} from '../../shared/components/ErkhetConfigColumnCells';
-
-type TConfigRow = TMovementErkhetConfig & { _id: string };
+  buildErkhetConfigBaseColumns,
+  erkhetConfigTextColumn,
+} from '../../shared/components/ErkhetConfigColumns';
 
 export const buildMovementConfigColumns = (
+  t: TFunction,
   onEdit: (id: string, data: TMovementErkhetConfig) => Promise<void>,
   onDelete: (id: string) => void,
   editLoading: boolean,
-): ColumnDef<TConfigRow>[] => [
-  {
-    id: 'more',
-    cell: (cell: CellContext<TConfigRow, unknown>) => (
-      <ErkhetConfigMoreCell
-        cell={cell}
-        onDelete={onDelete}
-        editLoading={editLoading}
-        renderEditSheet={(open, onOpenChange) => (
-          <MovementConfigEditSheet
-            config={cell.row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
+): ColumnDef<TMovementConfigRow>[] => [
+  ...buildErkhetConfigBaseColumns<TMovementConfigRow>({
+    t,
+    onDelete,
+    editLoading,
+    renderEditSheet: (config, open, onOpenChange) => (
+      <MovementConfigEditSheet
+        config={config}
+        open={open}
+        onOpenChange={onOpenChange}
+        onSubmit={onEdit}
+        loading={editLoading}
       />
     ),
-    size: 33,
-  },
-  checkboxColumn as ColumnDef<TConfigRow>,
-  {
-    id: 'title',
-    accessorKey: 'title',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAlignLeft} label={t('title')} />;
-    },
-    cell: ({ row }) => (
-      <ErkhetConfigTitleCell
-        config={row.original}
-        renderEditSheet={(open, onOpenChange) => (
-          <MovementConfigEditSheet
-            config={row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
-      />
-    ),
-    size: 200,
-  },
-  {
+  }),
+  erkhetConfigTextColumn<TMovementConfigRow>({
+    t,
     id: 'userEmail',
-    accessorKey: 'userEmail',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAt} label={t('user-email')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
-    size: 200,
-  },
-  {
+    icon: IconAt,
+    labelKey: 'user-email',
+  }),
+  erkhetConfigTextColumn<TMovementConfigRow>({
+    t,
     id: 'defaultCustomer',
-    accessorKey: 'defaultCustomer',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconUser} label={t('default-customer')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
+    icon: IconUser,
+    labelKey: 'default-customer',
     size: 160,
-  },
-  {
+  }),
+  erkhetConfigTextColumn<TMovementConfigRow>({
+    t,
     id: 'responseField',
-    accessorKey: 'responseField',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconLayoutKanban} label={t('response-field')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>
-        {(cell.getValue() as string) || '—'}
-      </RecordTableInlineCell>
-    ),
+    icon: IconLayoutKanban,
+    labelKey: 'response-field',
     size: 160,
-  },
+  }),
 ];

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/components/MovementConfigRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/components/MovementConfigRecordTable.tsx
@@ -1,13 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { TMovementErkhetConfig } from '../types';
+import { TMovementConfigRow, TMovementErkhetConfig } from '../types';
 import { buildMovementConfigColumns } from './MovementConfigColumns';
 import { MovementConfigCommandBar } from './MovementConfigCommandBar';
 import { ErkhetConfigRecordTable } from '../../shared/components/ErkhetConfigRecordTable';
 
-type TConfigRow = TMovementErkhetConfig & { _id: string };
-
 interface Props {
-  configs: TConfigRow[];
+  configs: TMovementConfigRow[];
   onEdit: (id: string, data: TMovementErkhetConfig) => Promise<void>;
   onDelete: (id: string) => void;
   onDeleteMany: (ids: string[]) => Promise<void>;
@@ -25,9 +23,15 @@ export const MovementConfigRecordTable = ({
   return (
     <ErkhetConfigRecordTable
       configs={configs}
-      columns={buildMovementConfigColumns(onEdit, onDelete, editLoading)}
+      columns={buildMovementConfigColumns(t, onEdit, onDelete, editLoading)}
+      tableId="mongolian_erkhet_movement_config_record_table"
       emptyDescription={t('create-first-movement-config')}
-      commandBar={<MovementConfigCommandBar onDeleteMany={onDeleteMany} loading={editLoading} />}
+      commandBar={
+        <MovementConfigCommandBar
+          onDeleteMany={onDeleteMany}
+          loading={editLoading}
+        />
+      }
     />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/types/index.ts
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-erkhet-movement-config/types/index.ts
@@ -26,3 +26,5 @@ export interface MovementErkhetConfig {
 export type TMovementErkhetConfig = z.infer<
   typeof addStageInMovementErkhetConfigSchema
 >;
+
+export type TMovementConfigRow = TMovementErkhetConfig & { _id: string };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-return-erkhet-config/components/ReturnErkhetConfigColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-return-erkhet-config/components/ReturnErkhetConfigColumns.tsx
@@ -1,88 +1,49 @@
-import { IconAlignLeft, IconAt, IconLayoutKanban } from '@tabler/icons-react';
-import { CellContext, ColumnDef } from '@tanstack/react-table';
-import { RecordTable, RecordTableInlineCell } from 'erxes-ui';
-import { checkboxColumn } from 'erxes-ui/modules/record-table/components/CheckboxColumn';
-import { useTranslation } from 'react-i18next';
+import { IconAt, IconLayoutKanban } from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+import { TFunction } from 'i18next';
 import { TReturnErkhetConfig } from '../types';
 import { TReturnErkhetConfigRow } from '../hooks/useReturnErkhetConfigs';
 import { RETURN_TYPES } from '../constants/returnTypesData';
 import { ReturnErkhetConfigEditSheet } from './ReturnErkhetConfigEditSheet';
-import { ErkhetConfigTitleCell, ErkhetConfigMoreCell } from '../../shared/components/ErkhetConfigColumnCells';
+import {
+  buildErkhetConfigBaseColumns,
+  erkhetConfigTextColumn,
+} from '../../shared/components/ErkhetConfigColumns';
 
 const returnTypeLabel = (value: string) =>
-  RETURN_TYPES.find((t) => t.value === value)?.label ?? (value || '—');
+  RETURN_TYPES.find((type) => type.value === value)?.label ?? (value || '—');
 
 export const buildReturnErkhetConfigColumns = (
+  t: TFunction,
   onEdit: (id: string, data: TReturnErkhetConfig) => Promise<void>,
   onDelete: (id: string) => void,
   editLoading: boolean,
 ): ColumnDef<TReturnErkhetConfigRow>[] => [
-  {
-    id: 'more',
-    cell: (cell: CellContext<TReturnErkhetConfigRow, unknown>) => (
-      <ErkhetConfigMoreCell
-        cell={cell}
-        onDelete={onDelete}
-        editLoading={editLoading}
-        renderEditSheet={(open, onOpenChange) => (
-          <ReturnErkhetConfigEditSheet
-            config={cell.row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
+  ...buildErkhetConfigBaseColumns<TReturnErkhetConfigRow>({
+    t,
+    onDelete,
+    editLoading,
+    renderEditSheet: (config, open, onOpenChange) => (
+      <ReturnErkhetConfigEditSheet
+        config={config}
+        open={open}
+        onOpenChange={onOpenChange}
+        onSubmit={onEdit}
+        loading={editLoading}
       />
     ),
-    size: 33,
-  },
-  checkboxColumn as ColumnDef<TReturnErkhetConfigRow>,
-  {
-    id: 'title',
-    accessorKey: 'title',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAlignLeft} label={t('title')} />;
-    },
-    cell: ({ row }) => (
-      <ErkhetConfigTitleCell
-        config={row.original}
-        renderEditSheet={(open, onOpenChange) => (
-          <ReturnErkhetConfigEditSheet
-            config={row.original}
-            open={open}
-            onOpenChange={onOpenChange}
-            onSubmit={onEdit}
-            loading={editLoading}
-          />
-        )}
-      />
-    ),
-    size: 200,
-  },
-  {
+  }),
+  erkhetConfigTextColumn<TReturnErkhetConfigRow>({
+    t,
     id: 'userEmail',
-    accessorKey: 'userEmail',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconAt} label={t('user-email')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>{(cell.getValue() as string) || '—'}</RecordTableInlineCell>
-    ),
-    size: 200,
-  },
-  {
+    icon: IconAt,
+    labelKey: 'user-email',
+  }),
+  erkhetConfigTextColumn<TReturnErkhetConfigRow>({
+    t,
     id: 'returnType',
-    accessorKey: 'returnType',
-    header: () => {
-      const { t } = useTranslation('mongolian');
-      return <RecordTable.InlineHead icon={IconLayoutKanban} label={t('return-type')} />;
-    },
-    cell: ({ cell }) => (
-      <RecordTableInlineCell>{returnTypeLabel(cell.getValue() as string)}</RecordTableInlineCell>
-    ),
-    size: 200,
-  },
+    icon: IconLayoutKanban,
+    labelKey: 'return-type',
+    format: returnTypeLabel,
+  }),
 ];

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-return-erkhet-config/components/ReturnErkhetConfigRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/settings/stage-in-return-erkhet-config/components/ReturnErkhetConfigRecordTable.tsx
@@ -24,9 +24,15 @@ export const ReturnErkhetConfigRecordTable = ({
   return (
     <ErkhetConfigRecordTable
       configs={configs}
-      columns={buildReturnErkhetConfigColumns(onEdit, onDelete, editLoading)}
+      columns={buildReturnErkhetConfigColumns(t, onEdit, onDelete, editLoading)}
+      tableId="mongolian_erkhet_return_erkhet_config_record_table"
       emptyDescription={t('create-first-return-erkhet-config')}
-      commandBar={<ReturnErkhetConfigCommandBar onDeleteMany={onDeleteMany} loading={editLoading} />}
+      commandBar={
+        <ReturnErkhetConfigCommandBar
+          onDeleteMany={onDeleteMany}
+          loading={editLoading}
+        />
+      }
     />
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/sync-erkhet-history/components/SyncErkhetHistoryMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/sync-erkhet-history/components/SyncErkhetHistoryMoreColumn.tsx
@@ -35,6 +35,7 @@ export const SyncErkhetHistoryMoreColumnCell = ({
 
 export const SyncErkhetHistoryMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: SyncErkhetHistoryMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/sync-erkhet-history/components/SyncErkhetHistoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/erkhet-sync/sync-erkhet-history/components/SyncErkhetHistoryRecordTable.tsx
@@ -18,6 +18,7 @@ export const SyncErkhetHistoryRecordTable = () => {
       data={SyncHistories || []}
       className="m-3"
       stickyColumns={['more', 'createdAt']}
+      tableId="mongolian_erkhet_sync_history_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/exchangeRates/components/ExchangeRatesTable.tsx
@@ -23,6 +23,7 @@ export const ExchangeRatesTable = () => {
       data={rows}
       className="m-3"
       stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_exchange_rates_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -30,45 +31,43 @@ export const ExchangeRatesTable = () => {
         dataLength={rows.length}
         sessionKey={EXCHANGE_RATES_CURSOR_SESSION_KEY}
       >
-        <RecordTable.Scroll>
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              <RecordTable.CursorBackwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-              {loading && rows.length === 0 && (
-                <RecordTable.RowSkeleton rows={40} />
-              )}
-              <RecordTable.RowList />
-              <RecordTable.CursorForwardSkeleton
-                handleFetchMore={handleFetchMore}
-              />
-            </RecordTable.Body>
-          </RecordTable>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.CursorBackwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+            {loading && rows.length === 0 && (
+              <RecordTable.RowSkeleton rows={40} />
+            )}
+            <RecordTable.RowList />
+            <RecordTable.CursorForwardSkeleton
+              handleFetchMore={handleFetchMore}
+            />
+          </RecordTable.Body>
+        </RecordTable>
 
-          {!isInitialLoading && totalCount === 0 && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="flex flex-col items-center text-center">
-                <IconArrowsExchange
-                  size={48}
-                  className="text-muted-foreground/40 mb-4"
-                />
-                <h3 className="text-lg font-semibold text-foreground">
-                  {searchValue
-                    ? t('no-matching-exchange-rates')
-                    : t('no-exchange-rates-yet')}
-                </h3>
-                <p className="mt-1 mb-4 text-sm text-muted-foreground">
-                  {searchValue
-                    ? t('try-different-currency')
-                    : t('create-first-exchange-rate')}
-                </p>
-                {!searchValue && <AddExchangeRate />}
-              </div>
+        {!isInitialLoading && totalCount === 0 && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="flex flex-col items-center text-center">
+              <IconArrowsExchange
+                size={48}
+                className="text-muted-foreground/40 mb-4"
+              />
+              <h3 className="text-lg font-semibold text-foreground">
+                {searchValue
+                  ? t('no-matching-exchange-rates')
+                  : t('no-exchange-rates-yet')}
+              </h3>
+              <p className="mt-1 mb-4 text-sm text-muted-foreground">
+                {searchValue
+                  ? t('try-different-currency')
+                  : t('create-first-exchange-rate')}
+              </p>
+              {!searchValue && <AddExchangeRate />}
             </div>
-          )}
-        </RecordTable.Scroll>
+          </div>
+        )}
       </RecordTable.CursorProvider>
       <ExchangeRatesCommandbar />
     </RecordTable.Provider>

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicConfigTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicConfigTable.tsx
@@ -28,22 +28,23 @@ export const MSDynamicConfigTable = () => {
     <RecordTable.Provider
       columns={columns}
       data={rows}
+      className="m-3"
+      stickyColumns={['more', 'checkbox']}
+      tableId="mongolian_msdynamic_config_record_table"
     >
-      <RecordTable.Scroll>
-        <RecordTable.CursorProvider
-          dataLength={rows.length}
-          sessionKey={MS_DYNAMIC_CONFIG_CURSOR_SESSION_KEY}
-        >
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              <RecordTable.RowList />
-              {(configsLoading || loading || saveLoading) && (
-                <RecordTable.RowSkeleton rows={4} />
-              )}
-            </RecordTable.Body>
-          </RecordTable>
-        </RecordTable.CursorProvider>
+      <RecordTable.CursorProvider
+        dataLength={rows.length}
+        sessionKey={MS_DYNAMIC_CONFIG_CURSOR_SESSION_KEY}
+      >
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            <RecordTable.RowList />
+            {(configsLoading || loading || saveLoading) && (
+              <RecordTable.RowSkeleton rows={4} />
+            )}
+          </RecordTable.Body>
+        </RecordTable>
         {!(configsLoading || loading || saveLoading) && rows.length === 0 && (
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="flex flex-col items-center text-center">
@@ -58,7 +59,7 @@ export const MSDynamicConfigTable = () => {
             </div>
           </div>
         )}
-      </RecordTable.Scroll>
+      </RecordTable.CursorProvider>
       <MSDynamicConfigCommandBar />
     </RecordTable.Provider>
   );

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/components/settings/MSDynamicMoreColumn.tsx
@@ -18,7 +18,10 @@ export const MSDynamicMoreColumnCell = ({
   const row = cell.row.original;
   const setEditDetail = useSetAtom(msDynamicConfigDetailAtom);
   const { configsMap, saveConfigs } = useMSDynamicConfigs();
-  const { removeConfig } = useMSDynamicConfigActions({ configsMap, saveConfigs });
+  const { removeConfig } = useMSDynamicConfigActions({
+    configsMap,
+    saveConfigs,
+  });
 
   return (
     <Popover>

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/containers/GeneralSettings.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/containers/GeneralSettings.tsx
@@ -27,10 +27,8 @@ export const GeneralSettings = () => {
         </div>
       }
     >
-      <section className="flex min-w-0 flex-1 flex-col">
-        <div className="min-h-0 flex-1 overflow-y-auto p-6">
-          <MSDynamicConfigTable />
-        </div>
+      <section className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+        <MSDynamicConfigTable />
       </section>
       <EditMSDynamicConfig />
     </SettingsLayout>

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-category/components/InventoryCategoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-category/components/InventoryCategoryRecordTable.tsx
@@ -35,6 +35,7 @@ export const InventoryCategoryRecordTable = () => {
       data={data}
       className="h-full w-full overflow-y-auto px-2"
       stickyColumns={['checkbox']}
+      tableId="mongolian_msdynamic_check_category_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-customers/components/CheckCustomerRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-customers/components/CheckCustomerRecordTable.tsx
@@ -17,6 +17,7 @@ export const CheckCustomerRecordTable = () => {
       data={paginatedItems}
       className="h-full w-full px-2 overflow-y-auto"
       stickyColumns={['checkbox', 'No']}
+      tableId="mongolian_msdynamic_check_customers_record_table"
     >
       <CheckCustomerCommandBar />
       <RecordTable.CursorProvider
@@ -26,7 +27,7 @@ export const CheckCustomerRecordTable = () => {
         sessionKey={MS_DYNAMIC_SESSION_KEYS.customers}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
               handleFetchMore={checkCustomers}

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
@@ -127,7 +127,9 @@ const CheckSyncedOrders = () => {
         toast({
           title: t('failed-to-resend-order'),
           description:
-            error instanceof Error ? error.message : t('please-try-again-later'),
+            error instanceof Error
+              ? error.message
+              : t('please-try-again-later'),
           variant: 'destructive',
         });
       }
@@ -146,6 +148,7 @@ const CheckSyncedOrders = () => {
       data={orders || []}
       className="m-0"
       stickyColumns={['more', 'checkbox', 'createdAt']}
+      tableId="mongolian_msdynamic_check_orders_record_table"
     >
       <MSDynamicCheckOrderCommandBar
         checking={checkingSyncedOrders}

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersMoreColumn.tsx
@@ -92,6 +92,7 @@ export const getCheckSyncedOrdersMoreColumn = ({
   onResend: (orderId: string) => void;
 }) => ({
   id: 'more' as const,
+  header: () => <RecordTable.ColumnSelector />,
   cell: (info: { cell: Cell<IMSDynamicCheckOrder, unknown> }) => (
     <CheckSyncedOrdersMoreColumnCell cell={info.cell} onResend={onResend} />
   ),

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-price/components/CheckPriceRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-price/components/CheckPriceRecordTable.tsx
@@ -16,6 +16,7 @@ export const CheckPriceRecordTable = () => {
       data={filteredItems || []}
       className="h-full w-full overflow-y-auto px-2"
       stickyColumns={['checkbox']}
+      tableId="mongolian_msdynamic_check_price_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={pageInfo.hasPreviousPage}
@@ -24,7 +25,7 @@ export const CheckPriceRecordTable = () => {
         sessionKey={MS_DYNAMIC_SESSION_KEYS.prices}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton handleFetchMore={checkPrice} />
             {checking && <RecordTable.RowSkeleton rows={20} />}
@@ -40,7 +41,9 @@ export const CheckPriceRecordTable = () => {
                   size={64}
                   className="text-muted-foreground mx-auto mb-4"
                 />
-                <h3 className="text-xl font-semibold mb-2">{t('no-prices-yet')}</h3>
+                <h3 className="text-xl font-semibold mb-2">
+                  {t('no-prices-yet')}
+                </h3>
                 <p className="text-muted-foreground max-w-md">
                   {t('select-brand-check-prices')}
                 </p>

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-products/components/MSDynamicCheckProductsRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-products/components/MSDynamicCheckProductsRecordTable.tsx
@@ -20,7 +20,7 @@ export const MSDynamicCheckProductsRecordTable = () => {
       data={filteredProducts}
       className="h-full w-full px-2 overflow-y-auto"
       stickyColumns={['checkbox']}
-      commandBar={<MSDynamicCheckProductsCommandBar />}
+      tableId="mongolian_msdynamic_check_products_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -29,7 +29,7 @@ export const MSDynamicCheckProductsRecordTable = () => {
         sessionKey={MS_DYNAMIC_SESSION_KEYS.products}
       >
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             <RecordTable.CursorBackwardSkeleton
               handleFetchMore={checkProducts}
@@ -61,6 +61,7 @@ export const MSDynamicCheckProductsRecordTable = () => {
           </div>
         )}
       </RecordTable.CursorProvider>
+      <MSDynamicCheckProductsCommandBar />
     </RecordTable.Provider>
   );
 };

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-sync-history/components/MSDynamicSyncHistoryMoreColumn.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-sync-history/components/MSDynamicSyncHistoryMoreColumn.tsx
@@ -35,6 +35,7 @@ export const MSDynamicSyncHistoryMoreColumnCell = ({
 
 export const MSDynamicSyncHistoryMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: MSDynamicSyncHistoryMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-sync-history/components/MSDynamicSyncHistoryRecordTable.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-sync-history/components/MSDynamicSyncHistoryRecordTable.tsx
@@ -21,6 +21,7 @@ export const MSDynamicSyncHistoryRecordTable = () => {
       data={syncHistories || []}
       className="m-3"
       stickyColumns={['more', 'createdAt']}
+      tableId="mongolian_msdynamic_sync_history_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -50,7 +51,9 @@ export const MSDynamicSyncHistoryRecordTable = () => {
                     size={64}
                     className="text-muted-foreground mx-auto mb-4"
                   />
-                  <h3 className="text-xl font-semibold mb-2">{t('no-sync-yet')}</h3>
+                  <h3 className="text-xl font-semibold mb-2">
+                    {t('no-sync-yet')}
+                  </h3>
                   <p className="text-muted-foreground max-w-md">
                     {t('create-first-sync')}
                   </p>


### PR DESCRIPTION
## What

Adds the record table column selector — show/hide, drag reorder, pin/unpin — and per-table preference persistence to **all 26 `mongolian_ui` tables** and the **loyalty Pricing** table.

- Tables with a `more` column render the selector as that column's header.
- Tables whose only utility column is `checkbox` use `<RecordTable.Header showColumnSelector />`.
- Every provider gets a unique `tableId`, so column visibility, order, pinning, and sizing persist per table in `localStorage` (`erxes_table_prefs_<tableId>`).
- `ErkhetConfigRecordTable` is shared by five Erkhet settings pages, so it now takes `tableId` as a prop — otherwise those five pages would share one set of preferences.
- `more`, `checkbox`, and `select` stay utility columns: excluded from the selector list, never hidden or reordered through it.

## Shared `RecordTable` fixes

Turning on preference persistence surfaced three defects in `erxes-ui` that could not be fixed from the plugins:

**1. Selector overlay collided with narrow utility columns**

`RecordTableHeader` hosted the selector on the first header and shifted its content with `pl-8`. `more` and `checkbox` are fixed at 33px, so the 32px overlay covered the cell and pushed the select-all checkbox onto the next column. The host is now the first non-structural header. The two existing `showColumnSelector` tables (`pos-summary`, `pos-by-items`) have no structural columns, so their host is unchanged.

**2. A pinned column could render ahead of `more` and `checkbox`**

Header order follows `columnPinning.left`. Once a stored preference existed, `stickyColumns` no longer reapplied, so pinning a column from the selector put it at index 0 — in front of the row menu and the checkbox. Structural columns are now always ordered first in the pinning state handed to the table, and this self-heals an already stored preference.

`stickyColumns` now only *seeds* the initial pinning, so those columns stay unpinnable. Previously — on any table without a `tableId` — the seeding effect reran on every parent render and silently re-pinned a column the user had just unpinned.

**3. The selector popover closed when clicking pin or a checkbox**

Pinning or hiding a column changes the header order, which moves the selector to a different header cell. That unmounts its `DropdownMenu.Trigger` and takes the portal content with it. The selector's open state now lives in `RecordTableProvider`, so it survives the remount.

**Also**: a stored `columnOrder` can predate the current columns. Both drag handlers resolve columns with `columnOrder.indexOf(...)`, and `arrayMove(order, -1, x)` silently moves the last column instead. The provider now reconciles the stored order with the actual column set whenever it changes.

## Validation

| Check | Result |
| --- | --- |
| `pnpm nx build mongolian_ui` / `loyalty_ui` | pass |
| `pnpm nx build sales_ui` / `operation_ui` / `frontline_ui` | pass (shared lib consumers) |
| `pnpm nx lint erxes-ui` | 39 warnings, 0 errors — unchanged from base |
| `pnpm nx lint mongolian_ui` / `loyalty_ui` | unchanged from base (60 / 31 problems) |
| `tsc --noEmit` | no new errors in `erxes-ui`, `mongolian_ui`, or `loyalty_ui` |

Static audit: 26 mongolian tables, 26 selectors, 26 unique `tableId`s, no duplicates, no provider left without one.

Manual: toggle a column, drag to reorder, pin and unpin, reload — each table restores only its own layout, checkbox and row actions keep working, and the popover stays open through pin and visibility clicks.

## Docs

- Adds `frontend/plugins/mongolian_ui/AGENTS.md`.
- Updates `frontend/plugins/loyalty_ui/AGENTS.md` with the shared record table rules.

## Summary by Sourcery

Add column selector and per-table layout persistence to record tables in mongolian_ui and loyalty pricing, and harden the shared RecordTable infrastructure to support stable pinning and ordering behavior.

New Features:
- Introduce a column selector UI (show/hide, reorder, pin) on record tables in mongolian_ui and the loyalty pricing table.
- Persist record table column visibility, order, pinning, and sizing per table via unique tableIds and stored preferences.

Bug Fixes:
- Prevent the column selector overlay from colliding with narrow utility columns by mounting it on the first non-structural header.
- Fix pinned columns rendering ahead of structural utility columns by normalizing pinning state so structural columns lead.
- Stop stickyColumns from repeatedly re-pinning columns on re-render when a tableId is not provided by only seeding initial pinning.
- Prevent the selector popover from closing when pinning or toggling columns by lifting open state into RecordTableProvider.
- Reconcile stored columnOrder with the actual column set to avoid mis-targeted drag operations when columns change.

Enhancements:
- Ensure structural utility columns (e.g., more, checkbox, select) are always treated as non-selectable and pinned ahead of data columns.
- Stabilize RecordTable column pinning, order reconciliation, and cursor behavior so user preferences are respected and do not reset on re-render.
- Maintain column selector open state at the provider level so the popover remains open across header re-renders triggered by layout changes.

Documentation:
- Add mongolian_ui AGENTS documentation outlining architecture, routing, GraphQL, and RecordTable usage conventions.
- Extend loyalty_ui AGENTS documentation with RecordTable rules and tableId usage for lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added column visibility selectors across pricing, configuration, synchronization, and history tables.
  - Added persistent table preferences for column order and visibility.
  - Added sticky utility columns for easier navigation in wide tables.
  - Improved selector placement across grouped and variable-width table headers.
- **Bug Fixes**
  - Prevented users from hiding the final visible column.
  - Preserved column selections and pinning when table layouts change.
- **Refactor**
  - Standardized configuration table columns and formatting across related screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->