### PR TITLE
perf(frontline): only show active members in channel members list

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/channels/components/settings/members/Members.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/components/settings/members/Members.tsx
@@ -10,6 +10,9 @@ export function Members() {
   const { t } = useTranslation('frontline');
   const { id: channelId } = useParams<{ id: string }>();
   const { members, loading } = useGetChannelMembers({ channelIds: channelId });
+  const activeMembers = members?.filter(
+    (member) => member.member?.isActive !== false,
+  );
 
   if (loading) {
     return <Spinner containerClassName="py-32" />;
@@ -24,7 +27,7 @@ export function Members() {
       <div className="bg-sidebar border border-sidebar pl-1 border-t-4 border-l-4 pb-2 pr-2 rounded-lg">
         <RecordTable.Provider
           columns={columns()}
-          data={members || []}
+          data={activeMembers || []}
           stickyColumns={['more', 'checkbox', 'name']}
           className="mt-1.5"
         >

--- a/frontend/plugins/frontline_ui/src/modules/channels/graphql/queries.ts
+++ b/frontend/plugins/frontline_ui/src/modules/channels/graphql/queries.ts
@@ -54,6 +54,7 @@ const GET_CHANNEL_MEMBERS = gql`
         _id
         email
         username
+        isActive
         details {
           firstName
           lastName


### PR DESCRIPTION
## Summary by Sourcery

Filter channel members list to only display active members and request the isActive field in the channel members GraphQL query.

New Features:
- Add support for retrieving the isActive flag for channel members in the GraphQL members query.

Enhancements:
- Restrict the channel members settings table to show only active members based on the isActive flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inactive channel members are no longer displayed in the members table.
  * Member activity status is now retrieved to ensure accurate filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->