### PR TITLE
fix(sales): search deals by customer phone

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
@@ -143,8 +143,8 @@ export const generateFilter = async (
     status
       ? { status }
       : noSkipArchive
-      ? {}
-      : { status: { $ne: SALES_STATUSES.ARCHIVED }, parentId: undefined },
+        ? {}
+        : { status: { $ne: SALES_STATUSES.ARCHIVED }, parentId: undefined },
   );
 
   let filterIds: string[] = [];

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
@@ -31,6 +31,56 @@ const isListEmpty = (value) => {
   return value.length === 1 && value[0].length === 0;
 };
 
+const getDealIdsByCustomerPhone = async (
+  subdomain: string,
+  search: string,
+): Promise<string[]> => {
+  const phoneDigits = search.replace(/\D/g, '');
+
+  if (phoneDigits.length < 4) {
+    return [];
+  }
+
+  const phonePattern = phoneDigits.split('').join('\\D*');
+  const customers: Array<{ _id: unknown }> = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'customers',
+    action: 'findActiveCustomers',
+    input: {
+      query: {
+        $or: [
+          { primaryPhone: { $regex: phonePattern } },
+          { phones: { $regex: phonePattern } },
+        ],
+      },
+      fields: { _id: 1 },
+      skip: 0,
+      limit: 0,
+    },
+    defaultValue: [],
+  });
+
+  if (!customers.length) {
+    return [];
+  }
+
+  return sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'relation',
+    action: 'filterRelationIds',
+    input: {
+      contentType: 'core:customer',
+      contentIds: customers.map(({ _id }) => String(_id)),
+      relatedContentType: 'sales:deal',
+    },
+    defaultValue: [],
+  });
+};
+
 export const generateFilter = async (
   models: IModels,
   subdomain: string,
@@ -93,8 +143,8 @@ export const generateFilter = async (
     status
       ? { status }
       : noSkipArchive
-        ? {}
-        : { status: { $ne: SALES_STATUSES.ARCHIVED }, parentId: undefined },
+      ? {}
+      : { status: { $ne: SALES_STATUSES.ARCHIVED }, parentId: undefined },
   );
 
   let filterIds: string[] = [];
@@ -301,10 +351,13 @@ export const generateFilter = async (
 
   if (search) {
     const escaped = escapeRegExp(search);
+    const customerDealIds = await getDealIdsByCustomerPhone(subdomain, search);
+
     Object.assign(filter, {
       $or: [
         { name: { $regex: escaped, $options: 'i' } },
         { number: { $regex: escaped, $options: 'i' } },
+        ...(customerDealIds.length ? [{ _id: { $in: customerDealIds } }] : []),
       ],
     });
   }


### PR DESCRIPTION
## Summary

- include deals related to customers whose primary or secondary phone matches the system search term
- normalize phone searches to digits and tolerate separators such as spaces and hyphens
- preserve existing deal name and number search behavior
- resolve customer and deal relationships through existing core tRPC contracts

## Validation

- pnpm exec eslint backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/deals.ts
- pnpm nx build sales_api
- verified plain and formatted values such as 45346544, 4534-6544, and +976 4534-6544 use the same phone match pattern

## Summary by Sourcery

New Features:
- Allow deal search results to include deals related to customers whose primary or secondary phone matches the search query, tolerating non-digit separators in phone formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deal searches now include deals associated with customers matching a phone number.
  * Phone searches support normalized digits and safely handle short or empty searches with no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->