### PR TITLE
perf(contacts): defer card customer queries

### DIFF
--- a/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
+++ b/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
@@ -31,6 +31,7 @@ interface SelectCustomerProviderProps {
   onValueChange?: (value: string[] | string) => void;
   mode?: 'single' | 'multiple';
   hideAvatar?: boolean;
+  loadSelectedCustomers?: boolean;
 }
 
 const SelectCustomerProvider = ({
@@ -39,10 +40,10 @@ const SelectCustomerProvider = ({
   onValueChange,
   mode = 'single',
   hideAvatar,
+  loadSelectedCustomers = true,
 }: SelectCustomerProviderProps) => {
   const [customers, setCustomers] = useState<ICustomer[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
-  const customerIds = customers.map((c) => c._id);
 
   const valueIds = useMemo(() => {
     if (!value) {
@@ -51,12 +52,13 @@ const SelectCustomerProvider = ({
 
     return Array.isArray(value) ? value : [value];
   }, [value]);
+  const customerIds = valueIds;
 
   const { customers: fetchedCustomers } = useCustomers({
     variables: {
       ids: valueIds,
     },
-    skip: valueIds.length === 0,
+    skip: valueIds.length === 0 || !loadSelectedCustomers,
   });
 
   useEffect(() => {
@@ -440,6 +442,7 @@ export const SelectCustomerFilterBar = ({
       value={query || []}
       onValueChange={handleValueChange}
       hideAvatar={hideAvatar}
+      loadSelectedCustomers={!isCardVariant || !hideAvatar || open}
     >
       <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
         <SelectTriggerOperation variant={variant || 'filter'}>


### PR DESCRIPTION
## Summary

- derive selected customer IDs directly from the controlled selector value
- defer selected-customer queries while card selectors that only display a count are closed
- load selected customers when the selector opens, reducing request contention on populated sales pipelines

## Testing

- `pnpm exec eslint frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx`
- `pnpm nx build sales_ui`

## Summary by Sourcery

Defer loading of selected customers in contact selectors to reduce unnecessary queries and contention in card-based views.

New Features:
- Allow SelectCustomer components to toggle loading of selected customer details via a new loadSelectedCustomers flag.

Enhancements:
- Derive selected customer IDs directly from the controlled selector value instead of local customer state.
- Conditionally load selected customers only when relevant UI (such as card selectors showing avatars) is open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved customer selection performance by avoiding unnecessary customer loading when no selections exist.
  * Added support for deferring selected-customer loading until filter controls are opened.
  * Preserved existing behavior by enabling selected-customer loading by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->