### PR TITLE
fix(frontline): order the inbox by real conversation activity

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/Conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/Conversations.ts
@@ -282,17 +282,14 @@ export const loadClass = (models: IModels) => {
       }
 
       const readUserIds = conversation.readUserIds || [];
-      // if current user is first one
-      if (!readUserIds || readUserIds.length === 0) {
-        await models.Conversations.updateConversation(_id, {
-          readUserIds: [userId],
-        });
-      }
 
-      // if current user is not in read users list then add it
+      // Not updateConversation: that stamps `updatedAt`, which the inbox sorts
+      // and shows its relative time from. Reading is not activity.
       if (!readUserIds.includes(userId)) {
-        readUserIds.push(userId);
-        await models.Conversations.updateConversation(_id, { readUserIds });
+        await models.Conversations.updateOne(
+          { _id },
+          { $addToSet: { readUserIds: userId } },
+        );
       }
 
       graphqlPubsub.publish(`conversationChanged:${_id}`, {

--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/Conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/Conversations.ts
@@ -286,10 +286,15 @@ export const loadClass = (models: IModels) => {
       // Not updateConversation: that stamps `updatedAt`, which the inbox sorts
       // and shows its relative time from. Reading is not activity.
       if (!readUserIds.includes(userId)) {
-        await models.Conversations.updateOne(
-          { _id },
-          { $addToSet: { readUserIds: userId } },
-        );
+        await models.Conversations.updateOne({ _id }, [
+          {
+            $set: {
+              readUserIds: {
+                $setUnion: [{ $ifNull: ['$readUserIds', []] }, [userId]],
+              },
+            },
+          },
+        ]);
       }
 
       graphqlPubsub.publish(`conversationChanged:${_id}`, {

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/inboxSubscriptions.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/inboxSubscriptions.ts
@@ -53,6 +53,7 @@ export const CONVERSATION_CLIENT_MESSAGE_INSERTED = gql`
       _id
       conversationId
       content
+      createdAt
     }
   }
 `;
@@ -86,6 +87,7 @@ const customerConnectionChanged = `
 export default {
   conversationChanged,
   conversationMessageInserted,
-  conversationClientTypingStatusChanged: CONVERSATION_CLIENT_TYPING_STATUS_CHANGED,
+  conversationClientTypingStatusChanged:
+    CONVERSATION_CLIENT_TYPING_STATUS_CHANGED,
   customerConnectionChanged,
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -128,23 +128,26 @@ export const useConversations = (
         const index = prev.conversations.list.findIndex(
           (conversation) => conversation._id === conversationId,
         );
-        const list = [...prev.conversations.list];
-        if (index === -1) {
-          // New conversation not yet in list — refetch to load the full entry
+        // Not in the list yet, or nothing to order it by — let the server say.
+        if (index === -1 || !newMessage.createdAt) {
           setTimeout(() => refetchRef.current(), 0);
           return prev;
-        } else {
-          const [conversation] = list.splice(index, 1);
-          list.unshift({
-            ...conversation,
-            readUserIds: conversation.readUserIds?.filter(
-              (id) => id !== userId,
-            ),
-            status: ConversationStatus.OPEN,
-            content: newMessage.content,
-            updatedAt: newMessage.createdAt || new Date().toISOString(),
-          });
         }
+
+        const list = [...prev.conversations.list];
+        const [conversation] = list.splice(index, 1);
+        list.unshift({
+          ...conversation,
+          readUserIds: conversation.readUserIds?.filter((id) => id !== userId),
+          status: ConversationStatus.OPEN,
+          content: newMessage.content,
+          // Events can arrive out of order; recency must never move backwards.
+          updatedAt:
+            Date.parse(newMessage.createdAt) >= getRecency(conversation)
+              ? newMessage.createdAt
+              : conversation.updatedAt,
+        });
+
         return { ...prev, conversations: { ...prev.conversations, list } };
       },
     });

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -8,7 +8,7 @@ import {
   validateFetchMore,
 } from 'erxes-ui';
 import { CONVERSATIONS_LIMIT } from '@/inbox/constants/conversationsConstants';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { CONVERSATION_CLIENT_MESSAGE_INSERTED } from '../graphql/subscriptions/inboxSubscriptions';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { currentUserState } from 'ui-modules';
@@ -19,6 +19,16 @@ import {
 } from '@/inbox/conversations/states/newMessagesCountState';
 import { refetchConversationsAtom } from '../states/refetchConversationState';
 import { activeConversationState } from '../states/activeConversationState';
+
+const getRecency = (conversation: IConversation) => {
+  const time = Date.parse(conversation.updatedAt || conversation.createdAt);
+  return Number.isNaN(time) ? 0 : time;
+};
+
+// Live cache writes only patch fields, so re-apply the server's order
+// (updatedAt desc, ascending _id) to keep the newest conversation on top.
+const compareByRecency = (a: IConversation, b: IConversation) =>
+  getRecency(b) - getRecency(a) || a._id.localeCompare(b._id);
 
 export const useConversations = (
   options?: QueryHookOptions<ICursorListResponse<IConversation>>,
@@ -31,7 +41,11 @@ export const useConversations = (
   const { _id: userId } = useAtomValue(currentUserState) || {};
 
   const { conversations } = data || {};
-  const { list = [], totalCount = 0, pageInfo } = conversations || {};
+  const { totalCount = 0, pageInfo } = conversations || {};
+  const sortedList = useMemo(
+    () => [...(conversations?.list ?? [])].sort(compareByRecency),
+    [conversations?.list],
+  );
   const setNewMessagesCount = useSetAtom(newMessagesCountState);
   const [refetchNewMessages, resetNewMessagesStates] = useAtom(
     resetNewMessagesState,
@@ -44,7 +58,7 @@ export const useConversations = (
 
   useEffect(() => {
     setRefetch(() => refetch);
-  }, [setRefetch]);
+  }, [refetch, setRefetch]);
 
   useEffect(() => {
     if (refetchNewMessages) {
@@ -86,7 +100,12 @@ export const useConversations = (
 
   useEffect(() => {
     const unsubscribe = subscribeToMore<{
-      conversationClientMessageInserted: { _id: string; conversationId: string; content: string };
+      conversationClientMessageInserted: {
+        _id: string;
+        conversationId: string;
+        content: string;
+        createdAt: string;
+      };
     }>({
       document: CONVERSATION_CLIENT_MESSAGE_INSERTED,
       variables: {
@@ -96,7 +115,8 @@ export const useConversations = (
         if (subscriptionData.data) {
           setNewMessagesCount((prev) => prev + 1);
           const incomingConversationId =
-            subscriptionData.data.conversationClientMessageInserted.conversationId;
+            subscriptionData.data.conversationClientMessageInserted
+              .conversationId;
           if (incomingConversationId !== activeConversationRef.current?._id) {
             playNotificationSound();
           }
@@ -114,11 +134,15 @@ export const useConversations = (
           setTimeout(() => refetchRef.current(), 0);
           return prev;
         } else {
-          list.splice(index, 1, {
-            ...list[index],
-            readUserIds: list[index].readUserIds?.filter((id) => id !== userId),
+          const [conversation] = list.splice(index, 1);
+          list.unshift({
+            ...conversation,
+            readUserIds: conversation.readUserIds?.filter(
+              (id) => id !== userId,
+            ),
             status: ConversationStatus.OPEN,
             content: newMessage.content,
+            updatedAt: newMessage.createdAt || new Date().toISOString(),
           });
         }
         return { ...prev, conversations: { ...prev.conversations, list } };
@@ -128,11 +152,11 @@ export const useConversations = (
     return () => {
       unsubscribe();
     };
-  }, []);
+  }, [playNotificationSound, setNewMessagesCount, subscribeToMore, userId]);
 
   return {
     totalCount,
-    conversations: list,
+    conversations: sortedList,
     loading,
     handleFetchMore,
     pageInfo,


### PR DESCRIPTION
## Problem

Two ordering bugs in the Frontline inbox list:

1. **A new message did not move its conversation to the top.** The
   `conversationClientMessageInserted` handler replaced the conversation in place
   (`list.splice(index, 1, {...})`), and an agent's own reply only patched cached
   fields via `cache.modify`, which cannot reorder the list array. The order was
   whatever the last server fetch returned, so it only corrected itself after
   pressing refresh or reloading the page.

2. **Opening a conversation reset its timestamp.** `markAsReadConversation` wrote
   the reader through `updateConversation`, which stamps `updatedAt` on every
   call. Since the sidebar renders `updatedAt` and the API sorts by it, simply
   reading an old conversation showed it as "just now" and lifted it to the top.

## Changes

- `useConversations` returns the list sorted by `updatedAt` descending with an
  ascending `_id` tiebreak, matching `cursorPaginate`'s order on the API. Any
  live cache write — incoming customer message, agent reply, Facebook/Instagram
  message — now reorders the list immediately.
- The subscription handler moves the touched conversation to the front and sets
  `updatedAt` from the message's `createdAt`; the client subscription document
  selects that existing field.
- `markAsReadConversation` adds the reader with a direct
  `updateOne` + `$addToSet`, leaving `updatedAt` alone. This also removes the
  duplicate write that happened for the first reader.

## Testing

- Ran the real `useConversations` hook in jsdom against a mocked Apollo link:
  on `main` both an incoming customer message and a cache-patched agent reply
  left the order untouched; with this change the affected conversation leads the
  list.
- Verified in the browser against a local stack: on `main` the row's preview text
  and unread badge updated but the row stayed in place; with this change it jumps
  to the top with no refresh, and the order survives a hard reload.
- `pnpm nx build frontline_ui`, `pnpm nx build frontline_api`,
  `npx tsc -p backend/plugins/frontline_api/tsconfig.json --noEmit` all pass; no
  new lint findings in the touched files.

## Summary by Sourcery

Ensure Frontline inbox conversations are ordered by actual message activity rather than read status updates.

New Features:
- Return conversations from the inbox hook in a consistently sorted order matching the API’s recency ordering.

Bug Fixes:
- Make incoming client messages immediately move their conversation to the top of the inbox list.
- Prevent opening a conversation from updating its activity timestamp and incorrectly lifting it to the top of the inbox.

Enhancements:
- Normalize conversation recency in the UI by deriving it from updatedAt or createdAt with a stable tie-breaker on _id.
- Use memoization in the inbox hook to avoid unnecessary re-sorting when the conversation list reference is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversations now appear in the correct order, with recently updated or created conversations shown first.
  * New incoming messages move the relevant conversation to the top of the inbox immediately.
  * Incoming message updates now display timestamps more reliably in real time.
  * New messages automatically reopen conversations and clear the current user’s read status.
  * Marking a conversation as read no longer changes its last-updated timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->