### PR TITLE
feat(payment): per-ticket QR codes with idempotent email and scan tracking

### DIFF
--- a/backend/plugins/payment_api/src/apis/controller.ts
+++ b/backend/plugins/payment_api/src/apis/controller.ts
@@ -162,6 +162,7 @@ export const callbackHandler = async (req, res) => {
 
         enqueuePaidInvoiceCallback(
           subdomain,
+          models,
           invoice,
           payment,
           'paymentCallback',

--- a/backend/plugins/payment_api/src/modules/payment/@types/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/@types/invoices.ts
@@ -1,7 +1,6 @@
 import { Document } from 'mongoose';
 import { ITransaction } from './transactions';
 
-
 export interface IInvoice {
   invoiceNumber: string;
   amount: number;

--- a/backend/plugins/payment_api/src/modules/payment/@types/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/@types/invoices.ts
@@ -17,6 +17,8 @@ export interface IInvoice {
   createdAt: Date;
   resolvedAt?: Date;
   scannedAt?: Date;
+  scannedCodes?: string[];
+  qrEmailSentAt?: Date;
   redirectUri?: string;
   paymentIds: string[];
   callback?: string;

--- a/backend/plugins/payment_api/src/modules/payment/db/definitions/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/definitions/invoices.ts
@@ -23,6 +23,8 @@ export const invoiceSchema = schemaWrapper(
     createdAt: { type: Date, default: Date.now },
     resolvedAt: { type: Date },
     scannedAt: { type: Date },
+    scannedCodes: { type: [String], default: [] },
+    qrEmailSentAt: { type: Date },
     data: { type: Schema.Types.Mixed },
     apiResponse: { type: Schema.Types.Mixed },
     callback: { type: String },

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -228,7 +228,10 @@ export const loadInvoiceClass = (models: IModels) => {
         throw new Error('Invoice is not paid');
       }
 
-      const quantity = Math.max(1, Math.floor(Number(invoice.data?.quantity) || 1));
+      const quantity = Math.max(
+        1,
+        Math.floor(Number(invoice.data?.quantity) || 1),
+      );
 
       if (quantity > 1 && (index === null || index < 1 || index > quantity)) {
         throw new Error('Invalid ticket code');

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -209,21 +209,45 @@ export const loadInvoiceClass = (models: IModels) => {
     }
 
     public static async scanBarcode(code: string) {
-      const invoice = await models.Invoices.findOneAndUpdate(
-        { invoiceNumber: code, scannedAt: null },
-        { $set: { scannedAt: new Date() } },
+      let invoice = await models.Invoices.findOne({ invoiceNumber: code });
+      let index: number | null = null;
+
+      if (!invoice) {
+        const match = code.match(/^(.+)-(\d+)$/);
+        if (match) {
+          invoice = await models.Invoices.findOne({ invoiceNumber: match[1] });
+          index = Number(match[2]);
+        }
+      }
+
+      if (!invoice) {
+        throw new Error(`Invoice not found for barcode: ${code}`);
+      }
+
+      if (invoice.status !== 'paid') {
+        throw new Error('Invoice is not paid');
+      }
+
+      const quantity = Math.max(1, Math.floor(Number(invoice.data?.quantity) || 1));
+
+      if (quantity > 1 && (index === null || index < 1 || index > quantity)) {
+        throw new Error('Invalid ticket code');
+      }
+
+      const scanned = await models.Invoices.findOneAndUpdate(
+        { _id: invoice._id, scannedCodes: { $ne: code } },
+        {
+          $addToSet: { scannedCodes: code },
+          $set: { scannedAt: new Date() },
+        },
         { new: true },
       );
 
-      if (!invoice) {
-        const exists = await models.Invoices.exists({ invoiceNumber: code });
-        if (!exists) {
-          throw new Error(`Invoice not found for barcode: ${code}`);
-        }
+      if (!scanned) {
         throw new Error('Barcode already scanned');
       }
 
-      return invoice;
+      return scanned;
     }
 
     public static async markAsPaid(_id: string) {

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/customResolvers/invoice.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/customResolvers/invoice.ts
@@ -19,6 +19,15 @@ export default {
     return invoice.description || invoice.invoiceNumber;
   },
 
+  ticketCount(invoice: IInvoiceDocument) {
+    const quantity = Math.floor(Number((invoice.data as any)?.quantity) || 1);
+    return Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+  },
+
+  scannedCount(invoice: IInvoiceDocument) {
+    return invoice.scannedCodes?.length || 0;
+  },
+
   async remainingAmount(
     invoice: IInvoiceDocument,
     _args,

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/customResolvers/invoice.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/customResolvers/invoice.ts
@@ -74,8 +74,6 @@ export default {
     }
   },
 
-
-
   idOfProvider(invoice: IInvoiceDocument) {
     return '';
     // const apiResponse: any = invoice.apiResponse || {};

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -83,7 +83,13 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
       const payment = await resolvePaymentForInvoice(models, invoice);
 
-      enqueuePaidInvoiceCallback(subdomain, invoice, payment, 'invoicesCheck');
+      enqueuePaidInvoiceCallback(
+        subdomain,
+        models,
+        invoice,
+        payment,
+        'invoicesCheck',
+      );
 
       if (invoice.callback) {
         // Fire callback – do not await
@@ -133,6 +139,7 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
       enqueuePaidInvoiceCallback(
         subdomain,
+        models,
         invoice,
         payment,
         'cpInvoicesCheck',
@@ -176,18 +183,6 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
     { code }: { code: string },
     { models }: IContext,
   ) {
-    const invoice = await models.Invoices.findOne({
-      invoiceNumber: code,
-    }).lean();
-
-    if (!invoice) {
-      throw new Error('Invoice not found');
-    }
-
-    if (invoice.status !== 'paid') {
-      throw new Error('Invoice is not paid');
-    }
-
     const scanned = await models.Invoices.scanBarcode(code);
 
     graphqlPubsub.publish(`invoiceUpdated:${scanned._id}`, {

--- a/backend/plugins/payment_api/src/modules/payment/graphql/schemas/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/schemas/invoices.ts
@@ -27,6 +27,8 @@ export const types = `
     createdAt: Date
     resolvedAt: Date
     scannedAt: Date
+    scannedCount: Int
+    ticketCount: Int
     redirectUri: String
     paymentIds: [String]
 

--- a/backend/plugins/payment_api/src/modules/payment/services/invoiceQrEmail.ts
+++ b/backend/plugins/payment_api/src/modules/payment/services/invoiceQrEmail.ts
@@ -18,8 +18,8 @@ const buildQrTableHtml = (code: string): string => {
             (_, c) => `
             <td width="${cell}" height="${cell}"
               style="width:${cell}px;height:${cell}px;background:${
-              data[r * size + c] ? '#000' : '#fff'
-            };padding:0;border:none;font-size:0;line-height:0;"></td>
+                data[r * size + c] ? '#000' : '#fff'
+              };padding:0;border:none;font-size:0;line-height:0;"></td>
           `,
           ).join('')}
         </tr>

--- a/backend/plugins/payment_api/src/modules/payment/services/invoiceQrEmail.ts
+++ b/backend/plugins/payment_api/src/modules/payment/services/invoiceQrEmail.ts
@@ -1,0 +1,177 @@
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import * as QRCode from 'qrcode';
+
+const buildQrTableHtml = (code: string): string => {
+  const qr = (QRCode as any).create(code, { errorCorrectionLevel: 'M' });
+  const { size, data } = qr.modules;
+  const cell = 6;
+
+  return `
+    <table cellpadding="0" cellspacing="0" border="0"
+      style="border-collapse:collapse;background:#fff;border:16px solid #fff">
+      ${Array.from(
+        { length: size },
+        (_, r) => `
+        <tr height="${cell}">
+          ${Array.from(
+            { length: size },
+            (_, c) => `
+            <td width="${cell}" height="${cell}"
+              style="width:${cell}px;height:${cell}px;background:${
+              data[r * size + c] ? '#000' : '#fff'
+            };padding:0;border:none;font-size:0;line-height:0;"></td>
+          `,
+          ).join('')}
+        </tr>
+      `,
+      ).join('')}
+    </table>
+  `;
+};
+
+const getQuantity = (invoice: any): number => {
+  const raw = invoice?.data?.quantity;
+  const quantity = Number(raw);
+  return Number.isFinite(quantity) && quantity > 0 ? Math.floor(quantity) : 1;
+};
+
+const buildTicketCodes = (invoice: any): string[] => {
+  const base = invoice.invoiceNumber || invoice._id;
+  const quantity = getQuantity(invoice);
+
+  if (quantity <= 1) {
+    return [base];
+  }
+
+  return Array.from({ length: quantity }, (_, index) => `${base}-${index + 1}`);
+};
+
+export const sendInvoiceQrEmail = async (subdomain: string, invoice: any) => {
+  if (!invoice.email) {
+    return;
+  }
+
+  const title = invoice.description || 'Тасалбар';
+  const amountStr = invoice.amount
+    ? `${invoice.amount.toLocaleString()} ${invoice.currency || 'MNT'}`
+    : '';
+
+  const codes = buildTicketCodes(invoice);
+
+  const ticketsHtml = codes
+    .map(
+      (code, index) => `
+      <tr>
+        <td style="padding:24px 32px;text-align:center;border-bottom:2px dashed #e5e7eb">
+          ${
+            codes.length > 1
+              ? `<p style="margin:0 0 8px;color:#111827;font-size:13px;font-weight:600">
+                   Тасалбар ${index + 1} / ${codes.length}
+                 </p>`
+              : ''
+          }
+          <p style="margin:0 0 16px;color:#6b7280;font-size:13px">
+            QR кодыг уншуулан нэвтрэнэ үү
+          </p>
+          <div align="center">${buildQrTableHtml(code)}</div>
+          <p style="margin:16px 0 0;color:#374151;font-size:13px;font-family:monospace">
+            ${code}
+          </p>
+        </td>
+      </tr>
+    `,
+    )
+    .join('');
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="margin:0;padding:0;background:#f4f4f4;font-family:sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 0">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0"
+          style="background:#fff;border-radius:12px;overflow:hidden">
+          <tr>
+            <td style="background:#111827;padding:24px 32px;text-align:center">
+              <p style="margin:0;color:#9ca3af;font-size:12px;text-transform:uppercase">
+                Төлбөр амжилттай
+              </p>
+              <h1 style="margin:8px 0 0;color:#fff;font-size:22px">${title}</h1>
+            </td>
+          </tr>
+          ${ticketsHtml}
+          ${
+            amountStr
+              ? `<tr>
+                   <td style="padding:24px 32px">
+                     <table width="100%">
+                       <tr>
+                         <td style="color:#6b7280;font-size:13px">Төлсөн дүн</td>
+                         <td style="color:#111827;font-size:13px;font-weight:600;text-align:right">
+                           ${amountStr}
+                         </td>
+                       </tr>
+                     </table>
+                   </td>
+                 </tr>`
+              : ''
+          }
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`;
+
+  await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'mutation',
+    module: 'notifications',
+    action: 'sendEmail',
+    input: {
+      toEmails: [invoice.email],
+      title: `Тасалбар – ${title}`,
+      customHtml: html,
+    },
+    defaultValue: null,
+  });
+};
+
+export const sendInvoiceQrEmailOnce = async (
+  subdomain: string,
+  models: any,
+  invoice: any,
+) => {
+  // `qrEmailSentAt: null` matches both a missing field and an explicit null
+  const claimed = await models.Invoices.findOneAndUpdate(
+    { _id: invoice._id, qrEmailSentAt: null },
+    { $set: { qrEmailSentAt: new Date() } },
+  );
+
+  if (!claimed) {
+    process.stdout.write(
+      `[invoiceQrEmail] Skipped invoice ${invoice._id}: QR email already sent\n`,
+    );
+    return;
+  }
+
+  try {
+    await sendInvoiceQrEmail(subdomain, invoice);
+
+    process.stdout.write(
+      `[invoiceQrEmail] Sent QR email for invoice ${invoice._id} to ${invoice.email}\n`,
+    );
+  } catch (e) {
+    // release the claim so the next paid-check retries instead of staying silent
+    await models.Invoices.updateOne(
+      { _id: invoice._id },
+      { $unset: { qrEmailSentAt: '' } },
+    );
+
+    throw e;
+  }
+};

--- a/backend/plugins/payment_api/src/modules/payment/services/paidInvoiceCallback.ts
+++ b/backend/plugins/payment_api/src/modules/payment/services/paidInvoiceCallback.ts
@@ -1,6 +1,7 @@
 import { splitType } from 'erxes-api-shared/core-modules';
 import { sendWorkerQueue } from 'erxes-api-shared/utils';
 import { IPaymentDealConfig } from '~/modules/payment/@types/payment';
+import { sendInvoiceQrEmailOnce } from '~/modules/payment/services/invoiceQrEmail';
 
 const JOB_OPTIONS = {
   attempts: 3,
@@ -28,12 +29,29 @@ export const resolvePaymentForInvoice = async (models: any, invoice: any) => {
 
 export const enqueuePaidInvoiceCallback = (
   subdomain: string,
+  models: any,
   invoice: any,
   payment: PaymentLike,
   logPrefix: string,
 ) => {
   const sendEmailOnPayment = payment?.sendEmailOnPayment !== false;
   const dealConfig = payment?.dealConfig;
+
+  if (!sendEmailOnPayment) {
+    process.stdout.write(
+      `[${logPrefix}] Skipped QR email for invoice ${invoice._id}: sendEmailOnPayment is off on the payment method\n`,
+    );
+  } else if (!invoice.email) {
+    process.stdout.write(
+      `[${logPrefix}] Skipped QR email for invoice ${invoice._id}: invoice has no email\n`,
+    );
+  } else {
+    sendInvoiceQrEmailOnce(subdomain, models, invoice).catch((err) => {
+      process.stderr.write(
+        `[${logPrefix}] Failed to send QR email for invoice ${invoice._id}: ${err.message}\n`,
+      );
+    });
+  }
 
   const baseData = {
     ...invoice,

--- a/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceColumns.tsx
+++ b/frontend/plugins/payment_ui/src/modules/payment/components/InvoiceColumns.tsx
@@ -103,19 +103,26 @@ export const invoicesColumns = (
     header: () => (
       <RecordTable.InlineHead label={t('scanned')} icon={IconQrcode} />
     ),
-    cell: ({ cell }) => {
-      const scannedAt = cell.getValue() as string | undefined;
+    cell: ({ row }) => {
+      const { scannedAt, ticketCount = 1 } = row.original as IInvoice;
+      const scannedCount = Math.max(
+        (row.original as IInvoice).scannedCount || 0,
+        scannedAt ? 1 : 0,
+      );
+
+      if (scannedCount === 0) {
+        return (
+          <RecordTableInlineCell>
+            <Badge variant="secondary">{t('not-scanned')}</Badge>
+          </RecordTableInlineCell>
+        );
+      }
+
       return (
         <RecordTableInlineCell>
-          {scannedAt ? (
-            <RelativeDateDisplay value={scannedAt} asChild>
-              <Badge variant="success">
-                <RelativeDateDisplay.Value value={scannedAt} />
-              </Badge>
-            </RelativeDateDisplay>
-          ) : (
-            <Badge variant="secondary">{t('not-scanned')}</Badge>
-          )}
+          <Badge variant={scannedCount >= ticketCount ? 'success' : 'warning'}>
+            {scannedCount} / {ticketCount}
+          </Badge>
         </RecordTableInlineCell>
       );
     },

--- a/frontend/plugins/payment_ui/src/modules/payment/graphql/queries.ts
+++ b/frontend/plugins/payment_ui/src/modules/payment/graphql/queries.ts
@@ -77,6 +77,8 @@ export const INVOICES = gql`
         invoiceNumber
         status
         scannedAt
+        scannedCount
+        ticketCount
         transactions {
           amount
           createdAt

--- a/frontend/plugins/payment_ui/src/modules/payment/types/Payment.ts
+++ b/frontend/plugins/payment_ui/src/modules/payment/types/Payment.ts
@@ -48,6 +48,8 @@ export interface IInvoice {
   invoiceNumber: string;
   status: string;
   scannedAt?: Date;
+  scannedCount?: number;
+  ticketCount?: number;
   transactions: {
     amount: number;
     createdAt: Date;


### PR DESCRIPTION
## Summary by Sourcery

Introduce per-ticket QR codes with idempotent email delivery and enhanced scan tracking for invoices

New Features:
- Generate and email QR codes for each ticket associated with a paid invoice, including multi-ticket support
- Expose ticket and scan counts for invoices via GraphQL and surface them in the payment UI invoice table

Bug Fixes:
- Ensure scanning an already-used barcode produces a clear error instead of updating scan metadata multiple times

Enhancements:
- Track individual barcode scans per invoice and prevent duplicate scans using scanned code lists
- Refine invoice scan validation to support indexed ticket codes, enforce paid status, and validate ticket index ranges
- Make paid-invoice callbacks capable of conditionally sending QR emails once per invoice based on payment method and invoice email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR-code ticket emails for successfully paid invoices.
  * Added ticket and scan counts to invoice data.
  * Improved barcode scanning with ticket quantities, duplicate-scan prevention, and payment validation.

* **UI Improvements**
  * Invoice scan status now displays progress, including completed and incomplete scans.
  * Added clearer “not scanned” status for invoices without scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->