### PR TITLE
fix(sales): enable new deal products by default

### DIFF
--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -364,7 +364,6 @@ export const createProductsData = async ({
   docs: IProductData[];
 }) => {
   const deal = await models.Deals.getDeal(dealId);
-  const stage = await models.Stages.getStage(deal.stageId);
 
   const oldDataIds = (deal.productsData || []).map((pd) => pd._id);
 
@@ -392,9 +391,7 @@ export const createProductsData = async ({
     }
   }
 
-  // undefined or null then true
-  const tickUsed = !(stage.defaultTick === false);
-  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed }));
+  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed: true }));
   const productsData: IProductData[] = (deal.productsData || []).concat(
     addDocs,
   );

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -420,7 +420,7 @@ export const createProductsData = async ({
       action: 'create',
       data: {
         dataIds,
-        docs,
+        docs: addDocs,
         productsData,
       },
     },

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -394,7 +394,10 @@ export const createProductsData = async ({
 
   // undefined or null then true
   const tickUsed = !(stage.defaultTick === false);
-  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed }));
+  const addDocs = (docs || []).map((doc) => ({
+    ...doc,
+    tickUsed: doc.tickUsed ?? tickUsed,
+  }));
   const productsData: IProductData[] = (deal.productsData || []).concat(
     addDocs,
   );
@@ -423,7 +426,7 @@ export const createProductsData = async ({
       action: 'create',
       data: {
         dataIds,
-        docs,
+        docs: addDocs,
         productsData,
       },
     },

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/utils.ts
@@ -364,6 +364,7 @@ export const createProductsData = async ({
   docs: IProductData[];
 }) => {
   const deal = await models.Deals.getDeal(dealId);
+  const stage = await models.Stages.getStage(deal.stageId);
 
   const oldDataIds = (deal.productsData || []).map((pd) => pd._id);
 
@@ -391,7 +392,9 @@ export const createProductsData = async ({
     }
   }
 
-  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed: true }));
+  // undefined or null then true
+  const tickUsed = !(stage.defaultTick === false);
+  const addDocs = (docs || []).map((doc) => ({ ...doc, tickUsed }));
   const productsData: IProductData[] = (deal.productsData || []).concat(
     addDocs,
   );
@@ -420,7 +423,7 @@ export const createProductsData = async ({
       action: 'create',
       data: {
         dataIds,
-        docs: addDocs,
+        docs,
         productsData,
       },
     },

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
@@ -36,7 +36,7 @@ export const Products = ({
             productsData={deal.productsData || ([] as IProductData[])}
             dealId={deal._id}
             refetch={refetch}
-            tickUsed
+            tickUsed={deal.stage?.defaultTick === false ? false : true}
           />
         </Tabs.Content>
         <Tabs.Content

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
@@ -36,7 +36,7 @@ export const Products = ({
             productsData={deal.productsData || ([] as IProductData[])}
             dealId={deal._id}
             refetch={refetch}
-            tickUsed={deal.stage?.defaultTick === false ? false : true}
+            tickUsed
           />
         </Tabs.Content>
         <Tabs.Content

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
@@ -376,7 +376,7 @@ export const PipelineStageItem = (props: Props) => {
                     <Controller
                       name={`stages.${index}.defaultTick`}
                       control={control}
-                      defaultValue={stage?.defaultTick ?? false}
+                      defaultValue={stage?.defaultTick ?? true}
                       render={({ field }) => (
                         <Checkbox
                           id={`defaultTick-${index}`}

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
@@ -44,6 +44,7 @@ export const PipelineStages = ({ form, stagesLoading }: Props) => {
       status: 'active',
       memberIds: [],
       departmentIds: [],
+      defaultTick: true,
     });
   };
 

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
@@ -28,6 +28,7 @@ const mapPipelineStages = (
     probability: stage.probability || '',
     memberIds: stage.memberIds ?? [],
     departmentIds: stage.departmentIds ?? [],
+    defaultTick: stage.defaultTick === false ? false : true,
   }));
 
 const getPipelineFormValues = (


### PR DESCRIPTION
## Summary

- create newly added deal products with `tickUsed: true` in the UI
- preserve the explicit product `tickUsed` value in the API and use the stage default only when the value is omitted
- publish the same normalized product documents that were persisted
- default new and legacy-unconfigured pipeline stages to select products
- preserve an existing stage `defaultTick` value during pipeline form synchronization

## Root cause

PR #8763 started persisting the pipeline stage `defaultTick` field while its form default was `false`. Existing stages could therefore supply `false` when a product was added. The API then overwrote the product value with that stage default, so the new row appeared unchecked.

## Validation

- touched-file ESLint
- `NX_DAEMON=false pnpm nx build sales_ui`
- `NX_DAEMON=false pnpm nx build sales_api`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline stages now default to being selected when no value is provided.
  * Newly added stages are initialized as selected.
  * Existing false selections are preserved during pipeline form updates.
  * Product selection states are now preserved consistently for individual products and pipeline stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->