### PR TITLE
fix(pipelines): preserve legacy property visibility

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/pipelines/types/index.ts
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/types/index.ts
@@ -16,7 +16,7 @@ export interface PermissionState {
   visibility: 'public' | 'private';
   memberIds: string[];
   propertyIds: string[];
-  isPropertySelectionConfigured: boolean;
+  isPropertySelectionConfigured?: boolean | null;
 }
 
 export interface IPipeline {

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketPipelineProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-detail/TicketPipelineProperties.tsx
@@ -78,7 +78,7 @@ export const TicketPipelineProperties = (props: Props) => {
   });
   const selectedIds = new Set(pipeline?.propertyIds || []);
 
-  if (!pipelineLoading && pipeline?.isPropertySelectionConfigured === false) {
+  if (!pipelineLoading && pipeline?.isPropertySelectionConfigured !== true) {
     return (
       <FieldsInDetail
         fieldContentType={CONTENT_TYPE}

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/DealPipelineProperties.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/DealPipelineProperties.tsx
@@ -80,7 +80,7 @@ export const DealPipelineProperties = (props: Props) => {
 
   if (
     !pipelineLoading &&
-    pipelineDetail?.isPropertySelectionConfigured === false
+    pipelineDetail?.isPropertySelectionConfigured !== true
   ) {
     return (
       <FieldsInDetail

--- a/frontend/plugins/sales_ui/src/modules/deals/types/pipelines.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/types/pipelines.ts
@@ -43,7 +43,7 @@ export interface IPipeline {
   paymentIds?: string[];
   paymentTypes?: PaymentConfigItem[];
   propertyIds?: string[];
-  isPropertySelectionConfigured?: boolean;
+  isPropertySelectionConfigured?: boolean | null;
 }
 
 export interface ISelectLabelContext {


### PR DESCRIPTION
## Why

Pipelines created before scoped property selection do not have `isPropertySelectionConfigured` stored in MongoDB. GraphQL therefore returns `null`, but the legacy fallback checked only for `false`. Those pipelines were incorrectly treated as an intentional empty selection and ticket/deal details displayed no property fields.

## What Changed

- Treat `null`, `undefined`, and `false` as an unconfigured legacy pipeline.
- Activate scoped filtering only when `isPropertySelectionConfigured` is explicitly `true`.
- Update frontend pipeline types to reflect the nullable GraphQL field.
- Apply the same correction to Frontline ticket details and Sales deal details.

Existing pipelines return to the original show-all behavior immediately after the UI deployment. Pipelines with an explicitly saved selection remain filtered as configured.

## Validation

- Focused ESLint for the four changed files — passed.
- `pnpm exec tsc --noEmit -p frontend/plugins/frontline_ui/tsconfig.json` — passed.
- `pnpm exec tsc --noEmit -p frontend/plugins/sales_ui/tsconfig.json` — passed.
- `git diff --check` — passed.

## Summary by Sourcery

Preserve legacy pipeline property visibility behavior by correctly handling nullable property selection configuration and aligning UI logic with updated types.

Bug Fixes:
- Ensure pipelines without stored property selection configuration show all properties instead of being treated as intentionally empty selections.
- Apply corrected property visibility handling to both Frontline ticket details and Sales deal details.

Enhancements:
- Update pipeline type definitions in Frontline and Sales UIs to reflect nullable isPropertySelectionConfigured values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline details now display default fields when property-selection settings are missing or unset.
  * Improved handling of incomplete pipeline configuration data across tickets and deals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->