### PR TITLE
feat(frontline): split pasted form options into separate tags

### DIFF
--- a/apps/frontline-widgets/Dockerfile
+++ b/apps/frontline-widgets/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache alpine-sdk && \
 FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm@9.12.3 && pnpm install
 COPY . .
 RUN pnpm nx build frontline-widgets --configuration=production --verbose
 

--- a/frontend/core-ui/Dockerfile
+++ b/frontend/core-ui/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache alpine-sdk && \
 FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm@9.12.3 && pnpm install
 COPY . .
 RUN pnpm nx build core-ui --configuration=production --verbose
 

--- a/frontend/libs/erxes-ui/src/components/string-array.tsx
+++ b/frontend/libs/erxes-ui/src/components/string-array.tsx
@@ -3,6 +3,7 @@
 import { type Tag, TagInput } from 'emblor';
 import { cn } from 'erxes-ui/lib';
 import { useState } from 'react';
+import { handleStringArrayPaste } from '../utils/string-array';
 
 export function StringArrayInput({
   value,
@@ -11,6 +12,7 @@ export function StringArrayInput({
   placeholder,
   styleClasses,
   onBlur,
+  splitOnPaste = false,
 }: {
   value: string[];
   onValueChange: (value: string[]) => void;
@@ -25,8 +27,10 @@ export function StringArrayInput({
     };
   };
   onBlur?: () => void;
+  splitOnPaste?: boolean;
 }) {
   const [activeTagIndex, setActiveTagIndex] = useState<number | null>(null);
+
   return (
     <TagInput
       activeTagIndex={activeTagIndex}
@@ -58,6 +62,11 @@ export function StringArrayInput({
       }}
       tags={value.map((tag) => ({ id: tag, text: tag }))}
       onBlur={onBlur}
+      inputProps={{
+        onPaste: (event) =>
+          splitOnPaste &&
+          handleStringArrayPaste({ event, value, onValueChange }),
+      }}
     />
   );
 }

--- a/frontend/libs/erxes-ui/src/utils/index.ts
+++ b/frontend/libs/erxes-ui/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './localization';
 export * from './regex';
 export * from './IsUndefinedOrNull';
 export * from './isEnabled';
+export * from './string-array';

--- a/frontend/libs/erxes-ui/src/utils/string-array.ts
+++ b/frontend/libs/erxes-ui/src/utils/string-array.ts
@@ -1,0 +1,24 @@
+import { type ClipboardEvent } from 'react';
+
+export const handleStringArrayPaste = ({
+  event,
+  value,
+  onValueChange,
+}: {
+  event: ClipboardEvent<HTMLInputElement>;
+  value: string[];
+  onValueChange: (value: string[]) => void;
+}) => {
+  const pastedValues = event.clipboardData
+    .getData('text')
+    .split(/\r\n|\r|\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (pastedValues.length <= 1) {
+    return;
+  }
+
+  event.preventDefault();
+  onValueChange(Array.from(new Set([...value, ...pastedValues])));
+};

--- a/frontend/plugins/frontline_ui/src/modules/forms/components/FormFieldDetail.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/forms/components/FormFieldDetail.tsx
@@ -333,10 +333,9 @@ export const FormFieldDetail = ({
                   styleClasses={{
                     inlineTagsContainer: 'shadow-xs',
                   }}
-                  value={fieldData?.options ?? []}
-                  onValueChange={(value) =>
-                    handleValueChange('options', value as string[])
-                  }
+                  value={fieldData.options}
+                  onValueChange={(value) => handleValueChange('options', value)}
+                  splitOnPaste
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary by Sourcery

Add paste-splitting support for string array inputs and enable it for frontline form option fields.

New Features:
- Allow StringArrayInput to optionally split pasted multiline text into separate tags via a splitOnPaste flag.

Enhancements:
- Extract shared string array paste-handling logic into a reusable utility and expose it via the UI utils index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional paste splitting for string-array inputs.
  * Pasting multiple newline-separated values now trims entries, removes duplicates, and adds them to the existing list.
  * Single-value pastes continue to work normally.

* **Improvements**
  * Form fields now preserve and apply configured string-array options more consistently.
  * Empty lines and unnecessary spaces are automatically excluded when multiple values are pasted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->