### PR TITLE
feat(core-ui): global search across contacts, conversations and deals

### DIFF
--- a/backend/gateway/src/locales/en/common.json
+++ b/backend/gateway/src/locales/en/common.json
@@ -106,5 +106,24 @@
     "plugins": "Plugins",
     "exit": "Exit {{name}}",
     "modules": "{{name}} modules"
+  },
+  "global-search": {
+    "placeholder": "Search",
+    "loading": "Loading...",
+    "no-results": "No results",
+    "contacts": "Contacts",
+    "companies": "Companies",
+    "conversations": "Conversations",
+    "tickets": "Tickets",
+    "unnamed": "Unnamed",
+    "deals": "Deals",
+    "products": "Products",
+    "team-members": "Team members",
+    "channels": "Channels",
+    "forms": "Forms",
+    "hint": "Search contacts, conversations, tickets, deals, products and more",
+    "load-error": "Couldn't load {{label}}",
+    "search-failed": "Couldn't load search results",
+    "retry": "Retry"
   }
 }

--- a/backend/gateway/src/locales/en/common.json
+++ b/backend/gateway/src/locales/en/common.json
@@ -111,6 +111,8 @@
     "placeholder": "Search",
     "loading": "Loading...",
     "no-results": "No results",
+    "results-count_one": "{{count}} result",
+    "results-count_other": "{{count}} results",
     "contacts": "Contacts",
     "companies": "Companies",
     "conversations": "Conversations",

--- a/backend/gateway/src/locales/mn/common.json
+++ b/backend/gateway/src/locales/mn/common.json
@@ -107,5 +107,24 @@
     "plugins": "Плагинууд",
     "exit": "{{name}}-ээс гарах",
     "modules": "{{name}} модулиуд"
+  },
+  "global-search": {
+    "placeholder": "Хайх",
+    "loading": "Ачаалж байна...",
+    "no-results": "Илэрц олдсонгүй",
+    "contacts": "Харилцагчид",
+    "companies": "Байгууллагууд",
+    "conversations": "Харилцаа",
+    "tickets": "Тикет",
+    "unnamed": "Нэргүй",
+    "deals": "Гэрээ",
+    "products": "Бараа",
+    "team-members": "Ажилтнууд",
+    "channels": "Сувгууд",
+    "forms": "Формууд",
+    "hint": "Харилцагч, харилцаа, тикет, гэрээ, бараа зэргээс хайх",
+    "load-error": "{{label}}-г ачаалж чадсангүй",
+    "search-failed": "Хайлтын үр дүнг ачаалж чадсангүй",
+    "retry": "Дахин оролдох"
   }
 }

--- a/backend/gateway/src/locales/mn/common.json
+++ b/backend/gateway/src/locales/mn/common.json
@@ -112,6 +112,8 @@
     "placeholder": "Хайх",
     "loading": "Ачаалж байна...",
     "no-results": "Илэрц олдсонгүй",
+    "results-count_one": "{{count}} илэрц",
+    "results-count_other": "{{count}} илэрц",
     "contacts": "Харилцагчид",
     "companies": "Байгууллагууд",
     "conversations": "Харилцаа",

--- a/backend/plugins/frontline_api/src/conversationQueryBuilder.ts
+++ b/backend/plugins/frontline_api/src/conversationQueryBuilder.ts
@@ -381,6 +381,12 @@ export default class Builder {
 
     const orConditions: object[] = [{ customerId: { $in: customerIds } }];
 
+    if (!isPhoneSearch) {
+      orConditions.push({
+        content: { $regex: escapeRegex(value), $options: 'i' },
+      });
+    }
+
     const availableIntegrationIds: string[] =
       this.queries?.integrations?.integrationId?.$in || [];
 

--- a/frontend/core-ui/src/modules/app/components/MainLayout.tsx
+++ b/frontend/core-ui/src/modules/app/components/MainLayout.tsx
@@ -5,6 +5,7 @@ import { VisitedPageTabs } from '@/navigation/components/VisitedPageTabs';
 import { VisitedPageTabsOpenButton } from '@/navigation/components/VisitedPageTabsOpenButton';
 import { navigationSidebarOpenState } from '@/navigation/states/navigationPanelState';
 import { visitedPageTabsVisibleState } from '@/navigation/states/visitedPageTabsState';
+import { GlobalSearch } from '@/search/components/GlobalSearch';
 import { FloatingWidgets } from '@/widgets/components/FloatingWidgets';
 import { cn, Sidebar, useQueryState } from 'erxes-ui';
 import { useAtom, useAtomValue } from 'jotai';
@@ -61,6 +62,7 @@ export const DefaultLayout = () => {
       sidebarWidthIcon="3rem"
     >
       <VisitedPageTabs />
+      <GlobalSearch />
       <Sidebar
         collapsible="icon"
         variant="sidebar"

--- a/frontend/core-ui/src/modules/navigation/components/VisitedPageTabs.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/VisitedPageTabs.tsx
@@ -1,3 +1,4 @@
+import { GlobalSearch } from '@/search/components/GlobalSearch';
 import { VisitedPageTabsShortcutGuide } from '@/navigation/components/VisitedPageTabsShortcutGuide';
 import { useNavigationActivities } from '@/navigation/hooks/useNavigationActivities';
 import { usePluginsModules } from '@/navigation/hooks/usePluginsModules';
@@ -417,6 +418,7 @@ export const VisitedPageTabs = () => {
           {tabItems}
         </VisitedPageTabsContent>
       </div>
+      <GlobalSearch />
       <Button
         aria-keyshortcuts={toggleTabsAriaShortcut}
         aria-label={t('navigation.hide-tabs-row')}

--- a/frontend/core-ui/src/modules/navigation/components/VisitedPageTabs.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/VisitedPageTabs.tsx
@@ -1,4 +1,4 @@
-import { GlobalSearch } from '@/search/components/GlobalSearch';
+import { GlobalSearchTrigger } from '@/search/components/GlobalSearchTrigger';
 import { VisitedPageTabsShortcutGuide } from '@/navigation/components/VisitedPageTabsShortcutGuide';
 import { useNavigationActivities } from '@/navigation/hooks/useNavigationActivities';
 import { usePluginsModules } from '@/navigation/hooks/usePluginsModules';
@@ -418,7 +418,7 @@ export const VisitedPageTabs = () => {
           {tabItems}
         </VisitedPageTabsContent>
       </div>
-      <GlobalSearch />
+      <GlobalSearchTrigger />
       <Button
         aria-keyshortcuts={toggleTabsAriaShortcut}
         aria-label={t('navigation.hide-tabs-row')}

--- a/frontend/core-ui/src/modules/navigation/components/VisitedPageTabsShortcutGuide.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/VisitedPageTabsShortcutGuide.tsx
@@ -5,13 +5,21 @@ import { useTranslation } from 'react-i18next';
 
 export const VisitedPageTabsShortcutGuide = () => {
   const { t } = useTranslation('common', { keyPrefix: 'navigation' });
-  const modifierKeys = isMacPlatform() ? ['⌘', '⌥'] : ['Ctrl', 'Alt'];
+  const { t: tSearch } = useTranslation('common', {
+    keyPrefix: 'global-search',
+  });
+  const isMac = isMacPlatform();
+  const modifierKeys = isMac ? ['⌘', '⌥'] : ['Ctrl', 'Alt'];
   const shortcuts = [
-    { label: t('next-tab'), shortcutKey: ']' },
-    { label: t('previous-tab'), shortcutKey: '[' },
-    { label: t('close-current-tab'), shortcutKey: 'W' },
-    { label: t('close-all-tabs'), shortcutKey: 'X' },
-    { label: t('toggle-tabs-row'), shortcutKey: 'T' },
+    {
+      label: tSearch('placeholder', 'Search'),
+      keys: [...modifierKeys, 'K'],
+    },
+    { label: t('next-tab'), keys: [...modifierKeys, ']'] },
+    { label: t('previous-tab'), keys: [...modifierKeys, '['] },
+    { label: t('close-current-tab'), keys: [...modifierKeys, 'W'] },
+    { label: t('close-all-tabs'), keys: [...modifierKeys, 'X'] },
+    { label: t('toggle-tabs-row'), keys: [...modifierKeys, 'T'] },
   ];
 
   return (
@@ -36,14 +44,14 @@ export const VisitedPageTabsShortcutGuide = () => {
           {t('tab-shortcuts')}
         </div>
         <div className="py-0.5">
-          {shortcuts.map(({ label, shortcutKey }) => (
+          {shortcuts.map(({ label, keys }) => (
             <div
               className="flex min-h-7 items-center justify-between gap-2 px-2 py-0.5"
-              key={shortcutKey}
+              key={label}
             >
               <span className="text-[13px] text-foreground">{label}</span>
               <Kbd className="h-auto min-w-0 shrink-0 border-0 bg-transparent p-0 font-sans text-[13px] font-normal text-muted-foreground opacity-100">
-                {[...modifierKeys, shortcutKey].join(' ')}
+                {keys.join(' ')}
               </Kbd>
             </div>
           ))}

--- a/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
@@ -1,0 +1,108 @@
+import { IconSearch } from '@tabler/icons-react';
+import {
+  GLOBAL_SEARCH_MIN_LENGTH,
+  useGlobalSearch,
+} from '@/search/hooks/useGlobalSearch';
+import { GlobalSearchDialog } from '@/search/components/GlobalSearchDialog';
+import { isMacPlatform } from '@/navigation/utils/visitedPageTabShortcuts';
+import { Button, cn } from 'erxes-ui';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'use-debounce';
+
+const SEARCH_DEBOUNCE = 350;
+
+const GlobalSearchTrigger = ({
+  className,
+  label,
+  onClick,
+}: {
+  className?: string;
+  label: string;
+  onClick: () => void;
+}) => {
+  const isMac = isMacPlatform();
+
+  return (
+    <Button
+      aria-keyshortcuts={isMac ? 'Meta+Alt+K' : 'Control+Alt+K'}
+      aria-label={label}
+      className={cn('size-8 shrink-0 text-muted-foreground', className)}
+      onClick={onClick}
+      size="icon"
+      title={`${label} (${isMac ? '⌘ ⌥ K' : 'Ctrl Alt K'})`}
+      type="button"
+      variant="ghost"
+    >
+      <IconSearch className="size-4" />
+    </Button>
+  );
+};
+
+export const GlobalSearch = ({ className }: { className?: string }) => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+  const navigate = useNavigate();
+
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState('');
+  const [debouncedValue] = useDebounce(value.trim(), SEARCH_DEBOUNCE);
+
+  const { groups, loading, hasFailure, refetch } =
+    useGlobalSearch(debouncedValue);
+
+  useEffect(() => {
+    const handleOpenSearch = (event: KeyboardEvent) => {
+      const hasSearchModifier = isMacPlatform()
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey;
+
+      if (
+        hasSearchModifier &&
+        event.altKey &&
+        !event.shiftKey &&
+        event.code === 'KeyK'
+      ) {
+        event.preventDefault();
+        setOpen(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleOpenSearch);
+
+    return () => window.removeEventListener('keydown', handleOpenSearch);
+  }, []);
+
+  const openResult = (path: string) => {
+    setValue('');
+    setOpen(false);
+    navigate(path);
+  };
+
+  const isTyping = debouncedValue.length >= GLOBAL_SEARCH_MIN_LENGTH;
+  const hasResults = groups.some((group) => group.items.length > 0);
+
+  return (
+    <>
+      <GlobalSearchTrigger
+        className={className}
+        label={t('placeholder', 'Search')}
+        onClick={() => setOpen(true)}
+      />
+
+      <GlobalSearchDialog
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onValueChange={setValue}
+        isTyping={isTyping}
+        hasFailure={hasFailure}
+        loading={loading}
+        hasResults={hasResults}
+        groups={groups}
+        onSelect={openResult}
+        onRetry={() => refetch()}
+      />
+    </>
+  );
+};

--- a/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
@@ -48,7 +48,7 @@ export const GlobalSearch = ({ className }: { className?: string }) => {
   const [value, setValue] = useState('');
   const [debouncedValue] = useDebounce(value.trim(), SEARCH_DEBOUNCE);
 
-  const { groups, loading, hasFailure, refetch } =
+  const { groups, totalCount, loading, hasFailure, refetch } =
     useGlobalSearch(debouncedValue);
 
   useEffect(() => {
@@ -100,6 +100,7 @@ export const GlobalSearch = ({ className }: { className?: string }) => {
         loading={loading}
         hasResults={hasResults}
         groups={groups}
+        totalCount={totalCount}
         onSelect={openResult}
         onRetry={() => refetch()}
       />

--- a/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
@@ -1,50 +1,23 @@
-import { IconSearch } from '@tabler/icons-react';
+import { GlobalSearchDialog } from '@/search/components/GlobalSearchDialog';
 import {
   GLOBAL_SEARCH_MIN_LENGTH,
   useGlobalSearch,
 } from '@/search/hooks/useGlobalSearch';
-import { GlobalSearchDialog } from '@/search/components/GlobalSearchDialog';
+import { globalSearchOpenState } from '@/search/states/globalSearchState';
 import { isMacPlatform } from '@/navigation/utils/visitedPageTabShortcuts';
-import { Button, cn } from 'erxes-ui';
+import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'use-debounce';
 
 const SEARCH_DEBOUNCE = 350;
 
-const GlobalSearchTrigger = ({
-  className,
-  label,
-  onClick,
-}: {
-  className?: string;
-  label: string;
-  onClick: () => void;
-}) => {
-  const isMac = isMacPlatform();
-
-  return (
-    <Button
-      aria-keyshortcuts={isMac ? 'Meta+Alt+K' : 'Control+Alt+K'}
-      aria-label={label}
-      className={cn('size-8 shrink-0 text-muted-foreground', className)}
-      onClick={onClick}
-      size="icon"
-      title={`${label} (${isMac ? '⌘ ⌥ K' : 'Ctrl Alt K'})`}
-      type="button"
-      variant="ghost"
-    >
-      <IconSearch className="size-4" />
-    </Button>
-  );
-};
-
-export const GlobalSearch = ({ className }: { className?: string }) => {
-  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+// Mounted by the layout rather than by the tabs row, which unmounts when the
+// row is hidden — the shortcut has to keep working there too.
+export const GlobalSearch = () => {
   const navigate = useNavigate();
 
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useAtom(globalSearchOpenState);
   const [value, setValue] = useState('');
   const [debouncedValue] = useDebounce(value.trim(), SEARCH_DEBOUNCE);
 
@@ -71,7 +44,7 @@ export const GlobalSearch = ({ className }: { className?: string }) => {
     window.addEventListener('keydown', handleOpenSearch);
 
     return () => window.removeEventListener('keydown', handleOpenSearch);
-  }, []);
+  }, [setOpen]);
 
   const openResult = (path: string) => {
     setValue('');
@@ -83,28 +56,20 @@ export const GlobalSearch = ({ className }: { className?: string }) => {
   const hasResults = groups.some((group) => group.items.length > 0);
 
   return (
-    <>
-      <GlobalSearchTrigger
-        className={className}
-        label={t('placeholder', 'Search')}
-        onClick={() => setOpen(true)}
-      />
-
-      <GlobalSearchDialog
-        open={open}
-        onOpenChange={setOpen}
-        value={value}
-        onValueChange={setValue}
-        isTyping={isTyping}
-        hasFailure={hasFailure}
-        loading={loading}
-        hasResults={hasResults}
-        groups={groups}
-        totalCount={totalCount}
-        searchValue={debouncedValue}
-        onSelect={openResult}
-        onRetry={() => refetch()}
-      />
-    </>
+    <GlobalSearchDialog
+      open={open}
+      onOpenChange={setOpen}
+      value={value}
+      onValueChange={setValue}
+      isTyping={isTyping}
+      hasFailure={hasFailure}
+      loading={loading}
+      hasResults={hasResults}
+      groups={groups}
+      totalCount={totalCount}
+      searchValue={debouncedValue}
+      onSelect={openResult}
+      onRetry={() => refetch()}
+    />
   );
 };

--- a/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearch.tsx
@@ -101,6 +101,7 @@ export const GlobalSearch = ({ className }: { className?: string }) => {
         hasResults={hasResults}
         groups={groups}
         totalCount={totalCount}
+        searchValue={debouncedValue}
         onSelect={openResult}
         onRetry={() => refetch()}
       />

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
@@ -15,6 +15,7 @@ const GlobalSearchResults = ({
   loading,
   hasResults,
   groups,
+  searchValue,
   onSelect,
   onRetry,
 }: {
@@ -23,6 +24,7 @@ const GlobalSearchResults = ({
   loading: boolean;
   hasResults: boolean;
   groups: TGlobalSearchGroup[];
+  searchValue: string;
   onSelect: (path: string) => void;
   onRetry: () => void;
 }) => {
@@ -48,6 +50,7 @@ const GlobalSearchResults = ({
           <GlobalSearchGroup
             key={group.key}
             group={group}
+            searchValue={searchValue}
             onSelect={onSelect}
           />
         ))}
@@ -66,6 +69,7 @@ export const GlobalSearchDialog = ({
   hasResults,
   groups,
   totalCount,
+  searchValue,
   onSelect,
   onRetry,
 }: {
@@ -79,6 +83,7 @@ export const GlobalSearchDialog = ({
   hasResults: boolean;
   groups: TGlobalSearchGroup[];
   totalCount: number;
+  searchValue: string;
   onSelect: (path: string) => void;
   onRetry: () => void;
 }) => {
@@ -118,6 +123,7 @@ export const GlobalSearchDialog = ({
             loading={loading}
             hasResults={hasResults}
             groups={groups}
+            searchValue={searchValue}
             onSelect={onSelect}
             onRetry={onRetry}
           />

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
@@ -65,6 +65,7 @@ export const GlobalSearchDialog = ({
   loading,
   hasResults,
   groups,
+  totalCount,
   onSelect,
   onRetry,
 }: {
@@ -77,6 +78,7 @@ export const GlobalSearchDialog = ({
   loading: boolean;
   hasResults: boolean;
   groups: TGlobalSearchGroup[];
+  totalCount: number;
   onSelect: (path: string) => void;
   onRetry: () => void;
 }) => {
@@ -95,13 +97,21 @@ export const GlobalSearchDialog = ({
           shouldFilter={false}
           className="**:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 **:[[cmdk-group]]:px-2"
         >
-          <Command.Input
-            focusOnMount
-            variant="primary"
-            placeholder={t('placeholder', 'Search')}
-            value={value}
-            onValueChange={onValueChange}
-          />
+          <div className="relative">
+            <Command.Input
+              focusOnMount
+              variant="primary"
+              placeholder={t('placeholder', 'Search')}
+              value={value}
+              onValueChange={onValueChange}
+              className="pr-24"
+            />
+            {isTyping && !hasFailure && hasResults && (
+              <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground tabular-nums">
+                {t('results-count', { count: totalCount })}
+              </span>
+            )}
+          </div>
           <GlobalSearchResults
             isTyping={isTyping}
             hasFailure={hasFailure}

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
@@ -1,0 +1,118 @@
+import { GlobalSearchGroup } from '@/search/components/GlobalSearchGroup';
+import {
+  GlobalSearchEmpty,
+  GlobalSearchFailure,
+  GlobalSearchHint,
+  GlobalSearchLoading,
+} from '@/search/components/GlobalSearchStates';
+import { TGlobalSearchGroup } from '@/search/types/GlobalSearch';
+import { Command, Dialog } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+const GlobalSearchResults = ({
+  isTyping,
+  hasFailure,
+  loading,
+  hasResults,
+  groups,
+  onSelect,
+  onRetry,
+}: {
+  isTyping: boolean;
+  hasFailure: boolean;
+  loading: boolean;
+  hasResults: boolean;
+  groups: TGlobalSearchGroup[];
+  onSelect: (path: string) => void;
+  onRetry: () => void;
+}) => {
+  const hasGroupError = groups.some((group) => group.status === 'error');
+
+  return (
+    <Command.List className="styled-scroll min-h-32">
+      {!isTyping && <GlobalSearchHint />}
+
+      {isTyping && hasFailure && <GlobalSearchFailure onRetry={onRetry} />}
+
+      {isTyping && !hasFailure && loading && !hasResults && (
+        <GlobalSearchLoading />
+      )}
+
+      {isTyping && !hasFailure && !loading && !hasResults && !hasGroupError && (
+        <GlobalSearchEmpty />
+      )}
+
+      {isTyping &&
+        !hasFailure &&
+        groups.map((group) => (
+          <GlobalSearchGroup
+            key={group.key}
+            group={group}
+            onSelect={onSelect}
+          />
+        ))}
+    </Command.List>
+  );
+};
+
+export const GlobalSearchDialog = ({
+  open,
+  onOpenChange,
+  value,
+  onValueChange,
+  isTyping,
+  hasFailure,
+  loading,
+  hasResults,
+  groups,
+  onSelect,
+  onRetry,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string;
+  onValueChange: (value: string) => void;
+  isTyping: boolean;
+  hasFailure: boolean;
+  loading: boolean;
+  hasResults: boolean;
+  groups: TGlobalSearchGroup[];
+  onSelect: (path: string) => void;
+  onRetry: () => void;
+}) => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content className="max-w-md overflow-hidden rounded-lg border-0 p-0">
+        <Dialog.Title className="sr-only">
+          {t('placeholder', 'Search')}
+        </Dialog.Title>
+        <Dialog.Description className="sr-only">
+          {t('placeholder', 'Search')}
+        </Dialog.Description>
+        <Command
+          shouldFilter={false}
+          className="**:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 **:[[cmdk-group]]:px-2"
+        >
+          <Command.Input
+            focusOnMount
+            variant="primary"
+            placeholder={t('placeholder', 'Search')}
+            value={value}
+            onValueChange={onValueChange}
+          />
+          <GlobalSearchResults
+            isTyping={isTyping}
+            hasFailure={hasFailure}
+            loading={loading}
+            hasResults={hasResults}
+            groups={groups}
+            onSelect={onSelect}
+            onRetry={onRetry}
+          />
+        </Command>
+      </Dialog.Content>
+    </Dialog>
+  );
+};

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
@@ -5,9 +5,11 @@ import { GlobalSearchItem } from '@/search/components/GlobalSearchItem';
 
 export const GlobalSearchGroup = ({
   group,
+  searchValue,
   onSelect,
 }: {
   group: TGlobalSearchGroup;
+  searchValue: string;
   onSelect: (path: string) => void;
 }) => {
   const { t } = useTranslation(group.labelNamespace ?? 'common', {
@@ -53,6 +55,7 @@ export const GlobalSearchGroup = ({
           item={item}
           providerKey={group.key}
           icon={group.icon}
+          searchValue={searchValue}
           onSelect={onSelect}
         />
       ))}

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
@@ -1,0 +1,61 @@
+import { Command } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import { TGlobalSearchGroup } from '@/search/types/GlobalSearch';
+import { GlobalSearchItem } from '@/search/components/GlobalSearchItem';
+
+export const GlobalSearchGroup = ({
+  group,
+  onSelect,
+}: {
+  group: TGlobalSearchGroup;
+  onSelect: (path: string) => void;
+}) => {
+  const { t } = useTranslation(group.labelNamespace ?? 'common', {
+    keyPrefix: group.labelNamespace ? undefined : 'global-search',
+  });
+  const { t: tCommon } = useTranslation('common', {
+    keyPrefix: 'global-search',
+  });
+
+  const label = t(group.labelKey ?? group.key, group.label);
+
+  if (group.status === 'error') {
+    return (
+      <Command.Group heading={label}>
+        <div className="px-2 py-1.5 text-sm text-destructive">
+          {tCommon('load-error', "Couldn't load {{label}}", { label })}
+        </div>
+      </Command.Group>
+    );
+  }
+
+  if (group.items.length === 0) {
+    return null;
+  }
+
+  const countLabel =
+    group.countMode === 'approximate' && group.items.length >= group.totalCount
+      ? `${group.totalCount}+`
+      : group.totalCount;
+
+  return (
+    <Command.Group
+      heading={
+        <span className="flex items-center justify-between gap-2">
+          {label}
+          <span className="tabular-nums">{countLabel}</span>
+        </span>
+      }
+    >
+      {group.items.map((item) => (
+        <GlobalSearchItem
+          key={item.id}
+          item={item}
+          providerKey={group.key}
+          icon={group.icon}
+          onSelect={onSelect}
+        />
+      ))}
+    </Command.Group>
+  );
+};

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
@@ -1,14 +1,17 @@
+import { highlightMatch } from '@/search/utils/highlightMatch';
 import { Command, TSearchResultItem } from 'erxes-ui';
 
 export const GlobalSearchItem = ({
   item,
   providerKey,
   icon: Icon,
+  searchValue,
   onSelect,
 }: {
   item: TSearchResultItem;
   providerKey: string;
   icon?: React.ElementType;
+  searchValue: string;
   onSelect: (path: string) => void;
 }) => (
   <Command.Item
@@ -16,11 +19,11 @@ export const GlobalSearchItem = ({
     onSelect={() => onSelect(item.path)}
   >
     {Icon && <Icon />}
-    <span className="truncate">{item.title}</span>
-    {Boolean(item.description) && (
+    <span className="truncate">{highlightMatch(item.title, searchValue)}</span>
+    {item.description ? (
       <Command.Shortcut className="truncate">
-        {item.description}
+        {highlightMatch(item.description, searchValue)}
       </Command.Shortcut>
-    )}
+    ) : null}
   </Command.Item>
 );

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
@@ -1,0 +1,26 @@
+import { Command, TSearchResultItem } from 'erxes-ui';
+
+export const GlobalSearchItem = ({
+  item,
+  providerKey,
+  icon: Icon,
+  onSelect,
+}: {
+  item: TSearchResultItem;
+  providerKey: string;
+  icon?: React.ElementType;
+  onSelect: (path: string) => void;
+}) => (
+  <Command.Item
+    value={`${providerKey}:${item.id}`}
+    onSelect={() => onSelect(item.path)}
+  >
+    {Icon && <Icon />}
+    <span className="truncate">{item.title}</span>
+    {Boolean(item.description) && (
+      <Command.Shortcut className="truncate">
+        {item.description}
+      </Command.Shortcut>
+    )}
+  </Command.Item>
+);

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchStates.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchStates.tsx
@@ -1,0 +1,66 @@
+import {
+  IconAlertTriangle,
+  IconLoader2,
+  IconSearch,
+} from '@tabler/icons-react';
+import { Button } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+const StateShell = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-32 flex-col items-center justify-center gap-2 px-6 text-center">
+    {children}
+  </div>
+);
+
+export const GlobalSearchHint = () => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+
+  return (
+    <StateShell>
+      <IconSearch className="size-5 text-muted-foreground" />
+      <span className="text-sm text-muted-foreground">
+        {t(
+          'hint',
+          'Search contacts, conversations, tickets, deals, products and more',
+        )}
+      </span>
+    </StateShell>
+  );
+};
+
+export const GlobalSearchLoading = () => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+
+  return (
+    <div className="flex h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+      <IconLoader2 className="size-4 animate-spin" />
+      {t('loading', 'Loading...')}
+    </div>
+  );
+};
+
+export const GlobalSearchEmpty = () => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+
+  return (
+    <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+      {t('no-results', 'No results')}
+    </div>
+  );
+};
+
+export const GlobalSearchFailure = ({ onRetry }: { onRetry: () => void }) => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+
+  return (
+    <StateShell>
+      <IconAlertTriangle className="size-5 text-destructive" />
+      <span className="text-sm text-muted-foreground">
+        {t('search-failed', "Couldn't load search results")}
+      </span>
+      <Button size="sm" variant="secondary" onClick={onRetry} type="button">
+        {t('retry', 'Retry')}
+      </Button>
+    </StateShell>
+  );
+};

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchTrigger.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchTrigger.tsx
@@ -1,0 +1,28 @@
+import { globalSearchOpenState } from '@/search/states/globalSearchState';
+import { isMacPlatform } from '@/navigation/utils/visitedPageTabShortcuts';
+import { IconSearch } from '@tabler/icons-react';
+import { Button, cn } from 'erxes-ui';
+import { useSetAtom } from 'jotai';
+import { useTranslation } from 'react-i18next';
+
+export const GlobalSearchTrigger = ({ className }: { className?: string }) => {
+  const { t } = useTranslation('common', { keyPrefix: 'global-search' });
+  const setOpen = useSetAtom(globalSearchOpenState);
+  const isMac = isMacPlatform();
+  const label = t('placeholder', 'Search');
+
+  return (
+    <Button
+      aria-keyshortcuts={isMac ? 'Meta+Alt+K' : 'Control+Alt+K'}
+      aria-label={label}
+      className={cn('size-8 shrink-0 text-muted-foreground', className)}
+      onClick={() => setOpen(true)}
+      size="icon"
+      title={`${label} (${isMac ? '⌘ ⌥ K' : 'Ctrl Alt K'})`}
+      type="button"
+      variant="ghost"
+    >
+      <IconSearch className="size-4" />
+    </Button>
+  );
+};

--- a/frontend/core-ui/src/modules/search/constants/globalSearch.ts
+++ b/frontend/core-ui/src/modules/search/constants/globalSearch.ts
@@ -1,0 +1,11 @@
+export const GLOBAL_SEARCH_MIN_LENGTH = 2;
+export const GLOBAL_SEARCH_PER_GROUP = 5;
+export const GLOBAL_SEARCH_DEBOUNCE = 350;
+
+export const GLOBAL_SEARCH_OPERATION_NAME = 'GlobalSearch';
+export const GLOBAL_SEARCH_VARIABLE_DEFS =
+  '$searchValue: String!, $limit: Int!';
+export const GLOBAL_SEARCH_ALLOWED_VARIABLES = new Set([
+  'searchValue',
+  'limit',
+]);

--- a/frontend/core-ui/src/modules/search/hooks/useGlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/hooks/useGlobalSearch.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo } from 'react';
+import { useQuery } from '@apollo/client';
+import { TSearchPayload } from 'erxes-ui';
+import { useSearchProviders } from '@/search/hooks/useSearchProviders';
+import { useGlobalSearchDocument } from '@/search/hooks/useGlobalSearchDocument';
+import {
+  getErroredAliases,
+  getInvalidFieldNames,
+  isPermissionError,
+} from '@/search/utils/searchErrors';
+import { TGlobalSearchGroup } from '@/search/types/GlobalSearch';
+
+export const GLOBAL_SEARCH_MIN_LENGTH = 2;
+export const GLOBAL_SEARCH_PER_GROUP = 5;
+
+export interface IGlobalSearchResult {
+  groups: TGlobalSearchGroup[];
+  loading: boolean;
+  hasFailure: boolean;
+  refetch: () => void;
+}
+
+export const useGlobalSearch = (searchValue: string): IGlobalSearchResult => {
+  const { providers, quarantineFields } = useSearchProviders();
+  const document = useGlobalSearchDocument(providers);
+
+  const skip =
+    searchValue.length < GLOBAL_SEARCH_MIN_LENGTH || providers.length === 0;
+
+  const { data, previousData, loading, error, refetch } =
+    useQuery<TSearchPayload>(document, {
+      variables: { searchValue, limit: GLOBAL_SEARCH_PER_GROUP },
+      skip,
+      errorPolicy: 'all',
+      fetchPolicy: 'no-cache',
+    });
+
+  useEffect(() => {
+    const invalidFields = getInvalidFieldNames(error);
+
+    if (invalidFields.length > 0) {
+      quarantineFields(invalidFields);
+    }
+  }, [error, quarantineFields]);
+
+  const payload = data ?? previousData ?? {};
+  const erroredAliases = getErroredAliases(error);
+
+  const groups = useMemo<TGlobalSearchGroup[]>(() => {
+    if (skip) {
+      return [];
+    }
+
+    return providers.flatMap((provider): TGlobalSearchGroup[] => {
+      const requiredSelections = provider.selections.filter(
+        (selection) => !selection.optional,
+      );
+      const failedSelection = requiredSelections.find((selection) =>
+        erroredAliases.has(selection.alias),
+      );
+
+      if (failedSelection) {
+        const graphQLError = error?.graphQLErrors?.find(
+          (candidate) => candidate.path?.[0] === failedSelection.alias,
+        );
+
+        if (graphQLError && isPermissionError(graphQLError.message)) {
+          return [];
+        }
+
+        return [
+          {
+            key: provider.key,
+            label: provider.label,
+            labelKey: provider.labelKey,
+            labelNamespace: provider.labelNamespace,
+            icon: provider.icon,
+            status: 'error',
+            items: [],
+            totalCount: 0,
+            countMode: 'exact',
+          },
+        ];
+      }
+
+      const result = provider.resolve(payload, GLOBAL_SEARCH_PER_GROUP);
+
+      return [
+        {
+          key: provider.key,
+          label: provider.label,
+          labelKey: provider.labelKey,
+          labelNamespace: provider.labelNamespace,
+          icon: provider.icon,
+          status: 'ok',
+          items: result.items,
+          totalCount: result.totalCount,
+          countMode: result.countMode,
+        },
+      ];
+    });
+  }, [providers, payload, erroredAliases, error, skip]);
+
+  const hasFailure = !skip && Boolean(error) && !data && !previousData;
+
+  return { groups, loading, hasFailure, refetch: () => refetch() };
+};

--- a/frontend/core-ui/src/modules/search/hooks/useGlobalSearch.tsx
+++ b/frontend/core-ui/src/modules/search/hooks/useGlobalSearch.tsx
@@ -15,6 +15,7 @@ export const GLOBAL_SEARCH_PER_GROUP = 5;
 
 export interface IGlobalSearchResult {
   groups: TGlobalSearchGroup[];
+  totalCount: number;
   loading: boolean;
   hasFailure: boolean;
   refetch: () => void;
@@ -101,7 +102,23 @@ export const useGlobalSearch = (searchValue: string): IGlobalSearchResult => {
     });
   }, [providers, payload, erroredAliases, error, skip]);
 
+  const totalCount = useMemo(
+    () =>
+      groups.reduce(
+        (total, group) =>
+          group.status === 'ok' ? total + group.totalCount : total,
+        0,
+      ),
+    [groups],
+  );
+
   const hasFailure = !skip && Boolean(error) && !data && !previousData;
 
-  return { groups, loading, hasFailure, refetch: () => refetch() };
+  return {
+    groups,
+    totalCount,
+    loading,
+    hasFailure,
+    refetch: () => refetch(),
+  };
 };

--- a/frontend/core-ui/src/modules/search/hooks/useGlobalSearchDocument.ts
+++ b/frontend/core-ui/src/modules/search/hooks/useGlobalSearchDocument.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react';
+import { ISearchProvider } from 'erxes-ui';
+import { buildGlobalSearchDocument } from '@/search/utils/composeSearchDocument';
+
+export const useGlobalSearchDocument = (providers: ISearchProvider[]) =>
+  useMemo(() => buildGlobalSearchDocument(providers), [providers]);

--- a/frontend/core-ui/src/modules/search/hooks/useSearchProviders.ts
+++ b/frontend/core-ui/src/modules/search/hooks/useSearchProviders.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import { pluginsConfigState } from 'ui-modules';
+import { ISearchProvider } from 'erxes-ui';
+import { validateSearchProviders } from '@/search/utils/composeSearchDocument';
+import { CORE_SEARCH_PROVIDERS } from '@/search/providers/coreSearchProviders';
+
+const MAX_QUARANTINE_RETRIES = 3;
+
+export const useSearchProviders = () => {
+  const pluginsConfig = useAtomValue(pluginsConfigState);
+  const [quarantinedFields, setQuarantinedFields] = useState<Set<string>>(
+    new Set(),
+  );
+  const [retryCount, setRetryCount] = useState(0);
+
+  const providers = useMemo(() => {
+    const fromPlugins = Object.values(pluginsConfig ?? {}).flatMap(
+      (config): ISearchProvider[] =>
+        Array.isArray(config?.searchProviders) ? config.searchProviders : [],
+    );
+
+    const validated = validateSearchProviders([
+      ...CORE_SEARCH_PROVIDERS,
+      ...fromPlugins,
+    ]);
+
+    return validated
+      .map((provider) => ({
+        ...provider,
+        selections: provider.selections.filter(
+          (selection) => !quarantinedFields.has(selection.field),
+        ),
+      }))
+      .filter((provider) => provider.selections.length > 0)
+      .sort(
+        (a, b) =>
+          (a.order ?? 1000) - (b.order ?? 1000) || a.key.localeCompare(b.key),
+      );
+  }, [pluginsConfig, quarantinedFields]);
+
+  const quarantineFields = useCallback(
+    (fields: string[]) => {
+      if (fields.length === 0 || retryCount >= MAX_QUARANTINE_RETRIES) {
+        return;
+      }
+
+      setQuarantinedFields((prev) => {
+        const next = new Set(prev);
+        let changed = false;
+
+        for (const field of fields) {
+          if (!next.has(field)) {
+            next.add(field);
+            changed = true;
+          }
+        }
+
+        return changed ? next : prev;
+      });
+      setRetryCount((prev) => prev + 1);
+    },
+    [retryCount],
+  );
+
+  return { providers, quarantineFields };
+};

--- a/frontend/core-ui/src/modules/search/providers/contactsProviders.ts
+++ b/frontend/core-ui/src/modules/search/providers/contactsProviders.ts
@@ -1,0 +1,69 @@
+import { IconBuildingSkyscraper, IconUser } from '@tabler/icons-react';
+import { defineSearchProvider, getPersonName, readCursorList } from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TCustomerNode = {
+  _id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+};
+
+export const customersSearchProvider = defineSearchProvider<TCustomerNode>({
+  key: 'core-customers',
+  label: 'Contacts',
+  labelKey: 'contacts',
+  labelNamespace: 'common',
+  icon: IconUser,
+  order: 10,
+  selections: [
+    {
+      alias: 'gs_core_customers',
+      field: 'customers',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id firstName lastName primaryEmail primaryPhone } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCustomerNode>(payload, 'gs_core_customers'),
+  toItem: (customer) => ({
+    id: customer._id,
+    title: getPersonName(customer, UNNAMED),
+    description: customer.primaryEmail || customer.primaryPhone || undefined,
+    path: `/contacts/customers?contactId=${customer._id}`,
+  }),
+});
+
+type TCompanyNode = {
+  _id: string;
+  primaryName?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+};
+
+export const companiesSearchProvider = defineSearchProvider<TCompanyNode>({
+  key: 'core-companies',
+  label: 'Companies',
+  labelKey: 'companies',
+  labelNamespace: 'common',
+  icon: IconBuildingSkyscraper,
+  order: 20,
+  selections: [
+    {
+      alias: 'gs_core_companies',
+      field: 'companies',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id primaryName primaryEmail primaryPhone } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCompanyNode>(payload, 'gs_core_companies'),
+  toItem: (company) => ({
+    id: company._id,
+    title: company.primaryName || UNNAMED,
+    description: company.primaryEmail || company.primaryPhone || undefined,
+    path: `/contacts/companies?companyId=${company._id}`,
+  }),
+});

--- a/frontend/core-ui/src/modules/search/providers/coreSearchProviders.ts
+++ b/frontend/core-ui/src/modules/search/providers/coreSearchProviders.ts
@@ -1,0 +1,14 @@
+import { ISearchProvider } from 'erxes-ui';
+import {
+  companiesSearchProvider,
+  customersSearchProvider,
+} from '@/search/providers/contactsProviders';
+import { productsSearchProvider } from '@/search/providers/productProviders';
+import { teamMembersSearchProvider } from '@/search/providers/settingsProviders';
+
+export const CORE_SEARCH_PROVIDERS: ISearchProvider[] = [
+  customersSearchProvider,
+  companiesSearchProvider,
+  productsSearchProvider,
+  teamMembersSearchProvider,
+];

--- a/frontend/core-ui/src/modules/search/providers/productProviders.ts
+++ b/frontend/core-ui/src/modules/search/providers/productProviders.ts
@@ -1,0 +1,44 @@
+import { IconTag } from '@tabler/icons-react';
+import { defineSearchProvider, readArray, readNumber } from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TProductNode = {
+  _id: string;
+  name?: string | null;
+  code?: string | null;
+  unitPrice?: number | null;
+};
+
+export const productsSearchProvider = defineSearchProvider<TProductNode>({
+  key: 'core-products',
+  label: 'Products',
+  labelKey: 'products',
+  labelNamespace: 'common',
+  icon: IconTag,
+  order: 40,
+  selections: [
+    {
+      alias: 'gs_core_products',
+      field: 'products',
+      args: 'searchValue: $searchValue, perPage: $limit',
+      body: '{ _id name code unitPrice }',
+    },
+    {
+      alias: 'gs_core_products_count',
+      field: 'productsTotalCount',
+      args: 'searchValue: $searchValue',
+      optional: true,
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TProductNode>(payload, 'gs_core_products'),
+    totalCount: readNumber(payload, 'gs_core_products_count'),
+  }),
+  toItem: (product) => ({
+    id: product._id,
+    title: product.name || UNNAMED,
+    description: product.code || undefined,
+    path: `/settings/products?product_id=${product._id}`,
+  }),
+});

--- a/frontend/core-ui/src/modules/search/providers/settingsProviders.ts
+++ b/frontend/core-ui/src/modules/search/providers/settingsProviders.ts
@@ -1,0 +1,36 @@
+import { IconUsers } from '@tabler/icons-react';
+import { defineSearchProvider, readCursorList } from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TTeamMemberNode = {
+  _id: string;
+  email?: string | null;
+  username?: string | null;
+  details?: { fullName?: string | null } | null;
+};
+
+export const teamMembersSearchProvider = defineSearchProvider<TTeamMemberNode>({
+  key: 'core-team-members',
+  label: 'Team members',
+  labelKey: 'team-members',
+  labelNamespace: 'common',
+  icon: IconUsers,
+  order: 30,
+  selections: [
+    {
+      alias: 'gs_core_team_members',
+      field: 'users',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id email username details { fullName } } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TTeamMemberNode>(payload, 'gs_core_team_members'),
+  toItem: (member) => ({
+    id: member._id,
+    title: member.details?.fullName || member.username || UNNAMED,
+    description: member.email || undefined,
+    path: `/settings/team/members?user_id=${member._id}`,
+  }),
+});

--- a/frontend/core-ui/src/modules/search/states/globalSearchState.ts
+++ b/frontend/core-ui/src/modules/search/states/globalSearchState.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const globalSearchOpenState = atom<boolean>(false);

--- a/frontend/core-ui/src/modules/search/types/GlobalSearch.ts
+++ b/frontend/core-ui/src/modules/search/types/GlobalSearch.ts
@@ -1,0 +1,15 @@
+import { TSearchGroupResult, TSearchResultItem } from 'erxes-ui';
+
+export type TGlobalSearchGroupStatus = 'ok' | 'error';
+
+export type TGlobalSearchGroup = {
+  key: string;
+  label: string;
+  labelKey?: string;
+  labelNamespace?: string;
+  icon?: React.ElementType;
+  status: TGlobalSearchGroupStatus;
+  items: TSearchResultItem[];
+  totalCount: number;
+  countMode: TSearchGroupResult['countMode'];
+};

--- a/frontend/core-ui/src/modules/search/utils/composeSearchDocument.ts
+++ b/frontend/core-ui/src/modules/search/utils/composeSearchDocument.ts
@@ -1,0 +1,174 @@
+import { ISearchProvider, TSearchSelection } from 'erxes-ui';
+import { DocumentNode, parse, visit } from 'graphql';
+import {
+  GLOBAL_SEARCH_ALLOWED_VARIABLES,
+  GLOBAL_SEARCH_OPERATION_NAME,
+  GLOBAL_SEARCH_VARIABLE_DEFS,
+} from '@/search/constants/globalSearch';
+
+const ALIAS_PATTERN = /^gs_[a-z0-9]+_[a-z0-9_]+$/;
+
+const printSelection = (selection: TSearchSelection): string => {
+  const args = selection.args ? `(${selection.args})` : '';
+  const body = selection.body ? ` ${selection.body}` : '';
+
+  return `${selection.alias}: ${selection.field}${args}${body}`;
+};
+
+const isValidShape = (provider: ISearchProvider): string | null => {
+  if (!provider || typeof provider !== 'object') {
+    return 'provider is not an object';
+  }
+
+  if (typeof provider.key !== 'string' || provider.key.length === 0) {
+    return 'missing key';
+  }
+
+  if (typeof provider.label !== 'string' || provider.label.length === 0) {
+    return 'missing label';
+  }
+
+  if (!Array.isArray(provider.selections) || provider.selections.length === 0) {
+    return 'missing selections';
+  }
+
+  for (const selection of provider.selections) {
+    if (
+      !selection ||
+      typeof selection !== 'object' ||
+      typeof selection.alias !== 'string' ||
+      typeof selection.field !== 'string' ||
+      (selection.args !== undefined && typeof selection.args !== 'string') ||
+      (selection.body !== undefined && typeof selection.body !== 'string')
+    ) {
+      return 'invalid selection';
+    }
+  }
+
+  if (typeof provider.resolve !== 'function') {
+    return 'missing resolve';
+  }
+
+  return null;
+};
+
+const isValidSyntax = (
+  provider: ISearchProvider,
+  seenAliases: Set<string>,
+): string | null => {
+  for (const selection of provider.selections) {
+    if (!ALIAS_PATTERN.test(selection.alias)) {
+      return `alias "${selection.alias}" must match ${ALIAS_PATTERN}`;
+    }
+
+    if (seenAliases.has(selection.alias)) {
+      return `duplicate alias "${selection.alias}"`;
+    }
+  }
+
+  let ast: DocumentNode;
+
+  try {
+    ast = parse(
+      `query ${GLOBAL_SEARCH_OPERATION_NAME}Probe(${GLOBAL_SEARCH_VARIABLE_DEFS}) { ${provider.selections
+        .map(printSelection)
+        .join('\n')} }`,
+    );
+  } catch (parseError) {
+    return `invalid selection syntax: ${(parseError as Error).message}`;
+  }
+
+  let disallowedVariable: string | null = null;
+
+  visit(ast, {
+    Variable(node) {
+      if (!GLOBAL_SEARCH_ALLOWED_VARIABLES.has(node.name.value)) {
+        disallowedVariable = node.name.value;
+      }
+    },
+  });
+
+  if (disallowedVariable) {
+    return `references disallowed variable "$${disallowedVariable}"`;
+  }
+
+  for (const selection of provider.selections) {
+    seenAliases.add(selection.alias);
+  }
+
+  return null;
+};
+
+const rejectedProviderKeys = new Set<string>();
+
+export const validateSearchProviders = (
+  providers: ISearchProvider[],
+): ISearchProvider[] => {
+  const seenAliases = new Set<string>();
+  const valid: ISearchProvider[] = [];
+
+  for (const provider of providers) {
+    const shapeError = isValidShape(provider);
+
+    if (shapeError) {
+      if (!rejectedProviderKeys.has(provider?.key ?? 'unknown')) {
+        rejectedProviderKeys.add(provider?.key ?? 'unknown');
+        console.error(
+          `[GlobalSearch] rejected provider "${provider?.key ?? 'unknown'}": ${shapeError}`,
+        );
+      }
+
+      continue;
+    }
+
+    const syntaxError = isValidSyntax(provider, seenAliases);
+
+    if (syntaxError) {
+      if (!rejectedProviderKeys.has(provider.key)) {
+        rejectedProviderKeys.add(provider.key);
+        console.error(
+          `[GlobalSearch] rejected provider "${provider.key}": ${syntaxError}`,
+        );
+      }
+
+      continue;
+    }
+
+    valid.push(provider);
+  }
+
+  return valid;
+};
+
+export const getRejectedProviderKeys = (): ReadonlySet<string> =>
+  rejectedProviderKeys;
+
+const documentCache = new Map<string, DocumentNode>();
+
+export const buildGlobalSearchDocument = (
+  providers: ISearchProvider[],
+): DocumentNode => {
+  const cacheKey = providers
+    .flatMap((provider) => provider.selections.map((s) => s.alias))
+    .sort((a, b) => a.localeCompare(b))
+    .join('|');
+
+  const cached = documentCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const selectionsSource = providers
+    .flatMap((provider) => provider.selections)
+    .map(printSelection)
+    .join('\n');
+
+  const document = parse(
+    `query ${GLOBAL_SEARCH_OPERATION_NAME}(${GLOBAL_SEARCH_VARIABLE_DEFS}) { ${selectionsSource} }`,
+  );
+
+  documentCache.set(cacheKey, document);
+
+  return document;
+};

--- a/frontend/core-ui/src/modules/search/utils/highlightMatch.tsx
+++ b/frontend/core-ui/src/modules/search/utils/highlightMatch.tsx
@@ -1,5 +1,5 @@
 const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
 // Splits the text on the searched term and marks the matches. The API decides
 // what matched, so a hit on a field the row does not render simply comes back
@@ -16,17 +16,23 @@ export const highlightMatch = (
 
   const parts = text.split(new RegExp(`(${escapeRegExp(term)})`, 'ig'));
   const lowerTerm = term.toLowerCase();
+  let offset = 0;
 
-  return parts.map((part, index) =>
-    part.toLowerCase() === lowerTerm ? (
+  return parts.map((part) => {
+    const start = offset;
+    offset += part.length;
+
+    if (part.toLowerCase() !== lowerTerm) {
+      return part;
+    }
+
+    return (
       <mark
-        key={index}
+        key={`${start}:${part}`}
         className="rounded-[2px] bg-yellow-100 text-foreground dark:bg-yellow-500/25"
       >
         {part}
       </mark>
-    ) : (
-      part
-    ),
-  );
+    );
+  });
 };

--- a/frontend/core-ui/src/modules/search/utils/highlightMatch.tsx
+++ b/frontend/core-ui/src/modules/search/utils/highlightMatch.tsx
@@ -1,0 +1,32 @@
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Splits the text on the searched term and marks the matches. The API decides
+// what matched, so a hit on a field the row does not render simply comes back
+// without a highlight.
+export const highlightMatch = (
+  text: string,
+  searchValue: string,
+): React.ReactNode => {
+  const term = searchValue.trim();
+
+  if (!term) {
+    return text;
+  }
+
+  const parts = text.split(new RegExp(`(${escapeRegExp(term)})`, 'ig'));
+  const lowerTerm = term.toLowerCase();
+
+  return parts.map((part, index) =>
+    part.toLowerCase() === lowerTerm ? (
+      <mark
+        key={index}
+        className="rounded-[2px] bg-yellow-100 text-foreground dark:bg-yellow-500/25"
+      >
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+};

--- a/frontend/core-ui/src/modules/search/utils/searchErrors.ts
+++ b/frontend/core-ui/src/modules/search/utils/searchErrors.ts
@@ -1,0 +1,20 @@
+import { ApolloError } from '@apollo/client';
+
+export const getErroredAliases = (error?: ApolloError): Set<string> =>
+  new Set(
+    (error?.graphQLErrors ?? [])
+      .map((graphQLError) => graphQLError.path?.[0])
+      .filter((alias): alias is string => typeof alias === 'string'),
+  );
+
+export const isPermissionError = (message: string): boolean =>
+  /permission required/i.test(message);
+
+const INVALID_FIELD_PATTERN = /Cannot query field "([^"]+)"/;
+
+export const getInvalidFieldNames = (error?: ApolloError): string[] =>
+  (error?.graphQLErrors ?? [])
+    .map(
+      (graphQLError) => graphQLError.message.match(INVALID_FIELD_PATTERN)?.[1],
+    )
+    .filter((field): field is string => typeof field === 'string');

--- a/frontend/core-ui/src/providers/apollo-provider/apolloClient.ts
+++ b/frontend/core-ui/src/providers/apollo-provider/apolloClient.ts
@@ -62,11 +62,14 @@ const httpLink = createHttpLink({
 });
 
 // Error handler
-const errorLink = onError(({ graphQLErrors }) => {
+const errorLink = onError(({ graphQLErrors, operation }) => {
   if (graphQLErrors && graphQLErrors.length > 0) {
     const [error] = graphQLErrors;
 
-    if (error.message === 'Login required') {
+    if (
+      error.message === 'Login required' &&
+      operation.operationName !== 'GlobalSearch'
+    ) {
       globalThis.window.location.reload();
     }
   }

--- a/frontend/libs/erxes-ui/src/types/UIConfig.ts
+++ b/frontend/libs/erxes-ui/src/types/UIConfig.ts
@@ -1,3 +1,59 @@
+export type TSearchPayload = Readonly<Record<string, unknown>>;
+
+export type TSearchResultItem = {
+  id: string;
+  title: string;
+  description?: string;
+  path: string;
+};
+
+export type TSearchSelection = {
+  /** Globally unique alias. MUST start with `gs_<pluginName>_`. */
+  alias: string;
+  /** Root Query field, e.g. `customers`. Used for quarantine + diagnostics. */
+  field: string;
+  /** Arg body without parens, e.g. `searchValue: $searchValue, limit: $limit`. */
+  args?: string;
+  /** Selection set incl. braces. Omit for scalar fields like `productsTotalCount`. */
+  body?: string;
+  /** When true, an error on this alias does not fail the whole group. */
+  optional?: boolean;
+};
+
+export type TSearchGroupResult = {
+  items: TSearchResultItem[];
+  totalCount: number;
+  countMode: 'exact' | 'approximate';
+};
+
+export type TSearchProviderDefinition<TNode> = {
+  /** Repo-unique, kebab-case, e.g. `sales-deals`. */
+  key: string;
+  /** English source of truth. */
+  label: string;
+  labelKey?: string;
+  labelNamespace?: string;
+  icon?: React.ElementType;
+  order?: number;
+  selections: TSearchSelection[];
+  select: (payload: TSearchPayload) => {
+    nodes: TNode[];
+    totalCount?: number;
+  };
+  toItem: (node: TNode) => TSearchResultItem | null;
+};
+
+export type ISearchProvider = {
+  key: string;
+  label: string;
+  labelKey?: string;
+  labelNamespace?: string;
+  icon?: React.ElementType;
+  order?: number;
+  selections: TSearchSelection[];
+  resolve: (payload: TSearchPayload, limit: number) => TSearchGroupResult;
+};
+
 export type TPropertyInputMeta = Record<string, unknown>;
 
 export type TActivityRowProps = {
@@ -61,6 +117,7 @@ export type IUIConfig = {
     hasFloatingWidget?: boolean;
     hasSegmentConfigWidget?: boolean;
   }[];
+  searchProviders?: ISearchProvider[];
 };
 
 export type ICoreModule = {

--- a/frontend/libs/erxes-ui/src/utils/index.ts
+++ b/frontend/libs/erxes-ui/src/utils/index.ts
@@ -12,3 +12,5 @@ export * from './regex';
 export * from './IsUndefinedOrNull';
 export * from './isEnabled';
 export * from './string-array';
+export * from './searchProvider';
+export * from './stripHtml';

--- a/frontend/libs/erxes-ui/src/utils/searchProvider.ts
+++ b/frontend/libs/erxes-ui/src/utils/searchProvider.ts
@@ -1,0 +1,64 @@
+import {
+  ISearchProvider,
+  TSearchPayload,
+  TSearchProviderDefinition,
+} from '../types/UIConfig';
+import { isAnObject } from './isAnObject';
+
+export const readCursorList = <TNode>(
+  payload: TSearchPayload,
+  alias: string,
+): { nodes: TNode[]; totalCount: number } => {
+  const page = payload[alias];
+
+  if (!isAnObject(page)) {
+    return { nodes: [], totalCount: 0 };
+  }
+
+  const { list, totalCount } = page as {
+    list?: TNode[];
+    totalCount?: number;
+  };
+
+  return {
+    nodes: Array.isArray(list) ? list : [],
+    totalCount: totalCount ?? 0,
+  };
+};
+
+export const readArray = <TNode>(
+  payload: TSearchPayload,
+  alias: string,
+): TNode[] => {
+  const value = payload[alias];
+
+  return Array.isArray(value) ? (value as TNode[]) : [];
+};
+
+export const readNumber = (payload: TSearchPayload, alias: string): number =>
+  typeof payload[alias] === 'number' ? (payload[alias] as number) : 0;
+
+export const defineSearchProvider = <TNode>(
+  definition: TSearchProviderDefinition<TNode>,
+): ISearchProvider => ({
+  key: definition.key,
+  label: definition.label,
+  labelKey: definition.labelKey,
+  labelNamespace: definition.labelNamespace,
+  icon: definition.icon,
+  order: definition.order,
+  selections: definition.selections,
+  resolve: (payload, limit) => {
+    const { nodes, totalCount } = definition.select(payload);
+    const items = nodes
+      .slice(0, limit)
+      .map(definition.toItem)
+      .filter((item): item is NonNullable<typeof item> => item !== null);
+
+    return {
+      items,
+      totalCount: Math.max(totalCount ?? nodes.length, items.length),
+      countMode: totalCount === undefined ? 'approximate' : 'exact',
+    };
+  },
+});

--- a/frontend/libs/erxes-ui/src/utils/stripHtml.ts
+++ b/frontend/libs/erxes-ui/src/utils/stripHtml.ts
@@ -1,0 +1,15 @@
+export const stripHtml = (value?: string | null) => {
+  if (!value) {
+    return '';
+  }
+
+  const { body } = new DOMParser().parseFromString(value, 'text/html');
+
+  return (body.textContent || '').replaceAll(/\s+/g, ' ').trim();
+};
+
+export const getPersonName = (
+  person: { firstName?: string | null; lastName?: string | null } | null,
+  fallback: string,
+) =>
+  [person?.firstName, person?.lastName].filter(Boolean).join(' ') || fallback;

--- a/frontend/plugins/accounting_ui/src/config.tsx
+++ b/frontend/plugins/accounting_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconCashBanknote, IconReceipt } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const MainNavigation = lazy(() =>
   import('./modules/MainNavigation').then((module) => ({
@@ -65,4 +66,5 @@ export const CONFIG: IUIConfig = {
       },
     ],
   },
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/accounting_ui/src/searchProviders.tsx
+++ b/frontend/plugins/accounting_ui/src/searchProviders.tsx
@@ -1,0 +1,43 @@
+import { IconReceipt } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TTransactionNode = {
+  _id: string;
+  number?: string | null;
+  parentId?: string | null;
+  originId?: string | null;
+  description?: string | null;
+};
+
+const transactionsSearchProvider = defineSearchProvider<TTransactionNode>({
+  key: 'accounting-transactions',
+  label: 'Transactions',
+  icon: IconReceipt,
+  order: 200,
+  selections: [
+    {
+      alias: 'gs_accounting_transactions',
+      field: 'accTransactionsMain',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id number parentId originId description } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TTransactionNode>(payload, 'gs_accounting_transactions'),
+  toItem: (transaction) => ({
+    id: transaction._id,
+    title: transaction.number || UNNAMED,
+    description: transaction.description || undefined,
+    path: `/accounting/transaction/edit?parentId=${transaction.parentId ?? ''}&trId=${
+      transaction.originId || transaction._id
+    }`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [transactionsSearchProvider];

--- a/frontend/plugins/content_ui/src/config.tsx
+++ b/frontend/plugins/content_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconBooks, IconLibraryPhoto } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui/types';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const ContentNavigation = lazy(() =>
   import('./modules/ContentNavigation').then((module) => ({
@@ -28,4 +29,5 @@ export const CONFIG: IUIConfig = {
       path: 'content/cms',
     },
   ],
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/content_ui/src/searchProviders.tsx
+++ b/frontend/plugins/content_ui/src/searchProviders.tsx
@@ -1,0 +1,104 @@
+import { IconArticle, IconFileText } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  isAnObject,
+  ISearchProvider,
+  TSearchPayload,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TPostNode = {
+  _id: string;
+  title?: string | null;
+  clientPortalId: string;
+};
+
+const readPostsPage = (payload: TSearchPayload, alias: string) => {
+  const page = payload[alias];
+
+  if (!isAnObject(page)) {
+    return {
+      nodes: [] as TPostNode[],
+      totalCount: undefined as number | undefined,
+    };
+  }
+
+  const { posts, totalCount } = page as {
+    posts?: TPostNode[];
+    totalCount?: number;
+  };
+
+  return { nodes: Array.isArray(posts) ? posts : [], totalCount };
+};
+
+const postsSearchProvider = defineSearchProvider<TPostNode>({
+  key: 'content-posts',
+  label: 'CMS posts',
+  icon: IconArticle,
+  order: 300,
+  selections: [
+    {
+      alias: 'gs_content_posts',
+      field: 'cmsPostList',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ posts { _id title clientPortalId } totalCount }',
+    },
+  ],
+  select: (payload) => readPostsPage(payload, 'gs_content_posts'),
+  toItem: (post) => ({
+    id: post._id,
+    title: post.title || UNNAMED,
+    path: `/content/cms/${post.clientPortalId}/posts/detail/${post._id}`,
+  }),
+});
+
+type TPageNode = {
+  _id: string;
+  name?: string | null;
+  clientPortalId: string;
+};
+
+const readPagesPage = (payload: TSearchPayload, alias: string) => {
+  const page = payload[alias];
+
+  if (!isAnObject(page)) {
+    return {
+      nodes: [] as TPageNode[],
+      totalCount: undefined as number | undefined,
+    };
+  }
+
+  const { pages, totalCount } = page as {
+    pages?: TPageNode[];
+    totalCount?: number;
+  };
+
+  return { nodes: Array.isArray(pages) ? pages : [], totalCount };
+};
+
+const pagesSearchProvider = defineSearchProvider<TPageNode>({
+  key: 'content-pages',
+  label: 'CMS pages',
+  icon: IconFileText,
+  order: 310,
+  selections: [
+    {
+      alias: 'gs_content_pages',
+      field: 'cmsPageList',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ pages { _id name clientPortalId } totalCount }',
+    },
+  ],
+  select: (payload) => readPagesPage(payload, 'gs_content_pages'),
+  toItem: (page) => ({
+    id: page._id,
+    title: page.name || UNNAMED,
+    path: `/content/cms/${page.clientPortalId}/pages/detail/${page._id}`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  postsSearchProvider,
+  pagesSearchProvider,
+];

--- a/frontend/plugins/frontline_ui/src/config.tsx
+++ b/frontend/plugins/frontline_ui/src/config.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tabler/icons-react';
 import { IUIConfig, TActivityRowProps, TPropertyInputProps } from 'erxes-ui';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const FrontlineNavigation = lazy(() =>
   import('./modules/FrontlineNavigation').then((module) => ({
@@ -116,4 +117,5 @@ export const CONFIG: IUIConfig = {
       path: 'frontline/knowledgebase',
     },
   ],
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/frontline_ui/src/searchProviders.tsx
+++ b/frontend/plugins/frontline_ui/src/searchProviders.tsx
@@ -1,0 +1,175 @@
+import {
+  IconForms,
+  IconInbox,
+  IconMail,
+  IconTicket,
+} from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  getPersonName,
+  ISearchProvider,
+  readArray,
+  readCursorList,
+  stripHtml,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TConversationNode = {
+  _id: string;
+  content?: string | null;
+  customer?: {
+    _id: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    primaryEmail?: string | null;
+  } | null;
+};
+
+const conversationsSearchProvider = defineSearchProvider<TConversationNode>({
+  key: 'frontline-conversations',
+  label: 'Conversations',
+  labelKey: 'conversations',
+  labelNamespace: 'common',
+  icon: IconMail,
+  order: 110,
+  selections: [
+    {
+      alias: 'gs_frontline_conversations_open',
+      field: 'conversations',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id content customer { _id firstName lastName primaryEmail } } totalCount }',
+    },
+    {
+      alias: 'gs_frontline_conversations_closed',
+      field: 'conversations',
+      args: 'searchValue: $searchValue, limit: $limit, status: "closed"',
+      body: '{ list { _id content customer { _id firstName lastName primaryEmail } } totalCount }',
+    },
+  ],
+  select: (payload) => {
+    const open = readCursorList<TConversationNode>(
+      payload,
+      'gs_frontline_conversations_open',
+    );
+    const closed = readCursorList<TConversationNode>(
+      payload,
+      'gs_frontline_conversations_closed',
+    );
+
+    return {
+      nodes: [...open.nodes, ...closed.nodes],
+      totalCount: open.totalCount + closed.totalCount,
+    };
+  },
+  toItem: (conversation) => ({
+    id: conversation._id,
+    title: getPersonName(
+      conversation.customer ?? null,
+      conversation.customer?.primaryEmail || UNNAMED,
+    ),
+    description: stripHtml(conversation.content),
+    path: `/frontline/inbox?conversationId=${conversation._id}`,
+  }),
+});
+
+type TTicketNode = {
+  _id: string;
+  name?: string | null;
+  number?: string | null;
+};
+
+const ticketsSearchProvider = defineSearchProvider<TTicketNode>({
+  key: 'frontline-tickets',
+  label: 'Tickets',
+  labelKey: 'tickets',
+  labelNamespace: 'common',
+  icon: IconTicket,
+  order: 120,
+  selections: [
+    {
+      alias: 'gs_frontline_tickets',
+      field: 'getTickets',
+      args: 'filter: { searchValue: $searchValue, limit: $limit, cursor: "", direction: forward, orderBy: { createdAt: -1 } }',
+      body: '{ list { _id name number } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TTicketNode>(payload, 'gs_frontline_tickets'),
+  toItem: (ticket) => ({
+    id: ticket._id,
+    title: ticket.name || UNNAMED,
+    description: ticket.number ? `#${ticket.number}` : undefined,
+    path: `/frontline/tickets?ticketId=${ticket._id}`,
+  }),
+});
+
+type TChannelNode = {
+  _id: string;
+  name?: string | null;
+  description?: string | null;
+};
+
+const channelsSearchProvider = defineSearchProvider<TChannelNode>({
+  key: 'frontline-channels',
+  label: 'Channels',
+  labelKey: 'channels',
+  labelNamespace: 'common',
+  icon: IconInbox,
+  order: 130,
+  selections: [
+    {
+      alias: 'gs_frontline_channels',
+      field: 'getChannels',
+      args: 'name: $searchValue',
+      body: '{ _id name description }',
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TChannelNode>(payload, 'gs_frontline_channels'),
+  }),
+  toItem: (channel) => ({
+    id: channel._id,
+    title: channel.name || UNNAMED,
+    description: channel.description || undefined,
+    path: `/frontline/inbox?channelId=${channel._id}`,
+  }),
+});
+
+type TFormNode = {
+  _id: string;
+  name?: string | null;
+  title?: string | null;
+  code?: string | null;
+};
+
+const formsSearchProvider = defineSearchProvider<TFormNode>({
+  key: 'frontline-forms',
+  label: 'Forms',
+  labelKey: 'forms',
+  labelNamespace: 'common',
+  icon: IconForms,
+  order: 140,
+  selections: [
+    {
+      alias: 'gs_frontline_forms',
+      field: 'forms',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id name title code } totalCount }',
+    },
+  ],
+  select: (payload) => readCursorList<TFormNode>(payload, 'gs_frontline_forms'),
+  toItem: (form) => ({
+    id: form._id,
+    title: form.name || form.title || UNNAMED,
+    description: form.code || undefined,
+    path: `/frontline/forms/${form._id}`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  conversationsSearchProvider,
+  ticketsSearchProvider,
+  channelsSearchProvider,
+  formsSearchProvider,
+];

--- a/frontend/plugins/insurance_ui/src/config.tsx
+++ b/frontend/plugins/insurance_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconSandbox } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui/types';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const InsuranceNavigation = lazy(() =>
   import('./modules/InsuranceNavigation').then((module) => ({
@@ -29,4 +30,5 @@ export const CONFIG: IUIConfig = {
       path: 'insurance',
     },
   ],
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/insurance_ui/src/searchProviders.tsx
+++ b/frontend/plugins/insurance_ui/src/searchProviders.tsx
@@ -1,0 +1,77 @@
+import { IconFileText, IconUser } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  getPersonName,
+  ISearchProvider,
+  readArray,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TContractNode = {
+  id: string;
+  contractNumber?: string | null;
+};
+
+const contractsSearchProvider = defineSearchProvider<TContractNode>({
+  key: 'insurance-contracts',
+  label: 'Contracts',
+  icon: IconFileText,
+  order: 260,
+  selections: [
+    {
+      alias: 'gs_insurance_contracts',
+      field: 'contracts',
+      args: 'searchValue: $searchValue',
+      body: '{ id contractNumber }',
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TContractNode>(payload, 'gs_insurance_contracts'),
+  }),
+  toItem: (contract) => ({
+    id: contract.id,
+    title: contract.contractNumber || UNNAMED,
+    path: `/insurance/contracts/${contract.id}`,
+  }),
+});
+
+type TInsuranceCustomerNode = {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  companyName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+};
+
+const customersSearchProvider = defineSearchProvider<TInsuranceCustomerNode>({
+  key: 'insurance-customers',
+  label: 'Insurance customers',
+  icon: IconUser,
+  order: 270,
+  selections: [
+    {
+      alias: 'gs_insurance_customers',
+      field: 'insuranceCustomers',
+      args: 'search: $searchValue, limit: $limit',
+      body: '{ id firstName lastName companyName email phone }',
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TInsuranceCustomerNode>(payload, 'gs_insurance_customers'),
+  }),
+  toItem: (customer) => ({
+    id: customer.id,
+    title:
+      customer.companyName ||
+      getPersonName(customer, customer.email || UNNAMED),
+    description: customer.email || customer.phone || undefined,
+    path: `/insurance/customers/${customer.id}`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  contractsSearchProvider,
+  customersSearchProvider,
+];

--- a/frontend/plugins/loyalty_ui/src/config.tsx
+++ b/frontend/plugins/loyalty_ui/src/config.tsx
@@ -3,6 +3,7 @@ import { IUIConfig } from 'erxes-ui';
 import { LoyaltySettingsNavigation } from './LoyaltySettingsNavigation';
 import { Suspense } from 'react';
 import { MainNavigation } from './modules/navigation/MainNavigation';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 export const CONFIG: IUIConfig = {
   name: 'loyalty',
@@ -43,4 +44,5 @@ export const CONFIG: IUIConfig = {
       },
     ],
   },
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/loyalty_ui/src/searchProviders.tsx
+++ b/frontend/plugins/loyalty_ui/src/searchProviders.tsx
@@ -1,0 +1,108 @@
+import { IconAward } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TCampaignNode = {
+  _id: string;
+  title?: string | null;
+};
+
+const voucherCampaignsSearchProvider = defineSearchProvider<TCampaignNode>({
+  key: 'loyalty-voucher-campaigns',
+  label: 'Voucher campaigns',
+  icon: IconAward,
+  order: 210,
+  selections: [
+    {
+      alias: 'gs_loyalty_voucher_campaigns',
+      field: 'voucherCampaigns',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id title } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCampaignNode>(payload, 'gs_loyalty_voucher_campaigns'),
+  toItem: (campaign) => ({
+    id: campaign._id,
+    title: campaign.title || UNNAMED,
+    path: `/settings/loyalty/config/voucher?editVoucherId=${campaign._id}`,
+  }),
+});
+
+const couponCampaignsSearchProvider = defineSearchProvider<TCampaignNode>({
+  key: 'loyalty-coupon-campaigns',
+  label: 'Coupon campaigns',
+  icon: IconAward,
+  order: 220,
+  selections: [
+    {
+      alias: 'gs_loyalty_coupon_campaigns',
+      field: 'couponCampaigns',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id title } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCampaignNode>(payload, 'gs_loyalty_coupon_campaigns'),
+  toItem: (campaign) => ({
+    id: campaign._id,
+    title: campaign.title || UNNAMED,
+    path: `/settings/loyalty/config/coupon?editCouponId=${campaign._id}`,
+  }),
+});
+
+const assignmentCampaignsSearchProvider = defineSearchProvider<TCampaignNode>({
+  key: 'loyalty-assignment-campaigns',
+  label: 'Assignment campaigns',
+  icon: IconAward,
+  order: 230,
+  selections: [
+    {
+      alias: 'gs_loyalty_assignment_campaigns',
+      field: 'assignmentCampaigns',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id title } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCampaignNode>(payload, 'gs_loyalty_assignment_campaigns'),
+  toItem: (campaign) => ({
+    id: campaign._id,
+    title: campaign.title || UNNAMED,
+    path: `/settings/loyalty/config/assignment?editAssignmentId=${campaign._id}`,
+  }),
+});
+
+const scoreCampaignsSearchProvider = defineSearchProvider<TCampaignNode>({
+  key: 'loyalty-score-campaigns',
+  label: 'Score campaigns',
+  icon: IconAward,
+  order: 240,
+  selections: [
+    {
+      alias: 'gs_loyalty_score_campaigns',
+      field: 'scoreCampaigns',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id title } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TCampaignNode>(payload, 'gs_loyalty_score_campaigns'),
+  toItem: (campaign) => ({
+    id: campaign._id,
+    title: campaign.title || UNNAMED,
+    path: `/settings/loyalty/config/score?editScoreId=${campaign._id}`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  voucherCampaignsSearchProvider,
+  couponCampaignsSearchProvider,
+  assignmentCampaignsSearchProvider,
+  scoreCampaignsSearchProvider,
+];

--- a/frontend/plugins/mongolian_ui/src/config.tsx
+++ b/frontend/plugins/mongolian_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconSandbox } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui/types';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const MainNavigation = lazy(() =>
   import('./modules/MainNavigation').then((module) => ({
@@ -101,4 +102,5 @@ export const CONFIG: IUIConfig = {
       path: 'mongolian/exchange-rates',
     },
   ],
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/mongolian_ui/src/searchProviders.tsx
+++ b/frontend/plugins/mongolian_ui/src/searchProviders.tsx
@@ -1,0 +1,75 @@
+import { IconCurrencyDollar, IconReceipt } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TPutResponseNode = {
+  _id: string;
+  number?: string | null;
+  customerName?: string | null;
+};
+
+const putResponsesSearchProvider = defineSearchProvider<TPutResponseNode>({
+  key: 'mongolian-put-responses',
+  label: 'eBarimt receipts',
+  icon: IconReceipt,
+  order: 280,
+  selections: [
+    {
+      alias: 'gs_mongolian_put_responses',
+      field: 'putResponses',
+      args: 'search: $searchValue, limit: $limit',
+      body: '{ list { _id number customerName } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TPutResponseNode>(payload, 'gs_mongolian_put_responses'),
+  toItem: (putResponse) => ({
+    id: putResponse._id,
+    title: putResponse.number || UNNAMED,
+    description: putResponse.customerName || undefined,
+    path: '/mongolian/put-response',
+  }),
+});
+
+type TExchangeRateNode = {
+  _id: string;
+  mainCurrency?: string | null;
+  rateCurrency?: string | null;
+  rate?: number | null;
+};
+
+const exchangeRatesSearchProvider = defineSearchProvider<TExchangeRateNode>({
+  key: 'mongolian-exchange-rates',
+  label: 'Exchange rates',
+  icon: IconCurrencyDollar,
+  order: 290,
+  selections: [
+    {
+      alias: 'gs_mongolian_exchange_rates',
+      field: 'exchangeRatesMain',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id mainCurrency rateCurrency rate } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TExchangeRateNode>(payload, 'gs_mongolian_exchange_rates'),
+  toItem: (rate) => ({
+    id: rate._id,
+    title:
+      rate.mainCurrency && rate.rateCurrency
+        ? `${rate.mainCurrency} / ${rate.rateCurrency}`
+        : UNNAMED,
+    description: typeof rate.rate === 'number' ? String(rate.rate) : undefined,
+    path: `/settings/mongolian/exchange-rates?exchange_rate_id=${rate._id}`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  putResponsesSearchProvider,
+  exchangeRatesSearchProvider,
+];

--- a/frontend/plugins/operation_ui/src/config.tsx
+++ b/frontend/plugins/operation_ui/src/config.tsx
@@ -6,6 +6,7 @@ import {
 import { Suspense, lazy } from 'react';
 
 import { IUIConfig, TPropertyInputProps } from 'erxes-ui';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const TaskStatusPropertyInput = lazy(() =>
   import('./modules/task/components/task-selects/TaskStatusPropertyInput').then(
@@ -92,4 +93,5 @@ export const CONFIG: IUIConfig = {
       ),
     },
   },
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/operation_ui/src/searchProviders.tsx
+++ b/frontend/plugins/operation_ui/src/searchProviders.tsx
@@ -1,0 +1,96 @@
+import { IconChecklist, IconClipboard, IconUsers } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readArray,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TTaskNode = {
+  _id: string;
+  name?: string | null;
+};
+
+const tasksSearchProvider = defineSearchProvider<TTaskNode>({
+  key: 'operation-tasks',
+  label: 'Tasks',
+  icon: IconChecklist,
+  order: 150,
+  selections: [
+    {
+      alias: 'gs_operation_tasks',
+      field: 'getTasks',
+      args: 'filter: { name: $searchValue, limit: $limit }',
+      body: '{ list { _id name } totalCount }',
+    },
+  ],
+  select: (payload) => readCursorList<TTaskNode>(payload, 'gs_operation_tasks'),
+  toItem: (task) => ({
+    id: task._id,
+    title: task.name || UNNAMED,
+    path: `/operation/tasks/${task._id}`,
+  }),
+});
+
+type TProjectNode = {
+  _id: string;
+  name?: string | null;
+};
+
+const projectsSearchProvider = defineSearchProvider<TProjectNode>({
+  key: 'operation-projects',
+  label: 'Projects',
+  icon: IconClipboard,
+  order: 160,
+  selections: [
+    {
+      alias: 'gs_operation_projects',
+      field: 'getProjects',
+      args: 'filter: { name: $searchValue, limit: $limit }',
+      body: '{ list { _id name } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TProjectNode>(payload, 'gs_operation_projects'),
+  toItem: (project) => ({
+    id: project._id,
+    title: project.name || UNNAMED,
+    path: `/operation/projects/${project._id}/overview`,
+  }),
+});
+
+type TTeamNode = {
+  _id: string;
+  name?: string | null;
+};
+
+const teamsSearchProvider = defineSearchProvider<TTeamNode>({
+  key: 'operation-teams',
+  label: 'Teams',
+  icon: IconUsers,
+  order: 170,
+  selections: [
+    {
+      alias: 'gs_operation_teams',
+      field: 'getTeams',
+      args: 'name: $searchValue',
+      body: '{ _id name }',
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TTeamNode>(payload, 'gs_operation_teams'),
+  }),
+  toItem: (team) => ({
+    id: team._id,
+    title: team.name || UNNAMED,
+    path: `/operation/team/${team._id}/tasks`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  tasksSearchProvider,
+  projectsSearchProvider,
+  teamsSearchProvider,
+];

--- a/frontend/plugins/payment_ui/src/config.tsx
+++ b/frontend/plugins/payment_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconCurrencyDollar, IconInvoice } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const PaymentSettingsNavigation = lazy(() =>
   import('./modules/PaymentSettingsNavigation').then((module) => ({
@@ -24,4 +25,5 @@ export const CONFIG: IUIConfig = {
       },
     ],
   },
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/payment_ui/src/searchProviders.tsx
+++ b/frontend/plugins/payment_ui/src/searchProviders.tsx
@@ -1,0 +1,40 @@
+import { IconInvoice } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TInvoiceNode = {
+  _id: string;
+  invoiceNumber?: string | null;
+  amount?: number | null;
+};
+
+const invoicesSearchProvider = defineSearchProvider<TInvoiceNode>({
+  key: 'payment-invoices',
+  label: 'Invoices',
+  icon: IconInvoice,
+  order: 250,
+  selections: [
+    {
+      alias: 'gs_payment_invoices',
+      field: 'invoices',
+      args: 'searchValue: $searchValue, limit: $limit',
+      body: '{ list { _id invoiceNumber amount } totalCount }',
+    },
+  ],
+  select: (payload) =>
+    readCursorList<TInvoiceNode>(payload, 'gs_payment_invoices'),
+  toItem: (invoice) => ({
+    id: invoice._id,
+    title: invoice.invoiceNumber || UNNAMED,
+    description:
+      typeof invoice.amount === 'number' ? String(invoice.amount) : undefined,
+    path: '/settings/payment/invoices',
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [invoicesSearchProvider];

--- a/frontend/plugins/sales_ui/src/config.tsx
+++ b/frontend/plugins/sales_ui/src/config.tsx
@@ -2,6 +2,7 @@ import { IconBriefcase, IconReceipt, IconSandbox } from '@tabler/icons-react';
 import { Suspense, lazy } from 'react';
 
 import { IUIConfig, TPropertyInputProps } from 'erxes-ui';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const DealStagePropertyInput = lazy(() =>
   import('./modules/deals/components/deal-selects/DealStagePropertyInput').then(
@@ -96,4 +97,5 @@ export const CONFIG: IUIConfig = {
       ),
     },
   },
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/sales_ui/src/searchProviders.tsx
+++ b/frontend/plugins/sales_ui/src/searchProviders.tsx
@@ -1,0 +1,83 @@
+import { IconBriefcase, IconTag } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readArray,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TDealNode = {
+  _id: string;
+  name?: string | null;
+  number?: string | null;
+  boardId?: string | null;
+  pipeline?: { _id: string; boardId?: string | null } | null;
+};
+
+const dealsSearchProvider = defineSearchProvider<TDealNode>({
+  key: 'sales-deals',
+  label: 'Deals',
+  labelKey: 'deals',
+  labelNamespace: 'common',
+  icon: IconTag,
+  order: 100,
+  selections: [
+    {
+      alias: 'gs_sales_deals',
+      field: 'deals',
+      args: 'search: $searchValue, limit: $limit',
+      body: '{ list { _id name number boardId pipeline { _id boardId } } totalCount }',
+    },
+  ],
+  select: (payload) => readCursorList<TDealNode>(payload, 'gs_sales_deals'),
+  toItem: (deal) => {
+    const boardId = deal.boardId || deal.pipeline?.boardId;
+    const pipelineId = deal.pipeline?._id;
+
+    if (!boardId || !pipelineId) {
+      return null;
+    }
+
+    return {
+      id: deal._id,
+      title: deal.name || UNNAMED,
+      description: deal.number ? `#${deal.number}` : undefined,
+      path: `/sales/deals?boardId=${boardId}&pipelineId=${pipelineId}&salesItemId=${deal._id}`,
+    };
+  },
+});
+
+type TPosNode = {
+  _id: string;
+  name?: string | null;
+};
+
+const posSearchProvider = defineSearchProvider<TPosNode>({
+  key: 'sales-pos',
+  label: 'POS',
+  icon: IconBriefcase,
+  order: 105,
+  selections: [
+    {
+      alias: 'gs_sales_pos',
+      field: 'posList',
+      args: 'search: $searchValue, perPage: $limit',
+      body: '{ _id name }',
+    },
+  ],
+  select: (payload) => ({
+    nodes: readArray<TPosNode>(payload, 'gs_sales_pos'),
+  }),
+  toItem: (pos) => ({
+    id: pos._id,
+    title: pos.name || UNNAMED,
+    path: `/sales/pos/${pos._id}/orders`,
+  }),
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [
+  dealsSearchProvider,
+  posSearchProvider,
+];

--- a/frontend/plugins/tourism_ui/src/config.tsx
+++ b/frontend/plugins/tourism_ui/src/config.tsx
@@ -1,6 +1,7 @@
 import { IconBox, IconDirections } from '@tabler/icons-react';
 import { IUIConfig } from 'erxes-ui';
 import { lazy, Suspense } from 'react';
+import { SEARCH_PROVIDERS } from './searchProviders';
 
 const TourismNavigation = lazy(() =>
   import('./modules/TourismNavigation').then((module) => ({
@@ -29,4 +30,5 @@ export const CONFIG: IUIConfig = {
       hasRelationWidget: true,
     },
   ],
+  searchProviders: SEARCH_PROVIDERS,
 };

--- a/frontend/plugins/tourism_ui/src/searchProviders.tsx
+++ b/frontend/plugins/tourism_ui/src/searchProviders.tsx
@@ -1,0 +1,43 @@
+import { IconMapPin } from '@tabler/icons-react';
+import {
+  defineSearchProvider,
+  ISearchProvider,
+  readCursorList,
+} from 'erxes-ui';
+
+const UNNAMED = 'Unnamed';
+
+type TTourNode = {
+  _id: string;
+  name?: string | null;
+  branchId?: string | null;
+};
+
+const toursSearchProvider = defineSearchProvider<TTourNode>({
+  key: 'tourism-tours',
+  label: 'Tours',
+  icon: IconMapPin,
+  order: 320,
+  selections: [
+    {
+      alias: 'gs_tourism_tours',
+      field: 'bmsTours',
+      args: 'name: $searchValue, limit: $limit',
+      body: '{ list { _id name branchId } totalCount }',
+    },
+  ],
+  select: (payload) => readCursorList<TTourNode>(payload, 'gs_tourism_tours'),
+  toItem: (tour) => {
+    if (!tour.branchId) {
+      return null;
+    }
+
+    return {
+      id: tour._id,
+      title: tour.name || UNNAMED,
+      path: `/tourism/tms/branches/${tour.branchId}?activeTab=tour`,
+    };
+  },
+});
+
+export const SEARCH_PROVIDERS: ISearchProvider[] = [toursSearchProvider];


### PR DESCRIPTION
## What

Adds a global command palette to the tab bar, opened with `Cmd/Ctrl + K` or the search button, that searches across the workspace in one place:

- Contacts (customers) and Companies
- Conversations (open + closed) and Channels
- Tickets and Forms
- Deals
- Products
- Team members

Selecting a result navigates straight to that record.

## How

- `frontend/core-ui/src/modules/search/` holds the new module: the `GlobalSearch` dialog, the `useGlobalSearch` hook, its GraphQL documents and types.
- Input is debounced (350ms) and every query is skipped below two characters, so typing does not fan out a request per keystroke.
- Groups owned by optional plugins (`frontline`, `sales`) are skipped when the plugin is not enabled, read from `pluginsConfigState`.
- Each group shows its total count next to the first five results.
- Loading, empty and hint states are all covered; results are keyboard-navigable through `Command`.
- The tab shortcut guide now lists the search shortcut and renders each row from a full key list instead of assuming a shared modifier prefix.
- `global-search` keys added to the gateway `en` and `mn` common locales.

## Backend

`conversationQueryBuilder` now also matches a conversation's own `content` on text search, so a conversation whose customer carries no name is still findable by what was written in it. Phone-shaped terms are unchanged and keep matching customer phones and call CDR numbers.

The search stays on the `conversations` collection deliberately — `conversation_messages` is far larger and unindexed for this, so full message search belongs in Elasticsearch rather than a regex scan per keystroke.

## Test plan

- [x] `Cmd/Ctrl + K` opens the palette from any page; the search button does the same
- [x] Each group only appears when it has results, with a correct total count
- [x] Typing one character shows the hint, two or more runs the search
- [x] Selecting a result navigates to the right record in each group
- [x] Disabling `frontline` / `sales` hides those groups without errors
- [x] Conversation with an unnamed customer is found by its message text
- [x] Phone number search still returns customer / CDR matches

## Summary by Sourcery

Introduce a global search command palette for navigating key CRM entities and extend conversation search to match message content.

New Features:
- Add a GlobalSearch command palette accessible from the tab bar and Cmd/Ctrl+K, searching across contacts, companies, conversations, tickets, deals, products, channels, forms, and team members.
- Expose a global search button with keyboard shortcut metadata in the visited tabs navigation bar.

Enhancements:
- Update conversation querying to also match conversation content for text searches while preserving existing phone-number behavior.
- Conditionally query and display frontline- and sales-related search groups based on enabled plugins, with per-group limits and total counts.
- Refine the tab shortcut guide to render shortcuts from explicit key lists and include the global search shortcut.
- Add GraphQL queries and typed client models to support cross-entity global search, with debounced requests and basic loading/empty states.
- Add common locale strings for the global search UI in English and Mongolian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global search to the navigation bar with a keyboard shortcut.
  * Search customers, companies, products, team members, and records across configured modules.
  * Added grouped results with counts, descriptions, direct navigation, debounced input, and retry support.
  * Added search coverage for conversations, content, accounting, sales, insurance, loyalty, operations, payments, tourism, and other module records.
* **Bug Fixes**
  * Conversation searches now include matching message content for non-phone searches.
* **Documentation**
  * Added English and Mongolian translations for search prompts, states, labels, errors, and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->