### PR TITLE
fix(sales): reveal errors in extended stage fields

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
@@ -74,15 +74,25 @@ export const PipelineStageItem = (props: Props) => {
   const { t } = useTranslation('sales');
   const { errors } = useFormState({
     control,
-    name: `stages.${index}.code`,
+    name: `stages.${index}`,
   });
-  const codeError = errors.stages?.[index]?.code;
+  const stageErrors = errors.stages?.[index];
+  const hasExtraFieldError = Boolean(
+    stageErrors?.code ||
+      stageErrors?.age ||
+      stageErrors?.canMoveMemberIds ||
+      stageErrors?.canEditMemberIds ||
+      stageErrors?.memberIds ||
+      stageErrors?.departmentIds ||
+      stageErrors?.defaultTick,
+  );
+  const extraFieldsVisible = showExtraFields || hasExtraFieldError;
 
   useEffect(() => {
-    if (codeError) {
+    if (hasExtraFieldError) {
       setShowExtraFields(true);
     }
-  }, [codeError]);
+  }, [hasExtraFieldError]);
 
   return (
     <div
@@ -250,7 +260,7 @@ export const PipelineStageItem = (props: Props) => {
                 )}
               />
             </div>
-            {showExtraFields && (
+            {extraFieldsVisible && (
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-2">
                 <Form.Field
                   name={`stages.${index}.code`}
@@ -401,9 +411,9 @@ export const PipelineStageItem = (props: Props) => {
               p-2 rounded bg-primary/10 hover:bg-primary/20 transition-colors duration-150
               select-none
             `}
-              onClick={() => setShowExtraFields(!showExtraFields)}
+              onClick={() => setShowExtraFields(!extraFieldsVisible)}
             >
-              {showExtraFields
+              {extraFieldsVisible
                 ? showTooltip(
                     <IconChevronUp size={16} />,
                     t('hide-extra-fields'),

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
@@ -79,12 +79,12 @@ export const PipelineStageItem = (props: Props) => {
   const stageErrors = errors.stages?.[index];
   const hasExtraFieldError = Boolean(
     stageErrors?.code ||
-      stageErrors?.age ||
-      stageErrors?.canMoveMemberIds ||
-      stageErrors?.canEditMemberIds ||
-      stageErrors?.memberIds ||
-      stageErrors?.departmentIds ||
-      stageErrors?.defaultTick,
+    stageErrors?.age ||
+    stageErrors?.canMoveMemberIds ||
+    stageErrors?.canEditMemberIds ||
+    stageErrors?.memberIds ||
+    stageErrors?.departmentIds ||
+    stageErrors?.defaultTick,
   );
   const extraFieldsVisible = showExtraFields || hasExtraFieldError;
 


### PR DESCRIPTION
## Problem

Pipeline validation can report an error for a field inside a stage's collapsed extended section. The validation toast appears, but the affected stage can remain collapsed, hiding the inline field message.

The expansion introduced in #8999 depended on an effect updating local state after the form error render and subscribed only to the stage code field.

## Changes

- Observe validation errors for the entire stage.
- Treat errors from any extended stage field as an immediate reason to render the section open.
- Preserve the expanded state after the error is corrected so the user can continue editing without the section collapsing again.

## User impact

Creating or updating a pipeline now reveals the affected stage's extended fields when validation fails, so the toast and the inline error message are both visible.

## Validation

- `pnpm exec eslint frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx`
- `NX_DAEMON=false pnpm nx build sales_ui`
- `git diff --check`

## Summary by Sourcery

Ensure pipeline stage extended fields automatically expand when any validation error occurs and remain visible for continued editing.

Bug Fixes:
- Fix hidden validation errors in collapsed pipeline stage extended sections by expanding the section when any extra field has an error.

Enhancements:
- Expand extra stage fields based on aggregated stage-level errors instead of only the code field.
- Preserve the expanded state of extra stage fields after validation errors are corrected to avoid collapsing while the user continues editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline stage extra fields now automatically expand when any relevant validation error is present.
  * Improved visibility and toggle behavior for stages with validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->