### PR TITLE
feat: add controlled public GraphQL API

### DIFF
--- a/backend/core-api/src/connectionResolvers.ts
+++ b/backend/core-api/src/connectionResolvers.ts
@@ -1,5 +1,4 @@
 import { IAppModel, loadAppClass } from '@/apps/db/models/Apps';
-import { IOAuthClientAppDocument } from 'erxes-api-shared/core-modules';
 import {
   IOAuthClientAppModel,
   loadOAuthClientAppClass,
@@ -94,6 +93,7 @@ import {
   IAutomationDocument,
   IAutomationExecutionDocument,
   IEmailDeliveryDocument,
+  IOAuthClientAppDocument,
   INotificationDocument,
   notificationSchema,
   NotificationSettings,

--- a/backend/core-api/src/connectionResolvers.ts
+++ b/backend/core-api/src/connectionResolvers.ts
@@ -1,5 +1,5 @@
 import { IAppModel, loadAppClass } from '@/apps/db/models/Apps';
-import { IOAuthClientAppDocument } from '@/auth/db/definitions/oauthClientApps';
+import { IOAuthClientAppDocument } from 'erxes-api-shared/core-modules';
 import {
   IOAuthClientAppModel,
   loadOAuthClientAppClass,

--- a/backend/core-api/src/meta/index.ts
+++ b/backend/core-api/src/meta/index.ts
@@ -5,6 +5,7 @@ import { tags } from './tags';
 import { properties } from './properties';
 import { references } from './references';
 import { templates } from './templates';
+import { publicApi } from './publicApi';
 
 export default {
   permissions,
@@ -14,4 +15,5 @@ export default {
   properties,
   references,
   templates,
+  publicApi,
 };

--- a/backend/core-api/src/meta/publicApi.ts
+++ b/backend/core-api/src/meta/publicApi.ts
@@ -1,0 +1,102 @@
+import type { IPublicApiConfig } from 'erxes-api-shared/core-types';
+
+export const publicApi: IPublicApiConfig = {
+  operations: [
+    {
+      id: 'core.contacts.customers.list.v1',
+      name: 'List customers',
+      description: 'List and search customer contacts',
+      operationName: 'CorePublicCustomersListV1',
+      kind: 'query',
+      requiredActions: ['contactsRead'],
+      document: `
+        query CorePublicCustomersListV1(
+          $limit: Int
+          $cursor: String
+          $direction: CURSOR_DIRECTION
+          $searchValue: String
+        ) {
+          customers(
+            limit: $limit
+            cursor: $cursor
+            direction: $direction
+            searchValue: $searchValue
+          ) {
+            list {
+              _id
+              firstName
+              lastName
+              primaryEmail
+              primaryPhone
+              createdAt
+              updatedAt
+              cursor
+            }
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            totalCount
+          }
+        }
+      `,
+    },
+    {
+      id: 'core.contacts.customers.detail.v1',
+      name: 'Get customer',
+      description: 'Get one customer contact by identifier',
+      operationName: 'CorePublicCustomerDetailV1',
+      kind: 'query',
+      requiredActions: ['contactsRead'],
+      document: `
+        query CorePublicCustomerDetailV1($_id: String!) {
+          customerDetail(_id: $_id) {
+            _id
+            firstName
+            lastName
+            primaryEmail
+            primaryPhone
+            createdAt
+            updatedAt
+          }
+        }
+      `,
+    },
+    {
+      id: 'core.contacts.customers.create.v1',
+      name: 'Create customer',
+      description: 'Create a customer contact',
+      operationName: 'CorePublicCustomerCreateV1',
+      kind: 'mutation',
+      requiredActions: ['contactsCreate'],
+      document: `
+        mutation CorePublicCustomerCreateV1(
+          $firstName: String
+          $lastName: String
+          $primaryEmail: String
+          $primaryPhone: String
+          $description: String
+        ) {
+          customersAdd(
+            firstName: $firstName
+            lastName: $lastName
+            primaryEmail: $primaryEmail
+            primaryPhone: $primaryPhone
+            description: $description
+          ) {
+            _id
+            firstName
+            lastName
+            primaryEmail
+            primaryPhone
+            description
+            createdAt
+            updatedAt
+          }
+        }
+      `,
+    },
+  ],
+};

--- a/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
+++ b/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
@@ -24,6 +24,7 @@ const normalizeRedirectUrls = (redirectUrls?: string[]) => {
     ...new Set((redirectUrls || []).map((url) => url.trim()).filter(Boolean)),
   ];
 };
+/** Normalize and deduplicate operation grants before persistence. */
 const normalizeAllowedPublicOperationIds = (operationIds?: string[]) => {
   return [
     ...new Set((operationIds || []).map((id) => id.trim()).filter(Boolean)),
@@ -95,7 +96,9 @@ export const loadOAuthClientAppClass = (
           throw new Error('Could not generate unique client id');
         }
 
-        const clientId = `${slugifyClientName(normalizedName)}-${generateClientId()}`;
+        const clientId = `${slugifyClientName(
+          normalizedName,
+        )}-${generateClientId()}`;
 
         try {
           return await models.OAuthClientApps.create({

--- a/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
+++ b/backend/core-api/src/modules/auth/db/models/OAuthClientApps.ts
@@ -1,19 +1,20 @@
 import crypto from 'crypto';
-import { EventDispatcherReturn } from 'erxes-api-shared/core-modules';
+import {
+  EventDispatcherReturn,
+  IOAuthClientAppDocument,
+  OAuthClientAccessTokenLifetime,
+  OAuthClientAppType,
+  oauthClientAppSchema,
+} from 'erxes-api-shared/core-modules';
 import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
-import type {
-  OAuthClientAccessTokenLifetime,
-  IOAuthClientAppDocument,
-  OAuthClientAppType,
-} from '@/auth/db/definitions/oauthClientApps';
-import { oauthClientAppSchema } from '@/auth/db/definitions/oauthClientApps';
 
 type OAuthClientAppDoc = {
   name: string;
   logo?: string;
   description?: string;
   redirectUrls?: string[];
+  allowedPublicOperationIds?: string[];
   type: OAuthClientAppType;
   accessTokenLifetime?: OAuthClientAccessTokenLifetime;
 };
@@ -21,6 +22,11 @@ type OAuthClientAppDoc = {
 const normalizeRedirectUrls = (redirectUrls?: string[]) => {
   return [
     ...new Set((redirectUrls || []).map((url) => url.trim()).filter(Boolean)),
+  ];
+};
+const normalizeAllowedPublicOperationIds = (operationIds?: string[]) => {
+  return [
+    ...new Set((operationIds || []).map((id) => id.trim()).filter(Boolean)),
   ];
 };
 
@@ -79,6 +85,9 @@ export const loadOAuthClientAppClass = (
     public static async createOAuthClientApp(doc: OAuthClientAppDoc) {
       const normalizedName = doc.name.trim();
       const redirectUrls = normalizeRedirectUrls(doc.redirectUrls);
+      const allowedPublicOperationIds = normalizeAllowedPublicOperationIds(
+        doc.allowedPublicOperationIds,
+      );
       const secret = doc.type === 'confidential' ? generateSecret() : undefined;
 
       const createWithUniqueId = async (attempt = 0): Promise<any> => {
@@ -100,6 +109,7 @@ export const loadOAuthClientAppClass = (
                 ? getConfidentialAccessTokenLifetime(doc.accessTokenLifetime)
                 : undefined,
             redirectUrls,
+            allowedPublicOperationIds,
             secretHash: secret ? hashSecret(secret) : undefined,
             status: 'active',
           });
@@ -143,6 +153,9 @@ export const loadOAuthClientAppClass = (
         description: doc.description?.trim() || undefined,
         type: nextType,
         redirectUrls: normalizeRedirectUrls(doc.redirectUrls),
+        allowedPublicOperationIds: normalizeAllowedPublicOperationIds(
+          doc.allowedPublicOperationIds,
+        ),
       };
 
       if (nextType === 'confidential') {

--- a/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
+++ b/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
@@ -42,6 +42,7 @@ const checkOAuthClientReadPermission = async (
     await checkPermission('appsManage');
   }
 };
+/** Reject OAuth client grants for operations that are not currently published. */
 const validatePublicOperationIds = async (operationIds?: string[]) => {
   const normalizedIds = [
     ...new Set((operationIds || []).map((id) => id.trim()).filter(Boolean)),

--- a/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
+++ b/backend/core-api/src/modules/auth/graphql/resolvers/oauthClientApps.ts
@@ -2,7 +2,8 @@ import { IContext } from '~/connectionResolvers';
 import type {
   OAuthClientAccessTokenLifetime,
   OAuthClientAppType,
-} from '@/auth/db/definitions/oauthClientApps';
+} from 'erxes-api-shared/core-modules';
+import { getPublicApiOperations } from 'erxes-api-shared/utils';
 
 type OAuthClientAppMutationArgs = {
   _id?: string;
@@ -12,6 +13,7 @@ type OAuthClientAppMutationArgs = {
   type: OAuthClientAppType;
   accessTokenLifetime?: OAuthClientAccessTokenLifetime;
   redirectUrls?: string[];
+  allowedPublicOperationIds?: string[];
 };
 
 const buildOAuthClientQuery = (searchValue?: string) => {
@@ -39,6 +41,22 @@ const checkOAuthClientReadPermission = async (
 
     await checkPermission('appsManage');
   }
+};
+const validatePublicOperationIds = async (operationIds?: string[]) => {
+  const normalizedIds = [
+    ...new Set((operationIds || []).map((id) => id.trim()).filter(Boolean)),
+  ];
+  const publishedOperations = await getPublicApiOperations();
+  const publishedIds = new Set(
+    publishedOperations.map((operation) => operation.id),
+  );
+  const unpublishedId = normalizedIds.find((id) => !publishedIds.has(id));
+
+  if (unpublishedId) {
+    throw new Error(`Public API operation is not published: ${unpublishedId}`);
+  }
+
+  return normalizedIds;
 };
 
 export const oauthClientAppQueries = {
@@ -76,6 +94,16 @@ export const oauthClientAppQueries = {
 
     return models.OAuthClientApps.findOne({ _id });
   },
+
+  async publicApiOperations(
+    _parent: undefined,
+    _args: undefined,
+    { checkPermission }: IContext,
+  ) {
+    await checkPermission('appsManage');
+
+    return getPublicApiOperations();
+  },
 };
 
 export const oauthClientAppMutations = {
@@ -86,7 +114,12 @@ export const oauthClientAppMutations = {
   ) {
     await checkPermission('appsManage');
 
-    return models.OAuthClientApps.createOAuthClientApp(params);
+    return models.OAuthClientApps.createOAuthClientApp({
+      ...params,
+      allowedPublicOperationIds: await validatePublicOperationIds(
+        params.allowedPublicOperationIds,
+      ),
+    });
   },
 
   async oauthClientAppsEdit(
@@ -96,7 +129,12 @@ export const oauthClientAppMutations = {
   ) {
     await checkPermission('appsManage');
 
-    return models.OAuthClientApps.updateOAuthClientApp(_id, doc);
+    return models.OAuthClientApps.updateOAuthClientApp(_id, {
+      ...doc,
+      allowedPublicOperationIds: await validatePublicOperationIds(
+        doc.allowedPublicOperationIds,
+      ),
+    });
   },
 
   async oauthClientAppsRevoke(

--- a/backend/core-api/src/modules/auth/graphql/schemas/auth.ts
+++ b/backend/core-api/src/modules/auth/graphql/schemas/auth.ts
@@ -32,11 +32,20 @@ export const types = `
     type: OAuthClientAppType
     accessTokenLifetime: OAuthClientAccessTokenLifetime
     redirectUrls: [String]
+    allowedPublicOperationIds: [String]
     status: OAuthClientAppStatus
     lastUsedAt: Date
     createdAt: Date
     updatedAt: Date
     generatedSecret: String
+  }
+
+  type PublicApiOperation {
+    id: String!
+    name: String!
+    description: String!
+    operationName: String!
+    kind: String!
   }
 `;
 
@@ -45,6 +54,7 @@ export const queries = `
   oauthClientApps(searchValue: String, page: Int, perPage: Int): [OAuthClientApp]
   oauthClientAppsTotalCount(searchValue: String): Int
   oauthClientAppDetail(_id: String!): OAuthClientApp
+  publicApiOperations: [PublicApiOperation!]!
 `;
 
 export const mutations = `
@@ -61,6 +71,7 @@ export const mutations = `
     type: OAuthClientAppType!
     accessTokenLifetime: OAuthClientAccessTokenLifetime
     redirectUrls: [String!]
+    allowedPublicOperationIds: [String!]
   ): OAuthClientApp
   oauthClientAppsEdit(
     _id: String!
@@ -70,6 +81,7 @@ export const mutations = `
     type: OAuthClientAppType!
     accessTokenLifetime: OAuthClientAccessTokenLifetime
     redirectUrls: [String!]
+    allowedPublicOperationIds: [String!]
   ): OAuthClientApp
   oauthClientAppsRevoke(_id: String!): OAuthClientApp
   oauthClientAppsRemove(_id: String!): JSON

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -10,7 +10,7 @@ import {
 import { Request, Response } from 'express';
 import * as jwt from 'jsonwebtoken';
 import { IModels } from '~/connectionResolvers';
-import type { OAuthClientAccessTokenLifetime } from '@/auth/db/definitions/oauthClientApps';
+import type { OAuthClientAccessTokenLifetime } from 'erxes-api-shared/core-modules';
 import {
   ACCESS_TOKEN_EXPIRES_IN_CONFIDENTIAL,
   ACCESS_TOKEN_EXPIRES_IN_PUBLIC,

--- a/backend/erxes-api-shared/src/core-modules/apps/db/definitions/oauthClientApps.ts
+++ b/backend/erxes-api-shared/src/core-modules/apps/db/definitions/oauthClientApps.ts
@@ -12,6 +12,7 @@ export interface IOAuthClientAppDocument extends Document {
   type: OAuthClientAppType;
   accessTokenLifetime?: OAuthClientAccessTokenLifetime;
   redirectUrls: string[];
+  allowedPublicOperationIds: string[];
   secretHash?: string;
   status: OAuthClientAppStatus;
   lastUsedAt?: Date;
@@ -46,6 +47,11 @@ export const oauthClientAppSchema = new Schema(
     redirectUrls: {
       type: [String],
       label: 'Redirect urls',
+      default: [],
+    },
+    allowedPublicOperationIds: {
+      type: [String],
+      label: 'Allowed public operation ids',
       default: [],
     },
     secretHash: { type: String, label: 'Secret hash' },

--- a/backend/erxes-api-shared/src/core-modules/apps/index.ts
+++ b/backend/erxes-api-shared/src/core-modules/apps/index.ts
@@ -1,2 +1,3 @@
 export * from './@types/app';
 export * from './db/definitions/apps';
+export * from './db/definitions/oauthClientApps';

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -167,8 +167,8 @@ const getOAuthActionScopeMap = async () => {
         const actionScopes = action.oauthScopes?.length
           ? action.oauthScopes
           : action.oauthScope
-            ? [action.oauthScope]
-            : [];
+          ? [action.oauthScope]
+          : [];
 
         if (actionScopes.length) {
           scopeMap[action.name] = actionScopes;
@@ -181,13 +181,12 @@ const getOAuthActionScopeMap = async () => {
 };
 
 const checkOAuthScope = async (action: string, user?: IUserDocument) => {
-  const oauthScopes = (
-    (user || {}) as IUserDocument & {
-      oauthScopes?: string[];
-    }
-  ).oauthScopes;
+  const oauthPrincipal = (user || {}) as IUserDocument & {
+    oauthClientId?: string;
+    oauthScopes?: string[];
+  };
 
-  if (!oauthScopes?.length) {
+  if (!oauthPrincipal.oauthClientId) {
     return;
   }
 
@@ -196,7 +195,7 @@ const checkOAuthScope = async (action: string, user?: IUserDocument) => {
 
   if (
     actionScopes.length === 0 ||
-    !actionScopes.some((scope) => oauthScopes.includes(scope))
+    !actionScopes.some((scope) => oauthPrincipal.oauthScopes?.includes(scope))
   ) {
     throw new ExpectedError('OAuth scope required', 'FORBIDDEN');
   }

--- a/backend/erxes-api-shared/src/core-types/index.ts
+++ b/backend/erxes-api-shared/src/core-types/index.ts
@@ -16,3 +16,4 @@ export * from './modules/relations/relations';
 export * from './modules/logs/logs';
 export * from './modules/automations/automations';
 export * from './modules/saas/organization';
+export * from './modules/public-api/publicApi';

--- a/backend/erxes-api-shared/src/core-types/modules/public-api/publicApi.ts
+++ b/backend/erxes-api-shared/src/core-types/modules/public-api/publicApi.ts
@@ -1,0 +1,15 @@
+export type PublicApiOperationKind = 'query' | 'mutation';
+
+export interface IPublicApiOperation {
+  id: string;
+  name: string;
+  description: string;
+  operationName: string;
+  kind: PublicApiOperationKind;
+  document: string;
+  requiredActions: string[];
+}
+
+export interface IPublicApiConfig {
+  operations: IPublicApiOperation[];
+}

--- a/backend/erxes-api-shared/src/utils/index.ts
+++ b/backend/erxes-api-shared/src/utils/index.ts
@@ -24,3 +24,4 @@ export * from './bulkUtils';
 export * from './editor';
 export * from './errorClassifier';
 export * from './sentry-init';
+export * from './public-api';

--- a/backend/erxes-api-shared/src/utils/public-api.ts
+++ b/backend/erxes-api-shared/src/utils/public-api.ts
@@ -1,0 +1,25 @@
+import type {
+  IPublicApiConfig,
+  IPublicApiOperation,
+} from '../core-types';
+import { getActivePlugins, getPlugin } from './service-discovery';
+
+export const getPublicApiOperations = async (): Promise<
+  IPublicApiOperation[]
+> => {
+  const pluginNames = await getActivePlugins();
+  const operations: IPublicApiOperation[] = [];
+
+  for (const pluginName of pluginNames) {
+    const plugin = await getPlugin(pluginName);
+    const config = plugin.config?.meta?.publicApi as
+      | IPublicApiConfig
+      | undefined;
+
+    if (config?.operations?.length) {
+      operations.push(...config.operations);
+    }
+  }
+
+  return operations;
+};

--- a/backend/erxes-api-shared/src/utils/public-api.ts
+++ b/backend/erxes-api-shared/src/utils/public-api.ts
@@ -1,9 +1,7 @@
-import type {
-  IPublicApiConfig,
-  IPublicApiOperation,
-} from '../core-types';
+import type { IPublicApiConfig, IPublicApiOperation } from '../core-types';
 import { getActivePlugins, getPlugin } from './service-discovery';
 
+/** Collect the public API operations published by active plugins. */
 export const getPublicApiOperations = async (): Promise<
   IPublicApiOperation[]
 > => {

--- a/backend/erxes-api-shared/src/utils/service-discovery.ts
+++ b/backend/erxes-api-shared/src/utils/service-discovery.ts
@@ -21,7 +21,7 @@ export const isDev = NODE_ENV === 'development';
 
 export const keyForConfig = (name: string) => `erxesservice:config:${name}`;
 
-export const getPlugins = async (): Promise<string[]> => {
+export const getPlugins = (): string[] => {
   const enabledServices = (process.env.ENABLED_PLUGINS || '')
     .split(',')
     .map((plugin) => plugin.trim())

--- a/backend/erxes-api-shared/src/utils/service-discovery.ts
+++ b/backend/erxes-api-shared/src/utils/service-discovery.ts
@@ -21,16 +21,18 @@ export const isDev = NODE_ENV === 'development';
 
 export const keyForConfig = (name: string) => `erxesservice:config:${name}`;
 
-export const getPlugins = (): Promise<string[]> => {
-  const enabledServices = (process.env.ENABLED_PLUGINS || '')
+/** Parse normalized plugin names from a comma-separated environment value. */
+const parsePluginNames = (value: string): string[] =>
+  value
     .split(',')
     .map((plugin) => plugin.trim())
     .filter(Boolean);
 
-  const enabledApiPlugins = (process.env.ENABLED_PLUGINS_ONLY_API || '')
-    .split(',')
-    .map((plugin) => plugin.trim())
-    .filter(Boolean);
+export const getPlugins = (): Promise<string[]> => {
+  const enabledServices = parsePluginNames(process.env.ENABLED_PLUGINS || '');
+  const enabledApiPlugins = parsePluginNames(
+    process.env.ENABLED_PLUGINS_ONLY_API || '',
+  );
 
   return Promise.resolve(['core', ...enabledServices, ...enabledApiPlugins]);
 };
@@ -67,6 +69,10 @@ export const getAvailablePlugins = async (
     const charges = organizationInfo.charge as IOrganizationCharge;
 
     const plugins: string[] = [];
+    const enabledPluginNames = new Set([
+      ...parsePluginNames(ENABLED_PLUGINS),
+      ...parsePluginNames(ENABLED_API_PLUGINS),
+    ]);
 
     Object.keys(charges).forEach((key) => {
       if (
@@ -75,10 +81,7 @@ export const getAvailablePlugins = async (
       ) {
         const pluginName = key.split(':')[0];
 
-        const enabledPluginsArray = ENABLED_PLUGINS.split(',');
-        enabledPluginsArray.push(...ENABLED_API_PLUGINS.split(','));
-
-        if (enabledPluginsArray.includes(pluginName)) {
+        if (enabledPluginNames.has(pluginName)) {
           plugins.push(pluginName);
         }
       }

--- a/backend/erxes-api-shared/src/utils/service-discovery.ts
+++ b/backend/erxes-api-shared/src/utils/service-discovery.ts
@@ -22,13 +22,15 @@ export const isDev = NODE_ENV === 'development';
 export const keyForConfig = (name: string) => `erxesservice:config:${name}`;
 
 export const getPlugins = async (): Promise<string[]> => {
-  const enabledServices: any[] =
-    process.env.ENABLED_PLUGINS?.split(',').map((plugin) => `${plugin}`) || [];
+  const enabledServices = (process.env.ENABLED_PLUGINS || '')
+    .split(',')
+    .map((plugin) => plugin.trim())
+    .filter(Boolean);
 
-  const enabledApiPlugins: any[] =
-    process.env.ENABLED_PLUGINS_ONLY_API?.split(',').map(
-      (plugin) => `${plugin}`,
-    ) || [];
+  const enabledApiPlugins = (process.env.ENABLED_PLUGINS_ONLY_API || '')
+    .split(',')
+    .map((plugin) => plugin.trim())
+    .filter(Boolean);
 
   return ['core', ...enabledServices, ...enabledApiPlugins];
 };

--- a/backend/erxes-api-shared/src/utils/service-discovery.ts
+++ b/backend/erxes-api-shared/src/utils/service-discovery.ts
@@ -21,7 +21,7 @@ export const isDev = NODE_ENV === 'development';
 
 export const keyForConfig = (name: string) => `erxesservice:config:${name}`;
 
-export const getPlugins = (): string[] => {
+export const getPlugins = (): Promise<string[]> => {
   const enabledServices = (process.env.ENABLED_PLUGINS || '')
     .split(',')
     .map((plugin) => plugin.trim())
@@ -32,7 +32,7 @@ export const getPlugins = (): string[] => {
     .map((plugin) => plugin.trim())
     .filter(Boolean);
 
-  return ['core', ...enabledServices, ...enabledApiPlugins];
+  return Promise.resolve(['core', ...enabledServices, ...enabledApiPlugins]);
 };
 
 const ACTIVE_PLUGINS_KEY = 'erxes-active-plugins';

--- a/backend/erxes-api-shared/src/utils/service-discovery.ts
+++ b/backend/erxes-api-shared/src/utils/service-discovery.ts
@@ -28,6 +28,7 @@ const parsePluginNames = (value: string): string[] =>
     .map((plugin) => plugin.trim())
     .filter(Boolean);
 
+/** Return core plus the normalized UI and API plugin configuration. */
 export const getPlugins = (): Promise<string[]> => {
   const enabledServices = parsePluginNames(process.env.ENABLED_PLUGINS || '');
   const enabledApiPlugins = parsePluginNames(

--- a/backend/erxes-api-shared/src/utils/start-plugin.ts
+++ b/backend/erxes-api-shared/src/utils/start-plugin.ts
@@ -32,7 +32,11 @@ import {
 import { AutomationConfigs } from '../core-modules/automations/types';
 import type { ImportExportConfigs } from '../core-modules/import-export/types';
 import { startImportExportWorker } from '../core-modules/import-export/worker';
-import { IMainContext, IPermissionConfig } from '../core-types';
+import {
+  IMainContext,
+  IPermissionConfig,
+  IPublicApiConfig,
+} from '../core-types';
 import {
   generateApolloContext,
   startBeforeResolvers,
@@ -82,6 +86,7 @@ type IMeta = {
   references?: TRecordReferencesConfig;
   permissions?: IPermissionConfig;
   beforeResolvers?: BeforeResolversConfig;
+  publicApi?: IPublicApiConfig;
   importExport?: ImportExportConfigs;
   relations?: {
     subscribedTypes: string[];

--- a/backend/gateway/src/connectionResolver.ts
+++ b/backend/gateway/src/connectionResolver.ts
@@ -1,5 +1,7 @@
 import {
   appSchema,
+  IOAuthClientAppDocument,
+  oauthClientAppSchema,
   clientPortalSchema,
   cpUserSchema,
   permissionSchema,
@@ -22,6 +24,7 @@ export interface IModels {
   Users: any;
   Permissions: any;
   Apps: any;
+  OAuthClientApps: mongoose.Model<IOAuthClientAppDocument>;
   Clients: any;
   Roles: any;
   ClientPortals: any;
@@ -39,6 +42,10 @@ export const loadClasses = (db: mongoose.Connection): IModels => {
   models.Users = db.model('users', userSchema);
   models.Permissions = db.model('permissions', permissionSchema);
   models.Apps = db.model('app_tokens', appSchema);
+  models.OAuthClientApps = db.model<IOAuthClientAppDocument>(
+    'oauth_client_apps',
+    oauthClientAppSchema,
+  );
   models.ClientPortals =
     db.models.client_portals || db.model('client_portals', clientPortalSchema);
 

--- a/backend/gateway/src/locales/en/settings.json
+++ b/backend/gateway/src/locales/en/settings.json
@@ -217,5 +217,12 @@
     "error": "Error",
     "confirm-delete-field": "Are you sure you want to delete this field?",
     "confirm-delete-group": "Are you sure you want to delete this field group?"
+  },
+  "oauth-clients": {
+    "public-operations": "Public operations",
+    "public-operations-description": "Choose which published operations this client may call through /public/graphql.",
+    "loading-public-operations": "Loading public operations",
+    "public-operations-load-failed": "Failed to load public operations",
+    "no-public-operations": "No public operations are published"
   }
 }

--- a/backend/gateway/src/locales/mn/settings.json
+++ b/backend/gateway/src/locales/mn/settings.json
@@ -209,5 +209,12 @@
     "error": "Алдаа",
     "confirm-delete-field": "Энэ талбарыг устгахдаа итгэлтэй байна уу?",
     "confirm-delete-group": "Энэ талбарын бүлгийг устгахдаа итгэлтэй байна уу?"
+  },
+  "oauth-clients": {
+    "public-operations": "Нийтийн үйлдлүүд",
+    "public-operations-description": "Энэ клиент /public/graphql-ээр дуудах боломжтой нийтлэгдсэн үйлдлүүдийг сонгоно уу.",
+    "loading-public-operations": "Нийтийн үйлдлүүдийг ачаалж байна",
+    "public-operations-load-failed": "Нийтийн үйлдлүүдийг ачаалж чадсангүй",
+    "no-public-operations": "Нийтлэгдсэн нийтийн үйлдэл алга"
   }
 }

--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -41,6 +41,8 @@ import {
   stopSubscriptionServer,
 } from './subscription';
 import { isValidLocaleParams, resolveLocale } from '~/util/locales';
+import { applyPublicApi } from '~/public-api/router';
+import { refreshPublicApiRegistry } from '~/public-api/registry';
 
 dotenv.config();
 
@@ -103,6 +105,19 @@ const gatewayRateLimiter: RateLimitRequestHandler = rateLimit({
 app.use(gatewayRateLimiter);
 
 app.use(async (req, res, next) => {
+  if (req.path === '/public/graphql') {
+    return cors({
+      credentials: false,
+      origin: true,
+      methods: ['POST'],
+      allowedHeaders: [
+        'Authorization',
+        'Content-Type',
+        'X-Erxes-Process-Id',
+      ],
+    })(req, res, next);
+  }
+
   const appToken = req.headers['x-app-api-token'] as string;
   // const clientPortalToken = req.headers['x-app-token'] as string;
 
@@ -233,6 +248,8 @@ async function start() {
     console.log('Starting the router...');
     await startRouter(global.currentTargets);
     console.log('Router started successfully');
+    await refreshPublicApiRegistry();
+    applyPublicApi(app);
 
     // Apply the initial proxy middleware
     applyGraphqlLimiters(app);

--- a/backend/gateway/src/middlewares/userMiddleware.ts
+++ b/backend/gateway/src/middlewares/userMiddleware.ts
@@ -15,16 +15,42 @@ import { generateModels, IModels } from '../connectionResolver';
 
 dotenv.config();
 
+export interface GatewayPrincipal {
+  _id?: string;
+  loginToken?: string;
+  sessionCode?: string | string[];
+  oauthClientId?: string;
+  oauthScopes?: string[];
+  oauthAllowedPublicOperationIds?: string[];
+  [key: string]: unknown;
+}
+
+interface OAuthAccessTokenPayload extends jwt.JwtPayload {
+  typ?: string;
+  user?: { _id?: string };
+  clientId?: string;
+  subdomain?: string;
+  scope?: string;
+}
+
+export type GatewayRequest = Request & {
+  user?: GatewayPrincipal;
+  cpUser?: GatewayPrincipal;
+  clientPortal?: GatewayPrincipal;
+};
+
 const DEBUG_GATEWAY_AUTH = process.env.DEBUG_GATEWAY_AUTH === 'true';
 
 const shouldDebugAuth = (req: Request) =>
-  DEBUG_GATEWAY_AUTH && req.originalUrl.startsWith('/graphql');
+  DEBUG_GATEWAY_AUTH &&
+  (req.originalUrl.startsWith('/graphql') ||
+    req.originalUrl.startsWith('/public/graphql'));
 
 const hashToken = (token: string) =>
   createHash('sha256').update(token).digest('hex').slice(0, 12);
 
 const debugAuth = (
-  req: Request & { user?: any; cpUser?: any; clientPortal?: any },
+  req: GatewayRequest,
   event: string,
   extra: Record<string, unknown> = {},
 ) => {
@@ -64,7 +90,7 @@ const getBearerToken = (req: Request) => {
 
 // skipcq: JS-R1005 — legacy middleware complexity
 export default async function userMiddleware(
-  req: Request & { user?: any; cpUser?: any; clientPortal?: any },
+  req: GatewayRequest,
   res: Response,
   next: NextFunction,
 ) {
@@ -186,19 +212,6 @@ export default async function userMiddleware(
         { $set: { lastUsedAt: new Date() } },
       );
 
-      // Forward the app as an authenticated system principal so plugin
-      // resolvers behind login/permission wrappers accept machine calls.
-      // Mirrors the JWT path's setUserHeader below; without this a valid
-      // app token authenticates the request but every wrapped mutation
-      // still fails "Login required".
-      if (!req.user) {
-        req.user = {
-          _id: `app:${appInDb._id}`,
-          username: appInDb.name,
-          isOwner: appInDb.allowAllPermission === true,
-        } as any;
-        setUserHeader(req.headers, req.user);
-      }
     } catch (e) {
       console.error(e);
       debugAuth(req, 'app-token-error', {
@@ -315,62 +328,88 @@ export default async function userMiddleware(
   }
 
   try {
-    // verify user token and retrieve stored user information
-    const decoded: any = jwt.verify(
+    const decodedValue = jwt.verify(
       token,
       process.env.JWT_TOKEN_SECRET || 'SECRET',
     );
-    const user = decoded.user;
 
-    if (!user?._id) {
+    if (typeof decodedValue === 'string') {
+      return next();
+    }
+
+    const decoded = decodedValue as OAuthAccessTokenPayload;
+    const tokenUser = decoded.user;
+
+    if (typeof tokenUser?._id !== 'string') {
       debugAuth(req, 'decoded-user-missing-id', {
         subdomain,
         tokenHash: hashToken(token),
-        decodedKeys: Object.keys(decoded || {}),
+        decodedKeys: Object.keys(decoded),
         durationMs: Date.now() - startedAt,
       });
       return next();
     }
 
+    const userId = tokenUser._id;
     const userDoc = await models.Users.findOne(
-      { _id: user._id },
+      { _id: userId },
       '_id email details isOwner groupIds brandIds username code branchIds departmentIds permissionGroupIds customPermissions',
     ).lean();
 
     if (!userDoc) {
       debugAuth(req, 'user-not-found', {
         subdomain,
-        userId: user._id,
+        userId,
         tokenHash: hashToken(token),
         durationMs: Date.now() - startedAt,
       });
       return next();
     }
 
-    const validatedToken = await redis.get(`user_token_${user._id}_${token}`);
+    const validatedToken = await redis.get(`user_token_${userId}_${token}`);
 
-    // invalid token access.
     if (!validatedToken) {
       debugAuth(req, 'redis-user-token-missing', {
         subdomain,
-        userId: user._id,
+        userId,
         tokenHash: hashToken(token),
         durationMs: Date.now() - startedAt,
       });
       return next();
     }
 
-    // save user in request
-    req.user = { ...userDoc };
-    req.user.loginToken = token;
-    req.user.sessionCode = req.headers.sessioncode || '';
+    const authenticatedUser: GatewayPrincipal = {
+      ...userDoc,
+      loginToken: token,
+      sessionCode: req.headers.sessioncode || '',
+    };
 
     if (decoded.typ === 'oauth_access') {
-      req.user.oauthClientId = decoded.clientId || '';
-      req.user.oauthScopes = String(decoded.scope || '')
+      const clientId =
+        typeof decoded.clientId === 'string' ? decoded.clientId : '';
+      const tokenSubdomain =
+        typeof decoded.subdomain === 'string' ? decoded.subdomain : '';
+
+      if (!clientId || tokenSubdomain !== subdomain) {
+        return res.status(401).json({ error: 'Invalid OAuth access token' });
+      }
+
+      const oauthClient = await models.OAuthClientApps.findOne(
+        { clientId, status: 'active' },
+        'allowedPublicOperationIds',
+      ).lean();
+
+      if (!oauthClient) {
+        return res.status(401).json({ error: 'OAuth client is not active' });
+      }
+
+      authenticatedUser.oauthClientId = clientId;
+      authenticatedUser.oauthScopes = String(decoded.scope || '')
         .split(/\s|,/)
         .map((scope) => scope.trim())
         .filter(Boolean);
+      authenticatedUser.oauthAllowedPublicOperationIds =
+        oauthClient.allowedPublicOperationIds || [];
     }
 
     const hostname = await redis.get('hostname');
@@ -379,10 +418,11 @@ export default async function userMiddleware(
       redis.set('hostname', process.env.DOMAIN || 'http://localhost:3001');
     }
 
-    setUserHeader(req.headers, req.user);
+    req.user = authenticatedUser;
+    setUserHeader(req.headers, authenticatedUser);
     debugAuth(req, 'user-header-set', {
       subdomain,
-      userId: req.user._id,
+      userId: authenticatedUser._id,
       tokenHash: hashToken(token),
       durationMs: Date.now() - startedAt,
     });

--- a/backend/gateway/src/mq/workers/workers.ts
+++ b/backend/gateway/src/mq/workers/workers.ts
@@ -5,6 +5,7 @@ import {
 } from 'erxes-api-shared/utils';
 import { restartRouter } from '~/apollo-router';
 import { retryGetProxyTargets } from '~/proxy/targets';
+import { refreshPublicApiRegistry } from '~/public-api/registry';
 
 let routerUpdateInFlight: Promise<void> | undefined;
 
@@ -18,6 +19,7 @@ const updateApolloRouter = async () => {
     clearServiceDiscoveryCache();
     global.currentTargets = await retryGetProxyTargets();
     await restartRouter(global.currentTargets);
+    await refreshPublicApiRegistry();
   })();
 
   try {

--- a/backend/gateway/src/public-api/registry.ts
+++ b/backend/gateway/src/public-api/registry.ts
@@ -9,6 +9,7 @@ let operationRegistry: ReadonlyMap<
   Readonly<IPublicApiOperation>
 > = new Map();
 
+/** Validate a published operation before admitting it to the runtime registry. */
 const validateOperation = (operation: IPublicApiOperation) => {
   if (!OPERATION_ID_PATTERN.test(operation.id)) {
     throw new Error(`Invalid public API operation id: ${operation.id}`);
@@ -34,15 +35,11 @@ const validateOperation = (operation: IPublicApiOperation) => {
   const [definition] = operationDefinitions;
 
   if (definition.name?.value !== operation.operationName) {
-    throw new Error(
-      `Public API operation name mismatch for ${operation.id}`,
-    );
+    throw new Error(`Public API operation name mismatch for ${operation.id}`);
   }
 
   if (definition.operation !== operation.kind) {
-    throw new Error(
-      `Public API operation kind mismatch for ${operation.id}`,
-    );
+    throw new Error(`Public API operation kind mismatch for ${operation.id}`);
   }
 
   visit(document, {
@@ -56,6 +53,7 @@ const validateOperation = (operation: IPublicApiOperation) => {
   });
 };
 
+/** Atomically rebuild the runtime registry from active plugin metadata. */
 export const refreshPublicApiRegistry = async () => {
   const operations = await getPublicApiOperations();
   const nextRegistry = new Map<string, Readonly<IPublicApiOperation>>();
@@ -79,5 +77,6 @@ export const refreshPublicApiRegistry = async () => {
   operationRegistry = nextRegistry;
 };
 
+/** Resolve a published operation by its stable public identifier. */
 export const getPublicApiOperation = (operationId: string) =>
   operationRegistry.get(operationId);

--- a/backend/gateway/src/public-api/registry.ts
+++ b/backend/gateway/src/public-api/registry.ts
@@ -1,0 +1,83 @@
+import type { IPublicApiOperation } from 'erxes-api-shared/core-types';
+import { getPublicApiOperations } from 'erxes-api-shared/utils';
+import { Kind, parse, visit } from 'graphql';
+
+const OPERATION_ID_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)*\.v\d+$/;
+
+let operationRegistry: ReadonlyMap<
+  string,
+  Readonly<IPublicApiOperation>
+> = new Map();
+
+const validateOperation = (operation: IPublicApiOperation) => {
+  if (!OPERATION_ID_PATTERN.test(operation.id)) {
+    throw new Error(`Invalid public API operation id: ${operation.id}`);
+  }
+
+  if (!operation.requiredActions.length) {
+    throw new Error(
+      `Public API operation requires a permission action: ${operation.id}`,
+    );
+  }
+
+  const document = parse(operation.document);
+  const operationDefinitions = document.definitions.filter(
+    (definition) => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+
+  if (operationDefinitions.length !== 1) {
+    throw new Error(
+      `Public API operation must contain one operation: ${operation.id}`,
+    );
+  }
+
+  const [definition] = operationDefinitions;
+
+  if (definition.name?.value !== operation.operationName) {
+    throw new Error(
+      `Public API operation name mismatch for ${operation.id}`,
+    );
+  }
+
+  if (definition.operation !== operation.kind) {
+    throw new Error(
+      `Public API operation kind mismatch for ${operation.id}`,
+    );
+  }
+
+  visit(document, {
+    Field(node) {
+      if (node.name.value.startsWith('__')) {
+        throw new Error(
+          `Public API introspection is not allowed: ${operation.id}`,
+        );
+      }
+    },
+  });
+};
+
+export const refreshPublicApiRegistry = async () => {
+  const operations = await getPublicApiOperations();
+  const nextRegistry = new Map<string, Readonly<IPublicApiOperation>>();
+
+  for (const operation of operations) {
+    validateOperation(operation);
+
+    if (nextRegistry.has(operation.id)) {
+      throw new Error(`Duplicate public API operation id: ${operation.id}`);
+    }
+
+    nextRegistry.set(
+      operation.id,
+      Object.freeze({
+        ...operation,
+        requiredActions: [...operation.requiredActions],
+      }),
+    );
+  }
+
+  operationRegistry = nextRegistry;
+};
+
+export const getPublicApiOperation = (operationId: string) =>
+  operationRegistry.get(operationId);

--- a/backend/gateway/src/public-api/router.ts
+++ b/backend/gateway/src/public-api/router.ts
@@ -90,7 +90,7 @@ const resolvePublicApiOperation = (
     };
   }
 
-  const operation = getPublicApiOperation(body.operationId);
+  const operation = getPublicApiOperation(body.operationId.trim());
 
   if (!operation) {
     return {

--- a/backend/gateway/src/public-api/router.ts
+++ b/backend/gateway/src/public-api/router.ts
@@ -113,7 +113,7 @@ const resolvePublicApiOperation = (
 /** Validate the public variables envelope and bounded list limit. */
 const getVariablesValidationError = (
   variables: unknown,
-): PublicApiHttpError | undefined => {
+): PublicApiHttpError | null => {
   if (
     variables !== undefined &&
     (typeof variables !== 'object' ||
@@ -127,7 +127,7 @@ const getVariablesValidationError = (
     ?.limit;
 
   if (requestedLimit === undefined) {
-    return;
+    return null;
   }
 
   if (
@@ -138,6 +138,8 @@ const getVariablesValidationError = (
   ) {
     return { statusCode: 400, message: 'limit must be between 1 and 100' };
   }
+
+  return null;
 };
 
 /** Send a normalized validation or authorization response. */

--- a/backend/gateway/src/public-api/router.ts
+++ b/backend/gateway/src/public-api/router.ts
@@ -1,0 +1,191 @@
+import { Express, Response, json } from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import fetch from 'node-fetch';
+import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
+import type { IUserDocument } from 'erxes-api-shared/core-types';
+import { getSubdomain } from 'erxes-api-shared/utils';
+import { apolloRouterPort } from '~/apollo-router';
+import type { GatewayRequest } from '~/middlewares/userMiddleware';
+import { getPublicApiOperation } from './registry';
+
+type PublicApiRequestBody = {
+  operationId?: unknown;
+  variables?: unknown;
+  query?: unknown;
+};
+
+type InternalGraphQLError = {
+  message?: unknown;
+  extensions?: { code?: unknown };
+};
+
+type InternalGraphQLResponse = {
+  data?: unknown;
+  errors?: InternalGraphQLError[];
+};
+
+const publicApiRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 1000,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: GatewayRequest) => {
+    const clientKey = req.user?.oauthClientId || ipKeyGenerator(req.ip || '');
+    return `${req.hostname}:${clientKey}`;
+  },
+});
+
+const sendPublicGraphQLRequest = async (
+  req: GatewayRequest,
+  res: Response,
+) => {
+  const authorization = req.headers.authorization;
+
+  if (
+    typeof authorization !== 'string' ||
+    !authorization.match(/^Bearer\s+\S+$/i) ||
+    !req.user?._id ||
+    !req.user.oauthClientId
+  ) {
+    return res.status(401).json({ error: 'OAuth bearer token required' });
+  }
+
+  const body = (req.body || {}) as PublicApiRequestBody;
+
+  if (body.query !== undefined) {
+    return res.status(400).json({ error: 'Raw GraphQL queries are not allowed' });
+  }
+
+  if (typeof body.operationId !== 'string' || !body.operationId.trim()) {
+    return res.status(400).json({ error: 'operationId is required' });
+  }
+
+  const operation = getPublicApiOperation(body.operationId);
+
+  if (!operation) {
+    return res.status(404).json({ error: 'Public API operation not found' });
+  }
+
+  if (
+    !req.user.oauthAllowedPublicOperationIds?.includes(operation.id)
+  ) {
+    return res.status(403).json({ error: 'Operation is not enabled for this client' });
+  }
+
+  if (
+    body.variables !== undefined &&
+    (typeof body.variables !== 'object' ||
+      body.variables === null ||
+      Array.isArray(body.variables))
+  ) {
+    return res.status(400).json({ error: 'variables must be an object' });
+  }
+
+  const variables = (body.variables || {}) as Record<string, unknown>;
+  const requestedLimit = variables.limit;
+
+  if (
+    requestedLimit !== undefined &&
+    (typeof requestedLimit !== 'number' ||
+      !Number.isInteger(requestedLimit) ||
+      requestedLimit < 1 ||
+      requestedLimit > 100)
+  ) {
+    return res.status(400).json({ error: 'limit must be between 1 and 100' });
+  }
+
+  const subdomain = getSubdomain(req);
+  const checkPermission = checkPermissionGroup(
+    subdomain,
+    req.user as unknown as IUserDocument,
+  );
+
+  for (const action of operation.requiredActions) {
+    await checkPermission(action);
+  }
+
+  const userHeader = req.headers.user;
+
+  if (typeof userHeader !== 'string') {
+    return res.status(401).json({ error: 'Authenticated user context required' });
+  }
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    hostname: req.hostname,
+    user: userHeader,
+    userid: req.user._id,
+  };
+  const processId = req.headers['x-erxes-process-id'];
+
+  if (typeof processId === 'string') {
+    headers['x-erxes-process-id'] = processId;
+  }
+
+  const internalResponse = await fetch(
+    `http://127.0.0.1:${apolloRouterPort}/`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: operation.document,
+        operationName: operation.operationName,
+        variables,
+      }),
+    },
+  );
+  const responseBody = (await internalResponse.json()) as InternalGraphQLResponse;
+
+  if (
+    responseBody === null ||
+    typeof responseBody !== 'object' ||
+    (!('data' in responseBody) && !Array.isArray(responseBody.errors))
+  ) {
+    return res.status(502).json({ error: 'Invalid response from internal API' });
+  }
+
+  return res.status(internalResponse.status).json({
+    ...(responseBody.data !== undefined ? { data: responseBody.data } : {}),
+    ...(Array.isArray(responseBody.errors)
+      ? {
+          errors: responseBody.errors.map((error) => ({
+            message:
+              typeof error.message === 'string'
+                ? error.message
+                : 'Operation failed',
+            extensions: {
+              code:
+                typeof error.extensions?.code === 'string'
+                  ? error.extensions.code
+                  : 'INTERNAL_SERVER_ERROR',
+            },
+          })),
+        }
+      : {}),
+  });
+};
+
+export const applyPublicApi = (app: Express) => {
+  app.post(
+    '/public/graphql',
+    json({ limit: '100kb' }),
+    publicApiRateLimiter,
+    async (req: GatewayRequest, res) => {
+      try {
+        return await sendPublicGraphQLRequest(req, res);
+      } catch (error) {
+        const statusCode =
+          error instanceof Error &&
+          (error.message === 'Login required' ||
+            error.message === 'Permission required' ||
+            error.message === 'OAuth scope required')
+            ? 403
+            : 500;
+
+        return res.status(statusCode).json({
+          error: statusCode === 403 ? error.message : 'Public API request failed',
+        });
+      }
+    },
+  );
+};

--- a/backend/gateway/src/public-api/router.ts
+++ b/backend/gateway/src/public-api/router.ts
@@ -2,7 +2,10 @@ import { Express, Response, json } from 'express';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import fetch from 'node-fetch';
 import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
-import type { IUserDocument } from 'erxes-api-shared/core-types';
+import type {
+  IPublicApiOperation,
+  IUserDocument,
+} from 'erxes-api-shared/core-types';
 import { getSubdomain } from 'erxes-api-shared/utils';
 import { apolloRouterPort } from '~/apollo-router';
 import type { GatewayRequest } from '~/middlewares/userMiddleware';
@@ -24,6 +27,26 @@ type InternalGraphQLResponse = {
   errors?: InternalGraphQLError[];
 };
 
+type PublicApiHttpError = {
+  statusCode: number;
+  message: string;
+};
+
+type PublicApiOperationResult =
+  | { operation: IPublicApiOperation; error?: never }
+  | { operation?: never; error: PublicApiHttpError };
+
+const AUTHORIZATION_PATTERN = /^Bearer\s+\S+$/i;
+const INTERNAL_GRAPHQL_REQUEST_TIMEOUT_MS = 30_000;
+const INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR';
+const EXPOSED_GRAPHQL_ERROR_CODES = new Set([
+  'BAD_USER_INPUT',
+  'CONFLICT',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'UNAUTHENTICATED',
+]);
+
 const publicApiRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 1000,
@@ -35,86 +58,102 @@ const publicApiRateLimiter = rateLimit({
   },
 });
 
-const sendPublicGraphQLRequest = async (
-  req: GatewayRequest,
-  res: Response,
-) => {
+/** Check that the request carries an authenticated OAuth bearer principal. */
+const isOAuthBearerRequest = (req: GatewayRequest) => {
   const authorization = req.headers.authorization;
 
-  if (
-    typeof authorization !== 'string' ||
-    !authorization.match(/^Bearer\s+\S+$/i) ||
-    !req.user?._id ||
-    !req.user.oauthClientId
-  ) {
-    return res.status(401).json({ error: 'OAuth bearer token required' });
-  }
+  return (
+    typeof authorization === 'string' &&
+    AUTHORIZATION_PATTERN.test(authorization) &&
+    Boolean(req.user?._id) &&
+    Boolean(req.user?.oauthClientId)
+  );
+};
 
-  const body = (req.body || {}) as PublicApiRequestBody;
-
+/** Resolve the requested operation while enforcing the client allowlist. */
+const resolvePublicApiOperation = (
+  body: PublicApiRequestBody,
+  req: GatewayRequest,
+): PublicApiOperationResult => {
   if (body.query !== undefined) {
-    return res.status(400).json({ error: 'Raw GraphQL queries are not allowed' });
+    return {
+      error: {
+        statusCode: 400,
+        message: 'Raw GraphQL queries are not allowed',
+      },
+    };
   }
 
   if (typeof body.operationId !== 'string' || !body.operationId.trim()) {
-    return res.status(400).json({ error: 'operationId is required' });
+    return {
+      error: { statusCode: 400, message: 'operationId is required' },
+    };
   }
 
   const operation = getPublicApiOperation(body.operationId);
 
   if (!operation) {
-    return res.status(404).json({ error: 'Public API operation not found' });
+    return {
+      error: { statusCode: 404, message: 'Public API operation not found' },
+    };
+  }
+
+  if (!req.user?.oauthAllowedPublicOperationIds?.includes(operation.id)) {
+    return {
+      error: {
+        statusCode: 403,
+        message: 'Operation is not enabled for this client',
+      },
+    };
+  }
+
+  return { operation };
+};
+
+/** Validate the public variables envelope and bounded list limit. */
+const getVariablesValidationError = (
+  variables: unknown,
+): PublicApiHttpError | undefined => {
+  if (
+    variables !== undefined &&
+    (typeof variables !== 'object' ||
+      variables === null ||
+      Array.isArray(variables))
+  ) {
+    return { statusCode: 400, message: 'variables must be an object' };
+  }
+
+  const requestedLimit = (variables as Record<string, unknown> | undefined)
+    ?.limit;
+
+  if (requestedLimit === undefined) {
+    return;
   }
 
   if (
-    !req.user.oauthAllowedPublicOperationIds?.includes(operation.id)
+    typeof requestedLimit !== 'number' ||
+    !Number.isInteger(requestedLimit) ||
+    requestedLimit < 1 ||
+    requestedLimit > 100
   ) {
-    return res.status(403).json({ error: 'Operation is not enabled for this client' });
+    return { statusCode: 400, message: 'limit must be between 1 and 100' };
   }
+};
 
-  if (
-    body.variables !== undefined &&
-    (typeof body.variables !== 'object' ||
-      body.variables === null ||
-      Array.isArray(body.variables))
-  ) {
-    return res.status(400).json({ error: 'variables must be an object' });
-  }
+/** Send a normalized validation or authorization response. */
+const sendPublicApiError = (res: Response, error: PublicApiHttpError) =>
+  res.status(error.statusCode).json({ error: error.message });
 
-  const variables = (body.variables || {}) as Record<string, unknown>;
-  const requestedLimit = variables.limit;
-
-  if (
-    requestedLimit !== undefined &&
-    (typeof requestedLimit !== 'number' ||
-      !Number.isInteger(requestedLimit) ||
-      requestedLimit < 1 ||
-      requestedLimit > 100)
-  ) {
-    return res.status(400).json({ error: 'limit must be between 1 and 100' });
-  }
-
-  const subdomain = getSubdomain(req);
-  const checkPermission = checkPermissionGroup(
-    subdomain,
-    req.user as unknown as IUserDocument,
-  );
-
-  for (const action of operation.requiredActions) {
-    await checkPermission(action);
-  }
-
-  const userHeader = req.headers.user;
-
-  if (typeof userHeader !== 'string') {
-    return res.status(401).json({ error: 'Authenticated user context required' });
-  }
-
+/** Build trusted headers for the gateway's internal GraphQL request. */
+const getInternalHeaders = (
+  req: GatewayRequest,
+  userHeader: string,
+): Record<string, string> => {
   const headers: Record<string, string> = {
     'content-type': 'application/json',
     hostname: req.hostname,
     user: userHeader,
-    userid: req.user._id,
+    userid: req.user?._id ?? '',
   };
   const processId = req.headers['x-erxes-process-id'];
 
@@ -122,49 +161,125 @@ const sendPublicGraphQLRequest = async (
     headers['x-erxes-process-id'] = processId;
   }
 
+  return headers;
+};
+
+/** Verify the minimum response envelope expected from Apollo Router. */
+const isInternalGraphQLResponse = (
+  responseBody: unknown,
+): responseBody is InternalGraphQLResponse => {
+  if (responseBody === null || typeof responseBody !== 'object') {
+    return false;
+  }
+
+  const response = responseBody as InternalGraphQLResponse;
+  return response.data !== undefined || Array.isArray(response.errors);
+};
+
+/** Normalize upstream error codes to the public API's stable error surface. */
+const getPublicGraphQLErrorCode = (error: InternalGraphQLError) => {
+  const code = error.extensions?.code;
+
+  if (typeof code === 'string' && EXPOSED_GRAPHQL_ERROR_CODES.has(code)) {
+    return code;
+  }
+
+  return INTERNAL_SERVER_ERROR;
+};
+
+/** Remove internal details from errors that are not explicitly public. */
+const mapInternalGraphQLError = (error: InternalGraphQLError) => {
+  const code = getPublicGraphQLErrorCode(error);
+  const canExposeMessage =
+    code !== INTERNAL_SERVER_ERROR && typeof error.message === 'string';
+
+  return {
+    message: canExposeMessage ? error.message : 'Operation failed',
+    extensions: { code },
+  };
+};
+
+/** Build the response without exposing unrecognized internal errors. */
+const buildPublicGraphQLResponse = (
+  responseBody: InternalGraphQLResponse,
+): InternalGraphQLResponse => {
+  const publicResponse: InternalGraphQLResponse = {};
+
+  if (responseBody.data !== undefined) {
+    publicResponse.data = responseBody.data;
+  }
+
+  if (Array.isArray(responseBody.errors)) {
+    publicResponse.errors = responseBody.errors.map(mapInternalGraphQLError);
+  }
+
+  return publicResponse;
+};
+/** Execute a validated public operation through the internal Apollo Router. */
+const sendPublicGraphQLRequest = async (req: GatewayRequest, res: Response) => {
+  if (!isOAuthBearerRequest(req)) {
+    return res.status(401).json({ error: 'OAuth bearer token required' });
+  }
+
+  const body = (req.body ?? {}) as PublicApiRequestBody;
+  const operationResult = resolvePublicApiOperation(body, req);
+
+  if (operationResult.error) {
+    return sendPublicApiError(res, operationResult.error);
+  }
+
+  const variablesError = getVariablesValidationError(body.variables);
+
+  if (variablesError) {
+    return sendPublicApiError(res, variablesError);
+  }
+
+  const variables = (body.variables ?? {}) as Record<string, unknown>;
+  const subdomain = getSubdomain(req);
+  const checkPermission = checkPermissionGroup(
+    subdomain,
+    req.user as unknown as IUserDocument,
+  );
+
+  for (const action of operationResult.operation.requiredActions) {
+    await checkPermission(action);
+  }
+
+  const userHeader = req.headers.user;
+
+  if (typeof userHeader !== 'string') {
+    return res
+      .status(401)
+      .json({ error: 'Authenticated user context required' });
+  }
+
   const internalResponse = await fetch(
     `http://127.0.0.1:${apolloRouterPort}/`,
     {
       method: 'POST',
-      headers,
+      headers: getInternalHeaders(req, userHeader),
       body: JSON.stringify({
-        query: operation.document,
-        operationName: operation.operationName,
+        query: operationResult.operation.document,
+        operationName: operationResult.operation.operationName,
         variables,
       }),
+      timeout: INTERNAL_GRAPHQL_REQUEST_TIMEOUT_MS,
     },
   );
-  const responseBody = (await internalResponse.json()) as InternalGraphQLResponse;
+  const responseBody = (await internalResponse.json()) as unknown;
 
-  if (
-    responseBody === null ||
-    typeof responseBody !== 'object' ||
-    (!('data' in responseBody) && !Array.isArray(responseBody.errors))
-  ) {
-    return res.status(502).json({ error: 'Invalid response from internal API' });
+  if (!isInternalGraphQLResponse(responseBody)) {
+    return res
+      .status(502)
+      .json({ error: 'Invalid response from internal API' });
   }
 
-  return res.status(internalResponse.status).json({
-    ...(responseBody.data !== undefined ? { data: responseBody.data } : {}),
-    ...(Array.isArray(responseBody.errors)
-      ? {
-          errors: responseBody.errors.map((error) => ({
-            message:
-              typeof error.message === 'string'
-                ? error.message
-                : 'Operation failed',
-            extensions: {
-              code:
-                typeof error.extensions?.code === 'string'
-                  ? error.extensions.code
-                  : 'INTERNAL_SERVER_ERROR',
-            },
-          })),
-        }
-      : {}),
-  });
+  return res
+    .status(internalResponse.status)
+    .json(buildPublicGraphQLResponse(responseBody));
 };
 
+/** Register the OAuth-protected public GraphQL endpoint. */
 export const applyPublicApi = (app: Express) => {
   app.post(
     '/public/graphql',
@@ -183,7 +298,8 @@ export const applyPublicApi = (app: Express) => {
             : 500;
 
         return res.status(statusCode).json({
-          error: statusCode === 403 ? error.message : 'Public API request failed',
+          error:
+            statusCode === 403 ? error.message : 'Public API request failed',
         });
       }
     },

--- a/frontend/core-ui/src/modules/settings/oauth-clients/components/EditOAuthClient.tsx
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/components/EditOAuthClient.tsx
@@ -37,6 +37,8 @@ export const EditOAuthClient = () => {
     type: editingOAuthClient?.type,
     accessTokenLifetime: getDefaultAccessTokenLifetime(editingOAuthClient),
     redirectUrls: editingOAuthClient?.redirectUrls || [],
+    allowedPublicOperationIds:
+      editingOAuthClient?.allowedPublicOperationIds || [],
   });
   const [revealedSecret, setRevealedSecret] = React.useState<{
     clientName: string;
@@ -52,6 +54,8 @@ export const EditOAuthClient = () => {
         type: editingOAuthClient.type,
         accessTokenLifetime: getDefaultAccessTokenLifetime(editingOAuthClient),
         redirectUrls: editingOAuthClient.redirectUrls || [],
+        allowedPublicOperationIds:
+          editingOAuthClient.allowedPublicOperationIds || [],
       });
     }
   }, [editingOAuthClient, reset]);

--- a/frontend/core-ui/src/modules/settings/oauth-clients/components/OAuthClientForm.tsx
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/components/OAuthClientForm.tsx
@@ -3,6 +3,7 @@ import { Form, Input, Select, StringArrayInput, Textarea } from 'erxes-ui';
 import { TOAuthClientsForm } from '../hooks/useOAuthClientsForm';
 import { OAUTH_CLIENT_ACCESS_TOKEN_LIFETIME_OPTIONS } from '../types';
 import { OAuthClientLogoUpload } from './OAuthClientLogoUpload';
+import { PublicApiOperationSelector } from './PublicApiOperationSelector';
 
 export const OAuthClientForm = () => {
   const form = useFormContext<TOAuthClientsForm>();
@@ -162,6 +163,8 @@ export const OAuthClientForm = () => {
           </Form.Item>
         )}
       />
+
+      <PublicApiOperationSelector />
     </div>
   );
 };

--- a/frontend/core-ui/src/modules/settings/oauth-clients/components/PublicApiOperationSelector.tsx
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/components/PublicApiOperationSelector.tsx
@@ -1,0 +1,88 @@
+import { Checkbox, Form, Spinner } from 'erxes-ui';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import type { TOAuthClientsForm } from '../hooks/useOAuthClientsForm';
+import { usePublicApiOperations } from '../hooks/usePublicApiOperations';
+
+export const PublicApiOperationSelector = () => {
+  const form = useFormContext<TOAuthClientsForm>();
+  const { operations, loading, error } = usePublicApiOperations();
+  const { t } = useTranslation('settings', {
+    keyPrefix: 'oauth-clients',
+  });
+
+  return (
+    <Form.Field
+      control={form.control}
+      name="allowedPublicOperationIds"
+      render={({ field }) => {
+        const selectedIds = field.value || [];
+
+        return (
+          <Form.Item>
+            <Form.Label>{t('public-operations')}</Form.Label>
+            <Form.Description>
+              {t('public-operations-description')}
+            </Form.Description>
+            <Form.Control>
+              <div className="flex flex-col gap-2 rounded-md border p-3">
+                {loading && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner />
+                    {t('loading-public-operations')}
+                  </div>
+                )}
+
+                {!loading && error && (
+                  <p className="text-sm text-destructive">
+                    {t('public-operations-load-failed')}
+                  </p>
+                )}
+
+                {!loading && !error && operations.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    {t('no-public-operations')}
+                  </p>
+                )}
+
+                {!loading &&
+                  !error &&
+                  operations.map((operation) => (
+                    <label
+                      key={operation.id}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2 hover:bg-muted"
+                    >
+                      <Checkbox
+                        checked={selectedIds.includes(operation.id)}
+                        onCheckedChange={(checked) =>
+                          field.onChange(
+                            checked
+                              ? selectedIds.includes(operation.id)
+                                ? selectedIds
+                                : [...selectedIds, operation.id]
+                              : selectedIds.filter((id) => id !== operation.id),
+                          )
+                        }
+                      />
+                      <span className="flex min-w-0 flex-col gap-1">
+                        <span className="text-sm font-medium">
+                          {operation.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {operation.description}
+                        </span>
+                        <code className="break-all text-xs text-muted-foreground">
+                          {operation.id}
+                        </code>
+                      </span>
+                    </label>
+                  ))}
+              </div>
+            </Form.Control>
+            <Form.Message />
+          </Form.Item>
+        );
+      }}
+    />
+  );
+};

--- a/frontend/core-ui/src/modules/settings/oauth-clients/components/PublicApiOperationSelector.tsx
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/components/PublicApiOperationSelector.tsx
@@ -4,6 +4,24 @@ import { useTranslation } from 'react-i18next';
 import type { TOAuthClientsForm } from '../hooks/useOAuthClientsForm';
 import { usePublicApiOperations } from '../hooks/usePublicApiOperations';
 
+/** Return the selected operation IDs after one checkbox transition. */
+const getUpdatedOperationIds = (
+  selectedIds: string[],
+  operationId: string,
+  checked: boolean,
+) => {
+  if (!checked) {
+    return selectedIds.filter((id) => id !== operationId);
+  }
+
+  if (selectedIds.includes(operationId)) {
+    return selectedIds;
+  }
+
+  return [...selectedIds, operationId];
+};
+
+/** Render the published-operation allowlist for an OAuth client. */
 export const PublicApiOperationSelector = () => {
   const form = useFormContext<TOAuthClientsForm>();
   const { operations, loading, error } = usePublicApiOperations();
@@ -16,7 +34,7 @@ export const PublicApiOperationSelector = () => {
       control={form.control}
       name="allowedPublicOperationIds"
       render={({ field }) => {
-        const selectedIds = field.value || [];
+        const selectedIds = field.value ?? [];
 
         return (
           <Form.Item>
@@ -56,11 +74,11 @@ export const PublicApiOperationSelector = () => {
                         checked={selectedIds.includes(operation.id)}
                         onCheckedChange={(checked) =>
                           field.onChange(
-                            checked
-                              ? selectedIds.includes(operation.id)
-                                ? selectedIds
-                                : [...selectedIds, operation.id]
-                              : selectedIds.filter((id) => id !== operation.id),
+                            getUpdatedOperationIds(
+                              selectedIds,
+                              operation.id,
+                              checked === true,
+                            ),
                           )
                         }
                       />

--- a/frontend/core-ui/src/modules/settings/oauth-clients/graphql/mutations/addOAuthClient.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/graphql/mutations/addOAuthClient.ts
@@ -8,6 +8,7 @@ const ADD_OAUTH_CLIENT = gql`
     $type: OAuthClientAppType!
     $accessTokenLifetime: OAuthClientAccessTokenLifetime
     $redirectUrls: [String!]
+    $allowedPublicOperationIds: [String!]
   ) {
     oauthClientAppsAdd(
       name: $name
@@ -16,6 +17,7 @@ const ADD_OAUTH_CLIENT = gql`
       type: $type
       accessTokenLifetime: $accessTokenLifetime
       redirectUrls: $redirectUrls
+      allowedPublicOperationIds: $allowedPublicOperationIds
     ) {
       _id
       name
@@ -25,6 +27,7 @@ const ADD_OAUTH_CLIENT = gql`
       type
       accessTokenLifetime
       redirectUrls
+      allowedPublicOperationIds
       status
       lastUsedAt
       createdAt

--- a/frontend/core-ui/src/modules/settings/oauth-clients/graphql/mutations/editOAuthClient.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/graphql/mutations/editOAuthClient.ts
@@ -9,6 +9,7 @@ const EDIT_OAUTH_CLIENT = gql`
     $type: OAuthClientAppType!
     $accessTokenLifetime: OAuthClientAccessTokenLifetime
     $redirectUrls: [String!]
+    $allowedPublicOperationIds: [String!]
   ) {
     oauthClientAppsEdit(
       _id: $_id
@@ -18,6 +19,7 @@ const EDIT_OAUTH_CLIENT = gql`
       type: $type
       accessTokenLifetime: $accessTokenLifetime
       redirectUrls: $redirectUrls
+      allowedPublicOperationIds: $allowedPublicOperationIds
     ) {
       _id
       name
@@ -27,6 +29,7 @@ const EDIT_OAUTH_CLIENT = gql`
       type
       accessTokenLifetime
       redirectUrls
+      allowedPublicOperationIds
       status
       lastUsedAt
       createdAt

--- a/frontend/core-ui/src/modules/settings/oauth-clients/graphql/queries/getOAuthClients.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/graphql/queries/getOAuthClients.ts
@@ -11,6 +11,7 @@ const GET_OAUTH_CLIENTS = gql`
       type
       accessTokenLifetime
       redirectUrls
+      allowedPublicOperationIds
       status
       lastUsedAt
       createdAt

--- a/frontend/core-ui/src/modules/settings/oauth-clients/graphql/queries/getPublicApiOperations.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/graphql/queries/getPublicApiOperations.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const GET_PUBLIC_API_OPERATIONS = gql`
+  query SettingsPublicApiOperations {
+    publicApiOperations {
+      id
+      name
+      description
+      operationName
+      kind
+    }
+  }
+`;

--- a/frontend/core-ui/src/modules/settings/oauth-clients/hooks/useOAuthClientsForm.tsx
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/hooks/useOAuthClientsForm.tsx
@@ -14,6 +14,7 @@ export const useOAuthClientsForm = (
       name: '',
       type: 'public',
       redirectUrls: [],
+      allowedPublicOperationIds: [],
       ...defaultValues,
     },
     resolver: zodResolver(OAUTH_CLIENTS_FORM_SCHEMA),

--- a/frontend/core-ui/src/modules/settings/oauth-clients/hooks/usePublicApiOperations.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/hooks/usePublicApiOperations.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@apollo/client';
+import { GET_PUBLIC_API_OPERATIONS } from '../graphql/queries/getPublicApiOperations';
+import type { IPublicApiOperation } from '../types';
+
+type PublicApiOperationsData = {
+  publicApiOperations: IPublicApiOperation[];
+};
+
+export const usePublicApiOperations = () => {
+  const { data, loading, error } = useQuery<PublicApiOperationsData>(
+    GET_PUBLIC_API_OPERATIONS,
+  );
+
+  return {
+    operations: data?.publicApiOperations || [],
+    loading,
+    error,
+  };
+};

--- a/frontend/core-ui/src/modules/settings/oauth-clients/schema.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/schema.ts
@@ -7,4 +7,5 @@ export const OAUTH_CLIENTS_FORM_SCHEMA = z.object({
   type: z.enum(['public', 'confidential']),
   accessTokenLifetime: z.enum(['trio', 'half', 'year']).optional(),
   redirectUrls: z.array(z.string().trim()).default([]),
+  allowedPublicOperationIds: z.array(z.string()).default([]),
 });

--- a/frontend/core-ui/src/modules/settings/oauth-clients/types.ts
+++ b/frontend/core-ui/src/modules/settings/oauth-clients/types.ts
@@ -20,11 +20,20 @@ export interface IOAuthClientApp {
   type: OAuthClientAppType;
   accessTokenLifetime?: OAuthClientAccessTokenLifetime;
   redirectUrls: string[];
+  allowedPublicOperationIds: string[];
   status: OAuthClientAppStatus;
   lastUsedAt?: string;
   createdAt: string;
   updatedAt?: string;
   generatedSecret?: string;
+}
+
+export interface IPublicApiOperation {
+  id: string;
+  name: string;
+  description: string;
+  operationName: string;
+  kind: 'query' | 'mutation';
 }
 
 export interface IOAuthClientAppData {


### PR DESCRIPTION
## Summary
- add an OAuth-protected `/public/graphql` endpoint that executes only registered server-side GraphQL documents
- publish initial customer list, detail, and create operations through core metadata
- persist per-client public operation grants and validate tenant, client status, OAuth scopes, and existing erxes permissions
- add the published-operation selector to OAuth client create and edit forms with English and Mongolian translations

## Security boundary
- raw GraphQL documents are rejected
- unknown and client-unapproved operation IDs fail before Apollo Router execution
- OAuth clients are revalidated on every public request
- existing internal `/graphql` behavior is unchanged

## Verification
- `pnpm nx build core-api`
- `pnpm nx build gateway`
- `pnpm nx build core-ui`
- `pnpm nx lint gateway`
- targeted ESLint for all changed public API and OAuth UI files
- browser flow: selected a published operation, created an OAuth client, and confirmed it appeared in the settings table
- end-to-end OAuth device flow and `/public/graphql` checks: approved `200`, unknown `404`, ungranted `403`, raw query `400`, missing token `401`

## Known baseline
Full `core-api` and `core-ui` lint targets still report unrelated pre-existing errors outside the changed feature files.

## Summary by Sourcery

Introduce an OAuth-protected public GraphQL endpoint backed by a registry of pre-published operations and wire it into gateway startup and router updates.

New Features:
- Add a `/public/graphql` gateway endpoint that only executes registered server-side GraphQL operations for authenticated OAuth clients.
- Expose public API operation metadata via core-api GraphQL and core meta configuration for plugins.
- Provide UI support in core-ui to select allowed public operations when creating or editing OAuth clients.

Enhancements:
- Extend gateway authentication to validate OAuth access tokens against active clients and attach public operation grants and scopes to the request principal.
- Normalize and harden plugin discovery and public API operation loading across services.
- Validate public API operation definitions at gateway startup, including ID format, operation kind, name consistency, and disabling introspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public GraphQL API for approved customer-contact searches, details, and creation.
  * OAuth client apps can now be restricted to selected public API operations.
  * Added operation discovery and selection to OAuth client settings.
  * Added authentication, permission checks, rate limiting, validation, and safe response handling for public API requests.
* **Bug Fixes**
  * Improved plugin configuration parsing by removing blank entries and whitespace.
  * Strengthened gateway authentication and OAuth client validation.
  * Improved permission enforcement for OAuth-protected actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->