### PR TITLE
feat(pipelines): add scoped property selection

### DIFF
--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `frontline_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/frontline_api`
-- **Last synchronized:** `2026-08-10`
+- **Last synchronized:** `2026-08-12`
 
 ## Scope
 
@@ -50,6 +50,10 @@
 
 ## Current Capabilities
 
+- Ticket pipelines persist an ordered unique `propertyIds` selection. Create
+  and update validate every id against Core `frontline:ticket` fields before
+  writing it. `isPropertySelectionConfigured` distinguishes untouched legacy
+  pipelines from an intentional empty selection.
 - Runs as a federated subgraph plus tRPC service on port `3304`, with GraphQL
   subscriptions enabled.
 - Multi-channel inbox with membership-scoped conversation visibility.
@@ -450,6 +454,15 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-08-12` — Pipeline-scoped ticket properties
+
+- **Summary:** Ticket pipelines now persist only validated Core ticket property
+  ids for pipeline-specific detail forms.
+- **Affected areas:** `src/modules/ticket/{@types,db,graphql,utils}`.
+- **Contracts changed:** `Pipeline`, `createPipeline`, and `updatePipeline`
+  gained optional `propertyIds: [String]`; `Pipeline` also exposes
+  `isPropertySelectionConfigured: Boolean` for backward-compatible rendering.
+
 ### `2026-08-10` — Improve Facebook delivery diagnostics
 
 - **Summary:** Suppressed typing indicators throughout comment-triggered bot flows and added privacy-safe Graph error metadata logging.
@@ -457,6 +470,7 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - **Contracts changed:** None
 
 ### `2026-08-07` — Indexed knowledge base articles carry their category name
+
 ### `2026-08-10` — Multi-select real pipeline status filter for ticket reports
 
 - **Summary:** Added `statusIds: [String]` to `TicketReportFilter` /

--- a/backend/plugins/frontline_api/src/modules/ticket/@types/pipeline.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/@types/pipeline.ts
@@ -28,6 +28,8 @@ export interface ITicketPipeline {
   visibility?: string;
   memberIds?: string[];
   statusId?: string;
+  propertyIds?: string[];
+  isPropertySelectionConfigured?: boolean;
 }
 
 export interface ITicketPipelineUpdate extends ITicketPipeline {
@@ -40,7 +42,9 @@ export interface ITicketPipelineDocument extends ITicketPipeline, Document {
 }
 
 export interface TicketsPipelineFilter
-  extends ICursorPaginateParams, IListParams, ITicketPipeline {
+  extends ICursorPaginateParams,
+    IListParams,
+    ITicketPipeline {
   userId?: string;
   createdAt?: Date;
   applyVisibilityFilter?: boolean;

--- a/backend/plugins/frontline_api/src/modules/ticket/@types/pipeline.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/@types/pipeline.ts
@@ -42,9 +42,7 @@ export interface ITicketPipelineDocument extends ITicketPipeline, Document {
 }
 
 export interface TicketsPipelineFilter
-  extends ICursorPaginateParams,
-    IListParams,
-    ITicketPipeline {
+  extends ICursorPaginateParams, IListParams, ITicketPipeline {
   userId?: string;
   createdAt?: Date;
   applyVisibilityFilter?: boolean;

--- a/backend/plugins/frontline_api/src/modules/ticket/db/definitions/pipeline.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/definitions/pipeline.ts
@@ -30,6 +30,8 @@ export const ticketPipelineSchema = new Schema(
     tagId: { type: String },
     visibility: { type: String },
     memberIds: [{ type: String }],
+    propertyIds: [{ type: String }],
+    isPropertySelectionConfigured: { type: Boolean, default: false },
   },
   {
     timestamps: true,

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/pipeline.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/pipeline.ts
@@ -1,20 +1,27 @@
 import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { IContext } from '~/connectionResolvers';
 import { ITicketPipelineUpdate } from '@/ticket/@types/pipeline';
-import { PermissionError } from '@/ticket/utils/permissionValidator';
+import { validatePipelinePropertyIds } from '@/ticket/utils/pipelineProperties';
 
 export const pipelineMutations = {
   createPipeline: async (
     _parent: undefined,
     params: ITicketPipelineUpdate,
-    { models, user }: IContext,
+    { models, user, subdomain }: IContext,
   ) => {
     if (!user) {
       throw new Error('Authentication required');
     }
 
+    const propertyIds = await validatePipelinePropertyIds(
+      subdomain,
+      params.propertyIds,
+    );
+
     const pipeline = await models.Pipeline.addPipeline({
       ...params,
+      propertyIds,
+      isPropertySelectionConfigured: params.propertyIds !== undefined,
       userId: user._id,
     });
 
@@ -31,11 +38,22 @@ export const pipelineMutations = {
   updatePipeline: async (
     _parent: undefined,
     params: ITicketPipelineUpdate & { _id: string },
-    { models, user }: IContext,
+    context: IContext,
   ) => {
+    const { models, user, subdomain } = context;
+    const propertyIds =
+      params.propertyIds === undefined
+        ? undefined
+        : await validatePipelinePropertyIds(subdomain, params.propertyIds);
     const updatedPipeline = await models.Pipeline.updatePipeline(
       params._id,
-      params,
+      {
+        ...params,
+        ...(propertyIds !== undefined && {
+          propertyIds,
+          isPropertySelectionConfigured: true,
+        }),
+      },
       user,
     );
 
@@ -52,7 +70,7 @@ export const pipelineMutations = {
   removePipeline: async (
     _parent: undefined,
     { _id }: { _id: string },
-    { models, user }: IContext,
+    { models }: IContext,
   ) => {
     const pipeline = await models.Pipeline.getPipeline(_id);
 

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/pipeline.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/pipeline.ts
@@ -27,6 +27,8 @@ export const types = `
     updatedAt: Date
     visibility: String
     memberIds: [String]
+    propertyIds: [String]
+    isPropertySelectionConfigured: Boolean
   }
 
   type PipelineSubscription {
@@ -76,6 +78,7 @@ const pipelineParams = `
     branchIds: [String],
     visibility: String,
     memberIds :[String]
+    propertyIds: [String]
 `;
 export const mutations = `
   createPipeline(

--- a/backend/plugins/frontline_api/src/modules/ticket/utils/pipelineProperties.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/utils/pipelineProperties.ts
@@ -1,0 +1,39 @@
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+
+const TICKET_PROPERTY_CONTENT_TYPE = 'frontline:ticket';
+
+export const validatePipelinePropertyIds = async (
+  subdomain: string,
+  propertyIds?: string[] | null,
+): Promise<string[]> => {
+  const uniquePropertyIds = [...new Set(propertyIds || [])].filter(Boolean);
+
+  if (!uniquePropertyIds.length) {
+    return [];
+  }
+
+  const fields: Array<{ _id: string }> = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'fields',
+    action: 'find',
+    input: {
+      query: {
+        _id: { $in: uniquePropertyIds },
+        contentType: TICKET_PROPERTY_CONTENT_TYPE,
+      },
+      projection: { _id: 1 },
+    },
+    defaultValue: [],
+  });
+
+  const validIds = new Set(fields.map(({ _id }) => String(_id)));
+  const invalidId = uniquePropertyIds.find((id) => !validIds.has(id));
+
+  if (invalidId) {
+    throw new Error(`Ticket property field not found: ${invalidId}`);
+  }
+
+  return uniquePropertyIds;
+};

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -1,0 +1,81 @@
+# `sales_api` Plugin Guide
+
+## Identity
+
+- **Plugin:** `sales`
+- **Project:** `sales_api`
+- **Layer:** `Backend API`
+- **Path:** `backend/plugins/sales_api`
+- **Last synchronized:** `2026-08-12`
+
+## Scope
+
+### Owns
+
+- Sales boards, pipelines, stages, deals, labels, checklists, and plugin-owned
+  sales data and API contracts.
+
+### Does not own
+
+- Core property definitions, users, teams, or shared platform packages.
+- Sales user interfaces; those live in `sales_ui`.
+
+## Current Capabilities
+
+- Runs as the sales federated GraphQL and tRPC plugin service.
+- Sales pipelines persist `propertyIds`; create and edit validate every id
+  against Core `sales:deal` fields before writing it. A separate configured
+  flag preserves legacy show-all behavior without making an empty selection
+  ambiguous.
+
+## Architecture
+
+| Area                | Path                                                                      | Responsibility                                    |
+| ------------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
+| Bootstrap           | `backend/plugins/sales_api/src/main.ts`                                   | Starts and registers the sales plugin             |
+| Models              | `backend/plugins/sales_api/src/modules/sales/db`                          | Sales Mongoose schemas and models                 |
+| GraphQL             | `backend/plugins/sales_api/src/modules/sales/graphql`                     | Sales schemas and resolvers                       |
+| Pipeline validation | `backend/plugins/sales_api/src/modules/sales/utils/pipelineProperties.ts` | Validates pipeline property ids through Core tRPC |
+
+## Contracts
+
+### Provides
+
+- Federated sales GraphQL contracts including `salesPipelineDetail`,
+  `salesPipelinesAdd`, and `salesPipelinesEdit`.
+
+### Consumes
+
+- Core `fields.find` over tRPC for `sales:deal` property validation.
+- Public `erxes-api-shared` utilities and core types.
+
+## Data and State
+
+- Tenant-scoped Mongoose models are generated per `subdomain`.
+- Pipeline documents store a unique array of selected Core field ids in
+  `propertyIds`; no property definitions are duplicated in sales storage.
+
+## Local Invariants
+
+- Never accept a pipeline property id outside Core `sales:deal` fields.
+- Preserve tenant isolation by validating through the request `subdomain`.
+- Pipeline stage updates and property selections remain one pipeline mutation.
+
+## Validation
+
+- `pnpm nx lint sales_api`
+- `pnpm nx build sales_api`
+- Create or edit a pipeline with valid and invalid deal property ids; valid ids
+  persist and an invalid id is rejected.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — Pipeline-scoped deal properties
+
+- **Summary:** Sales pipelines now persist only validated Core deal property ids.
+- **Affected areas:** `src/modules/sales/{@types,db,graphql,utils}`.
+- **Contracts changed:** `SalesPipeline`, `salesPipelinesAdd`, and
+  `salesPipelinesEdit` gained optional `propertyIds: [String]`;
+  `SalesPipeline` exposes `isPropertySelectionConfigured: Boolean`.

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -36,6 +36,7 @@
 | Models              | `backend/plugins/sales_api/src/modules/sales/db`                          | Sales Mongoose schemas and models                 |
 | GraphQL             | `backend/plugins/sales_api/src/modules/sales/graphql`                     | Sales schemas and resolvers                       |
 | Pipeline validation | `backend/plugins/sales_api/src/modules/sales/utils/pipelineProperties.ts` | Validates pipeline property ids through Core tRPC |
+
 - Sales deal, pipeline, board, stage, ecommerce, and POS API behavior implemented under `backend/plugins/sales_api`.
 - Sales-owned GraphQL, tRPC, Mongoose models, metadata, reference resolvers, documents, and after-process handlers.
 
@@ -133,6 +134,7 @@
 - **Contracts changed:** `SalesPipeline`, `salesPipelinesAdd`, and
   `salesPipelinesEdit` gained optional `propertyIds: [String]`;
   `SalesPipeline` exposes `isPropertySelectionConfigured: Boolean`.
+
 ### `2026-08-12` — `Exclude loyalty amount reference`
 
 - **Summary:** `excludeLoyaltyAmount` now returns deal total minus score-campaign payment amounts instead of summing non-score payments.

--- a/backend/plugins/sales_api/src/modules/sales/@types/pipeline.ts
+++ b/backend/plugins/sales_api/src/modules/sales/@types/pipeline.ts
@@ -29,6 +29,8 @@ export interface IPipeline {
   excludeProductIds?: string[];
   paymentIds?: string[];
   paymentTypes?: any[];
+  propertyIds?: string[];
+  isPropertySelectionConfigured?: boolean;
 
   userId?: string;
   order?: number;

--- a/backend/plugins/sales_api/src/modules/sales/db/definitions/pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/db/definitions/pipelines.ts
@@ -94,6 +94,12 @@ export const pipelineSchema = new Schema(
     },
     paymentIds: { type: [String], label: 'Online Payments' },
     paymentTypes: { type: [Object], label: 'Other Payments' },
+    propertyIds: { type: [String], label: 'Visible deal properties' },
+    isPropertySelectionConfigured: {
+      type: Boolean,
+      default: false,
+      label: 'Property selection configured',
+    },
 
     userId: { type: String, label: 'Created by' },
     order: { type: Number, label: 'Order' },

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/pipelines.ts
@@ -7,6 +7,7 @@ import {
   IStageDocument,
 } from '~/modules/sales/@types';
 import { checkNumberConfig } from '~/modules/sales/utils';
+import { validatePipelinePropertyIds } from '~/modules/sales/utils/pipelineProperties';
 
 export const pipelineMutations = {
   /**
@@ -15,7 +16,7 @@ export const pipelineMutations = {
   async salesPipelinesAdd(
     _root,
     { stages, ...doc }: IPipeline & { stages: IStageDocument[] },
-    { user, models, checkPermission }: IContext,
+    { user, models, checkPermission, subdomain }: IContext,
   ) {
     await checkPermission('pipelinesAdd');
     if (doc.numberConfig || doc.numberSize) {
@@ -31,8 +32,18 @@ export const pipelineMutations = {
     //   }
     // });
 
+    const propertyIds = await validatePipelinePropertyIds(
+      subdomain,
+      doc.propertyIds,
+    );
+
     return await models.Pipelines.createPipeline(
-      { userId: user._id, ...doc },
+      {
+        userId: user._id,
+        ...doc,
+        propertyIds,
+        isPropertySelectionConfigured: doc.propertyIds !== undefined,
+      },
       stages,
     );
   },
@@ -43,14 +54,29 @@ export const pipelineMutations = {
   async salesPipelinesEdit(
     _root,
     { _id, stages, ...doc }: IPipelineDocument & { stages: IStageDocument[] },
-    { models, checkPermission }: IContext,
+    { models, checkPermission, subdomain }: IContext,
   ) {
     await checkPermission('pipelinesEdit');
     if (doc.numberConfig || doc.numberSize) {
       await checkNumberConfig(doc.numberConfig || '', doc.numberSize || '');
     }
 
-    return await models.Pipelines.updatePipeline(_id, doc, stages);
+    const propertyIds =
+      doc.propertyIds === undefined
+        ? undefined
+        : await validatePipelinePropertyIds(subdomain, doc.propertyIds);
+
+    return await models.Pipelines.updatePipeline(
+      _id,
+      {
+        ...doc,
+        ...(propertyIds !== undefined && {
+          propertyIds,
+          isPropertySelectionConfigured: true,
+        }),
+      },
+      stages,
+    );
   },
 
   /**

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
@@ -37,6 +37,8 @@ export const types = `
     excludeProductIds: [String]
     paymentIds: [String]
     paymentTypes: JSON
+    propertyIds: [String]
+    isPropertySelectionConfigured: Boolean
     order: Int
     createdAt: Date
     type: String
@@ -99,6 +101,7 @@ const mutationParams = `
   excludeProductIds: [String]
   paymentIds: [String]
   paymentTypes: JSON
+  propertyIds: [String]
 `;
 
 export const mutations = `

--- a/backend/plugins/sales_api/src/modules/sales/utils/pipelineProperties.ts
+++ b/backend/plugins/sales_api/src/modules/sales/utils/pipelineProperties.ts
@@ -1,0 +1,39 @@
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+
+const DEAL_PROPERTY_CONTENT_TYPE = 'sales:deal';
+
+export const validatePipelinePropertyIds = async (
+  subdomain: string,
+  propertyIds?: string[] | null,
+): Promise<string[]> => {
+  const uniquePropertyIds = [...new Set(propertyIds || [])].filter(Boolean);
+
+  if (!uniquePropertyIds.length) {
+    return [];
+  }
+
+  const fields: Array<{ _id: string }> = await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    method: 'query',
+    module: 'fields',
+    action: 'find',
+    input: {
+      query: {
+        _id: { $in: uniquePropertyIds },
+        contentType: DEAL_PROPERTY_CONTENT_TYPE,
+      },
+      projection: { _id: 1 },
+    },
+    defaultValue: [],
+  });
+
+  const validIds = new Set(fields.map(({ _id }) => String(_id)));
+  const invalidId = uniquePropertyIds.find((id) => !validIds.has(id));
+
+  if (invalidId) {
+    throw new Error(`Deal property field not found: ${invalidId}`);
+  }
+
+  return uniquePropertyIds;
+};

--- a/frontend/plugins/frontline_ui/AGENTS.md
+++ b/frontend/plugins/frontline_ui/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `frontline_ui`
 - **Layer:** `Frontend UI`
 - **Path:** `frontend/plugins/frontline_ui`
-- **Last synchronized:** `2026-08-10`
+- **Last synchronized:** `2026-08-12`
 
 ## Scope
 
@@ -46,6 +46,11 @@
 
 ## Current Capabilities
 
+- Ticket pipeline settings include a Properties route that lists only Core
+  `frontline:ticket` properties, grouped by their Core field group. Checked
+  fields are stored on the pipeline, and ticket detail renders only that
+  pipeline's selected fields. Legacy pipelines continue rendering all fields
+  until their Properties selection is saved for the first time.
 - Runs as a Module Federation remote on port `3004`, bundled with Rspack.
 - The messenger ticket form builder lives on a pipeline's configuration sheet
   (`src/modules/pipelines/components/configs/`): a configuration picks a status
@@ -413,6 +418,16 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — Pipeline-scoped ticket properties
+
+- **Summary:** Ticket pipelines now choose grouped Core ticket properties, and
+  ticket detail shows only the selected fields after configuration while
+  legacy pipelines retain the previous show-all behavior until first save.
+- **Affected areas:** `src/modules/pipelines/**`,
+  `src/modules/ticket/components/ticket-detail/**`, `src/pages/PipelinePropertiesPage.tsx`.
+- **Contracts changed:** Ticket pipeline GraphQL reads and updates now include
+  `propertyIds`.
 
 ### `2026-08-10` — Ticket reports can filter by real pipeline status (multi-select)
 

--- a/frontend/plugins/frontline_ui/AGENTS.md
+++ b/frontend/plugins/frontline_ui/AGENTS.md
@@ -436,6 +436,7 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
   `src/modules/ticket/components/ticket-detail/**`, `src/pages/PipelinePropertiesPage.tsx`.
 - **Contracts changed:** Ticket pipeline GraphQL reads and updates now include
   `propertyIds`.
+
 ### `2026-08-12` — Comment-trigger message limit applies only before a button
 
 - **Summary:** The one-message cap for Facebook message actions under a comment

--- a/frontend/plugins/frontline_ui/src/modules/channels/components/settings/Settings.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/components/settings/Settings.tsx
@@ -104,6 +104,12 @@ export const PipelinePermissionsPage = lazy(() =>
   })),
 );
 
+export const PipelinePropertiesPage = lazy(() =>
+  import('~/pages/PipelinePropertiesPage').then((module) => ({
+    default: module.PipelinePropertiesPage,
+  })),
+);
+
 export const TicketStatusesPage = lazy(() =>
   import('~/pages/TicketStatusesPage').then((module) => ({
     default: module.TicketStatusesPage,
@@ -167,6 +173,10 @@ const ChannelsSettings = () => {
             <Route
               path={PIPELINE_TAB_SEGMENTS.permissions}
               element={<PipelinePermissionsPage />}
+            />
+            <Route
+              path={PIPELINE_TAB_SEGMENTS.properties}
+              element={<PipelinePropertiesPage />}
             />
           </Route>
           <Route

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineDetail.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelineDetail.tsx
@@ -34,6 +34,7 @@ export const PipelineDetail = () => {
       numberConfig: pipeline?.numberConfig || '',
       numberSize: pipeline?.numberSize || '',
       nameConfig: pipeline?.nameConfig || '',
+      propertyIds: pipeline?.propertyIds || [],
     });
   }, [form, pipeline, pipelineId]);
 

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
@@ -1,0 +1,83 @@
+import { Checkbox, Collapsible, Label, Spinner } from 'erxes-ui';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IField, useFieldGroups, useFields } from 'ui-modules';
+
+const CONTENT_TYPE = 'frontline:ticket';
+const PROPERTY_LIMIT = 100;
+
+type Props = {
+  value: string[];
+  onChange: (propertyIds: string[]) => void;
+};
+
+export const PipelinePropertySelector = ({ value, onChange }: Props) => {
+  const { t } = useTranslation('frontline');
+  const { fieldGroups, loading: groupsLoading } = useFieldGroups({
+    contentType: CONTENT_TYPE,
+    limit: PROPERTY_LIMIT,
+  });
+  const { fields, loading: fieldsLoading } = useFields({
+    contentType: CONTENT_TYPE,
+    limit: PROPERTY_LIMIT,
+  });
+
+  const groups = useMemo(
+    () =>
+      fieldGroups
+        .map((group) => ({
+          ...group,
+          fields: fields.filter((field) => field.groupId === group._id),
+        }))
+        .filter((group) => group.fields.length)
+        .sort((a, b) => a.order - b.order),
+    [fieldGroups, fields],
+  );
+
+  if (groupsLoading || fieldsLoading) {
+    return <Spinner containerClassName="py-8" />;
+  }
+
+  if (!groups.length) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t('no-ticket-property-fields')}
+      </p>
+    );
+  }
+
+  const toggle = (field: IField, checked: boolean) => {
+    onChange(
+      checked
+        ? [...new Set([...value, field._id])]
+        : value.filter((id) => id !== field._id),
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {groups.map((group) => (
+        <Collapsible key={group._id} defaultOpen>
+          <Collapsible.TriggerButton type="button">
+            <Collapsible.TriggerIcon className="size-3" />
+            {group.name}
+          </Collapsible.TriggerButton>
+          <Collapsible.Content className="grid gap-3 pt-3 pl-5 sm:grid-cols-2">
+            {group.fields.map((field) => (
+              <div key={field._id} className="flex items-center gap-2">
+                <Checkbox
+                  id={`pipeline-property-${field._id}`}
+                  checked={value.includes(field._id)}
+                  onCheckedChange={(checked) => toggle(field, checked === true)}
+                />
+                <Label htmlFor={`pipeline-property-${field._id}`}>
+                  {field.name}
+                </Label>
+              </div>
+            ))}
+          </Collapsible.Content>
+        </Collapsible>
+      ))}
+    </div>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/constants/pipelineTabs.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/constants/pipelineTabs.ts
@@ -3,6 +3,7 @@ export const PIPELINE_TAB_SEGMENTS = {
   statuses: 'statuses',
   configs: 'configs',
   permissions: 'permissions',
+  properties: 'properties',
 } as const;
 
 export type TPipelineTabSegment =
@@ -16,6 +17,7 @@ export const PIPELINE_TABS: {
   { segment: PIPELINE_TAB_SEGMENTS.statuses, labelKey: 'ticket-statuses' },
   { segment: PIPELINE_TAB_SEGMENTS.configs, labelKey: 'configuration' },
   { segment: PIPELINE_TAB_SEGMENTS.permissions, labelKey: 'permissions' },
+  { segment: PIPELINE_TAB_SEGMENTS.properties, labelKey: 'properties' },
 ];
 
 export const getPipelinePath = (

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/mutations/updatePipeline.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/mutations/updatePipeline.ts
@@ -16,6 +16,7 @@ export const UPDATE_PIPELINE = gql`
     $numberConfig: String
     $numberSize: String
     $nameConfig: String
+    $propertyIds: [String]
   ) {
     updatePipeline(
       _id: $_id
@@ -32,6 +33,7 @@ export const UPDATE_PIPELINE = gql`
       numberConfig: $numberConfig
       numberSize: $numberSize
       nameConfig: $nameConfig
+      propertyIds: $propertyIds
     ) {
       _id
       name
@@ -51,6 +53,8 @@ export const UPDATE_PIPELINE = gql`
       numberConfig
       numberSize
       nameConfig
+      propertyIds
+      isPropertySelectionConfigured
     }
   }
 `;

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/queries/getPipeline.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/graphql/queries/getPipeline.ts
@@ -37,6 +37,8 @@ export const GET_PIPELINE = gql`
       __typename
       memberIds
       visibility
+      propertyIds
+      isPropertySelectionConfigured
     }
   }
 `;

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/types/index.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/types/index.ts
@@ -15,6 +15,8 @@ export interface PermissionState {
   selectedUsers: string[];
   visibility: 'public' | 'private';
   memberIds: string[];
+  propertyIds: string[];
+  isPropertySelectionConfigured: boolean;
 }
 
 export interface IPipeline {

--- a/frontend/plugins/frontline_ui/src/modules/settings/schema/pipeline.ts
+++ b/frontend/plugins/frontline_ui/src/modules/settings/schema/pipeline.ts
@@ -16,6 +16,7 @@ const PIPELINE_FORM_BASE_SCHEMA = z.object({
       message: `${MIN_TICKET_NUMBER_SIZE}-${MAX_TICKET_NUMBER_SIZE}`,
     }),
   nameConfig: z.string().optional(),
+  propertyIds: z.array(z.string()).optional(),
 });
 
 export const CREATE_PIPELINE_FORM_SCHEMA = PIPELINE_FORM_BASE_SCHEMA.extend({

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketDetailSheet.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketDetailSheet.tsx
@@ -10,10 +10,11 @@ import {
   Sheet,
 } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
-import { FieldsInDetail, RelationWidgetSideTabs } from 'ui-modules';
+import { RelationWidgetSideTabs } from 'ui-modules';
 import { TicketSidebar } from './TicketSidebar';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useTicketCustomFieldEdit } from '@/ticket/hooks/useTicketCustomFieldEdit';
+import { TicketPipelineProperties } from './TicketPipelineProperties';
 
 export const TicketDetailSheet = ({
   hideRelationWidgetSideTabs = false,
@@ -71,8 +72,8 @@ export const TicketDetailSheet = ({
                 </Tabs.Content>
 
                 <Tabs.Content value="properties" className="p-6">
-                  <FieldsInDetail
-                    fieldContentType="frontline:ticket"
+                  <TicketPipelineProperties
+                    pipelineId={ticket?.pipelineId || ''}
                     propertiesData={ticket?.propertiesData || {}}
                     mutateHook={useTicketCustomFieldEdit}
                     id={ticket?._id || ''}

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketPipelineProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketPipelineProperties.tsx
@@ -1,0 +1,114 @@
+import { useGetPipeline } from '@/pipelines/hooks/useGetPipeline';
+import { Button, Collapsible, InfoCard, Spinner } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import {
+  FieldsInGroup,
+  IFieldGroup,
+  MultipleFieldsInGroup,
+  FieldsInDetail,
+  mutateFunction,
+  useFieldGroups,
+  useFields,
+} from 'ui-modules';
+
+const CONTENT_TYPE = 'frontline:ticket';
+
+type Props = {
+  id: string;
+  pipelineId: string;
+  propertiesData: Record<string, unknown>;
+  mutateHook: () => { mutate: mutateFunction; loading: boolean };
+};
+
+const SelectedGroup = ({
+  group,
+  selectedIds,
+  ...props
+}: Props & { group: IFieldGroup; selectedIds: Set<string> }) => {
+  const { fields, loading } = useFields({
+    groupId: group._id,
+    contentType: CONTENT_TYPE,
+  });
+  const selectedFields = fields.filter(
+    (field) => selectedIds.has(field._id) && field.isVisible !== false,
+  );
+
+  if (loading) return <Spinner containerClassName="py-4" />;
+  if (!selectedFields.length) return null;
+
+  if (group.configs?.isMultiple) {
+    return (
+      <MultipleFieldsInGroup
+        group={group}
+        fields={selectedFields}
+        contentType={CONTENT_TYPE}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <Collapsible defaultOpen>
+      <Collapsible.Trigger asChild>
+        <Button variant="secondary" className="justify-start w-full">
+          <Collapsible.TriggerIcon />
+          {group.name}
+        </Button>
+      </Collapsible.Trigger>
+      <Collapsible.Content className="pt-4">
+        <FieldsInGroup
+          group={group}
+          fields={selectedFields}
+          contentType={CONTENT_TYPE}
+          {...props}
+        />
+      </Collapsible.Content>
+    </Collapsible>
+  );
+};
+
+export const TicketPipelineProperties = (props: Props) => {
+  const { t } = useTranslation(['frontline', 'common']);
+  const { pipeline, loading: pipelineLoading } = useGetPipeline(
+    props.pipelineId,
+  );
+  const { fieldGroups, loading: groupsLoading } = useFieldGroups({
+    contentType: CONTENT_TYPE,
+    limit: 100,
+  });
+  const selectedIds = new Set(pipeline?.propertyIds || []);
+
+  if (!pipelineLoading && pipeline?.isPropertySelectionConfigured === false) {
+    return (
+      <FieldsInDetail
+        fieldContentType={CONTENT_TYPE}
+        propertiesData={props.propertiesData}
+        mutateHook={props.mutateHook}
+        id={props.id}
+      />
+    );
+  }
+
+  return (
+    <InfoCard title={t('common:properties')}>
+      <InfoCard.Content>
+        {pipelineLoading || groupsLoading ? (
+          <Spinner containerClassName="py-8" />
+        ) : selectedIds.size === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('no-ticket-property-fields')}
+          </p>
+        ) : (
+          fieldGroups.map((group) => (
+            <SelectedGroup
+              key={group._id}
+              group={group}
+              selectedIds={selectedIds}
+              {...props}
+            />
+          ))
+        )}
+      </InfoCard.Content>
+    </InfoCard>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/pages/PipelinePropertiesPage.tsx
+++ b/frontend/plugins/frontline_ui/src/pages/PipelinePropertiesPage.tsx
@@ -1,0 +1,55 @@
+import { PipelinePropertySelector } from '@/pipelines/components/PipelinePropertySelector';
+import { useGetPipeline } from '@/pipelines/hooks/useGetPipeline';
+import { useUpdatePipeline } from '@/pipelines/hooks/useUpdatePipeline';
+import { Button, InfoCard, Spinner } from 'erxes-ui';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+export const PipelinePropertiesPage = () => {
+  const { t } = useTranslation(['frontline', 'common']);
+  const { pipelineId } = useParams<{ pipelineId: string }>();
+  const { pipeline, loading } = useGetPipeline(pipelineId);
+  const { updatePipeline, loading: updating } = useUpdatePipeline();
+  const [propertyIds, setPropertyIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setPropertyIds(pipeline?.propertyIds || []);
+  }, [pipeline?.propertyIds]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <InfoCard
+        title={t('common:properties')}
+        description={t('select-ticket-property-fields-description')}
+      >
+        <InfoCard.Content>
+          {loading ? (
+            <Spinner containerClassName="py-8" />
+          ) : (
+            <PipelinePropertySelector
+              value={propertyIds}
+              onChange={setPropertyIds}
+            />
+          )}
+        </InfoCard.Content>
+      </InfoCard>
+      <div className="flex justify-end border-t pt-5">
+        <Button
+          disabled={!pipeline || updating}
+          onClick={() =>
+            updatePipeline({
+              variables: {
+                _id: pipelineId,
+                name: pipeline?.name,
+                propertyIds,
+              },
+            })
+          }
+        >
+          {updating ? <Spinner /> : t('update')}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/sales_ui/AGENTS.md
+++ b/frontend/plugins/sales_ui/AGENTS.md
@@ -1,0 +1,84 @@
+# `sales_ui` Plugin Guide
+
+## Identity
+
+- **Plugin:** `sales`
+- **Project:** `sales_ui`
+- **Layer:** `Frontend UI`
+- **Path:** `frontend/plugins/sales_ui`
+- **Last synchronized:** `2026-08-12`
+
+## Scope
+
+### Owns
+
+- Sales boards, pipelines, stages, deals, products, payments, and deal detail UI.
+
+### Does not own
+
+- Sales persistence or GraphQL resolvers; those live in `sales_api`.
+- Core property definitions and shared UI primitives.
+
+## Current Capabilities
+
+- Runs as the sales Module Federation remote.
+- Pipeline create/edit supports general settings, stages, product configuration,
+  and grouped selection of Core `sales:deal` properties.
+- Deal detail renders only the properties selected on the deal's pipeline.
+  Legacy pipelines continue showing all deal properties until their selection
+  is saved for the first time.
+
+## Architecture
+
+| Area            | Path                                                                  | Responsibility                                                |
+| --------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Registration    | `frontend/plugins/sales_ui/src/config.tsx`                            | Sales routes, navigation, and remote registration             |
+| Pipeline editor | `frontend/plugins/sales_ui/src/modules/deals/pipelines`               | Pipeline form, stages, product config, and property selection |
+| Deal detail     | `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail` | Deal overview, properties, activity, and products             |
+| GraphQL         | `frontend/plugins/sales_ui/src/modules/deals/graphql`                 | Sales client operations                                       |
+
+## Contracts
+
+### Provides
+
+- Sales routes and Module Federation UI entries registered by `src/config.tsx`.
+
+### Consumes
+
+- `sales_api` GraphQL pipeline and deal contracts.
+- Core properties through public `ui-modules` property hooks with
+  `contentType: 'sales:deal'`.
+- `erxes-ui` and `ui-modules` public components.
+
+## Data and State
+
+- Apollo Client owns pipeline/deal server state; React Hook Form owns pipeline
+  editor state.
+- `propertyIds` is submitted with pipeline create/edit and reloaded from
+  `salesPipelineDetail`.
+
+## Local Invariants
+
+- Property choices must come only from Core `sales:deal` fields.
+- Deal property detail must filter by the deal's `pipelineId` selection.
+- Pipeline mutations must refresh or update Apollo state immediately.
+
+## Validation
+
+- `pnpm nx lint sales_ui`
+- `pnpm nx build sales_ui`
+- Open a pipeline editor, check properties from multiple groups, save, and
+  verify a deal in that pipeline shows only those fields.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-12` — Pipeline-scoped deal properties
+
+- **Summary:** Sales pipelines now choose grouped Core deal properties; legacy
+  pipelines retain show-all behavior until first save, then deal detail renders
+  only the chosen fields.
+- **Affected areas:** `src/modules/deals/{pipelines,cards,graphql,types,schemas}`.
+- **Contracts changed:** Pipeline GraphQL reads and mutations now include
+  `propertyIds`.

--- a/frontend/plugins/sales_ui/AGENTS.md
+++ b/frontend/plugins/sales_ui/AGENTS.md
@@ -36,6 +36,7 @@
 | Pipeline editor | `frontend/plugins/sales_ui/src/modules/deals/pipelines`               | Pipeline form, stages, product config, and property selection |
 | Deal detail     | `frontend/plugins/sales_ui/src/modules/deals/cards/components/detail` | Deal overview, properties, activity, and products             |
 | GraphQL         | `frontend/plugins/sales_ui/src/modules/deals/graphql`                 | Sales client operations                                       |
+
 - POS, deal, order, cover, item, product, payment, appearance, delivery, and permission management screens for the sales frontend.
 
 ### Does not own
@@ -50,11 +51,11 @@
 
 ## Architecture
 
-| Area | Path | Responsibility |
-| ---- | ---- | -------------- |
-| POS permission form | `frontend/plugins/sales_ui/src/modules/pos/components/permission` | Manages admin and cashier POS permission controls. |
-| POS GraphQL | `frontend/plugins/sales_ui/src/modules/pos/graphql` | Provides POS queries and mutations used by settings screens. |
-| POS types | `frontend/plugins/sales_ui/src/modules/pos/types` | Describes POS configuration data consumed by the UI. |
+| Area                | Path                                                              | Responsibility                                               |
+| ------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| POS permission form | `frontend/plugins/sales_ui/src/modules/pos/components/permission` | Manages admin and cashier POS permission controls.           |
+| POS GraphQL         | `frontend/plugins/sales_ui/src/modules/pos/graphql`               | Provides POS queries and mutations used by settings screens. |
+| POS types           | `frontend/plugins/sales_ui/src/modules/pos/types`                 | Describes POS configuration data consumed by the UI.         |
 
 ## Contracts
 
@@ -124,6 +125,7 @@
 - **Affected areas:** `src/modules/deals/{pipelines,cards,graphql,types,schemas}`.
 - **Contracts changed:** Pipeline GraphQL reads and mutations now include
   `propertyIds`.
+
 ### `2026-08-12` — `Cashier report permission`
 
 - **Summary:** Added a cashier report visibility switch to POS permission settings and persisted it in `permissionConfig.cashiers.seeReport`.

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/usePipelineForm.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/hooks/usePipelineForm.tsx
@@ -44,6 +44,7 @@ export const usePipelineForm = () => {
       excludeCheckUserIds: [],
       paymentIds: [],
       paymentTypes: [],
+      propertyIds: [],
       stages: [],
     },
     resolver: zodResolver(schema),

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/DealPipelineProperties.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/DealPipelineProperties.tsx
@@ -1,0 +1,117 @@
+import { usePipelineDetail } from '@/deals/boards/hooks/usePipelines';
+import { Button, Collapsible, InfoCard, Spinner } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import {
+  FieldsInGroup,
+  IFieldGroup,
+  MultipleFieldsInGroup,
+  FieldsInDetail,
+  mutateFunction,
+  useFieldGroups,
+  useFields,
+} from 'ui-modules';
+
+const CONTENT_TYPE = 'sales:deal';
+
+type Props = {
+  id: string;
+  pipelineId: string;
+  propertiesData: Record<string, unknown>;
+  mutateHook: () => { mutate: mutateFunction; loading: boolean };
+};
+
+const SelectedGroup = ({
+  group,
+  selectedIds,
+  ...props
+}: Props & { group: IFieldGroup; selectedIds: Set<string> }) => {
+  const { fields, loading } = useFields({
+    groupId: group._id,
+    contentType: CONTENT_TYPE,
+  });
+  const selectedFields = fields.filter(
+    (field) => selectedIds.has(field._id) && field.isVisible !== false,
+  );
+
+  if (loading) return <Spinner containerClassName="py-4" />;
+  if (!selectedFields.length) return null;
+
+  if (group.configs?.isMultiple) {
+    return (
+      <MultipleFieldsInGroup
+        group={group}
+        fields={selectedFields}
+        contentType={CONTENT_TYPE}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <Collapsible defaultOpen>
+      <Collapsible.Trigger asChild>
+        <Button variant="secondary" className="justify-start w-full">
+          <Collapsible.TriggerIcon />
+          {group.name}
+        </Button>
+      </Collapsible.Trigger>
+      <Collapsible.Content className="pt-4">
+        <FieldsInGroup
+          group={group}
+          fields={selectedFields}
+          contentType={CONTENT_TYPE}
+          {...props}
+        />
+      </Collapsible.Content>
+    </Collapsible>
+  );
+};
+
+export const DealPipelineProperties = (props: Props) => {
+  const { t } = useTranslation('sales');
+  const { pipelineDetail, loading: pipelineLoading } = usePipelineDetail({
+    variables: { _id: props.pipelineId },
+  });
+  const { fieldGroups, loading: groupsLoading } = useFieldGroups({
+    contentType: CONTENT_TYPE,
+    limit: 100,
+  });
+  const selectedIds = new Set(pipelineDetail?.propertyIds || []);
+
+  if (
+    !pipelineLoading &&
+    pipelineDetail?.isPropertySelectionConfigured === false
+  ) {
+    return (
+      <FieldsInDetail
+        fieldContentType={CONTENT_TYPE}
+        propertiesData={props.propertiesData}
+        mutateHook={props.mutateHook}
+        id={props.id}
+      />
+    );
+  }
+
+  return (
+    <InfoCard title={t('properties')}>
+      <InfoCard.Content>
+        {pipelineLoading || groupsLoading ? (
+          <Spinner containerClassName="py-8" />
+        ) : selectedIds.size === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('configure-properties-in-settings')}
+          </p>
+        ) : (
+          fieldGroups.map((group) => (
+            <SelectedGroup
+              key={group._id}
+              group={group}
+              selectedIds={selectedIds}
+              {...props}
+            />
+          ))
+        )}
+      </InfoCard.Content>
+    </InfoCard>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/SalesItemDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FieldsInDetail, RelationWidgetSideTabs } from 'ui-modules';
+import { RelationWidgetSideTabs } from 'ui-modules';
 import { DealActivityTab } from './DealActivityTab';
 import {
   Empty,
@@ -23,6 +23,7 @@ import { useAtom } from 'jotai';
 import { useDealCustomFieldEdit } from '../../hooks/useDealCustomFieldEdit';
 import { useDealDetail } from '@/deals/cards/hooks/useDeals';
 import { useTranslation } from 'react-i18next';
+import { DealPipelineProperties } from './DealPipelineProperties';
 
 const SalesItemDetailView = () => {
   const { isSidebarOpen } = useFocusSheet();
@@ -58,11 +59,11 @@ const SalesItemDetailView = () => {
               <Tabs.Content value="properties" className="h-full">
                 <ScrollArea className="h-full">
                   <div className="w-full xl:max-w-6xl mx-auto p-6">
-                    <FieldsInDetail
+                    <DealPipelineProperties
                       key={`${deal?._id || ''}-${JSON.stringify(
                         deal?.propertiesData || {},
                       )}`}
-                      fieldContentType="sales:deal"
+                      pipelineId={deal?.pipelineId || ''}
                       propertiesData={deal?.propertiesData || {}}
                       mutateHook={useDealCustomFieldEdit}
                       id={deal?._id || ''}

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/PipelinesMutations.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/PipelinesMutations.ts
@@ -72,6 +72,7 @@ const commonPipelineParamsDef = `
   $excludeProductIds: [String],
   $paymentIds: [String],
   $paymentTypes: JSON
+  $propertyIds: [String]
 `;
 
 const commonPipelineParams = `
@@ -101,6 +102,7 @@ const commonPipelineParams = `
   excludeProductIds: $excludeProductIds,
   paymentIds: $paymentIds,
   paymentTypes: $paymentTypes
+  propertyIds: $propertyIds
 `;
 
 export const ADD_PIPELINE = gql`

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/PipelinesQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/PipelinesQueries.ts
@@ -35,6 +35,8 @@ export const GET_PIPELINE_DETAIL = gql`
       isCheckUser
       isCheckDepartment
       excludeCheckUserIds
+      propertyIds
+      isPropertySelectionConfigured
     }
   }
 `;

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineForm.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineForm.tsx
@@ -5,6 +5,7 @@ import { ProductConfig } from '@/deals/cards/components/detail/product/component
 import { useTranslation } from 'react-i18next';
 import type { TPipelineForm } from '@/deals/types/pipelines';
 import type { UseFormReturn } from 'react-hook-form';
+import { PipelinePropertySelector } from './PipelinePropertySelector';
 
 type Props = {
   form: UseFormReturn<TPipelineForm>;
@@ -46,6 +47,14 @@ export const PipelineForm = ({ form, stagesLoading }: Props) => {
             {t('product-config')}
           </Button>
         </Tabs.Trigger>
+        <Tabs.Trigger asChild value="properties">
+          <Button
+            variant={'outline'}
+            className="bg-transparent data-[state=active]:bg-background data-[state=inactive]:shadow-none"
+          >
+            {t('properties')}
+          </Button>
+        </Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value="general" className="h-full py-4 px-5 overflow-auto">
         <GeneralForm form={form} />
@@ -58,6 +67,12 @@ export const PipelineForm = ({ form, stagesLoading }: Props) => {
         className="h-full py-4 px-5 overflow-auto"
       >
         <ProductConfig form={form} />
+      </Tabs.Content>
+      <Tabs.Content
+        value="properties"
+        className="h-full py-4 px-5 overflow-auto"
+      >
+        <PipelinePropertySelector form={form} />
       </Tabs.Content>
     </Tabs>
   );

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
@@ -1,0 +1,92 @@
+import { Checkbox, Collapsible, InfoCard, Label, Spinner } from 'erxes-ui';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useWatch, type UseFormReturn } from 'react-hook-form';
+import { useFieldGroups, useFields } from 'ui-modules';
+import type { TPipelineForm } from '@/deals/types/pipelines';
+
+const CONTENT_TYPE = 'sales:deal';
+const PROPERTY_LIMIT = 100;
+
+export const PipelinePropertySelector = ({
+  form,
+}: {
+  form: UseFormReturn<TPipelineForm>;
+}) => {
+  const { t } = useTranslation('sales');
+  const propertyIds =
+    useWatch({ control: form.control, name: 'propertyIds' }) || [];
+  const { fieldGroups, loading: groupsLoading } = useFieldGroups({
+    contentType: CONTENT_TYPE,
+    limit: PROPERTY_LIMIT,
+  });
+  const { fields, loading: fieldsLoading } = useFields({
+    contentType: CONTENT_TYPE,
+    limit: PROPERTY_LIMIT,
+  });
+  const groups = useMemo(
+    () =>
+      fieldGroups
+        .map((group) => ({
+          ...group,
+          fields: fields.filter((field) => field.groupId === group._id),
+        }))
+        .filter((group) => group.fields.length)
+        .sort((a, b) => a.order - b.order),
+    [fieldGroups, fields],
+  );
+
+  const toggle = (fieldId: string, checked: boolean) => {
+    form.setValue(
+      'propertyIds',
+      checked
+        ? [...new Set([...propertyIds, fieldId])]
+        : propertyIds.filter((id) => id !== fieldId),
+      { shouldDirty: true },
+    );
+  };
+
+  return (
+    <InfoCard
+      title={t('properties')}
+      description={t('configure-properties-in-settings')}
+    >
+      <InfoCard.Content>
+        {groupsLoading || fieldsLoading ? (
+          <Spinner containerClassName="py-8" />
+        ) : groups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('configure-properties-in-settings')}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {groups.map((group) => (
+              <Collapsible key={group._id} defaultOpen>
+                <Collapsible.TriggerButton type="button">
+                  <Collapsible.TriggerIcon className="size-3" />
+                  {group.name}
+                </Collapsible.TriggerButton>
+                <Collapsible.Content className="grid gap-3 pt-3 pl-5 sm:grid-cols-2">
+                  {group.fields.map((field) => (
+                    <div key={field._id} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`pipeline-property-${field._id}`}
+                        checked={propertyIds.includes(field._id)}
+                        onCheckedChange={(checked) =>
+                          toggle(field._id, checked === true)
+                        }
+                      />
+                      <Label htmlFor={`pipeline-property-${field._id}`}>
+                        {field.name}
+                      </Label>
+                    </div>
+                  ))}
+                </Collapsible.Content>
+              </Collapsible>
+            ))}
+          </div>
+        )}
+      </InfoCard.Content>
+    </InfoCard>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
@@ -57,6 +57,7 @@ const getPipelineFormValues = (
       excludeCheckUserIds: [],
       paymentIds: [],
       paymentTypes: [],
+      propertyIds: [],
     };
   }
 
@@ -84,6 +85,7 @@ const getPipelineFormValues = (
       ...paymentType,
       config: formatPaymentConfig(paymentType.config),
     })),
+    propertyIds: pipelineDetail.propertyIds || [],
   };
 };
 

--- a/frontend/plugins/sales_ui/src/modules/deals/schemas/pipelineFormSchema.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/schemas/pipelineFormSchema.ts
@@ -90,6 +90,7 @@ export const createPipelineFormSchema = (
       excludeCategoryIds: z.array(z.string()).optional(),
       excludeProductIds: z.array(z.string()).optional(),
       paymentIds: z.array(z.string()).optional(),
+      propertyIds: z.array(z.string()).optional(),
       paymentTypes: paymentTypesSchema.optional().default([]),
       stages: z
         .array(

--- a/frontend/plugins/sales_ui/src/modules/deals/types/pipelines.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/types/pipelines.ts
@@ -42,6 +42,8 @@ export interface IPipeline {
 
   paymentIds?: string[];
   paymentTypes?: PaymentConfigItem[];
+  propertyIds?: string[];
+  isPropertySelectionConfigured?: boolean;
 }
 
 export interface ISelectLabelContext {


### PR DESCRIPTION
## Why

Ticket and deal detail views currently render every Core custom property for their content type. This mixes unrelated property groups into every pipeline and prevents administrators from tailoring a pipeline to the fields its workflow actually uses.

The rollout must also preserve production behavior for existing pipelines. Deploying the feature must not hide existing fields, delete stored values, or require an immediate migration.

## What Changed

- Added a grouped Core property picker to Frontline ticket pipeline settings using only `frontline:ticket` fields.
- Added a Properties tab to the Sales pipeline editor using only `sales:deal` fields.
- Persisted selected property IDs on the owning Frontline or Sales pipeline.
- Validated submitted IDs against the matching Core content type before storage.
- Filtered ticket and deal detail property sections using the item's pipeline selection.
- Added `isPropertySelectionConfigured` to distinguish untouched legacy pipelines from an intentional empty selection.
- Preserved show-all behavior for existing pipelines until their Properties selection is explicitly saved.
- Preserved stored ticket/deal `propertiesData`; this change only controls which fields are rendered.
- Updated the affected plugin guides.

## Production Compatibility

- No migration or backfill is required.
- Existing pipelines continue showing all properties after deployment.
- Once a pipeline selection is saved, only checked properties are shown.
- Saving zero checked properties intentionally shows none.
- Older clients that omit `propertyIds` preserve the current pipeline selection.

## Validation

- `pnpm exec tsc --noEmit -p frontend/plugins/frontline_ui/tsconfig.json` — passed.
- `pnpm exec tsc --noEmit -p frontend/plugins/sales_ui/tsconfig.json` — passed.
- Focused ESLint across all changed TypeScript/TSX files — passed with no introduced errors.
- `pnpm nx build sales_api --excludeTaskDependencies` — passed.
- `git diff --check` — passed.
- No test targets are defined by the four affected Nx projects.
- Full Frontline API build is currently blocked by existing missing Discord packages.
- Full UI bundle builds are currently blocked by the existing missing `qz-tray` dependency.

## Summary by Sourcery

Introduce pipeline-scoped property selection for Frontline ticket and Sales deal pipelines, persisting validated Core property ids and using them to control which fields render in detail views while preserving legacy show-all behavior until pipelines are explicitly configured.

New Features:
- Add grouped Core property selection UIs to Frontline ticket and Sales deal pipeline editors, storing chosen property ids on each pipeline.
- Render ticket and deal detail property sections based on the owning pipeline’s saved property selection instead of always showing all properties.

Enhancements:
- Extend Frontline and Sales pipeline schemas, GraphQL types, and mutations with optional propertyIds and an isPropertySelectionConfigured flag for backward-compatible behavior.
- Validate submitted pipeline propertyIds against Core frontline:ticket and sales:deal fields via tRPC before persisting them, rejecting invalid ids.
- Update Frontline and Sales plugin guides to document pipeline-scoped property selection behavior and contracts.

Documentation:
- Add and update AGENTS plugin guides for frontline_api, frontline_ui, sales_api, and sales_ui to describe pipeline property selection capabilities and the new GraphQL contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure which ticket or deal properties appear for each pipeline.
  * View selected properties grouped by field category in ticket and deal details.
  * Added dedicated pipeline property settings and selection interfaces.
  * Existing pipelines without configured selections continue displaying all properties.
* **Bug Fixes**
  * Invalid or duplicate property selections are filtered and rejected before saving.
  * Empty selections are handled safely without disrupting pipeline updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->