### PR TITLE
perf(products): improve bulk selection and actions

### DIFF
--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -17,7 +17,7 @@ import {
   Separator,
   toast,
 } from 'erxes-ui';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
@@ -59,12 +59,34 @@ export const ProductCommandBar = () => {
   const [mergeOpen, setMergeOpen] = useState(false);
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
-  const products = selectedRows.map((row: Row<IProduct>) => row.original);
-  const productIds = products.map((product) => product._id);
+  const products = useMemo(
+    () => selectedRows.map((row: Row<IProduct>) => row.original),
+    [selectedRows],
+  );
+  const productIds = useMemo(
+    () => products.map((product) => product._id),
+    [products],
+  );
 
-  const deletedProductIds = products
-    .filter((product) => product.status === 'deleted')
-    .map((product) => product._id);
+  const deletedProductIds = useMemo(
+    () =>
+      products
+        .filter((product) => product.status === 'deleted')
+        .map((product) => product._id),
+    [products],
+  );
+
+  const tagsValue = useMemo(
+    () => intersection(products.map((product) => product.tagIds ?? [])) || [],
+    [products],
+  );
+
+  const closeActionsPopover = () => {
+    setOpen(false);
+    setTimeout(() => {
+      setCurrentContent('main');
+    }, 100);
+  };
 
   return (
     <CommandBar open={selectedRows.length > 0}>
@@ -92,11 +114,12 @@ export const ProductCommandBar = () => {
         <Separator.Inline />
         <Popover
           open={open}
-          onOpenChange={(open) => {
-            setOpen(open);
-            setTimeout(() => {
-              setCurrentContent('main');
-            }, 100);
+          onOpenChange={(nextOpen) => {
+            if (nextOpen) {
+              setOpen(true);
+              return;
+            }
+            closeActionsPopover();
           }}
         >
           <Popover.Trigger asChild>
@@ -131,7 +154,7 @@ export const ProductCommandBar = () => {
                     <ProductMergeTrigger
                       productCount={selectedRows.length}
                       onOpen={() => {
-                        setOpen(false);
+                        closeActionsPopover();
                         setMergeOpen(true);
                       }}
                     />
@@ -177,11 +200,7 @@ export const ProductCommandBar = () => {
               <TagsSelect.Provider
                 type="core:product"
                 mode="multiple"
-                value={
-                  intersection(
-                    products.map((product) => product.tagIds ?? []),
-                  ) || []
-                }
+                value={tagsValue}
                 targetIds={productIds}
                 options={(newSelectedTagIds) => ({
                   update: (cache) =>
@@ -205,7 +224,7 @@ export const ProductCommandBar = () => {
             {currentContent === 'category' && (
               <ProductsChangeCategoryContent
                 products={products}
-                setOpen={setOpen}
+                setOpen={closeActionsPopover}
               />
             )}
           </Popover.Content>

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -1,12 +1,32 @@
-import { IconPlus } from '@tabler/icons-react';
+import {
+  IconPlus,
+  IconRepeat,
+  IconRestore,
+  IconTags,
+  IconTrash,
+} from '@tabler/icons-react';
 
 import { ApolloCache, ApolloError } from '@apollo/client';
 import { Row } from '@tanstack/table-core';
-import { Button, CommandBar, RecordTable, Separator, toast } from 'erxes-ui';
+import {
+  Button,
+  Command,
+  CommandBar,
+  Popover,
+  RecordTable,
+  Separator,
+  toast,
+} from 'erxes-ui';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Can, Export, IProduct, PrintDocument, TagsSelect } from 'ui-modules';
 import { ProductsDelete } from './delete/productDelete';
 import { ProductsRestore } from './restore/productRestore';
-import { ProductMerge } from './ProductMerge';
+import { ProductMerge, ProductMergeTrigger } from './ProductMerge';
+import {
+  ProductsChangeCategoryContent,
+  ProductsChangeCategoryTrigger,
+} from './ProductsChangeCategory';
 
 const updateProductsTagCache = (
   cache: ApolloCache<unknown>,
@@ -23,57 +43,33 @@ const updateProductsTagCache = (
   });
 };
 
+const intersection = (arrays: string[][]): string[] => {
+  if (arrays.length === 0) return [];
+  return arrays.reduce((common, current) =>
+    common.filter((item) => current.includes(item)),
+  );
+};
+
 export const ProductCommandBar = () => {
+  const { t } = useTranslation('product');
   const { table } = RecordTable.useRecordTable();
 
+  const [open, setOpen] = useState(false);
+  const [currentContent, setCurrentContent] = useState('main');
+  const [mergeOpen, setMergeOpen] = useState(false);
+
   const selectedRows = table.getFilteredSelectedRowModel().rows;
-  const productIds = selectedRows.map((row: Row<IProduct>) => row.original._id);
+  const products = selectedRows.map((row: Row<IProduct>) => row.original);
+  const productIds = products.map((product) => product._id);
 
-  const deletedProductIds = selectedRows
-    .filter((row: Row<IProduct>) => row.original.status === 'deleted')
-    .map((row: Row<IProduct>) => row.original._id);
-
-  const intersection = (arrays: string[][]): string[] => {
-    if (arrays.length === 0) return [];
-    return arrays.reduce((common, current) =>
-      common.filter((item) => current.includes(item)),
-    );
-  };
+  const deletedProductIds = products
+    .filter((product) => product.status === 'deleted')
+    .map((product) => product._id);
 
   return (
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>{selectedRows.length} selected</CommandBar.Value>
-        <Can action="tagsTag">
-          <>
-            <Separator.Inline />
-            <TagsSelect
-              type="core:product"
-              mode="multiple"
-              variant="secondary"
-              className="shadow-none"
-              value={
-                intersection(
-                  selectedRows.map(
-                    (row: Row<IProduct>) => row.original.tagIds ?? [],
-                  ),
-                ) || []
-              }
-              targetIds={productIds}
-              options={(newSelectedTagIds) => ({
-                update: (cache) =>
-                  updateProductsTagCache(cache, productIds, newSelectedTagIds),
-                onError: (e: ApolloError) => {
-                  toast({
-                    title: 'Error',
-                    description: e.message,
-                    variant: 'destructive',
-                  });
-                },
-              })}
-            />
-          </>
-        </Can>
         <Can action="productsExportManage">
           <Separator.Inline />
           <Export
@@ -84,31 +80,143 @@ export const ProductCommandBar = () => {
             ids={productIds}
           />
         </Can>
-        <Separator.Inline />
-        <ProductMerge
-          productIds={productIds}
-          products={selectedRows.map((row: Row<IProduct>) => row.original)}
-        />
-        <Separator.Inline />
-        <ProductsDelete productIds={productIds} />
-        {deletedProductIds.length > 0 && (
-          <>
-            <Separator.Inline />
-            <ProductsRestore productIds={deletedProductIds} />
-          </>
-        )}
-        <Separator.Inline />
         <Can action="productsCreate">
+          <Separator.Inline />
           <Button variant="secondary">
             <IconPlus />
             Create
           </Button>
         </Can>
-        <PrintDocument
-          items={selectedRows.map((row: Row<IProduct>) => row.original)}
-          contentType="core:product"
-        />
+        <Separator.Inline />
+        <PrintDocument items={products} contentType="core:product" />
+        <Separator.Inline />
+        <Popover
+          open={open}
+          onOpenChange={(open) => {
+            setOpen(open);
+            setTimeout(() => {
+              setCurrentContent('main');
+            }, 100);
+          }}
+        >
+          <Popover.Trigger asChild>
+            <Button variant="secondary">
+              <IconRepeat />
+              {t('actions', 'Actions')}
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content
+            className="min-w-[280px] p-0"
+            align="end"
+            side="top"
+            sideOffset={10}
+          >
+            {currentContent === 'main' && (
+              <Command>
+                <Command.List className="p-0">
+                  <Command.Group className="p-1">
+                    <Can action="tagsTag">
+                      <Command.Item onSelect={() => setCurrentContent('tags')}>
+                        <IconTags className="size-4" />
+                        <div className="flex items-center">
+                          {t('bulk.tags', 'Tags')}
+                        </div>
+                      </Command.Item>
+                    </Can>
+                    <Can action="productsUpdate">
+                      <ProductsChangeCategoryTrigger
+                        setCurrentContent={setCurrentContent}
+                      />
+                    </Can>
+                    <ProductMergeTrigger
+                      productCount={selectedRows.length}
+                      onOpen={() => {
+                        setOpen(false);
+                        setMergeOpen(true);
+                      }}
+                    />
+                  </Command.Group>
+                  <Command.Separator />
+                  <Command.Group className="p-1">
+                    <ProductsDelete productIds={productIds}>
+                      {({ onClick, disabled, trailing }) => (
+                        <Command.Item
+                          className="flex justify-between text-destructive"
+                          onSelect={onClick}
+                          disabled={disabled}
+                        >
+                          <div className="flex gap-2 items-center">
+                            <IconTrash className="size-4" />
+                            {t('delete', 'Delete')}
+                          </div>
+                          {trailing}
+                        </Command.Item>
+                      )}
+                    </ProductsDelete>
+                    {deletedProductIds.length > 0 && (
+                      <ProductsRestore productIds={deletedProductIds}>
+                        {({ onClick, disabled }) => (
+                          <Command.Item
+                            className="text-primary"
+                            onSelect={onClick}
+                            disabled={disabled}
+                          >
+                            <IconRestore className="size-4" />
+                            <div className="flex items-center">
+                              {t('restore', 'Restore')}
+                            </div>
+                          </Command.Item>
+                        )}
+                      </ProductsRestore>
+                    )}
+                  </Command.Group>
+                </Command.List>
+              </Command>
+            )}
+            {currentContent === 'tags' && (
+              <TagsSelect.Provider
+                type="core:product"
+                mode="multiple"
+                value={
+                  intersection(
+                    products.map((product) => product.tagIds ?? []),
+                  ) || []
+                }
+                targetIds={productIds}
+                options={(newSelectedTagIds) => ({
+                  update: (cache) =>
+                    updateProductsTagCache(
+                      cache,
+                      productIds,
+                      newSelectedTagIds,
+                    ),
+                  onError: (e: ApolloError) => {
+                    toast({
+                      title: 'Error',
+                      description: e.message,
+                      variant: 'destructive',
+                    });
+                  },
+                })}
+              >
+                <TagsSelect.Content />
+              </TagsSelect.Provider>
+            )}
+            {currentContent === 'category' && (
+              <ProductsChangeCategoryContent
+                products={products}
+                setOpen={setOpen}
+              />
+            )}
+          </Popover.Content>
+        </Popover>
       </CommandBar.Bar>
+      <ProductMerge
+        productIds={productIds}
+        products={products}
+        open={mergeOpen}
+        onOpenChange={setMergeOpen}
+      />
     </CommandBar>
   );
 };

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductCommandBar.tsx
@@ -139,12 +139,11 @@ export const ProductCommandBar = () => {
                 <Command.List className="p-0">
                   <Command.Group className="p-1">
                     <Can action="tagsTag">
-                      <Command.Item onSelect={() => setCurrentContent('tags')}>
-                        <IconTags className="size-4" />
-                        <div className="flex items-center">
-                          {t('bulk.tags', 'Tags')}
-                        </div>
-                      </Command.Item>
+                      <Command.ActionItem
+                        icon={IconTags}
+                        label={t('bulk.tags', 'Tags')}
+                        onSelect={() => setCurrentContent('tags')}
+                      />
                     </Can>
                     <Can action="productsUpdate">
                       <ProductsChangeCategoryTrigger
@@ -163,32 +162,26 @@ export const ProductCommandBar = () => {
                   <Command.Group className="p-1">
                     <ProductsDelete productIds={productIds}>
                       {({ onClick, disabled, trailing }) => (
-                        <Command.Item
-                          className="flex justify-between text-destructive"
+                        <Command.ActionItem
+                          className="text-destructive"
+                          icon={IconTrash}
+                          label={t('delete', 'Delete')}
                           onSelect={onClick}
                           disabled={disabled}
-                        >
-                          <div className="flex gap-2 items-center">
-                            <IconTrash className="size-4" />
-                            {t('delete', 'Delete')}
-                          </div>
-                          {trailing}
-                        </Command.Item>
+                          trailing={trailing}
+                        />
                       )}
                     </ProductsDelete>
                     {deletedProductIds.length > 0 && (
                       <ProductsRestore productIds={deletedProductIds}>
                         {({ onClick, disabled }) => (
-                          <Command.Item
+                          <Command.ActionItem
                             className="text-primary"
+                            icon={IconRestore}
+                            label={t('restore', 'Restore')}
                             onSelect={onClick}
                             disabled={disabled}
-                          >
-                            <IconRestore className="size-4" />
-                            <div className="flex items-center">
-                              {t('restore', 'Restore')}
-                            </div>
-                          </Command.Item>
+                          />
                         )}
                       </ProductsRestore>
                     )}

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
@@ -1,6 +1,15 @@
 import { useMutation } from '@apollo/client';
 import { IconArrowMerge, IconCheck } from '@tabler/icons-react';
-import { Button, cn, Input, ScrollArea, Sheet, Spinner, toast } from 'erxes-ui';
+import {
+  Button,
+  cn,
+  Command,
+  Input,
+  ScrollArea,
+  Sheet,
+  Spinner,
+  toast,
+} from 'erxes-ui';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Can, IProduct } from 'ui-modules';
@@ -101,26 +110,41 @@ const propertiesEntries = (product: any): [string, any][] =>
 const propertyDisplay = (value: any) =>
   typeof value === 'object' ? JSON.stringify(value) : String(value);
 
+export const ProductMergeTrigger = ({
+  productCount,
+  onOpen,
+}: {
+  productCount: number;
+  onOpen: () => void;
+}) => {
+  const { t } = useTranslation('product');
+  return (
+    <Can action="productsMerge">
+      <Command.Item disabled={productCount !== 2} onSelect={onOpen}>
+        <IconArrowMerge className="size-4" />
+        <div className="flex items-center">{t('merge', 'Merge')}</div>
+      </Command.Item>
+    </Can>
+  );
+};
+
 export const ProductMerge = ({
   productIds,
   products,
+  open,
+  onOpenChange,
 }: {
   productIds: string[];
   products: IProduct[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) => {
   const { t } = useTranslation('product');
-  const [open, setOpen] = useState(false);
   const canMerge = products.length === 2;
 
   return (
     <Can action="productsMerge">
-      <Sheet open={open} onOpenChange={setOpen}>
-        <Sheet.Trigger asChild>
-          <Button variant="secondary" disabled={!canMerge}>
-            <IconArrowMerge />
-            {t('merge', 'Merge')}
-          </Button>
-        </Sheet.Trigger>
+      <Sheet open={open} onOpenChange={onOpenChange}>
         <Sheet.View className="flex flex-col gap-0 p-0 sm:max-w-4xl">
           <Sheet.Header className="flex-row items-center gap-3 space-y-0 border-b p-3">
             <Sheet.Title>{t('merge-products', 'Merge products')}</Sheet.Title>
@@ -133,7 +157,7 @@ export const ProductMerge = ({
             <ProductMergeBody
               productIds={productIds}
               products={products}
-              setOpen={setOpen}
+              setOpen={onOpenChange}
             />
           )}
         </Sheet.View>

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductMerge.tsx
@@ -120,10 +120,12 @@ export const ProductMergeTrigger = ({
   const { t } = useTranslation('product');
   return (
     <Can action="productsMerge">
-      <Command.Item disabled={productCount !== 2} onSelect={onOpen}>
-        <IconArrowMerge className="size-4" />
-        <div className="flex items-center">{t('merge', 'Merge')}</div>
-      </Command.Item>
+      <Command.ActionItem
+        icon={IconArrowMerge}
+        label={t('merge', 'Merge')}
+        onSelect={onOpen}
+        disabled={productCount !== 2}
+      />
     </Can>
   );
 };

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
@@ -1,0 +1,150 @@
+import { IconCategory } from '@tabler/icons-react';
+import { useApolloClient } from '@apollo/client';
+import { Button, Popover, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IProduct, SelectCategory } from 'ui-modules';
+
+import { useProductsEdit } from '@/products/hooks/useProductsEdit';
+
+export const ProductsChangeCategory = ({
+  products,
+}: {
+  products: IProduct[];
+}) => {
+  const { t } = useTranslation('product');
+  const { toast } = useToast();
+  const { confirm } = useConfirm();
+  const { table } = RecordTable.useRecordTable();
+  const { productsEdit } = useProductsEdit();
+  const client = useApolloClient();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // productsEdit forces status back to 'active', so moving a soft-deleted
+  // product would silently restore it. Leave those out of the batch.
+  const movableProducts = products.filter(
+    (product) => product.status !== 'deleted',
+  );
+  const skippedCount = products.length - movableProducts.length;
+
+  const handleSelect = async (value: string | string[]) => {
+    const categoryId = Array.isArray(value) ? value[0] : value;
+
+    if (!categoryId || loading) {
+      return;
+    }
+
+    setOpen(false);
+
+    if (!movableProducts.length) {
+      toast({
+        title: t('bulk.no-movable-products', {
+          defaultValue: 'Deleted products cannot be moved to another category',
+        }),
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      // Moving is not reversible: once overwritten, there is no record of which
+      // category each product came from.
+      await confirm({
+        message: t('bulk.confirm-change-category', {
+          count: movableProducts.length,
+          defaultValue_one:
+            'Move the {{count}} selected product to this category? Its current category will be replaced.',
+          defaultValue_other:
+            'Move the {{count}} selected products to this category? Their current categories will be replaced.',
+        }),
+      });
+    } catch {
+      // User cancelled the confirmation
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const results = await Promise.allSettled(
+        movableProducts.map((product) =>
+          productsEdit({ variables: { _id: product._id, categoryId } }),
+        ),
+      );
+
+      const failedCount = results.filter(
+        (result) => result.status === 'rejected',
+      ).length;
+      const movedCount = results.length - failedCount;
+
+      const notes = [
+        failedCount > 0 &&
+          t('bulk.category-change-failed', {
+            count: failedCount,
+            defaultValue_one: '{{count}} product could not be moved',
+            defaultValue_other: '{{count}} products could not be moved',
+          }),
+        skippedCount > 0 &&
+          t('bulk.deleted-skipped', {
+            count: skippedCount,
+            defaultValue_one: '{{count}} deleted product was skipped',
+            defaultValue_other: '{{count}} deleted products were skipped',
+          }),
+      ].filter(Boolean) as string[];
+
+      if (movedCount === 0) {
+        toast({
+          title: t('bulk.category-change-failed', {
+            count: failedCount,
+            defaultValue_one: '{{count}} product could not be moved',
+            defaultValue_other: '{{count}} products could not be moved',
+          }),
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      toast({
+        title: t('bulk.category-changed', {
+          count: movedCount,
+          defaultValue_one: '{{count}} product moved to the new category',
+          defaultValue_other: '{{count}} products moved to the new category',
+        }),
+        description: notes.length ? notes.join(' · ') : undefined,
+        variant: 'success',
+      });
+
+      table.setRowSelection({});
+      client.refetchQueries({ include: ['ProductsMain'] });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button variant="secondary" disabled={loading || !products.length}>
+          <IconCategory />
+          {t('bulk.change-category', { defaultValue: 'Change category' })}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        className="p-0 w-96"
+        align="end"
+        side="top"
+        sideOffset={10}
+      >
+        <SelectCategory.Provider
+          mode="single"
+          value=""
+          onValueChange={handleSelect}
+        >
+          <SelectCategory.Content />
+        </SelectCategory.Provider>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
@@ -14,12 +14,11 @@ export const ProductsChangeCategoryTrigger = ({
 }) => {
   const { t } = useTranslation('product');
   return (
-    <Command.Item onSelect={() => setCurrentContent('category')}>
-      <IconCategory className="size-4" />
-      <div className="flex items-center">
-        {t('bulk.change-category', { defaultValue: 'Change category' })}
-      </div>
-    </Command.Item>
+    <Command.ActionItem
+      icon={IconCategory}
+      label={t('bulk.change-category', { defaultValue: 'Change category' })}
+      onSelect={() => setCurrentContent('category')}
+    />
   );
 };
 
@@ -39,8 +38,6 @@ export const ProductsChangeCategoryContent = ({
 
   const [loading, setLoading] = useState(false);
 
-  // productsEdit forces status back to 'active', so moving a soft-deleted
-  // product would silently restore it. Leave those out of the batch.
   const movableProducts = products.filter(
     (product) => product.status !== 'deleted',
   );
@@ -66,8 +63,6 @@ export const ProductsChangeCategoryContent = ({
     }
 
     try {
-      // Moving is not reversible: once overwritten, there is no record of which
-      // category each product came from.
       await confirm({
         message: t('bulk.confirm-change-category', {
           count: movableProducts.length,
@@ -78,7 +73,6 @@ export const ProductsChangeCategoryContent = ({
         }),
       });
     } catch {
-      // User cancelled the confirmation
       return;
     }
 

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/ProductsChangeCategory.tsx
@@ -1,16 +1,34 @@
 import { IconCategory } from '@tabler/icons-react';
 import { useApolloClient } from '@apollo/client';
-import { Button, Popover, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import { Command, RecordTable, useConfirm, useToast } from 'erxes-ui';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IProduct, SelectCategory } from 'ui-modules';
 
 import { useProductsEdit } from '@/products/hooks/useProductsEdit';
 
-export const ProductsChangeCategory = ({
+export const ProductsChangeCategoryTrigger = ({
+  setCurrentContent,
+}: {
+  setCurrentContent: (content: string) => void;
+}) => {
+  const { t } = useTranslation('product');
+  return (
+    <Command.Item onSelect={() => setCurrentContent('category')}>
+      <IconCategory className="size-4" />
+      <div className="flex items-center">
+        {t('bulk.change-category', { defaultValue: 'Change category' })}
+      </div>
+    </Command.Item>
+  );
+};
+
+export const ProductsChangeCategoryContent = ({
   products,
+  setOpen,
 }: {
   products: IProduct[];
+  setOpen: (open: boolean) => void;
 }) => {
   const { t } = useTranslation('product');
   const { toast } = useToast();
@@ -19,7 +37,6 @@ export const ProductsChangeCategory = ({
   const { productsEdit } = useProductsEdit();
   const client = useApolloClient();
 
-  const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
   // productsEdit forces status back to 'active', so moving a soft-deleted
@@ -124,27 +141,12 @@ export const ProductsChangeCategory = ({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
-        <Button variant="secondary" disabled={loading || !products.length}>
-          <IconCategory />
-          {t('bulk.change-category', { defaultValue: 'Change category' })}
-        </Button>
-      </Popover.Trigger>
-      <Popover.Content
-        className="p-0 w-96"
-        align="end"
-        side="top"
-        sideOffset={10}
-      >
-        <SelectCategory.Provider
-          mode="single"
-          value=""
-          onValueChange={handleSelect}
-        >
-          <SelectCategory.Content />
-        </SelectCategory.Provider>
-      </Popover.Content>
-    </Popover>
+    <SelectCategory.Provider
+      mode="single"
+      value=""
+      onValueChange={handleSelect}
+    >
+      <SelectCategory.Content />
+    </SelectCategory.Provider>
   );
 };

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/delete/productDelete.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/delete/productDelete.tsx
@@ -2,8 +2,7 @@ import { Button, RecordTable, useConfirm, useToast } from 'erxes-ui';
 import { IconTrash } from '@tabler/icons-react';
 import { ApolloError } from '@apollo/client';
 import { useRemoveProducts } from '@/products/product-detail/hooks/useRemoveProduct';
-import type { ReactNode } from 'react';
-import { useCallback } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import { BeforeResolverAvailability, Can } from 'ui-modules';
 import { useTranslation } from 'react-i18next';
 

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
@@ -1,8 +1,7 @@
 import { ApolloError } from '@apollo/client';
 import { IconRestore } from '@tabler/icons-react';
 import { Button, RecordTable, useConfirm, useToast } from 'erxes-ui';
-import type { ReactNode } from 'react';
-import { useCallback } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import { Can } from 'ui-modules';
 import { useRestoreProducts } from '@/products/product-detail/hooks/useRestoreProduct';
 

--- a/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
+++ b/frontend/core-ui/src/modules/products/components/product-command-bar/restore/productRestore.tsx
@@ -1,11 +1,18 @@
 import { ApolloError } from '@apollo/client';
 import { IconRestore } from '@tabler/icons-react';
 import { Button, RecordTable, useConfirm, useToast } from 'erxes-ui';
+import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import { Can } from 'ui-modules';
 import { useRestoreProducts } from '@/products/product-detail/hooks/useRestoreProduct';
 
-export const ProductsRestore = ({ productIds }: { productIds: string[] }) => {
+export const ProductsRestore = ({
+  productIds,
+  children,
+}: {
+  productIds: string[];
+  children?: (args: { onClick: () => void; disabled: boolean }) => ReactNode;
+}) => {
   const { confirm } = useConfirm();
   const { restoreProducts, loading } = useRestoreProducts();
   const { table } = RecordTable.useRecordTable();
@@ -45,6 +52,14 @@ export const ProductsRestore = ({ productIds }: { productIds: string[] }) => {
       // User cancelled the confirmation
     }
   }, [disabled, confirm, productIds, restoreProducts, toast, table]);
+
+  if (children) {
+    return (
+      <Can action="productsUpdate">
+        <>{children({ onClick: handleClick, disabled })}</>
+      </Can>
+    );
+  }
 
   return (
     <Can action="productsUpdate">

--- a/frontend/core-ui/src/modules/products/hooks/useProductsEdit.tsx
+++ b/frontend/core-ui/src/modules/products/hooks/useProductsEdit.tsx
@@ -7,12 +7,11 @@ export const useProductsEdit = () => {
     productsMutations.productsEdit,
   );
 
-  const mutate = ({ variables, ...options }: MutationHookOptions) => {
+  const mutate = ({ variables, ...options }: MutationHookOptions) =>
     productsEdit({
       ...options,
       variables,
     });
-  };
 
   return { productsEdit: mutate, loading };
 };

--- a/frontend/libs/erxes-ui/src/components/command.tsx
+++ b/frontend/libs/erxes-ui/src/components/command.tsx
@@ -202,6 +202,35 @@ const CommandItem = React.forwardRef<
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
+const CommandActionItem = ({
+  icon: Icon,
+  label,
+  onSelect,
+  disabled,
+  trailing,
+  className,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: React.ReactNode;
+  onSelect: () => void;
+  disabled?: boolean;
+  trailing?: React.ReactNode;
+  className?: string;
+}) => (
+  <CommandItem
+    className={cn('justify-between', className)}
+    onSelect={onSelect}
+    disabled={disabled}
+  >
+    <div className="flex gap-2 items-center">
+      <Icon className="size-4" />
+      <div className="flex items-center">{label}</div>
+    </div>
+    {trailing}
+  </CommandItem>
+);
+CommandActionItem.displayName = 'CommandActionItem';
+
 const CommandShortcut = ({
   className,
   ...props
@@ -225,6 +254,7 @@ export const Command = Object.assign(CommandRoot, {
   Empty: CommandEmpty,
   Group: CommandGroup,
   Item: CommandItem,
+  ActionItem: CommandActionItem,
   Shortcut: CommandShortcut,
   Separator: CommandSeparator,
   Primitive: CommandPrimitive,

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -1,5 +1,76 @@
 import { Checkbox } from 'erxes-ui/components/checkbox';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, Row, Table } from '@tanstack/react-table';
+
+const dragSelection = {
+  owner: null as Table<any> | null,
+  selecting: false,
+  suppressClickOn: null as { table: Table<any>; rowId: string } | null,
+};
+
+const DRAG_END_EVENTS = ['pointerup', 'pointercancel', 'blur'] as const;
+
+const endDragSelection = () => {
+  dragSelection.owner = null;
+  document.body.style.userSelect = '';
+  DRAG_END_EVENTS.forEach((event) =>
+    window.removeEventListener(event, endDragSelection),
+  );
+};
+
+const startDragSelection = (
+  selecting: boolean,
+  row: Row<any>,
+  table: Table<any>,
+) => {
+  dragSelection.owner = table;
+  dragSelection.selecting = selecting;
+  dragSelection.suppressClickOn = { table, rowId: row.id };
+  document.body.style.userSelect = 'none';
+  DRAG_END_EVENTS.forEach((event) =>
+    window.addEventListener(event, endDragSelection),
+  );
+};
+
+const CheckboxCell = ({ row, table }: { row: Row<any>; table: Table<any> }) => (
+  <div
+    className="flex items-center justify-center size-full"
+    onPointerDown={(event) => {
+      dragSelection.suppressClickOn = null;
+
+      if (!event.shiftKey || event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+      const selecting = !row.getIsSelected();
+      startDragSelection(selecting, row, table);
+      row.toggleSelected(selecting);
+    }}
+    onPointerEnter={(event) => {
+      if (dragSelection.owner !== table || event.buttons !== 1) {
+        return;
+      }
+
+      row.toggleSelected(dragSelection.selecting);
+    }}
+    onClickCapture={(event) => {
+      const suppressed = dragSelection.suppressClickOn;
+
+      if (suppressed?.table !== table || suppressed.rowId !== row.id) {
+        return;
+      }
+
+      dragSelection.suppressClickOn = null;
+      event.preventDefault();
+      event.stopPropagation();
+    }}
+  >
+    <Checkbox
+      checked={row.getIsSelected()}
+      onCheckedChange={(value) => row.toggleSelected(!!value)}
+    />
+  </div>
+);
 
 export const checkboxColumn: ColumnDef<any> = {
   accessorKey: 'checkbox',
@@ -19,12 +90,5 @@ export const checkboxColumn: ColumnDef<any> = {
     );
   },
   size: 33,
-  cell: ({ row }) => (
-    <div className="flex items-center justify-center">
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-      />
-    </div>
-  ),
+  cell: ({ row, table }) => <CheckboxCell row={row} table={table} />,
 };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/CheckboxColumn.tsx
@@ -2,9 +2,9 @@ import { Checkbox } from 'erxes-ui/components/checkbox';
 import { ColumnDef, Row, Table } from '@tanstack/react-table';
 
 const dragSelection = {
-  owner: null as Table<any> | null,
+  owner: null as Table<unknown> | null,
   selecting: false,
-  suppressClickOn: null as { table: Table<any>; rowId: string } | null,
+  suppressClickOn: null as { table: Table<unknown>; rowId: string } | null,
 };
 
 const DRAG_END_EVENTS = ['pointerup', 'pointercancel', 'blur'] as const;
@@ -17,21 +17,28 @@ const endDragSelection = () => {
   );
 };
 
-const startDragSelection = (
+const startDragSelection = <TData,>(
   selecting: boolean,
-  row: Row<any>,
-  table: Table<any>,
+  row: Row<TData>,
+  table: Table<TData>,
 ) => {
-  dragSelection.owner = table;
+  const owner = table as unknown as Table<unknown>;
+  dragSelection.owner = owner;
   dragSelection.selecting = selecting;
-  dragSelection.suppressClickOn = { table, rowId: row.id };
+  dragSelection.suppressClickOn = { table: owner, rowId: row.id };
   document.body.style.userSelect = 'none';
   DRAG_END_EVENTS.forEach((event) =>
     window.addEventListener(event, endDragSelection),
   );
 };
 
-const CheckboxCell = ({ row, table }: { row: Row<any>; table: Table<any> }) => (
+const CheckboxCell = <TData,>({
+  row,
+  table,
+}: {
+  row: Row<TData>;
+  table: Table<TData>;
+}) => (
   <div
     className="flex items-center justify-center size-full"
     onPointerDown={(event) => {
@@ -47,7 +54,10 @@ const CheckboxCell = ({ row, table }: { row: Row<any>; table: Table<any> }) => (
       row.toggleSelected(selecting);
     }}
     onPointerEnter={(event) => {
-      if (dragSelection.owner !== table || event.buttons !== 1) {
+      if (
+        dragSelection.owner !== (table as unknown as Table<unknown>) ||
+        event.buttons !== 1
+      ) {
         return;
       }
 
@@ -56,7 +66,10 @@ const CheckboxCell = ({ row, table }: { row: Row<any>; table: Table<any> }) => (
     onClickCapture={(event) => {
       const suppressed = dragSelection.suppressClickOn;
 
-      if (suppressed?.table !== table || suppressed.rowId !== row.id) {
+      if (
+        suppressed?.table !== (table as unknown as Table<unknown>) ||
+        suppressed.rowId !== row.id
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve bulk product selection UX and centralize bulk actions in a contextual actions menu.

New Features:
- Add a bulk actions popover for products with options for tagging, changing category, merging, deleting, and restoring.
- Introduce a bulk change-category flow for products with confirmation, status-aware filtering, and success/error toasts.

Bug Fixes:
- Prevent soft-deleted products from being unintentionally restored when changing category in bulk by skipping them in the operation.

Enhancements:
- Refine product merge to be controlled externally via a trigger component and open state passed from the command bar.
- Improve bulk tag editing UI by moving it into a dedicated actions popover view.
- Add drag-to-select support for record table checkbox rows using shift+pointer interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a consolidated product actions menu for tagging, category changes, merging, deletion, restoration, and printing.
  - Added bulk category changes with confirmation, progress feedback, and error reporting.
  - Added product merging for exactly two selected products.
  - Added translated labels and action icons throughout the product command bar.
  - Added shift-drag support for selecting ranges of table rows.

- **Bug Fixes**
  - Improved bulk operation handling, including skipped deleted products and partial failures.
  - Refined product restoration actions and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->