### PR TITLE
feat(frontline): add record table column selectors

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/forms/components/FormsList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/forms/components/FormsList.tsx
@@ -74,6 +74,7 @@ export const FormsList = () => {
       columns={formsColumns as unknown as ColumnDef<IForm>[]}
       data={forms || []}
       className="m-3"
+      tableId="frontline_channel_forms_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}
@@ -114,7 +115,7 @@ export const FormsMoreColumnCell = ({
 
   const [open, setOpen] = useState(false);
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
         <RecordTable.MoreButton className="w-full h-full" />
       </DropdownMenu.Trigger>
@@ -144,6 +145,7 @@ export const FormsMoreColumnCell = ({
 
 export const MoreColumn: ColumnDef<IForm> = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   size: 33,
   cell: FormsMoreColumnCell,
 };
@@ -154,8 +156,7 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'name',
     id: 'name',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormNameHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('col-name')} icon={IconLabel} />;
     },
@@ -177,10 +178,11 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'status',
     id: 'status',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormStatusHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('status')} icon={IconToggleRight} />;
+      return (
+        <RecordTable.InlineHead label={t('status')} icon={IconToggleRight} />
+      );
     },
     cell: ({ cell }) => {
       return (
@@ -197,13 +199,13 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'channelId',
     id: 'channelId',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormChannelHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('channel-label')} icon={IconCircles} />;
+      return (
+        <RecordTable.InlineHead label={t('channel-label')} icon={IconCircles} />
+      );
     },
-    cell: ({ cell }) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    cell: function FormChannelCell({ cell }) {
       const { t } = useTranslation('frontline');
       return (
         <RecordTableInlineCell>
@@ -218,8 +220,7 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'tagIds',
     id: 'tagIds',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormTagsHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('tags')} icon={IconTag} />;
     },
@@ -238,8 +239,7 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'createdUserId',
     id: 'createdUserId',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormCreatedByHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('created-by')} icon={IconUser} />;
     },
@@ -254,10 +254,14 @@ const formsColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'createdDate',
     id: 'createdDate',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormCreatedAtHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('created-at')} icon={IconCalendarEvent} />;
+      return (
+        <RecordTable.InlineHead
+          label={t('created-at')}
+          icon={IconCalendarEvent}
+        />
+      );
     },
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/frontline_ui/src/modules/forms/components/form-page/FormPageList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/forms/components/form-page/FormPageList.tsx
@@ -53,6 +53,7 @@ export const FormPageList = () => {
       columns={formColumns as unknown as ColumnDef<IForm>[]}
       data={forms || []}
       className="m-3"
+      tableId="frontline_forms_record_table"
     >
       <RecordTable.CursorProvider
         hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/frontline_ui/src/modules/forms/components/form-page/form-columns.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/forms/components/form-page/form-columns.tsx
@@ -42,7 +42,7 @@ export function FormToggleStatus({
   setOpen: (open: boolean) => void;
 }) {
   const { t } = useTranslation('frontline');
-  const { toggleStatus, loading } = useFormToggleStatus();
+  const { toggleStatus } = useFormToggleStatus();
 
   const onSelect = () => {
     toggleStatus({
@@ -85,7 +85,7 @@ export const MoveFormToChannel = ({
   type: string;
 }) => {
   const { t } = useTranslation('frontline');
-  const { editForm, loading } = useFormEdit();
+  const { editForm } = useFormEdit();
 
   const onSelect = (id: string) => {
     editForm({
@@ -146,7 +146,7 @@ export const FormsMoreColumnCell = ({
   const [open, setOpen] = useState(false);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
         <RecordTable.MoreButton className="w-full h-full" />
       </DropdownMenu.Trigger>
@@ -181,6 +181,7 @@ export const FormsMoreColumnCell = ({
 
 export const MoreColumn: ColumnDef<IForm> = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   size: 33,
   cell: FormsMoreColumnCell,
 };
@@ -191,12 +192,11 @@ export const formColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'name',
     id: 'name',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageNameHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('col-name')} icon={IconLabel} />;
     },
-    cell: ({ cell }) => {
+    cell: function FormPageNameCell({ cell }) {
       const navigate = useNavigate();
 
       return (
@@ -216,10 +216,11 @@ export const formColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'status',
     id: 'status',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageStatusHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('status')} icon={IconToggleRight} />;
+      return (
+        <RecordTable.InlineHead label={t('status')} icon={IconToggleRight} />
+      );
     },
     cell: ({ cell }) => {
       return (
@@ -231,17 +232,16 @@ export const formColumns: ColumnDef<IForm>[] = [
   },
   {
     accessorKey: 'channelId',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageChannelHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('channel-label')} icon={IconCircles} />;
+      return (
+        <RecordTable.InlineHead label={t('channel-label')} icon={IconCircles} />
+      );
     },
     id: 'channelId',
-    cell: ({ cell }) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    cell: function FormPageChannelCell({ cell }) {
       const { t } = useTranslation('frontline');
       const { channel, _id, name, type } = cell.row.original;
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       const { editForm } = useFormEdit();
 
       const onValueChange = (value: string | string[]) => {
@@ -281,8 +281,7 @@ export const formColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'tagIds',
     id: 'tagIds',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageTagsHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('tags')} icon={IconTag} />;
     },
@@ -301,8 +300,7 @@ export const formColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'createdUserId',
     id: 'createdUserId',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageCreatedByHeader() {
       const { t } = useTranslation('frontline');
       return <RecordTable.InlineHead label={t('created-by')} icon={IconUser} />;
     },
@@ -317,10 +315,14 @@ export const formColumns: ColumnDef<IForm>[] = [
   {
     accessorKey: 'createdDate',
     id: 'createdDate',
-    header: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+    header: function FormPageCreatedAtHeader() {
       const { t } = useTranslation('frontline');
-      return <RecordTable.InlineHead label={t('created-at')} icon={IconCalendarEvent} />;
+      return (
+        <RecordTable.InlineHead
+          label={t('created-at')}
+          icon={IconCalendarEvent}
+        />
+      );
     },
     cell: ({ cell }) => {
       return (

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallQueueRecordTable.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallQueueRecordTable.tsx
@@ -1,4 +1,7 @@
-import { useCallQueueList } from '@/integrations/call/hooks/useCallQueueList';
+import {
+  ICallQueueListItem,
+  useCallQueueList,
+} from '@/integrations/call/hooks/useCallQueueList';
 import { callConfigAtom } from '@/integrations/call/states/sipStates';
 import { formatSeconds } from '@/integrations/call/utils/callUtils';
 import { ColumnDef } from '@tanstack/table-core';
@@ -9,10 +12,12 @@ import {
   Badge,
   ChartContainer,
   HoverCard,
+  cn,
 } from 'erxes-ui';
 import { useAtomValue } from 'jotai';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import { Link } from 'react-router-dom';
+import { forwardRef, type ComponentProps, type ForwardedRef } from 'react';
 
 export const CallQueueRecordTable = ({
   basePath = '/frontline/calls/dashboard',
@@ -38,10 +43,11 @@ export const CallQueueRecordTable = ({
       data={callQueueList || (loading ? [{}] : [])}
       className="m-3"
       stickyColumns={['queue']}
+      tableId="frontline_call_queue_record_table"
     >
       <RecordTable.Scroll>
         <RecordTable>
-          <RecordTable.Header />
+          <RecordTable.Header showColumnSelector />
           <RecordTable.Body>
             {loading ? (
               <RecordTable.RowSkeleton rows={6} />
@@ -53,175 +59,6 @@ export const CallQueueRecordTable = ({
       </RecordTable.Scroll>
     </RecordTable.Provider>
   );
-};
-
-const useGetColumns = (basePath: string): ColumnDef<any>[] => {
-  const { t } = useTranslation('frontline');
-  return [
-  {
-    header: t('queue'),
-    accessorKey: 'queue',
-    size: 240,
-    cell: ({ row, cell }) => {
-      const {
-        queue,
-        queuechairman,
-        totalCalls,
-        answeredCalls,
-        abandonedCalls,
-        abandonedRate,
-        avgWait,
-        avgTalk,
-        answeredRate,
-      } = row.original;
-      return (
-        <HoverCard openDelay={100}>
-          <HoverCard.Trigger asChild>
-            <Link to={`${basePath}/${cell.getValue()}`} className="block">
-              <RecordTableInlineCell>
-                <Badge variant="secondary">
-                  {cell.getValue() as string} -{' '}
-                  {cell.row.original.queuechairman}
-                </Badge>
-              </RecordTableInlineCell>
-            </Link>
-          </HoverCard.Trigger>
-          <HoverCard.Content
-            sideOffset={4}
-            side="right"
-            align="start"
-            className="w-64 bg-accent p-1 rounded-xl"
-          >
-            <h4 className="text-xs uppercase font-mono font-semibold px-2 leading-8">
-              {queue} - {queuechairman}
-            </h4>
-            <div className="p-3 flex flex-col text-sm bg-background shadow-sm rounded-lg">
-              <div className="grid grid-cols-2 gap-1 pb-3">
-                <div className="flex-auto space-y-1 text-center">
-                  <span className="text-foreground ml-auto font-semibold flex items-center gap-1">
-                    <ProgressChart
-                      value={Math.round(abandonedRate)}
-                      variant="destructive"
-                    />
-                    {t('pct-of-total', { pct: Math.round(abandonedRate), total: totalCalls })}
-                  </span>
-                  <legend className="text-accent-foreground text-xs">
-                    {t('abandoned')}
-                  </legend>
-                </div>
-                <div className="flex-auto space-y-1 text-center">
-                  <span className="text-foreground ml-auto font-semibold flex items-center gap-1">
-                    <ProgressChart
-                      value={Math.round(answeredRate)}
-                      variant="success"
-                    />
-                    {t('pct-of-total', { pct: Math.round(answeredRate), total: totalCalls })}
-                  </span>
-                  <legend className="text-accent-foreground text-xs">
-                    {t('success-rate-label')}
-                  </legend>
-                </div>
-              </div>
-              <p className="text-sm flex items-center gap-1 justify-between">
-                <legend className="text-accent-foreground">{t('total')}</legend>
-                <span className="font-medium">{totalCalls}</span>
-              </p>
-              <p className="text-sm flex items-center gap-1 justify-between">
-                <legend className="text-accent-foreground">{t('answered')}</legend>
-                <span className="font-medium">{answeredCalls}</span>
-              </p>
-              <p className="text-sm flex items-center gap-1 justify-between">
-                <legend className="text-accent-foreground">{t('abandoned')}</legend>
-                <span className="font-medium">{abandonedCalls}</span>
-              </p>
-              <p className="text-sm flex items-center gap-1 justify-between">
-                <legend className="text-accent-foreground">
-                  {t('average-wait-time')}
-                </legend>
-                <span className="font-medium">{formatSeconds(avgWait)}</span>
-              </p>
-              <p className="text-sm flex items-center gap-1 justify-between">
-                <legend className="text-accent-foreground">
-                  {t('average-talk-time')}
-                </legend>
-                <span className="font-medium">{formatSeconds(avgTalk)}</span>
-              </p>
-            </div>
-          </HoverCard.Content>
-        </HoverCard>
-      );
-    },
-  },
-  {
-    header: t('abandoned-rate'),
-    accessorKey: 'abandonedRate',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        <ProgressChart
-          value={cell.getValue() as number}
-          variant="destructive"
-        />
-        {t('pct-of-total', { pct: Math.round(cell.getValue() as number), total: cell.row.original.totalCalls })}
-      </RecordTableInlineCell>
-    ),
-  },
-
-  {
-    header: t('answered-rate'),
-    accessorKey: 'answeredRate',
-    cell: ({ cell, row }) => (
-      <RecordTableInlineCell className="font-medium">
-        <ProgressChart value={cell.getValue() as number} variant="success" />
-        {t('pct-of-total', { pct: Math.round(cell.getValue() as number), total: row.original.totalCalls })}
-      </RecordTableInlineCell>
-    ),
-  },
-  {
-    header: t('answered-calls'),
-    accessorKey: 'answeredCalls',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        {cell.getValue() as string}
-      </RecordTableInlineCell>
-    ),
-  },
-  {
-    header: t('abandoned-calls'),
-    accessorKey: 'abandonedCalls',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        {cell.getValue() as string}
-      </RecordTableInlineCell>
-    ),
-  },
-  {
-    header: t('total-calls'),
-    accessorKey: 'totalCalls',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        {cell.getValue() as string}
-      </RecordTableInlineCell>
-    ),
-  },
-  {
-    header: t('average-wait-time'),
-    accessorKey: 'avgWait',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        {formatSeconds(cell.getValue() as number)}
-      </RecordTableInlineCell>
-    ),
-  },
-  {
-    header: t('average-talk-time'),
-    accessorKey: 'avgTalk',
-    cell: ({ cell }) => (
-      <RecordTableInlineCell className="font-medium">
-        {formatSeconds(cell.getValue() as number)}
-      </RecordTableInlineCell>
-    ),
-  },
-  ];
 };
 
 export const ProgressChart = ({
@@ -243,7 +80,7 @@ export const ProgressChart = ({
         data={[
           {
             name: 'Progress',
-            value: value,
+            value,
             fill: `var(--${variant})`,
           },
         ]}
@@ -265,3 +102,237 @@ export const ProgressChart = ({
     </ChartContainer>
   );
 };
+
+type CallQueueTriggerProps = Omit<ComponentProps<typeof Link>, 'to'> & {
+  basePath: string;
+  queue: string;
+  queueChairman: string;
+};
+
+function CallQueueTriggerComponent(
+  {
+    basePath,
+    queue,
+    queueChairman,
+    className,
+    ...props
+  }: CallQueueTriggerProps,
+  ref: ForwardedRef<HTMLAnchorElement>,
+) {
+  return (
+    <Link
+      {...props}
+      ref={ref}
+      to={`${basePath}/${queue}`}
+      className={cn('block', className)}
+    >
+      <RecordTableInlineCell>
+        <Badge variant="secondary">
+          {queue} - {queueChairman}
+        </Badge>
+      </RecordTableInlineCell>
+    </Link>
+  );
+}
+
+const CallQueueTrigger = forwardRef(CallQueueTriggerComponent);
+CallQueueTrigger.displayName = 'CallQueueTrigger';
+
+function CallQueueRate({
+  label,
+  totalCalls,
+  value,
+  variant,
+}: Readonly<{
+  label: string;
+  totalCalls: number;
+  value: number;
+  variant: 'destructive' | 'success';
+}>) {
+  const { t } = useTranslation('frontline');
+  const roundedValue = Math.round(value);
+
+  return (
+    <div className="flex-auto space-y-1 text-center">
+      <span className="text-foreground ml-auto font-semibold flex items-center gap-1">
+        <ProgressChart value={roundedValue} variant={variant} />
+        {t('pct-of-total', { pct: roundedValue, total: totalCalls })}
+      </span>
+      <legend className="text-accent-foreground text-xs">{label}</legend>
+    </div>
+  );
+}
+
+function CallQueueStat({
+  label,
+  value,
+}: Readonly<{
+  label: string;
+  value: string | number;
+}>) {
+  return (
+    <p className="text-sm flex items-center gap-1 justify-between">
+      <legend className="text-accent-foreground">{label}</legend>
+      <span className="font-medium">{value}</span>
+    </p>
+  );
+}
+
+function CallQueueSummaryCell({
+  basePath,
+  item,
+}: Readonly<{
+  basePath: string;
+  item: ICallQueueListItem;
+}>) {
+  const { t } = useTranslation('frontline');
+  const {
+    queue,
+    queuechairman,
+    totalCalls,
+    answeredCalls,
+    abandonedCalls,
+    abandonedRate,
+    avgWait,
+    avgTalk,
+    answeredRate,
+  } = item;
+
+  return (
+    <HoverCard openDelay={100}>
+      <HoverCard.Trigger asChild>
+        <CallQueueTrigger
+          basePath={basePath}
+          queue={queue}
+          queueChairman={queuechairman}
+        />
+      </HoverCard.Trigger>
+      <HoverCard.Content
+        sideOffset={4}
+        side="right"
+        align="start"
+        className="w-64 bg-accent p-1 rounded-xl"
+      >
+        <h4 className="text-xs uppercase font-mono font-semibold px-2 leading-8">
+          {queue} - {queuechairman}
+        </h4>
+        <div className="p-3 flex flex-col text-sm bg-background shadow-sm rounded-lg">
+          <div className="grid grid-cols-2 gap-1 pb-3">
+            <CallQueueRate
+              label={t('abandoned')}
+              totalCalls={totalCalls}
+              value={abandonedRate}
+              variant="destructive"
+            />
+            <CallQueueRate
+              label={t('success-rate-label')}
+              totalCalls={totalCalls}
+              value={answeredRate}
+              variant="success"
+            />
+          </div>
+          <CallQueueStat label={t('total')} value={totalCalls} />
+          <CallQueueStat label={t('answered')} value={answeredCalls} />
+          <CallQueueStat label={t('abandoned')} value={abandonedCalls} />
+          <CallQueueStat
+            label={t('average-wait-time')}
+            value={formatSeconds(avgWait)}
+          />
+          <CallQueueStat
+            label={t('average-talk-time')}
+            value={formatSeconds(avgTalk)}
+          />
+        </div>
+      </HoverCard.Content>
+    </HoverCard>
+  );
+}
+
+function useGetColumns(basePath: string): ColumnDef<ICallQueueListItem>[] {
+  const { t } = useTranslation('frontline');
+  return [
+    {
+      header: t('queue'),
+      accessorKey: 'queue',
+      size: 240,
+      cell: ({ row }) => (
+        <CallQueueSummaryCell basePath={basePath} item={row.original} />
+      ),
+    },
+    {
+      header: t('abandoned-rate'),
+      accessorKey: 'abandonedRate',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          <ProgressChart
+            value={cell.getValue() as number}
+            variant="destructive"
+          />
+          {t('pct-of-total', {
+            pct: Math.round(cell.getValue() as number),
+            total: cell.row.original.totalCalls,
+          })}
+        </RecordTableInlineCell>
+      ),
+    },
+
+    {
+      header: t('answered-rate'),
+      accessorKey: 'answeredRate',
+      cell: ({ cell, row }) => (
+        <RecordTableInlineCell className="font-medium">
+          <ProgressChart value={cell.getValue() as number} variant="success" />
+          {t('pct-of-total', {
+            pct: Math.round(cell.getValue() as number),
+            total: row.original.totalCalls,
+          })}
+        </RecordTableInlineCell>
+      ),
+    },
+    {
+      header: t('answered-calls'),
+      accessorKey: 'answeredCalls',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          {cell.getValue() as string}
+        </RecordTableInlineCell>
+      ),
+    },
+    {
+      header: t('abandoned-calls'),
+      accessorKey: 'abandonedCalls',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          {cell.getValue() as string}
+        </RecordTableInlineCell>
+      ),
+    },
+    {
+      header: t('total-calls'),
+      accessorKey: 'totalCalls',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          {cell.getValue() as string}
+        </RecordTableInlineCell>
+      ),
+    },
+    {
+      header: t('average-wait-time'),
+      accessorKey: 'avgWait',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          {formatSeconds(cell.getValue() as number)}
+        </RecordTableInlineCell>
+      ),
+    },
+    {
+      header: t('average-talk-time'),
+      accessorKey: 'avgTalk',
+      cell: ({ cell }) => (
+        <RecordTableInlineCell className="font-medium">
+          {formatSeconds(cell.getValue() as number)}
+        </RecordTableInlineCell>
+      ),
+    },
+  ];
+}

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/hooks/useCallQueueList.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/hooks/useCallQueueList.ts
@@ -1,13 +1,22 @@
 import { QueryHookOptions, useQuery } from '@apollo/client';
 import { CALL_QUEUE_LIST } from '../graphql/queries/callQueueList';
 
+export interface ICallQueueListItem {
+  queue: string;
+  queuechairman: string;
+  totalCalls: number;
+  answeredCalls: number;
+  abandonedCalls: number;
+  abandonedRate: number;
+  answeredRate: number;
+  avgWait: number;
+  avgTalk: number;
+}
+
 export const useCallQueueList = (
   options: QueryHookOptions<
     {
-      callQueueList: {
-        _id: string;
-        name: string;
-      }[];
+      callQueueList: ICallQueueListItem[];
     },
     {
       inboxId?: string;

--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationMoreColumn.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationMoreColumn.tsx
@@ -126,8 +126,11 @@ export const IntegrationMoreColumnCell = ({
   );
 };
 
-export const integrationMoreColumn = (): ColumnDef<IIntegrationDetail> => ({
+export const integrationMoreColumn = (
+  showColumnSelector = false,
+): ColumnDef<IIntegrationDetail> => ({
   id: 'more',
+  header: showColumnSelector ? () => <RecordTable.ColumnSelector /> : undefined,
   cell: (cell: CellContext<IIntegrationDetail, unknown>) => (
     <IntegrationMoreColumnCell cell={cell} />
   ),

--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationsRecordTable.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationsRecordTable.tsx
@@ -92,6 +92,7 @@ export const IntegrationsRecordTable = () => {
     <RecordTable.Provider
       columns={columns}
       data={(integrations || []).filter((integration) => integration)}
+      tableId={`frontline_${params?.integrationType}_integrations_record_table`}
       stickyColumns={
         isDiscord ? ['more', 'checkbox', 'name'] : ['more', 'name']
       }
@@ -247,11 +248,7 @@ const NameField = ({
   );
 };
 
-export const BrandField = ({
-  cell,
-}: {
-  cell: CellContext<IIntegrationDetail, unknown>;
-}) => {
+export const BrandField = () => {
   return null;
 };
 
@@ -260,7 +257,7 @@ export const useIntegrationTypeColumns = (
 ): ColumnDef<IIntegrationDetail>[] => {
   const { t } = useTranslation('frontline');
   return [
-    integrationMoreColumn(),
+    integrationMoreColumn(withSelection),
     ...(withSelection
       ? [RecordTable.checkboxColumn as ColumnDef<IIntegrationDetail>]
       : []),

--- a/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/ArticleList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/knowledgebase/components/ArticleList.tsx
@@ -1,7 +1,15 @@
-import { CommandBar, RecordTable, Separator, useConfirm } from 'erxes-ui';
+import {
+  Button,
+  CommandBar,
+  RecordTable,
+  Separator,
+  toast,
+  useConfirm,
+} from 'erxes-ui';
+import { ColumnDef } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useArticles } from '../hooks/useArticles';
+import { Article, useArticles } from '../hooks/useArticles';
 import { useMutation } from '@apollo/client';
 import { REMOVE_ARTICLE } from '../graphql/mutations';
 import {
@@ -15,8 +23,231 @@ import { useTranslation } from 'react-i18next';
 type StatusFilter = 'all' | 'draft' | 'published' | 'archived';
 
 interface ArticleListProps {
-  readonly onEditArticle: (article: any) => void;
+  readonly onEditArticle: (article: Article | null) => void;
   readonly onCreateArticle: () => void;
+}
+
+function ArticleTitleHeader() {
+  const { t } = useTranslation('frontline');
+  return <RecordTable.InlineHead icon={IconFileText} label={t('col-name')} />;
+}
+
+function ArticleTitleCell({
+  article,
+  onEditArticle,
+}: Readonly<{
+  article: Article;
+  onEditArticle: (article: Article) => void;
+}>) {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <Button
+      variant="ghost"
+      className="h-auto w-full justify-start p-1 font-semibold"
+      onClick={() => onEditArticle(article)}
+    >
+      {article.title || t('kb-untitled')}
+    </Button>
+  );
+}
+
+function ArticleStatusHeader() {
+  const { t } = useTranslation('frontline');
+  return <RecordTable.InlineHead icon={IconEye} label={t('status')} />;
+}
+
+function ArticleStatusCell({ article }: Readonly<{ article: Article }>) {
+  const status = String(article.status || 'unknown').toLowerCase();
+  const isPublished = status.includes('publish');
+  const isDraft = status.includes('draft');
+  const isArchived = status.includes('archived');
+
+  let statusColor = 'text-muted-foreground';
+  let bgColor = 'bg-muted';
+
+  if (isPublished) {
+    statusColor = 'text-success';
+    bgColor = 'bg-success/10';
+  } else if (isDraft) {
+    statusColor = 'text-info';
+    bgColor = 'bg-info/10';
+  } else if (isArchived) {
+    statusColor = 'text-destructive';
+    bgColor = 'bg-destructive/10';
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={`inline-flex rounded-full border px-2 py-0.5 text-xs ml-2 ${bgColor} ${statusColor}`}
+      >
+        {article.status || 'unknown'}
+      </span>
+    </div>
+  );
+}
+
+function ArticleOwnerHeader() {
+  const { t } = useTranslation('frontline');
+  return <RecordTable.InlineHead icon={IconUser} label={t('kb-owner')} />;
+}
+
+function ArticleCreatedHeader() {
+  const { t } = useTranslation('frontline');
+  return <RecordTable.InlineHead icon={IconCalendar} label={t('kb-created')} />;
+}
+
+function ArticleCreatedDateCell({ article }: Readonly<{ article: Article }>) {
+  const { t, i18n } = useTranslation('frontline');
+
+  if (!article.createdDate) {
+    return <div className="opacity-80 ml-2">-</div>;
+  }
+
+  const date = new Date(article.createdDate);
+  if (Number.isNaN(date.getTime())) {
+    return <div className="opacity-80 ml-2">{t('kb-invalid-date')}</div>;
+  }
+
+  return (
+    <div className="opacity-80 ml-2">
+      {date.toLocaleDateString(i18n.resolvedLanguage ?? i18n.language, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })}
+    </div>
+  );
+}
+
+function getArticleColumns(
+  onEditArticle: (article: Article) => void,
+): ColumnDef<Article>[] {
+  return [
+    RecordTable.checkboxColumn as ColumnDef<Article>,
+    {
+      id: 'title',
+      accessorKey: 'title',
+      size: 220,
+      header: ArticleTitleHeader,
+      cell: ({ row }) => (
+        <ArticleTitleCell
+          article={row.original}
+          onEditArticle={onEditArticle}
+        />
+      ),
+    },
+    {
+      id: 'status',
+      accessorKey: 'status',
+      size: 220,
+      header: ArticleStatusHeader,
+      cell: ({ row }) => <ArticleStatusCell article={row.original} />,
+    },
+    {
+      id: 'createdUser',
+      accessorKey: 'createdUser',
+      size: 220,
+      header: ArticleOwnerHeader,
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2 opacity-80 ml-2">
+          {row.original.createdUser?.username || '-'}
+        </div>
+      ),
+    },
+    {
+      id: 'createdDate',
+      accessorKey: 'createdDate',
+      size: 180,
+      header: ArticleCreatedHeader,
+      cell: ({ row }) => <ArticleCreatedDateCell article={row.original} />,
+    },
+  ];
+}
+
+function ArticleCommandBar({
+  onEditArticle,
+  refetch,
+}: Readonly<{
+  onEditArticle: (article: Article) => void;
+  refetch: () => void;
+}>) {
+  const { t } = useTranslation('frontline');
+  const { confirm } = useConfirm();
+  const [removeArticle] = useMutation(REMOVE_ARTICLE);
+  const { table } = RecordTable.useRecordTable();
+  const selectedArticles = table
+    .getFilteredSelectedRowModel()
+    .rows.map((row) => row.original as Article);
+  const articleIds = selectedArticles.map((article) => article._id);
+
+  function handleEdit() {
+    if (selectedArticles.length === 1) {
+      onEditArticle(selectedArticles[0]);
+    }
+  }
+
+  async function handleDelete() {
+    if (articleIds.length === 0) {
+      return;
+    }
+
+    try {
+      await confirm({
+        message: t('kb-confirm-delete-articles', {
+          count: articleIds.length,
+        }),
+        options: {
+          confirmationValue: 'delete',
+          description: t('kb-action-permanent'),
+        },
+      });
+    } catch {
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      articleIds.map((id) => removeArticle({ variables: { _id: id } })),
+    );
+    refetch();
+
+    if (results.some((result) => result.status === 'rejected')) {
+      toast({
+        title: t('error'),
+        description: t('something-went-wrong'),
+        variant: 'destructive',
+      });
+    }
+  }
+
+  return (
+    <CommandBar open={selectedArticles.length > 0}>
+      <CommandBar.Bar>
+        <CommandBar.Value>
+          {t('n-selected', { count: selectedArticles.length })}
+        </CommandBar.Value>
+        <Separator.Inline />
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleEdit}
+          disabled={selectedArticles.length !== 1}
+        >
+          {t('edit')}
+        </Button>
+        <Separator.Inline />
+        <Button
+          variant="secondary"
+          size="sm"
+          className="text-destructive"
+          onClick={handleDelete}
+        >
+          {t('delete')}
+        </Button>
+      </CommandBar.Bar>
+    </CommandBar>
+  );
 }
 
 export function ArticleList({
@@ -29,129 +260,20 @@ export function ArticleList({
 
   const [q, setQ] = useState('');
   const [status, setStatus] = useState<StatusFilter>('all');
-  const { confirm } = useConfirm();
 
-  // API hook
   const { articles, loading, refetch } = useArticles({
     categoryIds: [categoryId],
   });
-
-  // Remove article mutation
-  const [removeArticle] = useMutation(REMOVE_ARTICLE);
-
-  // Derived state (no setState, no useEffect)
   const articleList = useMemo(() => articles ?? [], [articles]);
-
-  // Create article
-  const handleCreateArticle = () => {
-    onEditArticle(null);
-  };
-
-  const handleEditArticle = (article: any) => {
-    onEditArticle(article);
-  };
-
-  // Article columns definition
-  const articleColumns = [
-    RecordTable.checkboxColumn,
-    {
-      id: 'title',
-      accessorKey: 'title',
-      size: 220,
-      header: () => <RecordTable.InlineHead icon={IconFileText} label={t('col-name')} />,
-      cell: ({ row }: any) => (
-        <div
-          className="flex items-center gap-2 ml-2 cursor-pointer hover:bg-accent rounded p-1 -m-1"
-          onClick={() => handleEditArticle(row.original)}
-        >
-          <div>
-            <div className="font-semibold opacity-80 ml-2">
-              {row.original?.title || t('kb-untitled')}
-            </div>
-          </div>
-        </div>
-      ),
-    },
-    {
-      id: 'status',
-      accessorKey: 'status',
-      size: 220,
-      header: () => <RecordTable.InlineHead icon={IconEye} label={t('status')} />,
-      cell: ({ row }: any) => {
-        const status = String(row.original?.status || 'unknown').toLowerCase();
-        const isPublished = status.includes('publish');
-        const isDraft = status.includes('draft');
-        const isArchived = status.includes('archived');
-
-        let statusColor = 'text-muted-foreground';
-        let bgColor = 'bg-muted';
-
-        if (isPublished) {
-          statusColor = 'text-success';
-          bgColor = 'bg-success/10';
-        } else if (isDraft) {
-          statusColor = 'text-info';
-          bgColor = 'bg-info/10';
-        } else if (isArchived) {
-          statusColor = 'text-destructive';
-          bgColor = 'bg-destructive/10';
-        }
-
-        return (
-          <div className="flex items-center gap-2">
-            <span
-              className={`inline-flex rounded-full border px-2 py-0.5 text-xs ml-2 ${bgColor} ${statusColor}`}
-            >
-              {row.original?.status || 'unknown'}
-            </span>
-          </div>
-        );
-      },
-    },
-    {
-      id: 'createdUser',
-      accessorKey: 'createdUser',
-      size: 220,
-      header: () => <RecordTable.InlineHead icon={IconUser} label={t('kb-owner')} />,
-      cell: ({ row }: any) => (
-        <div className="flex items-center gap-2 opacity-80 ml-2">
-          {row.original?.createdUser?.username || '-'}
-        </div>
-      ),
-    },
-    {
-      id: 'createdDate',
-      accessorKey: 'createdDate',
-      size: 180,
-      header: () => (
-        <RecordTable.InlineHead icon={IconCalendar} label={t('kb-created')} />
-      ),
-      cell: ({ row }: any) => {
-        const createdDate = row.original?.createdDate;
-        if (!createdDate) return <div className="opacity-80 ml-2">-</div>;
-
-        try {
-          const date = new Date(createdDate);
-          return (
-            <div className="opacity-80 ml-2">
-              {date.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })}
-            </div>
-          );
-        } catch (error) {
-          return <div className="opacity-80 ml-2">{t('kb-invalid-date')}</div>;
-        }
-      },
-    },
-  ];
+  const articleColumns = useMemo(
+    () => getArticleColumns(onEditArticle),
+    [onEditArticle],
+  );
 
   // Filter + search
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
-    return articleList.filter((a: any) => {
+    return articleList.filter((a) => {
       const title = String(a?.title || '').toLowerCase();
       const summary = String(a?.summary || '').toLowerCase();
       const textOk = query ? `${title} ${summary}`.includes(query) : true;
@@ -161,84 +283,16 @@ export function ArticleList({
         status === 'all'
           ? true
           : status === 'draft'
-          ? st.includes('draft')
-          : status === 'published'
-          ? st.includes('publish')
-          : status === 'archived'
-          ? st.includes('archived')
-          : true;
+            ? st.includes('draft')
+            : status === 'published'
+              ? st.includes('publish')
+              : status === 'archived'
+                ? st.includes('archived')
+                : true;
 
       return textOk && statusOk;
     });
   }, [articleList, q, status]);
-
-  // Command bar for bulk actions
-  const ArticleCommandBar = () => {
-    const { table } = RecordTable.useRecordTable();
-
-    const selectedArticles = table.getFilteredSelectedRowModel().rows;
-    const articleIds = selectedArticles.map((row) => row.original._id);
-
-    const handleEdit = () => {
-      if (selectedArticles.length === 1) {
-        const article = selectedArticles[0].original;
-        onEditArticle(article);
-      }
-    };
-
-    const handleDelete = async () => {
-      if (articleIds.length === 0) return;
-
-      const message = t('kb-confirm-delete-articles', { count: articleIds.length });
-
-      const confirmOptions = {
-        confirmationValue: 'delete',
-        description: t('kb-action-permanent'),
-      };
-
-      try {
-        await confirm({
-          message,
-          options: confirmOptions,
-        });
-
-        // Delete all selected articles
-        await Promise.all(
-          articleIds.map((id) => removeArticle({ variables: { _id: id } })),
-        );
-
-        // Refetch to update the list
-        refetch();
-      } catch (error) {
-        console.error('Error deleting articles:', error);
-      }
-    };
-
-    return (
-      <CommandBar open={selectedArticles.length > 0}>
-        <CommandBar.Bar>
-          <CommandBar.Value>
-            {t('n-selected', { count: selectedArticles.length })}
-          </CommandBar.Value>
-          <Separator.Inline />
-          <button
-            onClick={handleEdit}
-            disabled={selectedArticles.length !== 1}
-            className="inline-flex items-center justify-center gap-2 px-3 whitespace-nowrap rounded text-sm transition-colors outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none disabled:opacity-50 font-medium bg-accent text-foreground hover:bg-border h-7 py-1"
-          >
-            {t('edit')}
-          </button>
-          <Separator.Inline />
-          <button
-            onClick={handleDelete}
-            className="inline-flex items-center justify-center gap-2 px-3 whitespace-nowrap rounded text-sm transition-colors outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none disabled:opacity-50 font-medium bg-accent hover:bg-border h-7 py-1 text-destructive"
-          >
-            {t('delete')}
-          </button>
-        </CommandBar.Bar>
-      </CommandBar>
-    );
-  };
 
   return (
     <div className="space-y-4">
@@ -310,20 +364,22 @@ export function ArticleList({
               : t('kb-no-articles')}
           </div>
           <div className="mt-1 text-sm opacity-70 mb-4">
-            {q.trim()
-              ? t('kb-adjust-search')
-              : t('kb-create-first-article')}
+            {q.trim() ? t('kb-adjust-search') : t('kb-create-first-article')}
           </div>
+          {!q.trim() && (
+            <Button onClick={onCreateArticle}>{t('create')}</Button>
+          )}
         </div>
       ) : (
         <RecordTable.Provider
           columns={articleColumns}
           data={filtered}
           stickyColumns={['checkbox']}
+          tableId="frontline_knowledgebase_articles_record_table"
         >
-          <ArticleCommandBar />
+          <ArticleCommandBar onEditArticle={onEditArticle} refetch={refetch} />
           <RecordTable>
-            <RecordTable.Header />
+            <RecordTable.Header showColumnSelector />
             <RecordTable.Body>
               {loading ? (
                 <RecordTable.RowSkeleton rows={10} />

--- a/frontend/plugins/frontline_ui/src/modules/report/components/conversation-charts/ConversationList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/conversation-charts/ConversationList.tsx
@@ -22,7 +22,7 @@ import {
   IconChevronRight,
 } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import {
   getReportCallStatusFilterAtom,
   getReportDateFilterAtom,
@@ -60,17 +60,11 @@ export const ConversationList = ({
 }: ConversationListProps) => {
   const { t } = useTranslation('frontline');
   const id = title.toLowerCase().replace(/\s+/g, '-');
-  const [dateValue, setDateValue] = useAtom(getReportDateFilterAtom(id));
-  const [sourceFilter, setSourceFilter] = useAtom(
-    getReportSourceFilterAtom(id),
-  );
-  const [channelFilter, setChannelFilter] = useAtom(
-    getReportChannelFilterAtom(id),
-  );
-  const [memberFilter, setMemberFilter] = useAtom(
-    getReportMemberFilterAtom(id),
-  );
-  const [callStatusFilter] = useAtom(getReportCallStatusFilterAtom(id));
+  const dateValue = useAtomValue(getReportDateFilterAtom(id));
+  const sourceFilter = useAtomValue(getReportSourceFilterAtom(id));
+  const channelFilter = useAtomValue(getReportChannelFilterAtom(id));
+  const memberFilter = useAtomValue(getReportMemberFilterAtom(id));
+  const callStatusFilter = useAtomValue(getReportCallStatusFilterAtom(id));
   const [filters, setFilters] = useState(() => getFilters());
   const [exporting, setExporting] = useState(false);
   const [page, setPage] = useState(1);
@@ -198,7 +192,7 @@ export const ConversationList = ({
         </Button>
       </>
     ),
-    [id, handleExport, exporting],
+    [id, handleExport, exporting, t],
   );
 
   if (isInitialLoad) {
@@ -340,13 +334,13 @@ const ConversationListTable = memo(function ConversationListTable({
 }: {
   conversationList: ConversationListItem[];
 }) {
-  const navigate = useNavigate();
   return (
     <div className="bg-sidebar w-full rounded-lg [&_th]:last-of-type:text-right">
       <RecordTable.Provider
         data={conversationList}
         columns={conversationListColumns}
         className="m-3"
+        tableId="frontline_conversation_report_record_table"
       >
         <RecordTable.Scroll>
           <RecordTable>
@@ -465,6 +459,7 @@ export const conversationListColumns: ColumnDef<ConversationListItem>[] = [
   },
   {
     id: 'open',
+    header: () => <RecordTable.ColumnSelector />,
     size: 33,
     cell: ({ cell }) => <MoreCell cell={cell} />,
   },

--- a/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/ticket-charts/TicketList.tsx
@@ -163,7 +163,7 @@ export const TicketList = ({
         </Button>
       </>
     ),
-    [id, handleExport, exportLoading],
+    [id, handleExport, exportLoading, t],
   );
 
   if (isInitialLoad) {
@@ -308,6 +308,7 @@ const TicketListTable = memo(function TicketListTable({
         data={tickets}
         columns={ticketListColumns}
         className="m-3"
+        tableId="frontline_ticket_report_record_table"
       >
         <RecordTable.Scroll>
           <RecordTable>
@@ -438,6 +439,7 @@ export const ticketListColumns: ColumnDef<TicketListItem>[] = [
   },
   {
     id: 'open',
+    header: () => <RecordTable.ColumnSelector />,
     size: 33,
     cell: ({ cell }) => <TicketMoreCell cell={cell} />,
   },

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsMoreColumn.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsMoreColumn.tsx
@@ -1,17 +1,45 @@
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { Cell } from '@tanstack/react-table';
-import { Combobox, Command, Popover, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import {
+  Combobox,
+  Command,
+  Popover,
+  RecordTable,
+  useConfirm,
+  useToast,
+} from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { useTicketDetailSheet } from '../hooks/useTicketDetailSheet';
 import { ITicket } from '../types';
 
 import { useTicketRemove } from '../hooks/useRemoveTicket';
 
-export const TicketsMoreColumnCell = ({
+function TicketActionsList({
+  onEdit,
+  onDelete,
+}: Readonly<{
+  onEdit: () => void;
+  onDelete: () => void;
+}>) {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <Command.List>
+      <Command.Item value="edit" onSelect={onEdit}>
+        <IconEdit /> {t('edit')}
+      </Command.Item>
+      <Command.Item value="delete" onSelect={onDelete}>
+        <IconTrash /> {t('delete')}
+      </Command.Item>
+    </Command.List>
+  );
+}
+
+export function TicketsMoreColumnCell({
   cell,
-}: {
+}: Readonly<{
   cell: Cell<ITicket, unknown>;
-}) => {
+}>) {
   const { t } = useTranslation('frontline');
   const [, setActiveTicket] = useTicketDetailSheet();
   const { _id } = cell.row.original;
@@ -19,10 +47,11 @@ export const TicketsMoreColumnCell = ({
   const { toast } = useToast();
   const { removeTicket } = useTicketRemove();
 
-  const handleEdit = (ticketId: string) => {
-    setActiveTicket(ticketId);
-  };
-  const handleDelete = () => {
+  function handleEdit() {
+    setActiveTicket(_id);
+  }
+
+  function handleDelete() {
     if (!_id) {
       toast({
         title: t('error'),
@@ -42,15 +71,16 @@ export const TicketsMoreColumnCell = ({
           variant: 'success',
           description: t('ticket-deleted-successfully'),
         });
-      } catch (e: any) {
+      } catch (error: unknown) {
         toast({
           title: t('error'),
-          description: e.message,
+          description:
+            error instanceof Error ? error.message : t('something-went-wrong'),
           variant: 'destructive',
         });
       }
     });
-  };
+  }
   return (
     <Popover>
       <Popover.Trigger asChild>
@@ -58,22 +88,16 @@ export const TicketsMoreColumnCell = ({
       </Popover.Trigger>
       <Combobox.Content>
         <Command shouldFilter={false}>
-          <Command.List>
-            <Command.Item value="edit" onSelect={() => handleEdit(_id)}>
-              <IconEdit /> {t('edit')}
-            </Command.Item>
-            <Command.Item value="delete" onSelect={handleDelete}>
-              <IconTrash /> {t('delete')}
-            </Command.Item>
-          </Command.List>
+          <TicketActionsList onEdit={handleEdit} onDelete={handleDelete} />
         </Command>
       </Combobox.Content>
     </Popover>
   );
-};
+}
 
 export const ticketsMoreColumn = {
   id: 'more',
+  header: () => <RecordTable.ColumnSelector />,
   cell: TicketsMoreColumnCell,
   size: 33,
 };

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsRecordTable.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsRecordTable.tsx
@@ -40,6 +40,7 @@ export const TicketsRecordTable = () => {
         data={tickets || (loading ? [{}] : [])}
         className="m-3 h-full"
         stickyColumns={['more', 'checkbox', 'name']}
+        tableId="frontline_tickets_record_table"
       >
         <RecordTable.CursorProvider
           hasPreviousPage={hasPreviousPage}

--- a/frontend/plugins/frontline_ui/src/pages/CallDetailPage.tsx
+++ b/frontend/plugins/frontline_ui/src/pages/CallDetailPage.tsx
@@ -27,7 +27,7 @@ import {
   ICallQueueAgent,
   ICallQueueRealtimeSnapshot,
 } from '@/integrations/call/types/callTypes';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   formatSeconds,
   safeFormatDate,
@@ -225,10 +225,11 @@ export const CallDetailAgents = ({
       <RecordTable.Provider
         columns={useAgentColumns()}
         data={filteredMembersList}
+        tableId="frontline_call_agents_record_table"
       >
         <RecordTable.Scroll>
           <RecordTable>
-            <RecordTable.Header />
+            <RecordTable.Header showColumnSelector />
             <RecordTable.Body>
               <RecordTable.RowList />
             </RecordTable.Body>
@@ -373,7 +374,7 @@ export const CallDetailCard = ({
 
 type WaitingCall = {
   callerid: string;
-  callerchannel: string;
+  callerchannel?: string;
 };
 
 export const useWaitingColumns = (): ColumnDef<WaitingCall>[] => {
@@ -416,10 +417,7 @@ export const CallDetailWaiting = ({
       <h5 className="font-mono text-xs uppercase font-semibold">
         {t('waiting')}
       </h5>
-      <RecordTable.Provider
-        columns={useWaitingColumns()}
-        data={waitingList}
-      >
+      <RecordTable.Provider columns={useWaitingColumns()} data={waitingList}>
         <RecordTable.Scroll>
           <RecordTable>
             <RecordTable.Header />
@@ -436,8 +434,28 @@ export const CallDetailWaiting = ({
 type TalkingCall = {
   callerid: string;
   calleeid?: string;
-  bridge_time?: Date;
+  bridge_time?: string | Date;
 };
+
+function TalkingCallDurationCell({
+  value,
+}: Readonly<{ value?: string | Date }>) {
+  const startDate = useMemo(() => {
+    if (!value) {
+      return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }, [value]);
+  const duration = useCallDurationFromDate(startDate);
+
+  return (
+    <RecordTableInlineCell className="font-medium">
+      {startDate ? duration : '-'}
+    </RecordTableInlineCell>
+  );
+}
 
 export const useTalkingColumns = (): ColumnDef<TalkingCall>[] => {
   const { t } = useTranslation('frontline');
@@ -467,15 +485,11 @@ export const useTalkingColumns = (): ColumnDef<TalkingCall>[] => {
     {
       accessorKey: 'bridge_time',
       header: () => <RecordTable.InlineHead label={t('duration')} />,
-      cell: ({ cell }) => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const duration = useCallDurationFromDate(cell.getValue() as Date);
-        return (
-          <RecordTableInlineCell className="font-medium">
-            {duration}
-          </RecordTableInlineCell>
-        );
-      },
+      cell: ({ cell }) => (
+        <TalkingCallDurationCell
+          value={cell.getValue() as string | Date | undefined}
+        />
+      ),
     },
   ];
 };
@@ -491,10 +505,7 @@ export const CallDetailTalking = ({
       <h5 className="font-mono text-xs uppercase font-semibold">
         {t('talking')}
       </h5>
-      <RecordTable.Provider
-        columns={useTalkingColumns()}
-        data={talkingList}
-      >
+      <RecordTable.Provider columns={useTalkingColumns()} data={talkingList}>
         <RecordTable.Scroll>
           <RecordTable>
             <RecordTable.Header />

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/bots/components/automationBotsRecordTable.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/bots/components/automationBotsRecordTable.tsx
@@ -16,10 +16,11 @@ export const AutomationBotsRecordTable = () => {
         columns={automationFacebookBotsColumns}
         data={facebookMessengerBots || []}
         className="h-full"
+        tableId="frontline_facebook_automation_bots_record_table"
       >
         <RecordTable.Scroll>
           <RecordTable>
-            <RecordTable.Header />
+            <RecordTable.Header showColumnSelector />
             <RecordTable.Body>
               {loading && <RecordTable.RowSkeleton rows={10} />}
               <RecordTable.RowList />


### PR DESCRIPTION
## What

Adds the record table column selector — show/hide, drag reorder, pin/unpin — and per-table preference persistence to all 10 qualifying `frontline_ui` table surfaces with 5 or more columns.

- Tables with a `more` or action column render `RecordTable.ColumnSelector` in that column header.
- Tables without an action column use `<RecordTable.Header showColumnSelector />`.
- Every table gets a stable, unique `tableId`, so saved layouts remain isolated.
- The integrations table enables the selector only for the 5-column Discord layout; 4-column layouts remain unchanged.
- Utility columns such as `more` and `checkbox` remain outside the selectable data-column list.

## Validation

| Check | Result |
| --- | --- |
| `pnpm nx build frontline_ui` | pass |
| ESLint on changed TSX files with `--max-warnings=0` | pass |
| TypeScript diagnostics filtered to changed files | no errors |
| `pnpm nx lint frontline_ui` | existing project-wide errors outside the changed-file lint scope |
| Tests | not run — `frontline_ui` has no test target |

## Docs

- Adds `frontend/plugins/frontline_ui/AGENTS.md` with the plugin current-state guide and RecordTable invariants.

## Summary by Sourcery

Introduce persisted column selection controls across key frontline record tables and document plugin scope and table invariants.

New Features:
- Add column selector support (show/hide, reorder, pin) to frontline record tables with five or more columns, including forms, tickets, reports, integrations, call queues, call agents, knowledge-base articles, and Facebook automation bots.
- Persist per-table column preferences by assigning stable, unique table IDs to each qualifying RecordTable surface, including integration-type-specific IDs where column sets differ.

Enhancements:
- Standardize use of RecordTable.Header with an optional column selector and render the selector from action columns where present.
- Adjust data models and table column definitions for calls, integrations, and forms to better align with current usage and avoid unused fields and props.

Documentation:
- Add AGENTS.md as a current-state guide for the frontline_ui plugin, covering ownership, contracts, data/state, RecordTable invariants, and validation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added column selectors to more Frontline tables, including forms, integrations, calls, knowledge base articles, reports, tickets, and Facebook automation bots.
  * Table column selections now persist consistently across supported Frontline record tables.
* **Bug Fixes**
  * Improved table configuration and filtering reliability across Frontline screens.
  * Improved call duration display for missing or invalid values.
  * More-actions menus can now close reliably after an action.
  * Improved bulk deletion error handling and refresh behavior for knowledge base articles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->