### PR TITLE
fix(frontline): make the Facebook post + button reachable

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/ChooseIntegrationType.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/ChooseIntegrationType.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Sidebar,
   Skeleton,
   TextOverflowTooltip,
   cn,
@@ -91,10 +92,7 @@ export const IntegrationTypeItem = ({
   const trigger = (
     <Button
       variant={isActive ? 'secondary' : 'ghost'}
-      className={cn(
-        'justify-start pl-7 relative overflow-hidden text-left flex-auto',
-        canCreatePost && 'bg-transparent hover:bg-transparent',
-      )}
+      className="justify-start pl-7 relative overflow-hidden text-left w-full"
       onClick={handleClick}
     >
       {isActive ? (
@@ -127,16 +125,9 @@ export const IntegrationTypeItem = ({
   }
 
   return (
-    <div
-      className={cn(
-        'group/integration-type flex items-center w-full rounded-md pr-1',
-        isActive ? 'bg-secondary' : 'hover:bg-accent',
-      )}
-    >
+    <Sidebar.MenuItem>
       {trigger}
-      <div className="invisible shrink-0 group-hover/integration-type:visible focus-within:visible">
-        <FacebookPostSheet />
-      </div>
-    </div>
+      <FacebookPostSheet />
+    </Sidebar.MenuItem>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookPostSheet.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookPostSheet.tsx
@@ -14,6 +14,7 @@ import {
   Popover,
   Select,
   Sheet,
+  Sidebar,
   Spinner,
   Textarea,
   useToast,
@@ -37,15 +38,14 @@ export const FacebookPostSheet = () => {
   return (
     <Sheet>
       <Sheet.Trigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
+        <Sidebar.MenuAction
+          showOnHover
+          className="text-muted-foreground hover:text-foreground"
           aria-label={t('create-facebook-post')}
           onClick={(e) => e.stopPropagation()}
         >
           <IconPlus />
-        </Button>
+        </Sidebar.MenuAction>
       </Sheet.Trigger>
       <Sheet.View className="p-0">
         <FacebookPostForm />


### PR DESCRIPTION
The compose trigger sat in a raw div using invisible plus a one-off group/integration-type variant. visibility:hidden also removes the button from the tab order, so focus-within could never fire and touch devices got no button at all. The div was also nested directly inside the sidebar ul.

Use Sidebar.MenuItem plus Sidebar.MenuAction showOnHover: valid li nesting, opacity-based so keyboard focus works, md:opacity-0 so it stays visible on touch, and it reuses group/menu-item

## Summary by Sourcery

Improve the Facebook integration type item to use sidebar menu components for a reachable, properly nested compose trigger.

Bug Fixes:
- Ensure the Facebook post compose + button remains reachable via keyboard, hover, and touch by avoiding visibility-hidden based behavior.

Enhancements:
- Use Sidebar.MenuItem and Sidebar.MenuAction for the Facebook integration type entry to align with sidebar semantics and styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Facebook post integration controls with a more consistent sidebar layout.
  * Improved the appearance and interaction of the add-post action, including full-width integration items and refined hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->