### PR TITLE
feat/update TagsSelect to display selected tags count and add showSelected…

### DIFF
--- a/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags-new/components/TagsSelect.tsx
@@ -18,7 +18,7 @@ import type { VariantProps } from 'class-variance-authority';
 import React, { useState, useEffect, useMemo, forwardRef } from 'react';
 import { TagInline } from './TagInline';
 import { ITag } from 'ui-modules/modules/tags-new/types/Tag';
-import { IconCheck, IconPlus, IconTags } from '@tabler/icons-react';
+import { IconCheck, IconPlus, IconTag, IconTags } from '@tabler/icons-react';
 import { TagBadge } from 'ui-modules/modules/tags-new/components/TagBadge';
 import { useTagAdd } from 'ui-modules/modules/tags-new/hooks/useTagAdd';
 import { TAG_DEFAULT_COLORS } from 'ui-modules/modules/tags-new/constants';
@@ -147,17 +147,22 @@ const TagsSelectValue = ({
   showValue?: boolean;
   placeholder?: string;
 }) => {
-  const { selectedTags, mode } = useTagsSelectContext();
+  const { selectedTags } = useTagsSelectContext();
 
-  const text = useMemo(() => {
-    if (selectedTags.length === 0 || !showValue)
-      return placeholder || 'Select Tag';
-    if (mode === 'single') return selectedTags[0].name;
-    if (selectedTags.length === 1) return selectedTags[0].name;
-    return `${selectedTags.length} tags selected`;
-  }, [selectedTags, mode, showValue, placeholder]);
+  if (showValue && selectedTags.length > 0) {
+    return (
+      <span className="flex gap-1 items-center text-muted-foreground">
+        <IconTag className="w-4 h-4 text-gray-400" /> Tag +{selectedTags.length}
+      </span>
+    );
+  }
 
-  return <span>{text}</span>;
+  return (
+    <span className="flex gap-1 items-center">
+      <IconTags className="size-4" />
+      {placeholder || 'Select Tag'}
+    </span>
+  );
 };
 
 TagsSelectValue.displayName = 'TagsSelectValue';
@@ -189,8 +194,7 @@ const TagsSelectTrigger = forwardRef<
         {...props}
         className={cn('w-min text-sm font-medium shadow-xs', props.className)}
       >
-        <IconTags />
-        <TagsSelectValue showValue={false} placeholder={placeholder} />
+        <TagsSelectValue showValue={showValue} placeholder={placeholder} />
       </Button>
     </Popover.Trigger>
   );

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
@@ -175,6 +175,7 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
         />
         <DealTagsChip
           value={optimisticTags.value}
+          showSelectedTagsOutside={false}
           onValueChange={(value) =>
             optimisticTags.setValue(normalizeMultiValue(value))
           }

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/DealDetailChips.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/DealDetailChips.tsx
@@ -72,7 +72,11 @@ export const DealAssigneeChip = ({
   );
 };
 
-export const DealTagsChip = ({ value, onValueChange }: ChipProps) => {
+export const DealTagsChip = ({
+  value,
+  onValueChange,
+  showSelectedTagsOutside = true,
+}: ChipProps & { showSelectedTagsOutside?: boolean }) => {
   const { t } = useTranslation('sales');
   let tagIds: string[] = [];
 
@@ -90,8 +94,12 @@ export const DealTagsChip = ({ value, onValueChange }: ChipProps) => {
       onValueChange={onValueChange}
     >
       <div className="flex flex-wrap items-center gap-2">
-        <TagsSelect.Trigger variant="outline" placeholder={t('select-tags')} />
-        <TagsSelect.SelectedList />
+        <TagsSelect.Trigger
+          variant="outline"
+          placeholder={t('select-tags')}
+          showValue
+        />
+        {showSelectedTagsOutside ? <TagsSelect.SelectedList /> : null}
         <Combobox.Content>
           <TagsSelect.Content />
         </Combobox.Content>


### PR DESCRIPTION
…TagsOutside prop to DealTagsChip

## Summary by Sourcery

Update tag selection UI to show a compact count of selected tags in the trigger and make displaying the full selected tag list configurable for deal tags.

New Features:
- Display a tag icon and selected tag count in the TagsSelect trigger when tags are selected.
- Add a showSelectedTagsOutside option to DealTagsChip to control whether selected tags are rendered outside the selector.

Enhancements:
- Adjust DealTagsChip usage in SalesFormFields to rely on the compact selection display instead of the external selected tags list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated tag selectors to display a tags icon, placeholder text, and the number of selected tags more clearly.
  * Improved deal tag chips to show selected tags within the control by default.
  * Added flexibility to keep selected tags inside the chip or display them separately where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->