### PR TITLE
feat(pipelines): select properties by group

### DIFF
--- a/frontend/plugins/frontline_ui/AGENTS.md
+++ b/frontend/plugins/frontline_ui/AGENTS.md
@@ -427,6 +427,14 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-08-12` — Select ticket properties by group
+
+- **Summary:** Pipeline property configuration now selects an entire Core
+  ticket property group with one checkbox instead of selecting fields one by
+  one; the stored contract remains the group's field ids.
+- **Affected areas:** `src/modules/pipelines/components/PipelinePropertySelector.tsx`.
+- **Contracts changed:** None.
+
 ### `2026-08-12` — Pipeline-scoped ticket properties
 
 - **Summary:** Ticket pipelines now choose grouped Core ticket properties, and

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
@@ -1,7 +1,7 @@
-import { Checkbox, Collapsible, Label, Spinner } from 'erxes-ui';
+import { Checkbox, Label, Spinner } from 'erxes-ui';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IField, useFieldGroups, useFields } from 'ui-modules';
+import { useFieldGroups, useFields } from 'ui-modules';
 
 const CONTENT_TYPE = 'frontline:ticket';
 const PROPERTY_LIMIT = 100;
@@ -46,38 +46,54 @@ export const PipelinePropertySelector = ({ value, onChange }: Props) => {
     );
   }
 
-  const toggle = (field: IField, checked: boolean) => {
+  const toggleGroup = (fieldIds: string[], checked: boolean) => {
+    const groupFieldIds = new Set(fieldIds);
+
     onChange(
       checked
-        ? [...new Set([...value, field._id])]
-        : value.filter((id) => id !== field._id),
+        ? [...new Set([...value, ...fieldIds])]
+        : value.filter((id) => !groupFieldIds.has(id)),
     );
   };
 
   return (
     <div className="flex flex-col gap-3">
-      {groups.map((group) => (
-        <Collapsible key={group._id} defaultOpen>
-          <Collapsible.TriggerButton type="button">
-            <Collapsible.TriggerIcon className="size-3" />
-            {group.name}
-          </Collapsible.TriggerButton>
-          <Collapsible.Content className="grid gap-3 pt-3 pl-5 sm:grid-cols-2">
-            {group.fields.map((field) => (
-              <div key={field._id} className="flex items-center gap-2">
-                <Checkbox
-                  id={`pipeline-property-${field._id}`}
-                  checked={value.includes(field._id)}
-                  onCheckedChange={(checked) => toggle(field, checked === true)}
-                />
-                <Label htmlFor={`pipeline-property-${field._id}`}>
-                  {field.name}
-                </Label>
-              </div>
-            ))}
-          </Collapsible.Content>
-        </Collapsible>
-      ))}
+      {groups.map((group) => {
+        const fieldIds = group.fields.map((field) => field._id);
+        const selectedCount = fieldIds.filter((id) =>
+          value.includes(id),
+        ).length;
+        const checked =
+          selectedCount === fieldIds.length
+            ? true
+            : selectedCount > 0
+            ? 'indeterminate'
+            : false;
+
+        return (
+          <div
+            key={group._id}
+            className="flex items-center gap-3 rounded-md border p-3"
+          >
+            <Checkbox
+              id={`pipeline-property-group-${group._id}`}
+              checked={checked}
+              onCheckedChange={(nextChecked) =>
+                toggleGroup(fieldIds, nextChecked === true)
+              }
+            />
+            <Label
+              htmlFor={`pipeline-property-group-${group._id}`}
+              className="flex min-w-0 flex-1 items-center justify-between gap-3"
+            >
+              <span className="truncate">{group.name}</span>
+              <span className="text-xs text-muted-foreground">
+                {group.fields.length}
+              </span>
+            </Label>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/PipelinePropertySelector.tsx
@@ -67,8 +67,8 @@ export const PipelinePropertySelector = ({ value, onChange }: Props) => {
           selectedCount === fieldIds.length
             ? true
             : selectedCount > 0
-            ? 'indeterminate'
-            : false;
+              ? 'indeterminate'
+              : false;
 
         return (
           <div

--- a/frontend/plugins/sales_ui/AGENTS.md
+++ b/frontend/plugins/sales_ui/AGENTS.md
@@ -117,6 +117,14 @@
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-08-12` — Select deal properties by group
+
+- **Summary:** Pipeline property configuration now selects an entire Core deal
+  property group with one checkbox instead of selecting fields one by one; the
+  stored contract remains the group's field ids.
+- **Affected areas:** `src/modules/deals/pipelines/components/PipelinePropertySelector.tsx`.
+- **Contracts changed:** None.
+
 ### `2026-08-12` — Pipeline-scoped deal properties
 
 - **Summary:** Sales pipelines now choose grouped Core deal properties; legacy

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Collapsible, InfoCard, Label, Spinner } from 'erxes-ui';
+import { Checkbox, InfoCard, Label, Spinner } from 'erxes-ui';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWatch, type UseFormReturn } from 'react-hook-form';
@@ -36,12 +36,14 @@ export const PipelinePropertySelector = ({
     [fieldGroups, fields],
   );
 
-  const toggle = (fieldId: string, checked: boolean) => {
+  const toggleGroup = (fieldIds: string[], checked: boolean) => {
+    const groupFieldIds = new Set(fieldIds);
+
     form.setValue(
       'propertyIds',
       checked
-        ? [...new Set([...propertyIds, fieldId])]
-        : propertyIds.filter((id) => id !== fieldId),
+        ? [...new Set([...propertyIds, ...fieldIds])]
+        : propertyIds.filter((id) => !groupFieldIds.has(id)),
       { shouldDirty: true },
     );
   };
@@ -60,30 +62,42 @@ export const PipelinePropertySelector = ({
           </p>
         ) : (
           <div className="flex flex-col gap-3">
-            {groups.map((group) => (
-              <Collapsible key={group._id} defaultOpen>
-                <Collapsible.TriggerButton type="button">
-                  <Collapsible.TriggerIcon className="size-3" />
-                  {group.name}
-                </Collapsible.TriggerButton>
-                <Collapsible.Content className="grid gap-3 pt-3 pl-5 sm:grid-cols-2">
-                  {group.fields.map((field) => (
-                    <div key={field._id} className="flex items-center gap-2">
-                      <Checkbox
-                        id={`pipeline-property-${field._id}`}
-                        checked={propertyIds.includes(field._id)}
-                        onCheckedChange={(checked) =>
-                          toggle(field._id, checked === true)
-                        }
-                      />
-                      <Label htmlFor={`pipeline-property-${field._id}`}>
-                        {field.name}
-                      </Label>
-                    </div>
-                  ))}
-                </Collapsible.Content>
-              </Collapsible>
-            ))}
+            {groups.map((group) => {
+              const fieldIds = group.fields.map((field) => field._id);
+              const selectedCount = fieldIds.filter((id) =>
+                propertyIds.includes(id),
+              ).length;
+              const checked =
+                selectedCount === fieldIds.length
+                  ? true
+                  : selectedCount > 0
+                  ? 'indeterminate'
+                  : false;
+
+              return (
+                <div
+                  key={group._id}
+                  className="flex items-center gap-3 rounded-md border p-3"
+                >
+                  <Checkbox
+                    id={`pipeline-property-group-${group._id}`}
+                    checked={checked}
+                    onCheckedChange={(nextChecked) =>
+                      toggleGroup(fieldIds, nextChecked === true)
+                    }
+                  />
+                  <Label
+                    htmlFor={`pipeline-property-group-${group._id}`}
+                    className="flex min-w-0 flex-1 items-center justify-between gap-3"
+                  >
+                    <span className="truncate">{group.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {group.fields.length}
+                    </span>
+                  </Label>
+                </div>
+              );
+            })}
           </div>
         )}
       </InfoCard.Content>

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelinePropertySelector.tsx
@@ -71,8 +71,8 @@ export const PipelinePropertySelector = ({
                 selectedCount === fieldIds.length
                   ? true
                   : selectedCount > 0
-                  ? 'indeterminate'
-                  : false;
+                    ? 'indeterminate'
+                    : false;
 
               return (
                 <div


### PR DESCRIPTION
## Why

Pipeline property configuration currently requires checking fields one by one. Administrators organize Core properties into meaningful groups and need pipelines to opt into those groups as a unit.

## What Changed

- Replaced field-level checkboxes with one checkbox per Core property group in Frontline ticket pipeline settings.
- Applied the same group-level selection behavior to Sales deal pipeline settings.
- Selecting a group stores every current field ID in that group; clearing it removes every field ID in that group.
- Preserved the existing backend `propertyIds` contract and detail rendering logic.
- Displayed previously partial field selections as indeterminate, allowing administrators to normalize them by selecting or clearing the group.
- Added the number of fields beside each group.

## Validation

- Focused ESLint for both changed selectors — passed.
- `pnpm exec tsc --noEmit -p frontend/plugins/frontline_ui/tsconfig.json` — passed.
- `pnpm exec tsc --noEmit -p frontend/plugins/sales_ui/tsconfig.json` — passed.
- `git diff --check` — passed.

## Summary by Sourcery

Update pipeline property selection to operate at Core property group level for frontline tickets and sales deals while preserving existing property ID contracts.

New Features:
- Allow frontline ticket pipelines to select entire Core property groups via a single checkbox instead of individual fields.
- Allow sales deal pipelines to select entire Core property groups via a single checkbox instead of individual fields.

Enhancements:
- Represent partially selected groups as indeterminate checkboxes to let administrators normalize mixed selections.
- Display the number of fields in each Core property group within pipeline property selectors.
- Simplify the UI layout of pipeline property selectors by replacing collapsible field lists with compact group-level cards.

Documentation:
- Document group-based ticket property selection behavior and contracts in frontline UI AGENTS notes.
- Document group-based deal property selection behavior and contracts in sales UI AGENTS notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline configuration now lets you select or deselect complete property groups with one checkbox.
  * Group checkboxes show the number of available fields and an indeterminate state when only some fields are selected.
  * Existing field selections remain preserved when configuring pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->