### PR TITLE
feat(content): add record table column selectors

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesMoreColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesMoreColumn.tsx
@@ -34,8 +34,10 @@ export const CategoryMoreColumnCell = ({
   const navigate = useNavigate();
   const { confirm } = useConfirm();
   const { toast } = useToast();
-  const { removeSingleCategory, removeBulkCategories, loading } =
-    useRemoveCategories(clientPortalId, onRefetch || (() => {}));
+  const { removeSingleCategory, loading } = useRemoveCategories(
+    clientPortalId,
+    onRefetch || (() => undefined),
+  );
 
   const handleEdit = () => {
     const category = cell.row.original;
@@ -122,6 +124,7 @@ export const categoryMoreColumn = (
   onRefetch?: () => void,
 ) => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (cell: CellContext<any, unknown>) => (
     <CategoryMoreColumnCell
       cell={cell}

--- a/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/categories/components/CategoriesRecordTable.tsx
@@ -73,11 +73,7 @@ export const CategoriesRecordTable = ({
     [categories],
   );
 
-  const columns = useCategoriesColumns(
-    clientPortalId,
-    onEdit,
-    refetch,
-  );
+  const columns = useCategoriesColumns(clientPortalId, onEdit, refetch);
 
   return (
     <>
@@ -87,10 +83,7 @@ export const CategoriesRecordTable = ({
       {!loading && categories.length === 0 ? (
         <div className="rounded-lg overflow-hidden">
           {isFiltered ? (
-            <EmptyState
-              icon={IconArticle}
-              title={t('no-categories-found')}
-            />
+            <EmptyState icon={IconArticle} title={t('no-categories-found')} />
           ) : (
             <EmptyState
               icon={IconArticle}
@@ -109,6 +102,7 @@ export const CategoriesRecordTable = ({
               data={treeCategories}
               className="h-full"
               stickyColumns={['more', 'checkbox', 'name']}
+              tableId="content_categories_record_table"
             >
               <RecordTable.CursorProvider
                 hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/content_ui/src/modules/cms/custom-types/components/CustomTypesMoreColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-types/components/CustomTypesMoreColumn.tsx
@@ -105,6 +105,7 @@ export const customTypeMoreColumn = (
   onRefetch?: () => void,
 ) => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (cell: CellContext<any, unknown>) => (
     <CustomTypeMoreColumnCell
       cell={cell}

--- a/frontend/plugins/content_ui/src/modules/cms/custom-types/components/CustomTypesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/custom-types/components/CustomTypesRecordTable.tsx
@@ -20,7 +20,7 @@ export const CustomTypesRecordTable = ({
 
   const columns = createCustomTypesColumns(
     clientPortalId,
-    onEdit || (() => {}),
+    onEdit || (() => undefined),
     refetch,
   );
 
@@ -30,6 +30,7 @@ export const CustomTypesRecordTable = ({
       data={customTypes || []}
       className="m-3"
       stickyColumns={['more', 'checkbox', 'name']}
+      tableId="content_custom_types_record_table"
     >
       <RecordTable>
         <RecordTable.Header />

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusColumn.tsx
@@ -134,7 +134,7 @@ export const useMenusColumns = (
     },
     {
       id: 'more',
-      header: () => <span className="sr-only">{t('more')}</span>,
+      header: () => <RecordTable.ColumnSelector />,
       cell: ({ row }) => (
         <MoreCell row={row} onEdit={onEdit} refetch={refetch} />
       ),
@@ -143,7 +143,9 @@ export const useMenusColumns = (
     RecordTable.checkboxColumn as ColumnDef<MenuItem>,
     {
       id: 'label',
-      header: () => <RecordTable.InlineHead icon={IconList} label={t('label')} />,
+      header: () => (
+        <RecordTable.InlineHead icon={IconList} label={t('label')} />
+      ),
       accessorKey: 'label',
       cell: ({ cell }) => (
         <LabelCell cell={cell} refetch={refetch} isMissing={isMissing} />
@@ -165,7 +167,9 @@ export const useMenusColumns = (
     },
     {
       id: 'kind',
-      header: () => <RecordTable.InlineHead icon={IconArticle} label={t('kind')} />,
+      header: () => (
+        <RecordTable.InlineHead icon={IconArticle} label={t('kind')} />
+      ),
       accessorKey: 'kind',
       cell: ({ cell }) => (
         <div className={BADGE_CLASS}>

--- a/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/menus/components/MenusRecordTable.tsx
@@ -153,7 +153,8 @@ const SortableMenuRow = React.memo(
       const { attributes, listeners, setNodeRef, transform, transition } =
         useSortable({
           id: original?._id,
-          disabled: activeId ? !isDraggingItem && !isSibling : false,
+          disabled:
+            isDraggingAny && activeId ? !isDraggingItem && !isSibling : false,
         });
 
       const setRowRef = useCallback(
@@ -383,7 +384,7 @@ export const MenusRecordTable = ({
 
       mutationQueueRef.current[pId] = nextMutation;
     },
-    [orderedMenus, language, editMenu, refetch, menus],
+    [orderedMenus, language, t, refetch, editMenu, menus],
   );
 
   const columns = useMenusColumns(onEdit, refetch);
@@ -418,6 +419,7 @@ export const MenusRecordTable = ({
         data={orderedMenus}
         className="h-full m-3 pb-1"
         stickyColumns={['drag', 'more', 'checkbox', 'label']}
+        tableId="content_menus_record_table"
       >
         <SortableContext items={menuIds} strategy={verticalListSortingStrategy}>
           <RecordTable.Scroll>

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesMoreColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesMoreColumn.tsx
@@ -118,6 +118,7 @@ export const pageMoreColumn = (
   onRefetch?: () => void,
 ) => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (cell: CellContext<any, unknown>) => (
     <PageMoreColumnCell
       cell={cell}

--- a/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/pages/components/PagesRecordTable.tsx
@@ -56,6 +56,7 @@ export const PagesRecordTable = ({
           data={pages || []}
           className="h-full"
           stickyColumns={['more', 'checkbox', 'name']}
+          tableId="content_pages_record_table"
         >
           <RecordTable.CursorProvider
             hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostMoreColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostMoreColumn.tsx
@@ -209,6 +209,7 @@ export const postMoreColumn = (
   onRefetch?: () => void,
 ) => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (cell: CellContext<Posts, unknown>) => (
     <PostMoreColumnCell
       cell={cell}

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/PostsRecordTable.tsx
@@ -53,6 +53,7 @@ export const PostsRecordTable = ({
       data={posts || []}
       className="h-full"
       stickyColumns={['openPublicUrl', 'more', 'checkbox', 'title']}
+      tableId="content_posts_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsMoreColumn.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsMoreColumn.tsx
@@ -115,6 +115,7 @@ export const tagMoreColumn = (
   onRefetch?: () => void,
 ) => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (cell: CellContext<any, unknown>) => (
     <TagMoreColumnCell
       cell={cell}

--- a/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsRecordTable.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/tags/components/TagsRecordTable.tsx
@@ -32,6 +32,7 @@ export const TagsRecordTable = ({
       data={tags || []}
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name']}
+      tableId="content_tags_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}


### PR DESCRIPTION
## What

Adds the record table column selector — show/hide, drag reorder, pin/unpin — and per-table preference persistence to all 6 qualifying `content_ui` table surfaces with 5 or more columns.

- Each table renders `RecordTable.ColumnSelector` in its action-column header.
- Every table gets a stable, unique `tableId`, so saved layouts remain isolated.
- Categories, custom types, menus, pages, posts, and tags now use the same standard RecordTable behavior.
- Utility columns remain outside the selectable data-column list.

## Validation

| Check | Result |
| --- | --- |
| `pnpm nx build content_ui` | pass |
| ESLint on changed TSX files with `--max-warnings=0` | pass |
| TypeScript diagnostics filtered to changed files | no errors |
| `pnpm nx lint content_ui` | existing project-wide errors outside the changed-file lint scope |
| Tests | not run — `content_ui` has no test target |

## Docs

- Synchronizes `frontend/plugins/content_ui/AGENTS.md` with the required plugin guide structure and RecordTable invariants.

## Summary by Sourcery

Add persisted RecordTable column selectors to CMS content tables and update the content_ui plugin guide to reflect table behavior and ownership boundaries.

New Features:
- Introduce column selector headers on CMS record tables with five or more columns to control column visibility and ordering.
- Persist per-table RecordTable column layout (visibility, order, pinning, sizing) via stable table IDs across CMS surfaces.

Bug Fixes:
- Clean up unused drag-state props in the sortable menu row component and fix dependency ordering for the menus mutation hook.
- Simplify category deletion hook usage by removing unused bulk-delete behavior in the more column configuration.

Enhancements:
- Standardize RecordTable usage across CMS categories, custom types, menus, pages, posts, and tags with consistent sticky utility columns.
- Restructure AGENTS.md into a synchronized `content_ui` plugin guide documenting scope, contracts, data/state, invariants, and validation steps.

Documentation:
- Rewrite AGENTS.md as a formal `content_ui` plugin guide including ownership, capabilities, contracts, data/state rules, local invariants, validation steps, and a recent changes log entry for column selector support.

Tests:
- Clarify manual validation steps for CMS tables to ensure column visibility and order persist after reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added column selection controls to category, custom type, menu, page, post, and tag tables.
  * Added stable table identifiers to preserve table configuration across sessions.

* **Bug Fixes**
  * Improved menu row dragging behavior by disabling sorting only during an active drag.
  * Improved table fallback handling and empty-state presentation.
  * Improved table controls and presentation for a more consistent content management experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->