### PR TITLE
fix(operation): allow bulk status change for tasks without a team-scoped route

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksCommandBar.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksCommandBar.tsx
@@ -62,6 +62,11 @@ export const TasksCommandBar = () => {
   const [currentContent, setCurrentContent] = useState<string>('main');
   const isSingleTaskSelected = selectedRows.length === 1;
   const singleTask = isSingleTaskSelected ? selectedRows[0].original : null;
+  const selectedTeamIds = [
+    ...new Set(selectedRows.map((row: Row<ITask>) => row.original.teamId)),
+  ];
+  const statusTeamId =
+    teamId || (selectedTeamIds.length === 1 ? selectedTeamIds[0] : undefined);
 
   return (
     <CommandBar open={selectedRows.length > 0}>
@@ -90,7 +95,7 @@ export const TasksCommandBar = () => {
           <Popover.Trigger asChild>
             <Button variant="secondary">
               <IconRepeat />
-{t('actions')}
+              {t('actions')}
             </Button>
           </Popover.Trigger>
           <Popover.Content
@@ -137,7 +142,7 @@ export const TasksCommandBar = () => {
                     <TasksAssignToTrigger
                       setCurrentContent={setCurrentContent}
                     />
-                    {teamId && (
+                    {statusTeamId && (
                       <TasksEditStatusTrigger
                         setCurrentContent={setCurrentContent}
                       />
@@ -197,8 +202,12 @@ export const TasksCommandBar = () => {
                 currentTeamId={teamId}
               />
             )}
-            {currentContent === 'status' && teamId && (
-              <TasksEditStatusContent taskIds={taskIds} setOpen={setOpen} />
+            {currentContent === 'status' && statusTeamId && (
+              <TasksEditStatusContent
+                taskIds={taskIds}
+                teamId={statusTeamId}
+                setOpen={setOpen}
+              />
             )}
             {currentContent === 'project' && (
               <TasksAddProjectContent taskIds={taskIds} setOpen={setOpen} />

--- a/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksEditStatus.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/tasks-command-bar/TasksEditStatus.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next';
 import { IconChevronRight, IconProgressCheck } from '@tabler/icons-react';
 import { Command } from 'erxes-ui';
 import { SelectStatusTask } from '@/task/components/task-selects/SelectStatusTask';
-import { useParams } from 'react-router';
 import { useUpdateTask } from '@/task/hooks/useUpdateTask';
 
 export const TasksEditStatusTrigger = ({
@@ -29,14 +28,14 @@ export const TasksEditStatusTrigger = ({
 
 export const TasksEditStatusContent = ({
   taskIds,
+  teamId,
   setOpen,
 }: {
   taskIds: string[];
+  teamId: string;
   setOpen: (open: boolean) => void;
 }) => {
-  const { teamId } = useParams<{ teamId: string }>();
   const { updateTask } = useUpdateTask();
-  if (!teamId) return null;
   return (
     <SelectStatusTask.Provider
       teamId={teamId}
@@ -49,8 +48,8 @@ export const TasksEditStatusContent = ({
                 _id: taskId,
                 status: value,
               },
-            })
-          )
+            }),
+          ),
         );
         setOpen(false);
       }}


### PR DESCRIPTION
## Summary by Sourcery

Enable bulk task status changes when tasks lack a team-scoped route by deriving the team from the current selection.

Bug Fixes:
- Fix bulk status editing so it works for selected tasks even when no teamId is present in the route parameters.

Enhancements:
- Derive the effective teamId for status changes from the selected tasks when a route-level teamId is not available and pass it through the status edit components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task status editing when selected tasks share the same team.
  * Status actions now work reliably based on the selected tasks’ team when route information is unavailable.
  * Status updates continue to apply to all selected tasks and close the command bar afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->