### PR TITLE
fix(msdynamic): add trpc method

### DIFF
--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
@@ -163,6 +163,7 @@ export const msdynamicCheckMutations = {
 
     const products = await sendTRPCMessage({
       subdomain,
+      method: 'mutation',
       pluginName: 'core',
       module: 'products',
       action: 'find',
@@ -266,6 +267,7 @@ export const msdynamicCheckMutations = {
 
     const products = await sendTRPCMessage({
       subdomain,
+      method: 'mutation',
       pluginName: 'core',
       module: 'products',
       action: 'find',
@@ -337,6 +339,7 @@ export const msdynamicCheckMutations = {
 
       const result = await sendTRPCMessage({
         subdomain,
+        method:'mutation',
         pluginName: 'core',
         module: 'products',
         action: 'updateProduct',

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
@@ -276,7 +276,7 @@ export const msdynamicCheckMutations = {
     });
 
     const exchangeRates = config.exchangeRateApi
-      ? (await getExchangeRates(config)) ?? {}
+      ? ((await getExchangeRates(config)) ?? {})
       : {};
 
     const salesCodeFilter = pricePriority.replace(/, /g, ',').split(',');
@@ -339,7 +339,7 @@ export const msdynamicCheckMutations = {
 
       const result = await sendTRPCMessage({
         subdomain,
-        method:'mutation',
+        method: 'mutation',
         pluginName: 'core',
         module: 'products',
         action: 'updateProduct',


### PR DESCRIPTION
## Summary by Sourcery

Specify TRPC mutation method when fetching and updating products in the msdynamic GraphQL check mutations to ensure correct TRPC routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product lookup and price synchronization requests for more reliable processing.
  * Preserved existing exchange-rate fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->