### PR TITLE
fix: await failed log persistence in afterProcess error handler

### DIFF
--- a/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
+++ b/backend/services/logs/src/bullmq/eventLogs/eventLogHandler.ts
@@ -42,26 +42,39 @@ export const eventLogHandler = async (
       result = await models.Logs.insertOne(logDoc);
     }
 
-    if (status === 'success') {
+    if (status === LOG_STATUSES.SUCCESS) {
       const resultDoc = Array.isArray(result) ? result[0] : result;
-
-      handleAfterProcess(subdomain, {
+    
+      await handleAfterProcess(subdomain, {
         source,
         action: resultDoc?.action || action,
         contentType,
         payload: { ...payload, userId, processId },
-      }).catch((err) => {
-        models.Logs.insertOne({
-          source: 'afterProcess',
-          action: AFTER_PROCESS_CONSTANTS[`${source}.${action}`],
-          payload: { ...resultDoc?.payload, userId },
-          createdAt: new Date(),
-          userId,
-          status: LOG_STATUSES.FAILED,
-          processId,
-        });
+      }).catch(async (err) => {
+        try {
+          await models.Logs.insertOne({
+            source: 'afterProcess',
+            action: AFTER_PROCESS_CONSTANTS[`${source}.${action}`],
+            payload: { ...resultDoc?.payload, userId },
+            createdAt: new Date(),
+            userId,
+            status: LOG_STATUSES.FAILED,
+            processId,
+          });
+        } catch (insertErr) {
+          console.error(
+            `Failed to persist afterProcess failure log: ${
+              insertErr instanceof Error
+                ? insertErr.message
+                : String(insertErr)
+            }`,
+          );
+        }
+    
         console.error(
-          `Error occurred during afterProcess job ${jobId}: ${err.message}`,
+          `Error occurred during afterProcess job ${jobId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
         );
       });
     }


### PR DESCRIPTION
Refactor error handling in afterProcess to use async/await and improve logging.

## Summary by Sourcery

Improve reliability of afterProcess success handling by awaiting the handler and hardening error and logging behavior when failures occur.

Bug Fixes:
- Ensure afterProcess is properly awaited so its failures are captured and handled.
- Prevent unhandled failures when persisting afterProcess failure logs by wrapping log insertion in a try/catch.

Enhancements:
- Standardize success status comparison using LOG_STATUSES.SUCCESS.
- Improve robustness of error logging by safely handling non-Error values in afterProcess error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job completion logging for greater reliability.
  * Failed post-processing is now recorded more consistently, including when log persistence encounters an additional error.
  * Error messages are handled safely across different error formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->