### PR TITLE
fix(sales): apply date filters to stage totals and forecasts

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/useDealsBoardData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/useDealsBoardData.tsx
@@ -2,17 +2,31 @@
 
 import { useMemo } from 'react';
 import { useQueryState } from 'erxes-ui';
+import { useSearchParams } from 'react-router-dom';
 import { useStages } from '@/deals/stage/hooks/useStages';
 import type { BoardDealColumn } from '@/deals/types/boards';
+import { getDealsQueryVariables } from '@/deals/utils/queryVariables';
 
 export const useDealsBoardData = (): {
   columns: BoardDealColumn[];
   columnsLoading: boolean;
 } => {
   const [pipelineId] = useQueryState<string>('pipelineId');
+  const [searchParams] = useSearchParams();
+
+  const queryVariables = useMemo(
+    () =>
+      getDealsQueryVariables(searchParams, {
+        includeArchivedMode: false,
+      }),
+    [searchParams],
+  );
 
   const { stages, loading } = useStages({
-    variables: { pipelineId },
+    variables: {
+      pipelineId,
+      ...queryVariables,
+    },
     skip: !pipelineId,
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/StagesQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/StagesQueries.ts
@@ -15,8 +15,8 @@ export const commonParams = `
   $segmentData:String
   $createdStartDate: Date
   $createdEndDate: Date
-  $stateChangedStartDate: Date
-  $stateChangedEndDate: Date
+  $stageChangedStartDate: Date
+  $stageChangedEndDate: Date
   $startDateStartDate: Date
   $startDateEndDate: Date
   $closeDateStartDate: Date
@@ -38,8 +38,8 @@ export const commonParamDefs = `
   segmentData:$segmentData
   createdStartDate: $createdStartDate
   createdEndDate: $createdEndDate
-  stateChangedStartDate: $stateChangedStartDate
-  stateChangedEndDate: $stateChangedEndDate
+  stateChangedStartDate: $stageChangedStartDate
+  stateChangedEndDate: $stageChangedEndDate
   startDateStartDate: $startDateStartDate
   startDateEndDate: $startDateEndDate
   closeDateStartDate: $closeDateStartDate


### PR DESCRIPTION
## Summary

- pass active deal date-range variables to the sales stages query
- recalculate stage totals and probability forecasts for the filtered date range
- map stage-changed filter variables to the existing backend state-changed arguments

## Validation

- pnpm exec eslint frontend/plugins/sales_ui/src/modules/deals/boards/hooks/useDealsBoardData.tsx frontend/plugins/sales_ui/src/modules/deals/graphql/queries/StagesQueries.ts
- pnpm nx test sales_ui --runInBand --passWithNoTests
- pnpm nx build sales_ui

## Scope

- frontend sales plugin only
- AGENTS.md is intentionally excluded from this PR

## Summary by Sourcery

Apply deals board date and filter query parameters to the sales stages query so stage metrics reflect the currently filtered deal set.

Bug Fixes:
- Ensure sales stage totals and probability forecasts respect the active deals date-range and filter parameters on the board view.
- Map stage-changed filter parameters from the UI to the existing backend state-changed arguments in the stages GraphQL query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deal board data now respects relevant URL filters when loading stages.
  * Updated date filtering to correctly use deal stage-change dates, improving the accuracy of filtered board results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->