### PR TITLE
fix(content): preserve CMS editor spacing

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/blocks/components/Editor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/Editor.tsx
@@ -5,13 +5,17 @@ import { Block } from '@blocknote/core';
 import { BlockEditorProps, IEditorProps } from '../types';
 import { cn } from 'erxes-ui/lib';
 import { parseBlocks } from '../utils';
+import {
+  embedBlockStructureInHTML,
+  parseBlockStructureFromHTML,
+} from '../utils/blockStructureHTML';
 
 export const Editor = ({
   onChange,
   initialContent,
-  scope,
   className,
   isHTML = false,
+  preserveBlockStructure = false,
   uploadFile,
   ...props
 }: Omit<BlockEditorProps, 'editor' | 'onChange'> & IEditorProps) => {
@@ -27,6 +31,7 @@ export const Editor = ({
   const parsedInitialContent = parseBlocks(initialContent ?? '');
   const editor = useBlockEditor({
     initialContent: parsedInitialContent || undefined,
+    tabBehavior: preserveBlockStructure ? 'prefer-indent' : undefined,
     uploadFile,
   });
 
@@ -40,7 +45,10 @@ export const Editor = ({
       if (initialContent === lastEditorOutputRef.current) return;
 
       // Support legacy JSON content stored before isHTML mode was introduced
-      const parsed = parseBlocks(initialContent);
+      const parsed =
+        (preserveBlockStructure &&
+          parseBlockStructureFromHTML(initialContent)) ||
+        parseBlocks(initialContent);
       if (parsed) {
         const currentSerialized = JSON.stringify(editor.document);
         const nextSerialized = JSON.stringify(parsed);
@@ -71,8 +79,7 @@ export const Editor = ({
     return () => {
       isActive = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, initialContent, isHTML]);
+  }, [editor, initialContent, isHTML, preserveBlockStructure]);
 
   useEffect(() => {
     if (isHTML) return;
@@ -132,14 +139,18 @@ export const Editor = ({
       const content = editor?.document;
       if (!content) return;
       if (isHTML) {
-        const htmlContent = await editor.blocksToHTMLLossy(content as Block[]);
+        const blocks = content as Block[];
+        const interoperableHTML = await editor.blocksToHTMLLossy(blocks);
+        const htmlContent = preserveBlockStructure
+          ? embedBlockStructureInHTML(interoperableHTML, blocks)
+          : interoperableHTML;
         lastEditorOutputRef.current = htmlContent;
         onChange(htmlContent);
       } else {
         onChange(JSON.stringify(content));
       }
     }, 300);
-  }, [editor, isHTML, onChange]);
+  }, [editor, isHTML, onChange, preserveBlockStructure]);
 
   return (
     <BlockEditor

--- a/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/hooks/useBlockEditor.tsx
@@ -8,6 +8,7 @@ import { BLOCK_SCHEMA, TABLE_SCHEMA } from '../constant';
 export const useBlockEditor = (args?: {
   initialContent?: Block[];
   placeholder?: string;
+  tabBehavior?: 'prefer-navigate-ui' | 'prefer-indent';
   uploadFile?: (file: File) => Promise<string>;
 }) => {
   const { placeholder, uploadFile, ...restArgs } = args || {};

--- a/frontend/libs/erxes-ui/src/modules/blocks/types/TextEditor.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/types/TextEditor.ts
@@ -30,6 +30,7 @@ export interface IEditorProps {
   initialContent?: string;
   scope?: string;
   isHTML?: boolean;
+  preserveBlockStructure?: boolean;
   uploadFile?: (file: File) => Promise<string>;
 }
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/utils/blockStructureHTML.ts
+++ b/frontend/libs/erxes-ui/src/modules/blocks/utils/blockStructureHTML.ts
@@ -1,0 +1,62 @@
+import { Block } from '@blocknote/core';
+import { parseBlocks } from './parseBlocks';
+
+const BLOCK_STRUCTURE_ATTRIBUTE = 'data-erxes-editor-document';
+
+const encodeUtf8Base64 = (value: string): string => {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary);
+};
+
+const decodeUtf8Base64 = (value: string): string => {
+  const binary = atob(value);
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+
+  return new TextDecoder().decode(bytes);
+};
+
+/**
+ * Keeps BlockNote's non-lossy document structure alongside interoperable HTML.
+ * The data attribute is inert when the HTML is rendered by a CMS consumer.
+ */
+export const embedBlockStructureInHTML = (
+  html: string,
+  blocks: Block[],
+): string => {
+  const encodedBlocks = encodeUtf8Base64(JSON.stringify(blocks));
+
+  return `<div ${BLOCK_STRUCTURE_ATTRIBUTE}="${encodedBlocks}">${html}</div>`;
+};
+
+/**
+ * Reads editor structure previously embedded by embedBlockStructureInHTML.
+ * Invalid or legacy HTML falls back to BlockNote's regular HTML parser.
+ */
+export const parseBlockStructureFromHTML = (
+  html: string,
+): Block[] | undefined => {
+  if (!html.includes(BLOCK_STRUCTURE_ATTRIBUTE)) {
+    return undefined;
+  }
+
+  try {
+    const document = new DOMParser().parseFromString(html, 'text/html');
+    const encodedBlocks = document
+      .querySelector(`[${BLOCK_STRUCTURE_ATTRIBUTE}]`)
+      ?.getAttribute(BLOCK_STRUCTURE_ATTRIBUTE);
+
+    if (!encodedBlocks) {
+      return undefined;
+    }
+
+    return parseBlocks(decodeUtf8Base64(encodedBlocks)) || undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/frontend/plugins/content_ui/AGENTS.md
+++ b/frontend/plugins/content_ui/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `content_ui`
 - **Layer:** `Frontend UI`
 - **Path:** `frontend/plugins/content_ui`
-- **Last synchronized:** `2026-08-11`
+- **Last synchronized:** `2026-08-13`
 
 ## Scope
 
@@ -23,6 +23,8 @@
 
 - Provides CMS content, category, page, menu, custom-field, and media workflows.
 - Provides Web Builder configuration and editing surfaces.
+- Preserves blank lines and tab-indented block structure when CMS posts are
+  saved and reopened in the post editor.
 - Allows individual CMS custom-field file uploads up to 630 MiB through the
   platform's chunked-upload contract.
 
@@ -69,6 +71,8 @@
 - Main feature internals belong under `src/modules/cms` or
   `src/modules/web-builder`.
 - CMS shared layout/components belong under `src/modules/cms/shared`.
+- The CMS post editor must enable the shared editor's structure-preserving HTML
+  mode so blank and nested blocks survive the HTML persistence boundary.
 - `src/widgets` is for plugin widget exports, not general shared CMS UI.
 - Keep hooks, GraphQL documents, states, constants, and types near the feature
   they support.
@@ -155,8 +159,11 @@
 
 ## Validation
 
-- `pnpm nx lint content_ui` (when a lint target is defined)
+- `pnpm nx lint content_ui`
 - `pnpm nx build content_ui`
+- `pnpm nx test content_ui`
+- Create or edit a CMS post with a blank paragraph and a Tab-indented paragraph,
+  save it, reopen it, and verify both structures remain visible.
 - Directly select a CMS file custom field and verify a file no larger than
   630 MiB is accepted while a larger file is rejected.
 
@@ -174,6 +181,14 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-13` — Preserve post editor spacing
+
+- **Summary:** Preserved blank lines and tab-indented blocks across CMS post
+  saves and reloads while retaining HTML output for CMS consumers.
+- **Affected areas:** `src/modules/cms/posts/PostPreview.tsx`
+- **Contracts changed:** Consumes the optional `preserveBlockStructure` prop
+  from the public `erxes-ui` editor API.
 
 ### `2026-08-11` — Increase custom-field upload limit
 

--- a/frontend/plugins/content_ui/src/modules/cms/posts/PostPreview.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/PostPreview.tsx
@@ -41,6 +41,7 @@ export const PostPreview = ({
                   className="h-[calc(100vh-200px)] border text-justify"
                   key={`editor-${selectedLanguage}-${fullPost?._id || 'new'}`}
                   isHTML
+                  preserveBlockStructure
                   initialContent={form.getValues('content') || ''}
                   onChange={handleEditorChange}
                   uploadFile={async (file) => {


### PR DESCRIPTION
## Summary

- preserve blank paragraphs and Tab-indented block nesting when CMS posts are saved and reopened
- keep interoperable HTML output while embedding the non-lossy BlockNote document as inert metadata
- make structure preservation opt-in through the shared `Editor` API and enable it for CMS posts
- retain the legacy HTML parsing fallback for existing posts

## Validation

- `pnpm nx build content_ui`
- `pnpm nx test content_ui --runInBand` — 3 suites, 7 tests passed
- focused ESLint and Prettier checks for changed source files
- manual structure round-trip check covering Unicode text, an empty block, and an indented child block

## Known repository issue

- `pnpm nx lint content_ui` still fails on six unrelated pre-existing errors in custom-field, custom-type, and client-portal files; all files changed by this PR pass focused ESLint.

## Summary by Sourcery

Preserve CMS post editor block structure and spacing while retaining interoperable HTML output, and make the behavior configurable via the shared editor API.

New Features:
- Add an optional structure-preserving HTML mode to the shared blocks Editor that embeds the full BlockNote document into HTML metadata.
- Enable structure-preserving HTML mode for the CMS post editor so blank lines and tab-indented blocks survive save and reload cycles.

Enhancements:
- Extend the block editor hook and props to support configurable Tab key behavior favoring indentation when structure preservation is enabled.

Documentation:
- Update content_ui agent documentation to describe the new spacing preservation behavior, validation steps, and the editor API contract for CMS posts.

Tests:
- Document a manual validation flow to verify blank and indented block preservation across CMS post saves and reopenings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CMS post editing and previews now preserve blank lines, indentation, and embedded block structure.
  * HTML content retains richer formatting when saved and reopened.
  * Added configurable tab behavior for navigating or indenting content.

* **Bug Fixes**
  * Improved restoration of structured content from HTML while maintaining compatibility with standard or legacy HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->