### PR TITLE
feat(tourism): add discount config

### DIFF
--- a/backend/gateway/src/locales/en/tourism.json
+++ b/backend/gateway/src/locales/en/tourism.json
@@ -606,6 +606,17 @@
   "check-out-amount": "Check out amount",
 
   "add-discount": "Add discount",
+  "applies-to": "Applies to",
+  "choose-discount-type": "Choose target",
+  "pricing-plan": "Pricing plan",
+  "rooms": "Rooms",
+  "extra-products": "Extra products",
+  "appointments": "Appointments",
+  "select-pricing-plan": "Select pricing plan",
+  "search-pricing-plan": "Search pricing plan",
+  "loading-pricing-plans": "Loading pricing plans...",
+  "no-pricing-plans-found": "No pricing plans found",
+  "failed-to-load-pricing-plans": "Failed to load pricing plans",
 
   "website-reservation-lock": "Website Reservation Lock",
   "reservation-lock-duration": "Reservation lock duration",

--- a/backend/gateway/src/locales/mn/tourism.json
+++ b/backend/gateway/src/locales/mn/tourism.json
@@ -606,6 +606,17 @@
   "check-out-amount": "Гарах хэмжээ",
 
   "add-discount": "Хөнгөлөлт нэмэх",
+  "applies-to": "Хамаарах",
+  "choose-discount-type": "Хамаарахыг сонгох",
+  "pricing-plan": "Үнийн төлөвлөгөө",
+  "rooms": "Өрөөнүүд",
+  "extra-products": "Нэмэлт бүтээгдэхүүн",
+  "appointments": "Цаг захиалга",
+  "select-pricing-plan": "Үнийн төлөвлөгөө сонгох",
+  "search-pricing-plan": "Үнийн төлөвлөгөө хайх",
+  "loading-pricing-plans": "Үнийн төлөвлөгөө ачаалж байна...",
+  "no-pricing-plans-found": "Үнийн төлөвлөгөө олдсонгүй",
+  "failed-to-load-pricing-plans": "Үнийн төлөвлөгөө ачаалахад алдаа гарлаа",
 
   "website-reservation-lock": "Вэбсайтын захиалгын түгжээ",
   "reservation-lock-duration": "Захиалгын түгжээний хугацаа",

--- a/backend/plugins/tourism_api/src/modules/pms/constants.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/constants.ts
@@ -1,3 +1,5 @@
+export const ARCHIVED_DEAL_STATUS = 'archived';
+
 export const PAYMENT_STATUS_TYPES = [
   { label: 'paid', value: 'paid' },
   { label: 'notPaid', value: 'notPaid' },

--- a/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
@@ -1,5 +1,6 @@
 import { Resolver } from 'erxes-api-shared/core-types';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { ARCHIVED_DEAL_STATUS } from '@/pms/constants';
 import { IContext } from '~/connectionResolvers';
 
 const escapeRegExp = (value: string) =>
@@ -167,6 +168,7 @@ const configQueries: Record<string, Resolver> = {
       action: 'find',
       input: {
         query: {
+          status: { $ne: ARCHIVED_DEAL_STATUS },
           stageId: { $in: newArray },
           productsData: {
             $elemMatch: {
@@ -225,6 +227,7 @@ const configQueries: Record<string, Resolver> = {
       action: 'find',
       input: {
         query: {
+          status: { $ne: ARCHIVED_DEAL_STATUS },
           stageId: { $in: newArray },
           productsData: {
             $elemMatch: {
@@ -281,6 +284,7 @@ const configQueries: Record<string, Resolver> = {
       action: 'find',
       input: {
         query: {
+          status: { $ne: ARCHIVED_DEAL_STATUS },
           stageId: { $in: newArray },
           // 1. Broad filter: Find any deal that touches our range and has our rooms
           productsData: {
@@ -355,6 +359,7 @@ const configQueries: Record<string, Resolver> = {
       action: 'find',
       input: {
         query: {
+          status: { $ne: ARCHIVED_DEAL_STATUS },
           stageId: { $in: newArray },
           productsData: {
             $elemMatch: {

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsFormContent.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsFormContent.tsx
@@ -18,7 +18,7 @@ export const CreatePmsFormContent = ({
   const renderStepContent = () => {
     switch (currentStep) {
       case 1:
-        return <General control={form.control} />;
+        return <General form={form} />;
       case 2:
         return <Payments control={form.control} />;
       case 3:

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsSheet.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/CreatePmsSheet.tsx
@@ -1,5 +1,5 @@
 import { IconPlus } from '@tabler/icons-react';
-import { Button, Sheet, Sidebar } from 'erxes-ui';
+import { Button, Sheet, Sidebar, Spinner } from 'erxes-ui';
 import { FC, PropsWithChildren, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import CreatePmsForm from './CreatePmsForm';
@@ -15,7 +15,14 @@ type CreatePmsSheetContentLayoutProps = PropsWithChildren & {
 };
 
 const STEP_VALIDATION_FIELDS: Record<number, Array<keyof PmsBranchFormType>> = {
-  1: ['name', 'checkInTime', 'checkOutTime', 'checkInAmount', 'checkOutAmount'],
+  1: [
+    'name',
+    'checkInTime',
+    'checkOutTime',
+    'checkInAmount',
+    'checkOutAmount',
+    'discount',
+  ],
   2: [],
   3: ['user1Ids'],
   4: [],
@@ -112,37 +119,45 @@ export const PmsCreateSheetFooter = ({
     setCurrentStep(currentStep + 1);
   };
 
-  const handleSaveOrNext = async () => {
-    if (currentStep === steps.length) {
-      const isValid = await validateStep(currentStep, form);
-      if (isValid) {
-        await Promise.resolve(onSave?.());
+  // Saving from an earlier step still has to clear every step, so an unmet
+  // requirement sends the user to the step that owns it.
+  const handleSave = async () => {
+    for (const step of Object.keys(STEP_VALIDATION_FIELDS)
+      .map(Number)
+      .sort((left, right) => left - right)) {
+      if (!(await validateStep(step, form))) {
+        setCurrentStep(step);
+        return;
       }
-    } else {
-      await handleNextButton();
     }
+
+    await Promise.resolve(onSave?.());
   };
+
+  const isLastStep = currentStep === steps.length;
+  const isEdit = mode === 'edit';
 
   return (
     <Sheet.Footer className="flex sm:justify-between lg:p-5">
       <Button variant={'outline'} onClick={handlePreviousButton} type="button">
         {currentStep === 1 ? t('cancel') : t('previous')}
       </Button>
-      <Button
-        disabled={currentStep === steps.length && loading}
-        type="button"
-        onClick={handleSaveOrNext}
-      >
-        {currentStep === steps.length
-          ? loading
-            ? mode === 'edit'
-              ? t('saving')
-              : t('creating')
-            : mode === 'edit'
-              ? t('save')
-              : t('create')
-          : t('next')}
-      </Button>
+      <div className="flex gap-2">
+        {!isLastStep && (
+          <Button
+            variant={isEdit ? 'secondary' : 'default'}
+            type="button"
+            onClick={handleNextButton}
+          >
+            {t('next')}
+          </Button>
+        )}
+        {(isEdit || isLastStep) && (
+          <Button type="button" disabled={loading} onClick={handleSave}>
+            {loading ? <Spinner /> : isEdit ? t('save') : t('create')}
+          </Button>
+        )}
+      </div>
     </Sheet.Footer>
   );
 };

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Discount.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/Discount.tsx
@@ -1,22 +1,67 @@
-import { Control, useFieldArray } from 'react-hook-form';
-import { Button, Form, Input } from 'erxes-ui';
+import { UseFormReturn, useFieldArray, useWatch } from 'react-hook-form';
+import { Button, Form, Input, Select } from 'erxes-ui';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { PmsBranchFormType } from '@/pms/constants/formSchema';
+import { PMS_DISCOUNT_TYPE_OPTIONS } from '@/pms/constants/discount.constants';
+import { IPmsPricingPlan } from '@/pms/hooks/usePmsPricingPlans';
+import { SelectPricingPlan } from './SelectPricingPlan';
 
-const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
+const Discount = ({ form }: { form: UseFormReturn<PmsBranchFormType> }) => {
   const { t } = useTranslation('tourism');
+  const { control, getValues, setValue } = form;
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'discount',
   });
+  const rows = useWatch({ control, name: 'discount' });
+
+  // Each target takes a single plan, so a target already spoken for elsewhere
+  // is not offered again.
+  const takenTypes = (rows || []).map((row) => row?.type).filter(Boolean);
+
+  // Saved branches may still hold duplicate targets, so the schema error needs
+  // a home outside the per-row fields.
+  const discountError = form.formState.errors.discount;
+  const discountMessage =
+    discountError?.root?.message || discountError?.message;
+
+  const handlePricingPlanChange = (
+    index: number,
+    pricingPlan: IPmsPricingPlan,
+  ) => {
+    setValue(`discount.${index}.config`, pricingPlan._id, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+
+    if (!getValues(`discount.${index}.title`)?.trim()) {
+      setValue(`discount.${index}.title`, pricingPlan.name, {
+        shouldDirty: true,
+      });
+    }
+  };
+
+  const availableTypes = PMS_DISCOUNT_TYPE_OPTIONS.filter(
+    ({ value }) => !takenTypes.includes(value),
+  );
 
   return (
     <div className="space-y-4">
-      <Button onClick={() => append({})}>
+      <Button
+        type="button"
+        disabled={availableTypes.length === 0}
+        onClick={() =>
+          append({ type: availableTypes[0]?.value, title: '', config: '' })
+        }
+      >
         <IconPlus />
         {t('add-discount')}
       </Button>
+
+      {discountMessage && (
+        <p className="text-sm text-destructive">{discountMessage}</p>
+      )}
 
       {fields.map((field, index) => (
         <div key={field.id} className="flex gap-4 items-end">
@@ -26,10 +71,31 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name={`discount.${index}.type`}
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('type')}</Form.Label>
+                  <Form.Label>{t('applies-to')}</Form.Label>
                   <Form.Control>
-                    <Input {...field} />
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger>
+                        <Select.Value placeholder={t('choose-discount-type')} />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {PMS_DISCOUNT_TYPE_OPTIONS.map(
+                          ({ value, labelKey }) => (
+                            <Select.Item
+                              key={value}
+                              value={value}
+                              disabled={
+                                value !== field.value &&
+                                takenTypes.includes(value)
+                              }
+                            >
+                              {t(labelKey)}
+                            </Select.Item>
+                          ),
+                        )}
+                      </Select.Content>
+                    </Select>
                   </Form.Control>
+                  <Form.Message className="text-destructive" />
                 </Form.Item>
               )}
             />
@@ -43,6 +109,7 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
+                  <Form.Message className="text-destructive" />
                 </Form.Item>
               )}
             />
@@ -52,16 +119,23 @@ const Discount = ({ control }: { control: Control<PmsBranchFormType> }) => {
               name={`discount.${index}.config`}
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t('config')}</Form.Label>
+                  <Form.Label>{t('pricing-plan')}</Form.Label>
                   <Form.Control>
-                    <Input {...field} />
+                    <SelectPricingPlan
+                      value={field.value}
+                      onValueChange={(pricingPlan) =>
+                        handlePricingPlanChange(index, pricingPlan)
+                      }
+                    />
                   </Form.Control>
+                  <Form.Message className="text-destructive" />
                 </Form.Item>
               )}
             />
           </div>
 
           <Button
+            type="button"
             variant="destructive"
             size="icon"
             className="w-8 h-8"

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
@@ -38,7 +38,10 @@ const General = ({ form }: { form: UseFormReturn<PmsBranchFormType> }) => {
                 <Form.Item>
                   <Form.Label>{t('description')}</Form.Label>
                   <Form.Control>
-                    <Textarea {...field} placeholder={t('description-placeholder')} />
+                    <Textarea
+                      {...field}
+                      placeholder={t('description-placeholder')}
+                    />
                   </Form.Control>
                   <Form.Message className="text-destructive" />
                 </Form.Item>

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/General.tsx
@@ -1,4 +1,4 @@
-import { Control } from 'react-hook-form';
+import { UseFormReturn } from 'react-hook-form';
 import { Form, Input, Textarea, InfoCard } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import PmsFormFieldsLayout from '../PmsFormFieldsLayout';
@@ -7,8 +7,9 @@ import Discount from './Discount';
 import Lock from './Lock';
 import { PmsBranchFormType } from '@/pms/constants/formSchema';
 
-const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
+const General = ({ form }: { form: UseFormReturn<PmsBranchFormType> }) => {
   const { t } = useTranslation('tourism');
+  const { control } = form;
   return (
     <PmsFormFieldsLayout>
       <div className="space-y-3">
@@ -54,7 +55,7 @@ const General = ({ control }: { control: Control<PmsBranchFormType> }) => {
 
         <InfoCard title={t('discount')}>
           <InfoCard.Content>
-            <Discount control={control} />
+            <Discount form={form} />
           </InfoCard.Content>
         </InfoCard>
 

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/SelectPricingPlan.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/SelectPricingPlan.tsx
@@ -43,7 +43,9 @@ export const SelectPricingPlan = ({
 
   const renderTriggerValue = () => {
     if (selectedPlan) {
-      return <TextOverflowTooltip value={selectedPlan.name} className="max-w-40" />;
+      return (
+        <TextOverflowTooltip value={selectedPlan.name} className="max-w-40" />
+      );
     }
 
     if (value && loading) {

--- a/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/SelectPricingPlan.tsx
+++ b/frontend/plugins/tourism_ui/src/modules/pms/components/pmsFormFields/general/SelectPricingPlan.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Combobox,
+  Command,
+  PopoverScoped,
+  TextOverflowTooltip,
+} from 'erxes-ui';
+import {
+  IPmsPricingPlan,
+  usePmsPricingPlans,
+} from '@/pms/hooks/usePmsPricingPlans';
+
+export const SelectPricingPlan = ({
+  value,
+  onValueChange,
+  placeholder,
+  disabled,
+}: {
+  value?: string;
+  onValueChange: (pricingPlan: IPmsPricingPlan) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}) => {
+  const { t } = useTranslation('tourism');
+  const { pricingPlans, loading, error } = usePmsPricingPlans();
+  const [open, setOpen] = useState(false);
+
+  const selectedPlan = pricingPlans.find(
+    (pricingPlan) => pricingPlan._id === value,
+  );
+
+  const handleSelect = (pricingPlan: IPmsPricingPlan) => {
+    onValueChange(pricingPlan);
+    setOpen(false);
+  };
+
+  const emptyMessage = loading
+    ? t('loading-pricing-plans')
+    : error
+      ? t('failed-to-load-pricing-plans')
+      : t('no-pricing-plans-found');
+
+  const renderTriggerValue = () => {
+    if (selectedPlan) {
+      return <TextOverflowTooltip value={selectedPlan.name} className="max-w-40" />;
+    }
+
+    if (value && loading) {
+      return (
+        <span className="text-accent-foreground/80">
+          {t('loading-pricing-plans')}
+        </span>
+      );
+    }
+
+    return (
+      <span className="text-accent-foreground/80">
+        {placeholder || t('select-pricing-plan')}
+      </span>
+    );
+  };
+
+  return (
+    <PopoverScoped open={open} onOpenChange={setOpen}>
+      <Combobox.Trigger className="w-full h-8" disabled={disabled}>
+        {renderTriggerValue()}
+      </Combobox.Trigger>
+      <Combobox.Content>
+        <Command>
+          <Command.Input focusOnMount placeholder={t('search-pricing-plan')} />
+          <Command.List>
+            <Command.Empty>
+              <div className="text-muted-foreground">{emptyMessage}</div>
+            </Command.Empty>
+            {pricingPlans.map((pricingPlan) => (
+              <Command.Item
+                key={pricingPlan._id}
+                value={pricingPlan._id}
+                keywords={[pricingPlan.name]}
+                onSelect={() => handleSelect(pricingPlan)}
+              >
+                <div className="flex overflow-hidden flex-1 gap-2 items-center">
+                  <TextOverflowTooltip value={pricingPlan.name} />
+                </div>
+                <Combobox.Check checked={value === pricingPlan._id} />
+              </Command.Item>
+            ))}
+          </Command.List>
+        </Command>
+      </Combobox.Content>
+    </PopoverScoped>
+  );
+};

--- a/frontend/plugins/tourism_ui/src/modules/pms/constants/discount.constants.ts
+++ b/frontend/plugins/tourism_ui/src/modules/pms/constants/discount.constants.ts
@@ -1,0 +1,21 @@
+/**
+ * A discount row targets one product group of the branch, mirroring the groups
+ * configured in the pipeline config step.
+ */
+export const PMS_DISCOUNT_TYPES = {
+  ROOMS: 'rooms',
+  EXTRA_PRODUCTS: 'extraProducts',
+  APPOINTMENTS: 'appointments',
+} as const;
+
+export type PmsDiscountType =
+  (typeof PMS_DISCOUNT_TYPES)[keyof typeof PMS_DISCOUNT_TYPES];
+
+export const PMS_DISCOUNT_TYPE_OPTIONS: {
+  value: PmsDiscountType;
+  labelKey: string;
+}[] = [
+  { value: PMS_DISCOUNT_TYPES.ROOMS, labelKey: 'rooms' },
+  { value: PMS_DISCOUNT_TYPES.EXTRA_PRODUCTS, labelKey: 'extra-products' },
+  { value: PMS_DISCOUNT_TYPES.APPOINTMENTS, labelKey: 'appointments' },
+];

--- a/frontend/plugins/tourism_ui/src/modules/pms/constants/formSchema.ts
+++ b/frontend/plugins/tourism_ui/src/modules/pms/constants/formSchema.ts
@@ -14,15 +14,23 @@ export const PmsBranchFormSchema = z.object({
   checkInAmount: optionalNonNegativeNumber,
   checkOutTime: z.string().min(1, 'Check out time is required'),
   checkOutAmount: optionalNonNegativeNumber,
-  discount: z.array(
-    z.object({
-      _id: z.string().optional(),
-      type: z.string().optional(),
-      title: z.string().optional(),
-      icon: z.string().optional(),
-      config: z.string().optional(),
-    }),
-  ),
+  discount: z
+    .array(
+      z.object({
+        _id: z.string().optional(),
+        type: z.string().optional(),
+        title: z.string().optional(),
+        icon: z.string().optional(),
+        config: z.string().optional(),
+      }),
+    )
+    .refine(
+      (rows) => {
+        const targets = rows.map((row) => row.type).filter(Boolean);
+        return new Set(targets).size === targets.length;
+      },
+      { message: 'Each discount target can use only one pricing plan' },
+    ),
   websiteReservationLock: z.boolean().optional(),
   time: z.string().optional(),
   paymentIds: z.array(z.string()).optional(),

--- a/frontend/plugins/tourism_ui/src/modules/pms/graphql/queries.ts
+++ b/frontend/plugins/tourism_ui/src/modules/pms/graphql/queries.ts
@@ -91,9 +91,22 @@ const ProductCategories = gql`
   }
 `;
 
+const PmsPricingPlans = gql`
+  query PmsPricingPlans($status: String) {
+    pricingPlans(status: $status) {
+      _id
+      name
+      status
+      type
+      value
+    }
+  }
+`;
+
 export const pmsQueries = {
   PmsBranchList,
   PmsBranchDetail,
   Payments,
   ProductCategories,
+  PmsPricingPlans,
 };

--- a/frontend/plugins/tourism_ui/src/modules/pms/hooks/usePmsPricingPlans.ts
+++ b/frontend/plugins/tourism_ui/src/modules/pms/hooks/usePmsPricingPlans.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@apollo/client';
+
+import { pmsQueries } from '@/pms/graphql/queries';
+
+export interface IPmsPricingPlan {
+  _id: string;
+  name: string;
+  status: string;
+  type: string;
+  value?: number | null;
+}
+
+export const usePmsPricingPlans = () => {
+  const { data, loading, error } = useQuery<{
+    pricingPlans: IPmsPricingPlan[];
+  }>(pmsQueries.PmsPricingPlans, {
+    variables: { status: 'active' },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  return {
+    pricingPlans: data?.pricingPlans || [],
+    loading,
+    error,
+  };
+};


### PR DESCRIPTION
## Summary by Sourcery

Add configurable discount targets to PMS branches and enforce unique pricing plan per product group.

New Features:
- Introduce discount type options that map discounts to specific product groups (rooms, extra products, appointments).
- Allow selecting active pricing plans for each discount via a searchable combobox in the PMS branch form.
- Validate discounts as part of the first step in the PMS branch creation wizard and ensure all steps pass validation before saving.

Bug Fixes:
- Exclude archived deals from PMS configuration queries to prevent invalid pricing data from being used.

Enhancements:
- Improve discount form UX with select inputs, automatic title population, and global duplicate-target error messaging.
- Refactor general PMS form components to work with the full form instance instead of just the control object.
- Update branch creation footer controls to separate next-step navigation from save, with clearer button states and a loading spinner.

Chores:
- Add GraphQL query and hook for fetching active pricing plans for use in discount configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configure discounts for rooms, extra products, and appointments.
  - Select pricing plans with search, loading, and empty-state feedback.
  - Automatically populate discount titles from selected pricing plans.

- **Bug Fixes**
  - Prevent duplicate discount types and display clear validation messages.
  - Archived deals are excluded from room availability and room-check results.
  - Form saving now validates all steps and directs users to incomplete sections.

- **Localization**
  - Added English and Mongolian translations for discount and pricing-plan workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->