### PR TITLE
fix: posclient report with permission

### DIFF
--- a/apps/posclient-front/app/(main)/(orders)/components/history/columns.tsx
+++ b/apps/posclient-front/app/(main)/(orders)/components/history/columns.tsx
@@ -49,6 +49,12 @@ const columns: ColumnDef<IOrderHistory>[] = [
     cell: formatDate,
   },
   {
+    id: "user",
+    accessorFn: (order) => order.user?.email,
+    header: "Хэрэглэгч",
+    cell: (info) => info.getValue() || "-",
+  },
+  {
     id: "actions",
     enableHiding: false,
     cell: ({ row }: CellContext<IOrderHistory, unknown>) => (

--- a/apps/posclient-front/app/(main)/(orders)/components/history/list.mobile.tsx
+++ b/apps/posclient-front/app/(main)/(orders)/components/history/list.mobile.tsx
@@ -72,7 +72,7 @@ const Loading = () => {
 }
 
 const OrderItem = (props: IOrderHistory) => {
-  const { type, status, number, createdAt, modifiedAt, paidDate } = props
+  const { type, status, number, createdAt, modifiedAt, user, paidDate } = props
   const TypeIcon = type === "eat" ? SoupIcon : TruckIcon
   const fd = (date: string) =>
     date ? format(new Date(date), "yyyy.MM.dd HH:mm") : "-"
@@ -93,6 +93,10 @@ const OrderItem = (props: IOrderHistory) => {
         <div className="flex items-center justify-between text-sm">
           <span className="text-neutral-600">Өөрчилсөн огноо</span>
           {fd(modifiedAt)}
+        </div>
+        <div className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-neutral-600">Хэрэглэгч</span>
+          <span className="truncate">{user?.email || "-"}</span>
         </div>
         <div className="flex items-center justify-between text-sm">
           <span className="text-neutral-600">Төлбөр төлсөн огноо</span>

--- a/apps/posclient-front/app/(main)/report/page.tsx
+++ b/apps/posclient-front/app/(main)/report/page.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { isAdminAtom } from "@/store/config.store"
+import { isAdminAtom, permissionConfigAtom } from "@/store/config.store"
 import { useLazyQuery } from "@apollo/client"
-import { useAtom } from "jotai"
+import { useAtomValue } from "jotai"
 import { ShieldXIcon } from "lucide-react"
 
 import ReportForm from "./components/form"
@@ -25,9 +25,10 @@ interface ReportVariables {
 const Report = () => {
   const [getReport, { loading, data }] = useLazyQuery<DailyReportResponse, ReportVariables>(queries.report)
   const { report } = data?.dailyReport || {}
-  const isAdmin = useAtom(isAdminAtom)
+  const isAdmin = useAtomValue(isAdminAtom)
+  const permissionConfig = useAtomValue(permissionConfigAtom)
 
-  if (!isAdmin)
+  if (!isAdmin && !permissionConfig?.seeReport)
     return (
       <div className="flex flex-auto items-center justify-center shadow-inner bg-neutral-50">
         <div className="flex items-center flex-col shadow-xl py-12 px-20 rounded-lg bg-white">

--- a/apps/posclient-front/components/headerMenu/index.tsx
+++ b/apps/posclient-front/components/headerMenu/index.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link"
 import Logout from "@/modules/auth/components/logout"
 import { modeAtom } from "@/store"
-import { configAtom, currentUserAtom } from "@/store/config.store"
+import {
+  configAtom,
+  currentUserAtom,
+  permissionConfigAtom,
+} from "@/store/config.store"
 import { useAtomValue } from "jotai"
 import {
   FileBarChart2Icon,
@@ -27,19 +31,20 @@ import {
 const HeaderMenu = () => {
   const mode = useAtomValue(modeAtom)
   const user = useAtomValue(currentUserAtom)
+  const permissionConfig = useAtomValue(permissionConfigAtom)
   const { waitingScreen, kitchenScreen, adminIds } =
     useAtomValue(configAtom) || {}
 
   const getMenu = () => {
     if (mode === "market") return supermarketMenu
-    let menu = [...supermarketMenu]
+    const menu = [...supermarketMenu]
     if (kitchenScreen?.isActive) {
       menu.push(progressMenu)
     }
     if (waitingScreen?.isActive) {
       menu.push(waitingMenu)
     }
-    if (adminIds?.includes(user?._id || "")) {
+    if (adminIds?.includes(user?._id || "") || permissionConfig?.seeReport) {
       menu.push(reportMenu)
     }
 

--- a/apps/posclient-front/modules/orders/graphql/queries.ts
+++ b/apps/posclient-front/modules/orders/graphql/queries.ts
@@ -334,6 +334,9 @@ const ordersHistory = gql`
       type
       createdAt
       modifiedAt
+      user {
+        email
+      }
       paidDate
     }
   }

--- a/apps/posclient-front/types/config.types.ts
+++ b/apps/posclient-front/types/config.types.ts
@@ -75,6 +75,7 @@ export interface IKitchenScreen {
 
 export interface IPermissionConfig {
   isTempBill?: boolean
+  seeReport?: boolean
   directDiscount?: boolean
   directDiscountLimit?: number
 }

--- a/apps/posclient-front/types/order.types.ts
+++ b/apps/posclient-front/types/order.types.ts
@@ -192,6 +192,7 @@ export interface IOrderHistory {
   type: string
   createdAt: string
   modifiedAt: string
+  user?: Customer
   paidDate: string
 }
 

--- a/backend/plugins/posclient_api/AGENTS.md
+++ b/backend/plugins/posclient_api/AGENTS.md
@@ -1,0 +1,71 @@
+# `posclient_api` Plugin Guide
+
+## Identity
+
+- **Plugin:** `posclient`
+- **Project:** `posclient_api`
+- **Layer:** `Backend API`
+- **Path:** `backend/plugins/posclient_api`
+- **Last synchronized:** `2026-08-12`
+
+## Scope
+
+### Owns
+
+- POS client GraphQL API, local POS config sync, POS users, orders, covers, reports, and POS runtime mutations.
+
+### Does not own
+
+- Sales POS settings UI, sales API persistence, shared core services, gateway routing, or other plugin data models.
+
+## Current Capabilities
+
+- Authenticates POS users against POS client context.
+- Serves POS client config, order, cover, user, and daily report GraphQL operations.
+- Calculates daily reports for authorized POS admins and cashiers with report permission.
+
+## Architecture
+
+| Area | Path | Responsibility |
+| ---- | ---- | -------------- |
+| GraphQL reports | `backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/report.ts` | Calculates daily POS report totals and product summaries. |
+| GraphQL schemas | `backend/plugins/posclient_api/src/modules/posclient/graphql/schemas` | Declares POS client GraphQL types and operations. |
+| Config models | `backend/plugins/posclient_api/src/modules/posclient/db` | Stores synced POS client configuration and runtime data. |
+| Sync utilities | `backend/plugins/posclient_api/src/modules/posclient/utils/syncUtils.ts` | Synchronizes sales POS configuration into POS client config. |
+
+## Contracts
+
+### Provides
+
+- `dailyReport(posUserIds, dateType, startDate, endDate): DailyReport` GraphQL query.
+- POS client GraphQL and tRPC contracts for order, cover, config, and user flows.
+
+### Consumes
+
+- Synced POS config fields including `adminIds`, `cashierIds`, `token`, and `permissionConfig`.
+- Shared `erxes-api-shared` context, GraphQL, and date utility contracts.
+
+## Data and State
+
+- Tenant-scoped POS client collections are generated per `subdomain`.
+- `Configs.permissionConfig.cashiers.seeReport` controls cashier access to `dailyReport`.
+
+## Local Invariants
+
+- POS client report queries must require a logged-in POS user.
+- Cashiers may access `dailyReport` only when `permissionConfig.cashiers.seeReport` is true; admins remain allowed by `adminIds`.
+
+## Validation
+
+- `pnpm nx build posclient_api`
+- POS report smoke scenario: as a cashier without `seeReport`, `dailyReport` returns permission denied; after enabling it, the same cashier can fetch the report.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — `Guard cashier reports`
+
+- **Summary:** Restricted `dailyReport` to POS admins or cashiers with `permissionConfig.cashiers.seeReport`.
+- **Affected areas:** `backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/report.ts`
+- **Contracts changed:** `dailyReport` now enforces `permissionConfig.cashiers.seeReport` for cashier users.

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/report.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/report.ts
@@ -3,6 +3,17 @@ import { IProductDocument } from '~/modules/posclient/@types/products';
 import { IContext } from '~/modules/posclient/@types/types';
 import { assertPosUser } from '~/modules/posclient/utils/assertPosUser';
 
+const hasReportPermission = ({ config, posUser }: IContext) => {
+  const isAdmin = (config.adminIds || []).includes(posUser?._id || '');
+  const isCashier = (config.cashierIds || []).includes(posUser?._id || '');
+
+  if (isAdmin) {
+    return true;
+  }
+
+  return isCashier && !!config.permissionConfig?.cashiers?.seeReport;
+};
+
 const getDateFilter = (dateType, startDate, endDate) => {
   if (dateType === 'created') {
     return {
@@ -64,9 +75,14 @@ const reportQueries = {
       startDate: Date;
       endDate: Date;
     },
-    { models, config, posUser }: IContext,
+    context: IContext,
   ) {
+    const { models, config, posUser } = context;
     assertPosUser(posUser);
+
+    if (!hasReportPermission(context)) {
+      throw new Error('Permission denied');
+    }
 
     const report: any = {};
     // dateType: created | modified | paid | due | close | return

--- a/frontend/plugins/sales_ui/AGENTS.md
+++ b/frontend/plugins/sales_ui/AGENTS.md
@@ -1,0 +1,71 @@
+# `sales_ui` Plugin Guide
+
+## Identity
+
+- **Plugin:** `sales`
+- **Project:** `sales_ui`
+- **Layer:** `Frontend UI`
+- **Path:** `frontend/plugins/sales_ui`
+- **Last synchronized:** `2026-08-12`
+
+## Scope
+
+### Owns
+
+- POS, deal, order, cover, item, product, payment, appearance, delivery, and permission management screens for the sales frontend.
+
+### Does not own
+
+- Backend POS persistence, POS client runtime behavior, shared UI primitives, core settings infrastructure, or other plugin routes.
+
+## Current Capabilities
+
+- POS permission settings assign admins and cashiers.
+- POS permission settings persist cashier temp bill, report visibility, and direct discount controls through `permissionConfig`.
+- POS management screens read and write sales GraphQL contracts through the plugin's local documents and hooks.
+
+## Architecture
+
+| Area | Path | Responsibility |
+| ---- | ---- | -------------- |
+| POS permission form | `frontend/plugins/sales_ui/src/modules/pos/components/permission` | Manages admin and cashier POS permission controls. |
+| POS GraphQL | `frontend/plugins/sales_ui/src/modules/pos/graphql` | Provides POS queries and mutations used by settings screens. |
+| POS types | `frontend/plugins/sales_ui/src/modules/pos/types` | Describes POS configuration data consumed by the UI. |
+
+## Contracts
+
+### Provides
+
+- Module Federation sales UI routes and exposed POS settings components.
+- POS edit mutation payloads containing `permissionConfig.cashiers.seeReport`.
+
+### Consumes
+
+- `erxes-ui` and `ui-modules` public React components.
+- Sales POS GraphQL queries and mutations from the sales API.
+
+## Data and State
+
+- Uses React Hook Form state for POS settings forms.
+- Uses Apollo Client for POS detail loading and POS edit mutations.
+- Persists report access as `permissionConfig.cashiers.seeReport` in the POS document.
+
+## Local Invariants
+
+- POS settings controls must remain backed by `erxes-ui` form primitives and must save through the existing POS edit mutation.
+- Cashier report access must use the `permissionConfig.cashiers.seeReport` boolean key.
+
+## Validation
+
+- `pnpm nx build sales_ui`
+- POS settings smoke scenario: open POS permission tab, toggle cashier "SEE REPORT", save, and verify the value persists after reload.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — `Cashier report permission`
+
+- **Summary:** Added a cashier report visibility switch to POS permission settings and persisted it in `permissionConfig.cashiers.seeReport`.
+- **Affected areas:** `frontend/plugins/sales_ui/src/modules/pos/components/permission`, `frontend/plugins/sales_ui/src/modules/pos/types`
+- **Contracts changed:** POS edit mutation payload may include `permissionConfig.cashiers.seeReport`.

--- a/frontend/plugins/sales_ui/src/modules/pos/components/permission/CashierPermissions.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/components/permission/CashierPermissions.tsx
@@ -68,6 +68,26 @@ export const CashierPermissions: React.FC<CashierPermissionsProps> = ({
 
         <Form.Field
           control={control}
+          name="cashierSeeReport"
+          render={({ field }) => (
+            <Form.Item>
+              <div className="flex gap-2 items-center">
+                <Label className="text-xs">
+                  {t('SEE-REPORT', { defaultValue: 'SEE REPORT' })}
+                </Label>
+                <Form.Control>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </Form.Control>
+              </div>
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={control}
           name="cashierDirectDiscount"
           render={({ field }) => (
             <Form.Item>

--- a/frontend/plugins/sales_ui/src/modules/pos/components/permission/Permission.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/components/permission/Permission.tsx
@@ -22,6 +22,7 @@ export interface PermissionFormData {
   adminDirectDiscountLimit: string;
   cashierIds: string[];
   cashierIsPrintTempBill: boolean;
+  cashierSeeReport: boolean;
   cashierDirectDiscount: boolean;
   cashierDirectDiscountLimit: string;
 }
@@ -35,6 +36,7 @@ const DEFAULT_FORM_VALUES: PermissionFormData = {
   adminDirectDiscountLimit: '',
   cashierIds: [],
   cashierIsPrintTempBill: false,
+  cashierSeeReport: false,
   cashierDirectDiscount: false,
   cashierDirectDiscountLimit: '',
 };
@@ -73,6 +75,7 @@ const Permission: React.FC<PermissionProps> = ({
         adminConfig?.directDiscountLimit?.toString() || '',
       cashierIds: posDetail.cashierIds || [],
       cashierIsPrintTempBill: cashierConfig?.isTempBill ?? false,
+      cashierSeeReport: cashierConfig?.seeReport ?? false,
       cashierDirectDiscount: cashierConfig?.directDiscount ?? false,
       cashierDirectDiscountLimit:
         cashierConfig?.directDiscountLimit?.toString() || '',
@@ -111,6 +114,7 @@ const Permission: React.FC<PermissionProps> = ({
               },
               cashiers: {
                 isTempBill: data.cashierIsPrintTempBill,
+                seeReport: data.cashierSeeReport,
                 directDiscount: data.cashierDirectDiscount,
                 directDiscountLimit: parseLimit(
                   data.cashierDirectDiscountLimit,

--- a/frontend/plugins/sales_ui/src/modules/pos/types/pos.ts
+++ b/frontend/plugins/sales_ui/src/modules/pos/types/pos.ts
@@ -119,6 +119,7 @@ export interface IPos {
     };
     cashiers?: {
       isTempBill?: boolean;
+      seeReport?: boolean;
       directDiscount?: boolean;
       directDiscountLimit?: number;
     };


### PR DESCRIPTION
## Summary by Sourcery

Add cashier-specific report visibility permission and enforce it across POS settings, backend report queries, and POS client UI.

New Features:
- Introduce a cashier "SEE REPORT" toggle in POS permission settings and persist it in the POS configuration.
- Expose cashier report visibility via `permissionConfig.seeReport` to the POS client front-end to control access to the report page and header menu entry.
- Display the order creator's email in order history tables and mobile list views.

Bug Fixes:
- Restrict POS client daily report access so cashiers can only fetch reports when explicitly granted report permission, while admins retain access by default.

Enhancements:
- Document the `posclient_api` and `sales_ui` plugins with agent guides describing ownership, contracts, invariants, and recent changes.

Documentation:
- Add AGENTS guides for `posclient_api` and `sales_ui` plugins outlining scope, capabilities, architecture, and recent changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a cashier permission setting to control access to reports.
  - Admins and authorized cashiers can now view reports; unauthorized users see an access-denied message.
  - Added order customer email addresses to order history on desktop and mobile, with a fallback when unavailable.
- **Bug Fixes**
  - Improved handling and display of long customer email addresses in mobile order history.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->