### PR TITLE
Feat/mask frontline integrations config secret

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/call/db/models/Integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/db/models/Integrations.ts
@@ -8,16 +8,12 @@ import {
 import { integrationSchema } from '@/integrations/call/db/definitions/integrations';
 
 export interface ICallIntegrationModel extends Model<ICallIntegrationDocument> {
-  getIntegrations(
-    userId: string,
-  ): Promise<ICallIntegration[]>;
+  getIntegrations(userId: string): Promise<ICallIntegration[]>;
   getIntegration(
     userId: string,
     integrationId: string,
   ): Promise<ICallIntegrationDocument>;
-  getIntegrationQueuesByUser(
-    userId: string,
-  ): Promise<string[]>;
+  getIntegrationQueuesByUser(userId: string): Promise<string[]>;
 }
 
 export const loadCallIntegrationClass = (models: IModels) => {

--- a/backend/plugins/frontline_api/src/modules/integrations/call/db/models/Integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/db/models/Integrations.ts
@@ -10,7 +10,7 @@ import { integrationSchema } from '@/integrations/call/db/definitions/integratio
 export interface ICallIntegrationModel extends Model<ICallIntegrationDocument> {
   getIntegrations(
     userId: string,
-  ): Promise<ICallIntegrationDocument>;
+  ): Promise<ICallIntegration[]>;
   getIntegration(
     userId: string,
     integrationId: string,

--- a/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/mutations.ts
@@ -207,7 +207,8 @@ const callsMutations = {
       user,
     );
 
-    const status = callTransferResponse?.status ?? callTransferResponse?.response?.status;
+    const status =
+      callTransferResponse?.status ?? callTransferResponse?.response?.status;
     if (status === 0 || callTransferResponse?.response?.need_apply) {
       return 'success';
     }

--- a/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/call/graphql/resolvers/mutations.ts
@@ -75,7 +75,13 @@ const callsMutations = {
     };
   },
 
-  async callsUpdateConfigs(_root, { configsMap }, { models }: IContext) {
+  async callsUpdateConfigs(
+    _root,
+    { configsMap },
+    { models, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
     await models.CallConfigs.updateConfigs(configsMap);
 
     return { status: 'ok' };

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
@@ -12,7 +12,13 @@ import {
 import { sendNotifications } from '@/inbox/graphql/resolvers/mutations/conversations';
 import { TCreateBotInputDoc } from '../../db/models/Bots';
 export const facebookMutations = {
-  async facebookUpdateConfigs(_root, { configsMap }, { subdomain }: IContext) {
+  async facebookUpdateConfigs(
+    _root,
+    { configsMap },
+    { subdomain, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
     await updateConfigs(subdomain, configsMap);
 
     return { status: 'ok' };

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/queries.ts
@@ -98,7 +98,13 @@ const appendRelatedMessengerMessages = async (
 };
 
 export const facebookQueries = {
-  async facebookGetConfigs(_root, _args, { models }: IContext) {
+  async facebookGetConfigs(
+    _root,
+    _args,
+    { models, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
     return await models.FacebookConfigs.find({});
   },
   async facebookGetAccounts(_root, { kind }: IKind, { models }: IContext) {

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/mutations.ts
@@ -8,7 +8,13 @@ import { sendReply } from '@/integrations/instagram/utils';
 import { sendNotifications } from '@/inbox/graphql/resolvers/mutations/conversations';
 
 export const instagramMutations = {
-  async instagramUpdateConfigs(_root, { configsMap }, { subdomain }: IContext) {
+  async instagramUpdateConfigs(
+    _root,
+    { configsMap },
+    { subdomain, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
     await updateConfigs(subdomain, configsMap);
 
     return { status: 'ok' };

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
@@ -47,7 +47,13 @@ export const instagramQueries = {
     return models.InstagramIntegrations.findOne({ erxesApiId });
   },
 
-  async instagramGetConfigs(_root, _args, { models }: IContext) {
+  async instagramGetConfigs(
+    _root,
+    _args,
+    { models, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
     return models.InstagramConfigs.find({}).lean();
   },
 
@@ -202,7 +208,7 @@ export const instagramQueries = {
     { models }: IContext,
   ) {
     const conversation = await models.Conversations.findOne({ _id });
-    if (conversation) {
+   if (conversation) {
       return conversation;
     }
     return models.InstagramCommentConversation.findOne({ _id });
@@ -224,7 +230,7 @@ export const instagramQueries = {
       models.InstagramConversations,
     );
 
-   if (conversation) {
+    if (conversation) {
       if (limit) {
         const sort: any = getFirst ? { createdAt: 1 } : { createdAt: -1 };
 

--- a/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/instagram/graphql/resolvers/queries.ts
@@ -208,7 +208,7 @@ export const instagramQueries = {
     { models }: IContext,
   ) {
     const conversation = await models.Conversations.findOne({ _id });
-   if (conversation) {
+    if (conversation) {
       return conversation;
     }
     return models.InstagramCommentConversation.findOne({ _id });
@@ -438,7 +438,9 @@ export const instagramQueries = {
           ? facebookPageTokensMap[facebookPageId]
           : undefined;
         if (!accessToken) {
-          debugInstagram(`Access token missing for page ID: ${instagramPageId}`);
+          debugInstagram(
+            `Access token missing for page ID: ${instagramPageId}`,
+          );
           return [];
         }
 

--- a/frontend/plugins/frontline_ui/src/modules/FrontlineSettings.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/FrontlineSettings.tsx
@@ -1,6 +1,7 @@
 import { FrontlinePaths } from '@/types/FrontlinePaths';
 import { lazy, Suspense } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { usePermissionCheck } from 'ui-modules';
 
 const ConfigsSettings = lazy(() => import('@/integrations-config/Settings'));
 
@@ -14,13 +15,27 @@ const FormPreviewPage = lazy(() =>
   })),
 );
 
+const IntegrationsConfigRoute = () => {
+  const { isLoaded, hasActionPermission } = usePermissionCheck();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  if (!hasActionPermission('integrationsEdit')) {
+    return <Navigate to="/settings" replace />;
+  }
+
+  return <ConfigsSettings />;
+};
+
 const FrontlineSettings = () => {
   return (
     <Suspense fallback={<div />}>
       <Routes>
         <Route
           path={FrontlinePaths.IntegrationConfig}
-          element={<ConfigsSettings />}
+          element={<IntegrationsConfigRoute />}
         />
         <Route
           path={FrontlinePaths.ChannelsCatchAll}

--- a/frontend/plugins/frontline_ui/src/modules/FrontlineSettingsNavigation.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/FrontlineSettingsNavigation.tsx
@@ -1,5 +1,6 @@
 import { FrontlinePaths } from '@/types/FrontlinePaths';
 import { SettingsNavigationMenuLinkItem, Sidebar } from 'erxes-ui';
+import { Can } from 'ui-modules';
 
 export const FrontlineSettingsNavigation = () => {
   return (
@@ -13,11 +14,13 @@ export const FrontlineSettingsNavigation = () => {
             name="Channels"
           />
 
-          <SettingsNavigationMenuLinkItem
-            pathPrefix={FrontlinePaths.Frontline}
-            path={FrontlinePaths.IntegrationConfig}
-            name="Integrations Config"
-          />
+          <Can action="integrationsEdit">
+            <SettingsNavigationMenuLinkItem
+              pathPrefix={FrontlinePaths.Frontline}
+              path={FrontlinePaths.IntegrationConfig}
+              name="Integrations Config"
+            />
+          </Can>
         </Sidebar.Menu>
       </Sidebar.GroupContent>
     </Sidebar.Group>

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallConfigUpdate.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallConfigUpdate.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+import { SecretInput } from '@/integrations/components/SecretInput';
 
 export const CallConfigUpdateCollapse = () => {
   const { t } = useTranslation('frontline');
@@ -132,7 +133,7 @@ export const CallConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('turn-server-username')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -144,7 +145,7 @@ export const CallConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('turn-server-credential')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/components/SipContainer.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/components/SipContainer.tsx
@@ -19,7 +19,9 @@ export const SipContainer = ({ children }: { children: React.ReactNode }) => {
 
   const { callUserIntegrations, loading: callUserIntegrationLoading } =
     useCallUserIntegration();
-  const { callConfigs, loading: callConfigLoading } = useCallGetConfigs();
+  const { callConfigs, loading: callConfigLoading } = useCallGetConfigs({
+    skip: callUserIntegrationLoading || Boolean(!callUserIntegrations?.length),
+  });
 
   const { createActiveSession } = useCallCreateSession();
 

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/hooks/useCallGetConfigs.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/hooks/useCallGetConfigs.ts
@@ -3,11 +3,14 @@ import { CALL_GET_CONFIGS } from '../graphql/queries/callConfigQueries';
 import { toast } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 
-export const useCallGetConfigs = () => {
+export const useCallGetConfigs = ({
+  skip = false,
+}: { skip?: boolean } = {}) => {
   const { t } = useTranslation('frontline');
   const { data, loading } = useQuery<{
     callsGetConfigs: { _id: string; code: string; value: string }[];
   }>(CALL_GET_CONFIGS, {
+    skip,
     onError: (e) => {
       toast({
         title: t('something-went-wrong-getting-configs'),

--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/SecretInput.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/SecretInput.tsx
@@ -1,0 +1,60 @@
+import { IconCopy, IconEye, IconEyeOff } from '@tabler/icons-react';
+import { Button, cn, Input, toast } from 'erxes-ui';
+import { ComponentPropsWithoutRef, forwardRef, useState } from 'react';
+
+type SecretInputProps = Omit<ComponentPropsWithoutRef<typeof Input>, 'type'>;
+
+export const SecretInput = forwardRef<HTMLInputElement, SecretInputProps>(
+  ({ className, value, ...props }, ref) => {
+    const [isVisible, setIsVisible] = useState(false);
+    const secret = typeof value === 'string' ? value : '';
+
+    const handleCopy = async () => {
+      try {
+        await navigator.clipboard.writeText(secret);
+        toast({ title: 'Secret copied to clipboard', variant: 'success' });
+      } catch {
+        toast({ title: 'Failed to copy secret', variant: 'destructive' });
+      }
+    };
+
+    return (
+      <div className="relative">
+        <Input
+          {...props}
+          ref={ref}
+          value={secret}
+          type={isVisible ? 'text' : 'password'}
+          autoComplete="off"
+          className={cn('pr-16 font-mono', className)}
+        />
+        <div className="absolute inset-y-0 right-1 flex items-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 rounded-sm p-0 text-accent-foreground/60 hover:text-foreground"
+            onClick={() => setIsVisible((visible) => !visible)}
+            aria-label={isVisible ? 'Hide secret' : 'Show secret'}
+            aria-pressed={isVisible}
+          >
+            {isVisible ? <IconEyeOff size={15} /> : <IconEye size={15} />}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 rounded-sm p-0 text-accent-foreground/60 hover:text-foreground"
+            onClick={handleCopy}
+            disabled={!secret}
+            aria-label="Copy secret"
+          >
+            <IconCopy size={15} />
+          </Button>
+        </div>
+      </div>
+    );
+  },
+);
+
+SecretInput.displayName = 'SecretInput';

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookConfigUpdate.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookConfigUpdate.tsx
@@ -22,6 +22,7 @@ import { z } from 'zod';
 import { facebookConfigSchema } from '../constants/FbConfigSchema';
 import { useFacebookGetConfigs } from '../hooks/useFacebookGetConfigs';
 import { useFacebookUpdateConfigs } from '../hooks/useFacebookUpdateConfigs';
+import { SecretInput } from '@/integrations/components/SecretInput';
 
 export const FacebookConfigUpdateCollapse = () => {
   return (
@@ -128,7 +129,7 @@ export const FacebookConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('facebook-app-secret')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -140,7 +141,7 @@ export const FacebookConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('facebook-verify-token')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>

--- a/frontend/plugins/frontline_ui/src/modules/integrations/instagram/components/InstagramConfigUpdate.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/instagram/components/InstagramConfigUpdate.tsx
@@ -21,6 +21,7 @@ import { IntegrationLogo } from '@/integrations/components/IntegrationLogo';
 import { INTEGRATIONS } from '@/integrations/constants/integrations';
 import { IntegrationType } from '@/types/Integration';
 import { getPluginAssetsUrl } from 'erxes-ui';
+import { SecretInput } from '@/integrations/components/SecretInput';
 
 export const InstagramConfigUpdateCollapse = () => {
   return (
@@ -117,7 +118,7 @@ export const InstagramConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('instagram-app-secret')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>
@@ -129,7 +130,7 @@ export const InstagramConfigUpdate = () => {
             <Form.Item>
               <Form.Label>{t('instagram-verify-token')}</Form.Label>
               <Form.Control>
-                <Input {...field} />
+                <SecretInput {...field} />
               </Form.Control>
               <Form.Message />
             </Form.Item>


### PR DESCRIPTION
## Summary by Sourcery

Restrict access to frontline integrations configuration and improve handling of sensitive config values.

New Features:
- Add a permission-gated route and navigation entry for the frontline integrations configuration settings.
- Introduce a reusable SecretInput component for masking, toggling visibility, and copying sensitive integration secrets.

Bug Fixes:
- Prevent fetching call configuration when user integrations are not yet loaded or unavailable to avoid unnecessary queries and potential errors.
- Correct the return type of call integrations model helper to match the actual integrations collection.

Enhancements:
- Enforce integrationsEdit permission checks on backend GraphQL resolvers for getting and updating Facebook, Instagram, and call integration configs.
- Hide the integrations configuration navigation link for users without the integrationsEdit permission.
- Mask TURN server and social app secret/verify token fields in call, Facebook, and Instagram configuration forms using the new SecretInput component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-based access controls for integration settings and configuration actions.
  * Unauthorized users are redirected away from restricted integration pages, and restricted navigation options are hidden.
  * Added masked secret fields with visibility toggling and clipboard-copy support.
* **Bug Fixes**
  * Prevented unnecessary call configuration requests while integration data is loading or unavailable.
  * Corrected integration list result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->