### PR TITLE
fix: await handleAfterProcess before completing log job

### DIFF
--- a/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
+++ b/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
@@ -44,24 +44,37 @@ export const eventLogHandler = async (
 
     if (status === 'success') {
       const resultDoc = Array.isArray(result) ? result[0] : result;
-
+    
       await handleAfterProcess(subdomain, {
         source,
         action: resultDoc?.action || action,
         contentType,
         payload: { ...payload, userId, processId },
-      }).catch((err) => {
-        models.Logs.insertOne({
-          source: 'afterProcess',
-          action: AFTER_PROCESS_CONSTANTS[`${source}.${action}`],
-          payload: { ...resultDoc?.payload, userId },
-          createdAt: new Date(),
-          userId,
-          status: LOG_STATUSES.FAILED,
-          processId,
-        });
+      }).catch(async (err) => {
+        try {
+          await models.Logs.insertOne({
+            source: 'afterProcess',
+            action: AFTER_PROCESS_CONSTANTS[`${source}.${action}`],
+            payload: { ...resultDoc?.payload, userId },
+            createdAt: new Date(),
+            userId,
+            status: LOG_STATUSES.FAILED,
+            processId,
+          });
+        } catch (insertErr) {
+          console.error(
+            `Failed to persist afterProcess failure log: ${
+              insertErr instanceof Error
+                ? insertErr.message
+                : String(insertErr)
+            }`,
+          );
+        }
+    
         console.error(
-          `Error occurred during afterProcess job ${jobId}: ${err.message}`,
+          `Error occurred during afterProcess job ${jobId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
         );
       });
     }

--- a/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
+++ b/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
@@ -44,18 +44,24 @@ export const eventLogHandler = async (
 
     if (status === 'success') {
       const resultDoc = Array.isArray(result) ? result[0] : result;
-    
+
+      const afterProcessAction = resultDoc?.action ?? action;
+      const afterProcessPayload = { ...payload, userId, processId };
+
       await handleAfterProcess(subdomain, {
         source,
-        action: resultDoc?.action || action,
+        action: afterProcessAction,
         contentType,
-        payload: { ...payload, userId, processId },
+        payload: afterProcessPayload,
       }).catch(async (err) => {
         try {
           await models.Logs.insertOne({
             source: 'afterProcess',
-            action: AFTER_PROCESS_CONSTANTS[`${source}.${action}`],
-            payload: { ...resultDoc?.payload, userId },
+            action:
+              AFTER_PROCESS_CONSTANTS[
+                `${source}.${afterProcessAction}`
+              ],
+            payload: afterProcessPayload,
             createdAt: new Date(),
             userId,
             status: LOG_STATUSES.FAILED,
@@ -70,7 +76,7 @@ export const eventLogHandler = async (
             }`,
           );
         }
-    
+
         console.error(
           `Error occurred during afterProcess job ${jobId}: ${
             err instanceof Error ? err.message : String(err)

--- a/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
+++ b/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
@@ -45,7 +45,7 @@ export const eventLogHandler = async (
     if (status === 'success') {
       const resultDoc = Array.isArray(result) ? result[0] : result;
 
-      handleAfterProcess(subdomain, {
+      await handleAfterProcess(subdomain, {
         source,
         action: resultDoc?.action || action,
         contentType,


### PR DESCRIPTION
## Summary

This PR ensures that `handleAfterProcess` is awaited before `eventLogHandler` completes processing a successful log event.

## Changes

* Added `await` when invoking `handleAfterProcess`.
* Ensured the log worker waits for all post-processing tasks to complete before finishing the job.
* Preserved existing error handling for failures during post-processing.

## Why

Previously, `handleAfterProcess` was executed as a fire-and-forget operation, allowing `eventLogHandler` to return before post-processing finished. This could result in the queue acknowledging a job while follow-up operations were still running, increasing the risk of incomplete processing if the worker shut down or crashed.

## Impact

* Improves job processing reliability.
* Ensures post-processing completes before the job is considered successful.
* Reduces the risk of losing after-process tasks during unexpected worker termination.

## Summary by Sourcery

Bug Fixes:
- Ensure the log worker waits for handleAfterProcess to finish before marking a job as successfully processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event log processing by ensuring follow-up handling completes before processing continues.
  * Enhanced reliability when event processing fails by recording failed events asynchronously and reporting logging issues clearly.
  * Improved error reporting for unexpected failure values while preserving the original failure details.
  * Increased resilience so logging issues do not interrupt the handling of the original event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->