### PR TITLE
fix(payment): validate event before ticket scan

### DIFF
--- a/backend/plugins/payment_api/AGENTS.md
+++ b/backend/plugins/payment_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `payment_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/payment_api`
-- **Last synchronized:** `2026-08-10`
+- **Last synchronized:** `2026-08-12`
 
 ## Scope
 
@@ -36,7 +36,8 @@
   fan-out through `enqueuePaidInvoiceCallback`.
 - Issues one random ticket code per unit of `invoice.data.quantity`, renders
   them into a QR PDF, and emails it once per invoice.
-- Redeems ticket codes with per-code scan state.
+- Redeems ticket codes with per-code scan state and can atomically reject a
+  code whose invoice does not match the scanner's expected event slug.
 - Optionally enqueues a sales deal for the paid invoice when the payment
   method's `dealConfig.enabled` is set.
 - Declares the plugin permission config (`invoice` module with
@@ -69,7 +70,9 @@
 - GraphQL: `payment*` queries/mutations/subscriptions (invoices, payments,
   ticket redemption), including
   `invoiceEdit(_id: String!, input: InvoiceEditInput!)` for admin invoice
-  corrections (`description`, `amount`, `currency`, `status`).
+  corrections (`description`, `amount`, `currency`, `status`) and
+  `invoiceScanBarcode(code: String!, eventSlug: String)` for optional
+  event-scoped ticket redemption.
 - Permission actions `paymentInvoiceView` / `paymentInvoiceEdit` and the
   default groups `payment:admin` and `payment:viewer`, published through
   `startPlugin({ meta: { permissions } })`.
@@ -109,6 +112,9 @@
   `email_deliveries` collection.
 - Ticket codes are unguessable random tokens; never fall back to a predictable
   identifier for newly issued tickets.
+- When `invoiceScanBarcode` receives an `eventSlug`, the invoice's
+  `data.eventSlug` must match before any per-ticket or legacy scan timestamp is
+  written; a mismatch must leave the ticket unused.
 - Every callback, resolver, and worker path must keep operating on the request
   `subdomain`'s models.
 - `invoiceEdit` moving `status` into `paid` stamps `resolvedAt`, publishes
@@ -133,10 +139,23 @@
 - Smoke: edit a pending invoice that has `email` to `status: paid` and confirm
   one QR ticket email is sent; repeat on an already-paid invoice and confirm the
   `QR email already sent` skip log instead of a second email.
+- Smoke: scan a paid ticket with its matching `eventSlug` (succeeds), then scan
+  an unused ticket with a different `eventSlug` and confirm it is rejected and
+  remains unused.
 
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — `Event-scoped ticket redemption`
+
+- **Summary:** Added an optional expected event slug to barcode redemption so
+  scanners can reject a ticket for another event without consuming its code.
+- **Affected areas:** `src/modules/payment/db/models/Invoices.ts`,
+  `src/modules/payment/graphql/schemas/invoices.ts`,
+  `src/modules/payment/graphql/resolvers/mutations/invoices.ts`
+- **Contracts changed:** `invoiceScanBarcode` now accepts optional
+  `eventSlug: String`.
 
 ### `2026-08-10` — `Invoice edit permission and mutation`
 

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -211,18 +211,19 @@ export const loadInvoiceClass = (models: IModels) => {
       }
 
       const expectedEventSlug = eventSlug?.trim();
+      let storedEventSlug: string | undefined;
       if (expectedEventSlug) {
-        const invoiceEventSlug =
+        storedEventSlug =
           typeof invoice.data?.eventSlug === 'string'
-            ? invoice.data.eventSlug.trim()
-            : '';
-        if (invoiceEventSlug !== expectedEventSlug) {
+            ? invoice.data.eventSlug
+            : undefined;
+        if (storedEventSlug?.trim() !== expectedEventSlug) {
           throw new Error('Ticket belongs to a different event');
         }
       }
 
-      const eventFilter = expectedEventSlug
-        ? { 'data.eventSlug': expectedEventSlug }
+      const eventFilter = storedEventSlug
+        ? { 'data.eventSlug': storedEventSlug }
         : {};
 
       const hasTicketCodes =

--- a/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/db/models/Invoices.ts
@@ -14,7 +14,7 @@ export interface IInvoiceModel extends Model<IInvoiceDocument> {
   checkInvoice(_id: string, subdomain: string): Promise<string>;
   removeInvoices(_ids: string[]): Promise<any>;
   markAsPaid(_id: string): Promise<string>;
-  scanBarcode(code: string): Promise<IInvoiceDocument>;
+  scanBarcode(code: string, eventSlug?: string): Promise<IInvoiceDocument>;
 }
 
 export const loadInvoiceClass = (models: IModels) => {
@@ -197,7 +197,7 @@ export const loadInvoiceClass = (models: IModels) => {
       return 'removed';
     }
 
-    public static async scanBarcode(code: string) {
+    public static async scanBarcode(code: string, eventSlug?: string) {
       const invoice =
         (await models.Invoices.findOne({ 'ticketCodes.code': code })) ||
         (await models.Invoices.findOne({ invoiceNumber: code }));
@@ -210,6 +210,21 @@ export const loadInvoiceClass = (models: IModels) => {
         throw new Error('Invoice is not paid');
       }
 
+      const expectedEventSlug = eventSlug?.trim();
+      if (expectedEventSlug) {
+        const invoiceEventSlug =
+          typeof invoice.data?.eventSlug === 'string'
+            ? invoice.data.eventSlug.trim()
+            : '';
+        if (invoiceEventSlug !== expectedEventSlug) {
+          throw new Error('Ticket belongs to a different event');
+        }
+      }
+
+      const eventFilter = expectedEventSlug
+        ? { 'data.eventSlug': expectedEventSlug }
+        : {};
+
       const hasTicketCodes =
         Array.isArray(invoice.ticketCodes) && invoice.ticketCodes.length > 0;
 
@@ -217,6 +232,7 @@ export const loadInvoiceClass = (models: IModels) => {
         const scanned = await models.Invoices.findOneAndUpdate(
           {
             _id: invoice._id,
+            ...eventFilter,
             ticketCodes: { $elemMatch: { code, scannedAt: null } },
           },
           {
@@ -236,7 +252,7 @@ export const loadInvoiceClass = (models: IModels) => {
       }
 
       const scanned = await models.Invoices.findOneAndUpdate(
-        { _id: invoice._id, scannedAt: null },
+        { _id: invoice._id, ...eventFilter, scannedAt: null },
         { $set: { scannedAt: new Date() } },
         { new: true },
       );

--- a/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/resolvers/mutations/invoices.ts
@@ -182,10 +182,10 @@ const mutations: Record<string, Resolver<any, any, IContext>> = {
 
   async invoiceScanBarcode(
     _root,
-    { code }: { code: string },
+    { code, eventSlug }: { code: string; eventSlug?: string },
     { models }: IContext,
   ) {
-    const scanned = await models.Invoices.scanBarcode(code);
+    const scanned = await models.Invoices.scanBarcode(code, eventSlug);
 
     graphqlPubsub.publish(`invoiceUpdated:${scanned._id}`, {
       invoiceUpdated: scanned,

--- a/backend/plugins/payment_api/src/modules/payment/graphql/schemas/invoices.ts
+++ b/backend/plugins/payment_api/src/modules/payment/graphql/schemas/invoices.ts
@@ -78,7 +78,7 @@ export const mutations = `
   invoiceEdit(_id: String!, input: InvoiceEditInput!): Invoice
   invoicesCheck(_id:String!): String
   invoicesRemove(_ids: [String]!): String
-  invoiceScanBarcode(code: String!): Invoice
+  invoiceScanBarcode(code: String!, eventSlug: String): Invoice
 
   cpInvoiceCreate(input: InvoiceInput!): Invoice
   cpInvoicesCheck(_id:String!): String


### PR DESCRIPTION
## Summary
- add an optional eventSlug argument to invoiceScanBarcode
- reject tickets whose invoice data.eventSlug does not match before writing scan state
- preserve the legacy mutation behavior when callers omit eventSlug

## Why
Concert door scanners must not consume a valid QR for a different event before learning that it belongs elsewhere.

## Validation
- pnpm nx build erxes-api-shared
- pnpm nx build payment_api
- focused ESLint on the three changed TypeScript files (no errors; two existing unused-variable warnings)

## Summary by Sourcery

Add event-scoped validation to ticket barcode scanning so invoices can only be redeemed for the expected event without consuming mismatched tickets.

New Features:
- Expose an optional eventSlug argument on the invoiceScanBarcode GraphQL mutation and underlying invoice scanBarcode model method for event-scoped ticket redemption.

Bug Fixes:
- Ensure ticket scans are rejected when the invoice's eventSlug does not match the scanner's expected event, leaving the ticket unused.

Enhancements:
- Document event-scoped ticket redemption behavior, constraints, and smoke tests in the payment_api agent guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice barcode scanning can now be restricted to a specific event.
  * Scans for invoices belonging to a different event are rejected without consuming tickets.
  * The event restriction is optional, preserving existing scanning behavior when omitted.

* **Documentation**
  * Updated payment API guidance, contracts, capabilities, invariants, and smoke-test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->