### PR TITLE
fix(record-table): attach per-row cursors and recover from a poisoned one

### DIFF
--- a/backend/erxes-api-shared/src/utils/mongo/cursor-util.test.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-util.test.ts
@@ -1,0 +1,74 @@
+import { Types } from 'mongoose';
+import { attachCursors, decodeCursor, encodeCursor } from './cursor-util';
+
+describe('cursor-util', () => {
+  describe('attachCursors', () => {
+    it('gives every item an opaque cursor', () => {
+      const list = [
+        { _id: 'a', createdAt: '2026-01-01' },
+        { _id: 'b', createdAt: '2026-01-02' },
+      ];
+
+      const result = attachCursors(list, ['createdAt']);
+
+      expect(result).toHaveLength(2);
+      for (const item of result) {
+        expect(typeof item.cursor).toBe('string');
+        expect(item.cursor).not.toHaveLength(0);
+      }
+    });
+
+    it('produces a cursor the server can decode back to the same row', () => {
+      const _id = new Types.ObjectId();
+      const [item] = attachCursors([{ _id, createdAt: '2026-01-01' }], [
+        'createdAt',
+      ]);
+
+      const decoded = decodeCursor(item.cursor);
+
+      expect(decoded._id.toString()).toBe(_id.toString());
+      expect(decoded.createdAt).toBe('2026-01-01');
+    });
+
+    it('matches encodeCursor, so a row cursor is a valid pagination cursor', () => {
+      const list = [{ _id: 'a', createdAt: '2026-01-01' }];
+
+      const [item] = attachCursors(list, ['createdAt']);
+
+      expect(item.cursor).toBe(encodeCursor(list[0], ['createdAt']));
+    });
+
+    it('gives each row a distinct cursor', () => {
+      const list = [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }];
+
+      const cursors = attachCursors(list, []).map((item) => item.cursor);
+
+      expect(new Set(cursors).size).toBe(3);
+    });
+
+    it('preserves the original fields', () => {
+      const [item] = attachCursors([{ _id: 'a', firstName: 'Ada' }], []);
+
+      expect(item._id).toBe('a');
+      expect(item.firstName).toBe('Ada');
+    });
+
+    it('handles an empty page', () => {
+      expect(attachCursors([], ['createdAt'])).toEqual([]);
+    });
+  });
+
+  describe('decodeCursor', () => {
+    it('rejects a raw row id, which is what poisoned the record table', () => {
+      expect(() => decodeCursor('68a1f4c2e9b1a20012345678')).toThrow(
+        'Invalid cursor format',
+      );
+    });
+
+    it('rejects a non-base64 leftover value', () => {
+      expect(() => decodeCursor('not-a-cursor')).toThrow(
+        'Invalid cursor format',
+      );
+    });
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
@@ -55,6 +55,23 @@ export const encodeCursor = (item: any, sortFields: string[]): string => {
   return Buffer.from(JSON.stringify(cursorData)).toString('base64');
 };
 
+/**
+ * Attaches an opaque per-item cursor to every row of a page.
+ *
+ * Several GraphQL types already expose a `cursor` field per record and the
+ * record table reads it to remember its scroll position. Without this the
+ * field resolves to null, the client persists an empty/invalid value and the
+ * next list query fails with "Invalid cursor format".
+ */
+export const attachCursors = <T>(
+  list: T[],
+  sortFields: string[],
+): (T & { cursor: string })[] =>
+  list.map((item) => ({
+    ...item,
+    cursor: encodeCursor(item, sortFields),
+  }));
+
 export const decodeCursor = (cursor: string): any => {
   try {
     const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString());

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -7,6 +7,7 @@ import mongoose, {
 import { nanoid } from 'nanoid';
 
 import {
+  attachCursors,
   buildCursorQuery,
   CursorPaginateAggregationParams,
   CursorPaginateParams,
@@ -156,7 +157,7 @@ export const cursorPaginate = async <T extends Document>({
   };
 
   return {
-    list: list as T[],
+    list: attachCursors(list, sortFields) as T[],
     totalCount,
     pageInfo,
   };
@@ -241,7 +242,7 @@ export async function cursorPaginateAggregation<T>({
   };
 
   return {
-    list,
+    list: attachCursors(list, sortFields),
     totalCount,
     pageInfo,
   };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
@@ -37,7 +37,10 @@ export const RecordTableCursorProvider = ({
   const handleScroll = () => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     const firstVisibleRow = scrollRef.current?.querySelector('.in-view');
-    if (firstVisibleRow && sessionKey) {
+    // Only persist a real, non-empty cursor. A row whose `cursor` is missing
+    // renders with an empty id, and storing that would send an invalid cursor
+    // on the next load, erroring the query into a blank table.
+    if (firstVisibleRow && firstVisibleRow.id && sessionKey) {
       sessionStorage.setItem(sessionKey, firstVisibleRow.id);
     }
     debounceTimer.current = setTimeout(() => {

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
@@ -40,7 +40,7 @@ export const RecordTableCursorProvider = ({
     // Only persist a real, non-empty cursor. A row whose `cursor` is missing
     // renders with an empty id, and storing that would send an invalid cursor
     // on the next load, erroring the query into a blank table.
-    if (firstVisibleRow && firstVisibleRow.id && sessionKey) {
+    if (firstVisibleRow?.id && sessionKey) {
       sessionStorage.setItem(sessionKey, firstVisibleRow.id);
     }
     debounceTimer.current = setTimeout(() => {

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
@@ -1,6 +1,8 @@
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { recordTableCursorAtomFamily } from '../states/RecordTableCursorState';
+import { isValidCursor } from '../utils/cursorUtils';
+
 export const useRecordTableCursor = ({
   sessionKey,
 }: {
@@ -12,7 +14,17 @@ export const useRecordTableCursor = ({
 
   useEffect(() => {
     if (!sessionKey) return;
-    setCursor(sessionStorage.getItem(sessionKey) || '');
+
+    const stored = sessionStorage.getItem(sessionKey);
+
+    if (isValidCursor(stored)) {
+      setCursor(stored);
+      return;
+    }
+
+    // Purge a poisoned or legacy value so it cannot be read back again.
+    if (stored) sessionStorage.removeItem(sessionKey);
+    setCursor('');
   }, [sessionKey, setCursor]);
 
   return {

--- a/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.test.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.test.ts
@@ -1,0 +1,46 @@
+import { isValidCursor } from './cursorUtils';
+
+const encodeCursor = (data: Record<string, unknown>) =>
+  btoa(JSON.stringify(data));
+
+describe('isValidCursor', () => {
+  it('accepts an opaque cursor produced by the server', () => {
+    expect(isValidCursor(encodeCursor({ _id: '68a1f4c2e9b1a20012345678' }))).toBe(
+      true,
+    );
+  });
+
+  it('accepts a cursor carrying sort fields alongside _id', () => {
+    const cursor = encodeCursor({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      _id: '68a1f4c2e9b1a20012345678',
+    });
+
+    expect(isValidCursor(cursor)).toBe(true);
+  });
+
+  it('rejects a raw row id, the value that poisoned the record table', () => {
+    expect(isValidCursor('68a1f4c2e9b1a20012345678')).toBe(false);
+  });
+
+  it('rejects an empty string written from a row with no cursor', () => {
+    expect(isValidCursor('')).toBe(false);
+  });
+
+  it('rejects a missing value', () => {
+    expect(isValidCursor(null)).toBe(false);
+  });
+
+  it('rejects base64 that does not decode to JSON', () => {
+    expect(isValidCursor(btoa('not json'))).toBe(false);
+  });
+
+  it('rejects base64 JSON without an _id', () => {
+    expect(isValidCursor(encodeCursor({ createdAt: '2026-01-01' }))).toBe(false);
+  });
+
+  it('rejects base64 JSON that is not an object', () => {
+    expect(isValidCursor(btoa(JSON.stringify('a string')))).toBe(false);
+    expect(isValidCursor(btoa(JSON.stringify(null)))).toBe(false);
+  });
+});

--- a/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.ts
@@ -10,13 +10,20 @@ interface ICursorResult<T> {
 }
 
 /**
+ * A string that has been checked by `isValidCursor`. The brand keeps the
+ * narrowing honest: passing `isValidCursor` yields a `Cursor`, not a bare
+ * `string`, so an unchecked string cannot be mistaken for a validated one.
+ */
+export type Cursor = string & { readonly __cursor: unique symbol };
+
+/**
  * A valid cursor is base64(JSON) carrying at least an `_id`, matching the
  * server's encodeCursor/decodeCursor. A raw row id or any other leftover value
  * is rejected server-side as "Invalid cursor format", which errors the list
  * query and leaves the table permanently blank. Treat anything that is not an
  * opaque cursor as "no cursor" so the table falls back to the first page.
  */
-export const isValidCursor = (value: string | null): value is string => {
+export const isValidCursor = (value: string | null): value is Cursor => {
   if (!value) return false;
 
   try {

--- a/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.ts
@@ -9,6 +9,24 @@ interface ICursorResult<T> {
   totalCount?: number;
 }
 
+/**
+ * A valid cursor is base64(JSON) carrying at least an `_id`, matching the
+ * server's encodeCursor/decodeCursor. A raw row id or any other leftover value
+ * is rejected server-side as "Invalid cursor format", which errors the list
+ * query and leaves the table permanently blank. Treat anything that is not an
+ * opaque cursor as "no cursor" so the table falls back to the first page.
+ */
+export const isValidCursor = (value: string | null): value is string => {
+  if (!value) return false;
+
+  try {
+    const decoded = JSON.parse(atob(value));
+    return typeof decoded === 'object' && decoded !== null && '_id' in decoded;
+  } catch {
+    return false;
+  }
+};
+
 export const mergeCursorData = <T>({
   direction,
   fetchMoreResult,


### PR DESCRIPTION
Fixes #8853.

## Problem

`RecordTableRow` renders `id={original?.cursor}`, but `cursorPaginate` / `cursorPaginateAggregation` only ever computed `pageInfo.startCursor` / `endCursor` — they never attached a cursor to the returned items. Sixteen GraphQL types already declare `cursor: String` per record, so the field resolved to `null` and every row rendered with an empty `id`.

On scroll the table persists the first visible row's `id` into `sessionStorage`, and on the next load reads it back **unvalidated** as the pagination cursor. A non-empty leftover value (a legacy raw `_id`, a cursor from a previous data set) is rejected by `decodeCursor` as `Invalid cursor format`, which errors the whole list query — `data.customers` is `null`, and the table renders headers only, permanently, until `sessionStorage` is cleared.

Reproduced on Contacts → Customers with ~1064 rows. It affects every cursor-based `RecordTable` (companies, tickets, projects, tasks, cycles, deals, …).

## Changes

Per @Amartuvshins0404's review, this covers both the source and the defensive path:

1. **Attach an opaque cursor to every returned item** — new `attachCursors()` helper in `cursor-util.ts`, applied in both `cursorPaginate` and `cursorPaginateAggregation`, so all existing call sites are covered without touching them.
2. **Avoid persisting empty row IDs** — `handleScroll` now requires a non-empty `firstVisibleRow.id` before writing.
3. **Clear invalid or legacy stored cursors and fall back to the first page** — `useRecordTableCursor` validates on read and purges anything that is not a proper opaque cursor.
4. **Focused tests** for per-row cursor generation and the `sessionStorage` recovery path.

On the clarification about the empty-string case: agreed, `''` is restored as "no cursor" and is not itself what throws. The failure needs a **non-empty** stale value, so the regression tests assert exactly that — `rejects a raw row id, the value that poisoned the record table` uses a raw `_id` (`68a1f4c2e9b1a20012345678`) on both sides: `decodeCursor` throws `Invalid cursor format` for it, and `isValidCursor` returns `false`. The empty-string case is covered separately as a write-side guard so that value cannot be stored in the first place.

`isValidCursor` is placed in `cursorUtils.ts` next to the other pure cursor helpers rather than inline in the hook, which keeps it unit-testable without React.

## Notes

- `attachCursors` returns `(T & { cursor: string })[]`, so the added field is visible to TypeScript rather than being cast away.
- Both pagination paths already produce plain objects (`.lean()` and `.aggregate()`), so spreading each item is safe.
- No API contract change: the `cursor` field was already declared in the schemas; it was simply never populated.

## Testing

Both new suites pass (8 backend + 8 frontend), and the touched files typecheck clean:

```
PASS backend/erxes-api-shared/src/utils/mongo/cursor-util.test.ts
  attachCursors
    ✓ gives every item an opaque cursor
    ✓ produces a cursor the server can decode back to the same row
    ✓ matches encodeCursor, so a row cursor is a valid pagination cursor
    ✓ gives each row a distinct cursor
    ✓ preserves the original fields
    ✓ handles an empty page
  decodeCursor
    ✓ rejects a raw row id, which is what poisoned the record table
    ✓ rejects a non-base64 leftover value

PASS frontend/libs/erxes-ui/src/modules/record-table/utils/cursorUtils.test.ts
  isValidCursor
    ✓ accepts an opaque cursor produced by the server
    ✓ accepts a cursor carrying sort fields alongside _id
    ✓ rejects a raw row id, the value that poisoned the record table
    ✓ rejects an empty string written from a row with no cursor
    ✓ rejects a missing value
    ✓ rejects base64 that does not decode to JSON
    ✓ rejects base64 JSON without an _id
    ✓ rejects base64 JSON that is not an object
```

One note for maintainers: `erxes-api-shared` and `erxes-ui` have no `test` target in their `project.json`, so `nx test` does not pick up these files (this already applies to the existing `errorClassifier.test.ts` and `outputResolvers.test.ts`). I ran them with a local jest config. Happy to wire up the targets here or in a separate PR if you'd like.

## Summary by Sourcery

Ensure record tables use per-row opaque cursors and recover safely from invalid stored cursors to avoid blank lists.

New Features:
- Populate a `cursor` field on every paginated record returned by cursor-based Mongo helpers so record tables can track scroll position per row.

Bug Fixes:
- Prevent legacy or invalid cursor values in sessionStorage from breaking subsequent record-table list queries by validating and purging bad cursors on read.
- Avoid persisting empty row IDs from record-table scroll handling so that missing cursors do not poison future pagination requests.

Enhancements:
- Introduce shared cursor utilities on both backend and frontend to attach per-row cursors, validate cursor formats, and keep behavior aligned with existing encode/decode logic.

Tests:
- Add backend tests covering per-row cursor attachment and cursor decoding failures for invalid values.
- Add frontend tests covering cursor validation for valid opaque cursors and a range of invalid or malformed values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encoded cursors to paginated records, including standard and aggregated results.
  * Added cursor validation for reliable pagination state restoration.

* **Bug Fixes**
  * Prevented invalid, incomplete, or legacy cursors from being stored or restored.
  * Preserved cursor state only when required record identifiers are available.

* **Tests**
  * Added coverage for cursor encoding, decoding, uniqueness, validation, malformed values, and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->