### PR TITLE
fix(payment): preserve failed TDB invoice status

### DIFF
--- a/backend/plugins/payment_api/src/apis/tdb/api.ts
+++ b/backend/plugins/payment_api/src/apis/tdb/api.ts
@@ -89,7 +89,6 @@ export const tdbCallbackHandler = async (
     if (status === PAYMENT_STATUS.PENDING) {
       return transaction;
     }
-
     await models.Transactions.updateOne(
       { _id: transaction._id },
       {
@@ -164,7 +163,6 @@ export class TDBAPI extends BaseAPI {
     }).then((r) => r.json());
 
     const status = (response?.order?.status || '').toUpperCase();
-
     switch (status) {
       case 'FULLYPAID':
       case 'PARTPAID':
@@ -172,6 +170,11 @@ export class TDBAPI extends BaseAPI {
       case 'PAID':
         return PAYMENT_STATUS.PAID;
 
+      case 'CLOSED':
+      case 'DECLINED':
+      case 'REFUSED':
+      case 'REJECTED':
+      case 'VOIDED':
       case 'EXPIRED':
         return PAYMENT_STATUS.FAILED;
 

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -130,7 +130,7 @@ export const loadInvoiceClass = (models: IModels) => {
               },
               update: {
                 $set: {
-                  status: statusChecks[index] === 'paid' ? 'paid' : 'pending',
+                  status: statusChecks[index],
                 },
               },
             },
@@ -164,6 +164,15 @@ export const loadInvoiceClass = (models: IModels) => {
       ]);
 
       if (totalAmount.length === 0) {
+        const failed = await models.Transactions.exists({
+          invoiceId: _id,
+          status: PAYMENT_STATUS.FAILED,
+        });
+
+        if (failed) {
+          return PAYMENT_STATUS.FAILED;
+        }
+
         return PAYMENT_STATUS.PENDING;
       }
 


### PR DESCRIPTION
## Summary by Sourcery

Preserve failed TDB invoice and transaction statuses and map additional TDB terminal failure states to internal FAILED payments.

Bug Fixes:
- Avoid overwriting existing paid or failed invoice statuses by directly using the computed status value.
- Return FAILED status for invoices when any associated transaction has already failed even if no payments are recorded.

Enhancements:
- Map additional TDB order terminal states (closed/declined/refused/rejected/voided) to internal FAILED payment status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment status reporting for closed, declined, refused, rejected, and voided invoices.
  * Failed transactions are now correctly reflected as failed payments instead of remaining pending.
  * Invoice checks now distinguish between failed and pending payment states more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->