### PR TITLE
feat(tourism): add record table column selectors

### DIFF
--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityMoreCell.tsx
@@ -122,6 +122,7 @@ export const amenityMoreColumn = (
   mainLanguage?: string,
 ): ColumnDef<IAmenity> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => (
     <AmenityMoreColumn
       {...props}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/amenities/_components/AmenityRecordTable.tsx
@@ -56,6 +56,7 @@ export const AmenityRecordTable = ({
       data={amenities || []}
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name', 'icon']}
+      tableId="tourism_amenities_record_table"
     >
       <AmenityCommandBar />
       <RecordTable.CursorProvider

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryMoreCell.tsx
@@ -19,6 +19,7 @@ export const categoryMoreColumn = (
   mainLanguage?: string,
 ): ColumnDef<ICategory & { hasChildren: boolean }> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => (
     <CategoryMoreColumn
       {...props}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/category/_components/CategoryRecordTable.tsx
@@ -16,6 +16,20 @@ interface CategoryRecordTableProps {
   mainLanguage?: string;
 }
 
+function CategoryTableContent({ loading }: Readonly<{ loading: boolean }>) {
+  return (
+    <RecordTable.Scroll>
+      <RecordTable>
+        <RecordTable.Header />
+        <RecordTable.Body>
+          <RecordTable.RowList Row={RecordTableTree.Row} />
+          {loading && <RecordTable.RowSkeleton rows={10} />}
+        </RecordTable.Body>
+      </RecordTable>
+    </RecordTable.Scroll>
+  );
+}
+
 export const CategoryRecordTable = ({
   branchId,
   branchLanguages,
@@ -58,21 +72,19 @@ export const CategoryRecordTable = ({
 
   return (
     <RecordTable.Provider
-      columns={categoryColumns(categoryObject, branchLanguages, mainLanguage, t)}
+      columns={categoryColumns(
+        categoryObject,
+        branchLanguages,
+        mainLanguage,
+        t,
+      )}
       data={categoriesWithChildren || []}
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name']}
+      tableId="tourism_categories_record_table"
     >
       <RecordTableTree id="tour-categories" ordered>
-        <RecordTable.Scroll>
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              <RecordTable.RowList Row={RecordTableTree.Row} />
-              {loading && <RecordTable.RowSkeleton rows={10} />}
-            </RecordTable.Body>
-          </RecordTable>
-        </RecordTable.Scroll>
+        <CategoryTableContent loading={loading} />
       </RecordTableTree>
       <CategoryCommandBar />
     </RecordTable.Provider>

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementMoreCell.tsx
@@ -112,6 +112,7 @@ export const elementMoreColumn = (
   mainLanguage?: string,
 ): ColumnDef<IElement> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => (
     <ElementMoreColumn
       {...props}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/elements/_components/ElementRecordTable.tsx
@@ -64,6 +64,7 @@ export const ElementRecordTable = ({
       data={elements || []}
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name']}
+      tableId="tourism_elements_record_table"
     >
       <ElementCommandBar />
       <RecordTable.CursorProvider

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryMoreCell.tsx
@@ -110,6 +110,7 @@ export const itineraryMoreColumn = (
   mainLanguage?: string,
 ): ColumnDef<IItinerary> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => (
     <ItineraryMoreColumn
       {...props}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/itinerary/_components/ItineraryRecordTable.tsx
@@ -78,12 +78,15 @@ export const ItineraryRecordTable = ({
   );
   const columns = useMemo(
     () =>
-      itineraryColumns({
-        onEditClick: handleEditClick,
-        branchId,
-        branchLanguages,
-        mainLanguage,
-      }, t),
+      itineraryColumns(
+        {
+          onEditClick: handleEditClick,
+          branchId,
+          branchLanguages,
+          mainLanguage,
+        },
+        t,
+      ),
     [branchId, branchLanguages, handleEditClick, mainLanguage, t],
   );
   const rowData = itineraries || [];
@@ -105,6 +108,7 @@ export const ItineraryRecordTable = ({
         data={rowData}
         className="h-full"
         stickyColumns={['more', 'checkbox', 'name']}
+        tableId="tourism_itineraries_record_table"
       >
         <ItineraryCommandBar
           branchId={branchId}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupList.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupList.tsx
@@ -14,6 +14,28 @@ import { flattenGroups } from './TourGroupUtils';
 import { TourEditForm } from './TourEditForm';
 import { TourSideTab } from './TourOrdersSidePanel';
 
+function TourGroupTableContent({
+  loading,
+  length,
+}: Readonly<{
+  loading: boolean;
+  length: number;
+}>) {
+  return (
+    <RecordTableTree id="tour-groups-list" ordered length={length}>
+      <RecordTable.Scroll>
+        <RecordTable>
+          <RecordTable.Header />
+          <RecordTable.Body>
+            {loading && <RecordTable.RowSkeleton rows={30} />}
+            <RecordTable.RowList Row={RecordTableTree.Row} />
+          </RecordTable.Body>
+        </RecordTable>
+      </RecordTable.Scroll>
+    </RecordTableTree>
+  );
+}
+
 export const TourGroupList = ({
   branchId,
   branchLanguages,
@@ -41,19 +63,22 @@ export const TourGroupList = ({
   const groupedTours = useMemo(() => flattenGroups(groups), [groups]);
   const columns = useMemo(
     () =>
-      GroupedTourColumns({
-        onEdit: (id) => setEditTourId(id),
-        onAddTour: (row) => {
-          if (!row.groupCode || !row.templateTourId) {
-            return;
-          }
+      GroupedTourColumns(
+        {
+          onEdit: (id) => setEditTourId(id),
+          onAddTour: (row) => {
+            if (!row.groupCode || !row.templateTourId) {
+              return;
+            }
 
-          setAddTourContext({
-            groupCode: row.groupCode,
-            templateTourId: row.templateTourId,
-          });
+            setAddTourContext({
+              groupCode: row.groupCode,
+              templateTourId: row.templateTourId,
+            });
+          },
         },
-      }, t),
+        t,
+      ),
     [t],
   );
   const tableOptions: TableOptions<TourGroupRow> = useMemo(
@@ -83,22 +108,9 @@ export const TourGroupList = ({
       className="h-full"
       stickyColumns={['more', 'checkbox', 'name']}
       tableOptions={tableOptions}
+      tableId="tourism_tour_groups_record_table"
     >
-      <RecordTableTree
-        id="tour-groups-list"
-        ordered
-        length={groupedTours.length}
-      >
-        <RecordTable.Scroll>
-          <RecordTable>
-            <RecordTable.Header />
-            <RecordTable.Body>
-              {loading && <RecordTable.RowSkeleton rows={30} />}
-              <RecordTable.RowList Row={RecordTableTree.Row} />
-            </RecordTable.Body>
-          </RecordTable>
-        </RecordTable.Scroll>
-      </RecordTableTree>
+      <TourGroupTableContent loading={loading} length={groupedTours.length} />
       <TourCommandBar
         branchId={branchId}
         branchLanguages={branchLanguages}

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourGroupMoreCell.tsx
@@ -43,6 +43,7 @@ export const tourGroupMoreColumn = (
   onAddTour?: (row: TourGroupRow) => void,
 ): ColumnDef<TourGroupRow> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => <TourGroupMoreColumn {...props} onAddTour={onAddTour} />,
   size: 33,
 });

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourMoreCell.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourMoreCell.tsx
@@ -93,6 +93,7 @@ export const tourMoreColumn = (
   onDuplicate?: (tourId: string, dateType?: 'fixed' | 'flexible') => void,
 ): ColumnDef<ITour> => ({
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: (props) => (
     <TourMoreColumn {...props} onEdit={onEdit} onDuplicate={onDuplicate} />
   ),

--- a/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourRecordTable.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/tms/branch-detail/dashboard/tours/_components/TourRecordTable.tsx
@@ -87,6 +87,7 @@ export const TourRecordTable = ({
         data={rowData}
         className="h-full"
         stickyColumns={['more', 'checkbox', 'name']}
+        tableId="tourism_tours_record_table"
       >
         <TourCommandBar
           branchId={branchId}


### PR DESCRIPTION
## What

Adds the record table column selector — show/hide, drag reorder, pin/unpin — and per-table preference persistence to all 6 qualifying `tourism_ui` table surfaces with 5 or more columns.

- Each table renders `RecordTable.ColumnSelector` in its action-column header.
- Every table gets a stable, unique `tableId`, so saved layouts remain isolated.
- Amenity, category, element, itinerary, tour-group, and tour tables use the same standard RecordTable behavior.
- Utility columns remain outside the selectable data-column list.

## Validation

| Check | Result |
| --- | --- |
| `pnpm nx build tourism_ui` | pass |
| `pnpm nx lint tourism_ui` | pass |
| ESLint on changed TSX files with `--max-warnings=0` | pass |
| TypeScript diagnostics filtered to changed files | no errors |
| Tests | not run — `tourism_ui` has no test target |

## Docs

- Adds `frontend/plugins/tourism_ui/AGENTS.md` with the plugin current-state guide and RecordTable invariants.

## Summary by Sourcery

Add configurable column selectors with per-table layout persistence to tourism branch dashboard record tables.

Enhancements:
- Render RecordTable column selectors in the action-column header for amenities, categories, elements, itineraries, tour groups, and tours tables.
- Assign stable, unique table IDs to each tourism record table to isolate and persist user column layout preferences.

Documentation:
- Introduce AGENTS.md plugin guide documenting tourism_ui scope, architecture, record table invariants, and validation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added column selectors to tourism dashboard tables for amenities, categories, elements, itineraries, tours, and tour groups.
  * Table column preferences can now remain associated with their respective tables.

* **Documentation**
  * Added documentation describing the tourism plugin’s capabilities, architecture, state management, and validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->