### PR TITLE
fix: calc score with scoreCampaigns product filter

### DIFF
--- a/backend/plugins/loyalty_api/AGENTS.md
+++ b/backend/plugins/loyalty_api/AGENTS.md
@@ -23,8 +23,8 @@
 ## Current Capabilities
 
 - Score campaigns can add, subtract, set, refund, repair, and expose owner score balances.
-- Deal score campaign totals always count only deal `productsData` rows with `tickUsed === true`; discounted rows are skipped only when the campaign has `additionalConfig.discountCheck === true`.
-- POS order score campaign totals use order item amounts without deal-specific discount filtering.
+- Deal score campaign totals count only deal `productsData` rows that pass campaign product/category/tag restrictions and have `tickUsed === true`; discounted rows are skipped only when the campaign has `additionalConfig.discountCheck === true`.
+- POS order score campaign totals count only order item rows that pass campaign product/category/tag restrictions and use item amount or `count * unitPrice` without deal-specific discount filtering.
 - Pricing plans calculate product discounts through the loyalty pricing module and tRPC `pricing.checkPricing`.
 - Voucher, coupon, lottery, spin, reward, and agent modules provide their plugin-owned loyalty behaviors.
 
@@ -63,7 +63,7 @@
 ## Local Invariants
 
 - Preserve tenant isolation by using the request `subdomain` for every model and service access.
-- Deal score totals must exclude rows where `tickUsed` is not exactly `true`; discounted rows are excluded only when `additionalConfig.discountCheck === true`.
+- Deal score totals must exclude rows where `tickUsed` is not exactly `true`; discounted rows are excluded only when `additionalConfig.discountCheck === true`; product/category/tag restrictions must also filter deal and POS order rows that contribute to `totalAmount`.
 - Score campaign mutations must keep owner score caches and score logs consistent, including refunds for cleared or moved targets.
 - Pricing eligibility must fail closed when required core lookups are unavailable.
 - Do not introduce new `schemaWrapper` usage in backend schemas.
@@ -73,14 +73,14 @@
 - `pnpm nx build loyalty_api`
 - `pnpm nx test loyalty_api`
 - `pnpm nx test loyalty_api --testPathPattern scoreTarget`
-- Smoke scenario: trigger a sales deal score campaign with mixed `productsData`; only ticked rows should contribute to `totalAmount`, and discounted ticked rows should be skipped only when `additionalConfig.discountCheck` is enabled.
+- Smoke scenario: trigger a sales deal and POS order score campaign with mixed product rows; only rows matching product/category/tag restrictions should contribute to `totalAmount`, deal rows must also have `tickUsed === true`, and discounted deal rows should be skipped only when `additionalConfig.discountCheck` is enabled.
 
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
 
-### `2026-08-12` — `Campaign-specific deal discount check`
+### `2026-08-12` — `Campaign-specific product totals`
 
-- **Summary:** Deal score campaign totals now always require `tickUsed` and apply discounted-product skipping only for campaigns with `additionalConfig.discountCheck`.
+- **Summary:** Deal and POS order score campaign totals now apply product/category/tag restrictions, with deal-only `tickUsed` and discount-check handling preserved.
 - **Affected areas:** `src/modules/score/db/models/ScoreCampaign.ts`, `src/utils/utils.ts`, `src/utils/__tests__/scoreTarget.test.ts`
 - **Contracts changed:** `None`

--- a/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
+++ b/backend/plugins/loyalty_api/src/modules/score/db/models/ScoreCampaign.ts
@@ -28,7 +28,10 @@ import { Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import { getLoyaltyOwner } from '~/utils';
 import { EventDispatcherReturn } from 'erxes-api-shared/core-modules';
-import { generateTargetTotalAmountDeal } from '~/utils/utils';
+import {
+  generateTargetTotalAmountDeal,
+  getAllowedProductIdsByRestrictions,
+} from '~/utils/utils';
 
 export interface IScoreCampaignModel extends Model<IScoreCampaignDocument> {
   getScoreCampaign(_id: string): Promise<IScoreCampaignDocument>;
@@ -495,10 +498,29 @@ export const loadScoreCampaignClass = (
         [ownerType]: owner,
       };
 
-      if (Array.isArray(target?.productsData)) {
+      const productRows = Array.isArray(target?.productsData)
+        ? target.productsData
+        : Array.isArray(target?.items)
+          ? target.items
+          : undefined;
+
+      if (productRows) {
+        const isPosOrderTarget = Array.isArray(target?.items);
+        const allowedProductIds = await getAllowedProductIdsByRestrictions({
+          subdomain,
+          restrictions: campaign.restrictions,
+          productsData: productRows,
+        });
+
         calculationTarget.totalAmount = generateTargetTotalAmountDeal(
-          target.productsData,
-          campaign.additionalConfig?.discountCheck === true,
+          productRows,
+          {
+            allowedProductIds,
+            discountCheck:
+              !isPosOrderTarget &&
+              campaign.additionalConfig?.discountCheck === true,
+            requireTickUsed: !isPosOrderTarget,
+          },
         );
       }
 

--- a/backend/plugins/loyalty_api/src/utils/__tests__/scoreTarget.test.ts
+++ b/backend/plugins/loyalty_api/src/utils/__tests__/scoreTarget.test.ts
@@ -3,13 +3,16 @@ import { generateTargetTotalAmountDeal } from '../utils';
 describe('deal score target totals', () => {
   it('always excludes products that are not ticked', () => {
     expect(
-      generateTargetTotalAmountDeal([
-        { amount: 100, tickUsed: true },
-        { amount: 200, tickUsed: true, discount: 0 },
-        { amount: 300, tickUsed: false, discount: 0 },
-        { amount: 400, tickUsed: true, discount: 5 },
-        { amount: 500, tickUsed: true, discount: '10' },
-      ]),
+      generateTargetTotalAmountDeal(
+        [
+          { amount: 100, tickUsed: true },
+          { amount: 200, tickUsed: true, discount: 0 },
+          { amount: 300, tickUsed: false, discount: 0 },
+          { amount: 400, tickUsed: true, discount: 5 },
+          { amount: 500, tickUsed: true, discount: '10' },
+        ],
+        { requireTickUsed: true },
+      ),
     ).toBe(1200);
   });
 
@@ -23,7 +26,35 @@ describe('deal score target totals', () => {
           { amount: 400, tickUsed: true, discount: 5 },
           { amount: 500, tickUsed: true, discount: '10' },
         ],
-        true,
+        { discountCheck: true, requireTickUsed: true },
+      ),
+    ).toBe(300);
+  });
+
+  it('counts only allowed products when campaign product filters match rows', () => {
+    expect(
+      generateTargetTotalAmountDeal(
+        [
+          { productId: 'product-a', amount: 100, tickUsed: true },
+          { productId: 'product-b', amount: 200, tickUsed: true },
+          { productId: 'product-c', amount: 300, tickUsed: false },
+        ],
+        {
+          allowedProductIds: new Set(['product-a', 'product-c']),
+          requireTickUsed: true,
+        },
+      ),
+    ).toBe(100);
+  });
+
+  it('applies product filters to pos order rows without requiring tickUsed', () => {
+    expect(
+      generateTargetTotalAmountDeal(
+        [
+          { productId: 'product-a', count: 2, unitPrice: 100 },
+          { productId: 'product-b', count: 3, unitPrice: 100 },
+        ],
+        { allowedProductIds: new Set(['product-b']) },
       ),
     ).toBe(300);
   });

--- a/backend/plugins/loyalty_api/src/utils/utils.ts
+++ b/backend/plugins/loyalty_api/src/utils/utils.ts
@@ -67,6 +67,15 @@ interface IProductD {
   unitPrice: number;
 }
 
+type DealProductScoreData = {
+  amount?: number | string | null;
+  count?: number | string | null;
+  discount?: number | string | null;
+  productId?: string | null;
+  tickUsed?: boolean | null;
+  unitPrice?: number | string | null;
+};
+
 const availableVoucherTypes = ['bonus', 'discount'];
 
 // Core service helpers
@@ -120,14 +129,33 @@ export const applyRestriction = async ({
   restrictions: Record<string, any>;
   products: IProductD[];
 }) => {
-  const {
-    categoryIds = [],
-    excludeCategoryIds = [],
-    productIds = [],
-    excludeProductIds = [],
-    tagIds = [],
-    excludeTagIds = [],
-  } = restrictions || {};
+  const normalizeRestrictionIds = (value: unknown) => {
+    if (Array.isArray(value)) {
+      return value.filter((id): id is string => typeof id === 'string' && !!id);
+    }
+
+    if (typeof value === 'string') {
+      return value
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean);
+    }
+
+    return [];
+  };
+
+  const categoryIds = normalizeRestrictionIds(
+    restrictions?.categoryIds || restrictions?.productCategoryIds,
+  );
+  const excludeCategoryIds = normalizeRestrictionIds(
+    restrictions?.excludeCategoryIds || restrictions?.excludeProductCategoryIds,
+  );
+  const productIds = normalizeRestrictionIds(restrictions?.productIds);
+  const excludeProductIds = normalizeRestrictionIds(
+    restrictions?.excludeProductIds,
+  );
+  const tagIds = normalizeRestrictionIds(restrictions?.tagIds);
+  const excludeTagIds = normalizeRestrictionIds(restrictions?.excludeTagIds);
 
   const inputProductsIds = products.map((p) => p.productId);
 
@@ -177,6 +205,48 @@ export const applyRestriction = async ({
   }, 0);
 
   return { productDocs, restrictedAmount: totalAmount };
+};
+
+export const getAllowedProductIdsByRestrictions = async ({
+  subdomain,
+  restrictions,
+  productsData,
+}: {
+  subdomain: string;
+  restrictions?: Record<string, unknown>;
+  productsData: DealProductScoreData[];
+}) => {
+  const hasRestrictions = Object.values(restrictions || {}).some((value) => {
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+
+    return typeof value === 'string' && !!value.trim();
+  });
+
+  if (!hasRestrictions) {
+    return undefined;
+  }
+
+  const productIds = productsData
+    .map(({ productId }) => productId)
+    .filter((productId): productId is string => !!productId);
+
+  if (!productIds.length) {
+    return undefined;
+  }
+
+  const { productDocs } = await applyRestriction({
+    subdomain,
+    restrictions: restrictions || {},
+    products: productIds.map((productId) => ({
+      productId,
+      quantity: 0,
+      unitPrice: 0,
+    })),
+  });
+
+  return new Set(productDocs.map(({ _id }: { _id: string }) => _id));
 };
 
 // Helper for processing a single product discount (reduces duplication)
@@ -785,20 +855,31 @@ export const doScoreCampaign = async (models: IModels, data) => {
 };
 
 export const generateTargetTotalAmountDeal = (
-  productsData: Array<{
-    amount?: number | string | null;
-    discount?: number | string | null;
-    tickUsed?: boolean | null;
-  }> = [],
-  discountCheck = false,
+  productsData: DealProductScoreData[] = [],
+  options: {
+    allowedProductIds?: Set<string>;
+    discountCheck?: boolean;
+    requireTickUsed?: boolean;
+  } = {},
 ) =>
   productsData
-    .filter((pdata) => pdata.tickUsed === true)
+    .filter((pdata) => !options.requireTickUsed || pdata.tickUsed === true)
     .filter(
       (pdata) =>
-        !discountCheck || Math.abs(Number(pdata.discount) || 0) < 0.005,
+        !options.allowedProductIds ||
+        options.allowedProductIds.has(pdata.productId || ''),
     )
-    .reduce((sum, product) => sum + (Number(product?.amount) || 0), 0);
+    .filter(
+      (pdata) =>
+        !options.discountCheck || Math.abs(Number(pdata.discount) || 0) < 0.005,
+    )
+    .reduce(
+      (sum, product) =>
+        sum +
+        (Number(product?.amount) ||
+          (Number(product?.count) || 0) * (Number(product?.unitPrice) || 0)),
+      0,
+    );
 
 const generateTargetTotalAmountOrder = (productsData: any[] = []) =>
   productsData.reduce((sum, product) => sum + (product?.amount || 0), 0);
@@ -826,7 +907,9 @@ const normalizeDealTarget = ({
       type,
       ...(obj ?? {}),
     })),
-    totalAmount: generateTargetTotalAmountDeal(target?.productsData || []),
+    totalAmount: generateTargetTotalAmountDeal(target?.productsData || [], {
+      requireTickUsed: true,
+    }),
     excludeAmount: paymentEntries
       .filter(([type]) => !scorePaymentTypes.has(type))
       .map(([type, obj]) => ({


### PR DESCRIPTION
## Summary by Sourcery

Apply campaign product/category/tag restrictions when calculating deal and POS order score campaign totals, while preserving existing tickUsed and discount-check behavior.

New Features:
- Support campaign product/category/tag filters when scoring POS order item rows via reusable restriction-based product ID selection.

Enhancements:
- Generalize deal product score data structure to handle both deal products and POS order items with optional count and unitPrice fields.
- Refine restriction ID handling to normalize category, product, and tag identifiers from multiple config shapes and string/array forms.
- Extend deal target total amount calculation to optionally respect allowed product IDs, toggle discount checking, and support POS order rows without tickUsed.

Documentation:
- Refresh loyalty API agent documentation to describe how score campaign totals honor product/category/tag restrictions for deals and POS orders and to record the new behavior in recent changes.

Tests:
- Update and expand score target tests to cover discount-check options, product filters, and POS order item handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loyalty campaigns can now target specific products, categories, and tags when calculating deal and POS scores.
  * POS score totals support order items without requiring ticket-use data.
  * Score calculations can derive item totals from quantity and unit price when needed.

* **Bug Fixes**
  * Deal totals now consistently require used tickets and correctly handle discounted items.
  * Improved handling of campaign restrictions provided in multiple formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->