### PR TITLE
fix(sales): keep deal product updates in sync

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/Products.tsx
@@ -36,7 +36,7 @@ export const Products = ({
             productsData={deal.productsData || ([] as IProductData[])}
             dealId={deal._id}
             refetch={refetch}
-            tickUsed={deal.stage?.defaultTick === false ? false : true}
+            tickUsed={deal.stage?.defaultTick ?? true}
           />
         </Tabs.Content>
         <Tabs.Content

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/product-table/ProductRecordTable.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/product-table/ProductRecordTable.tsx
@@ -66,7 +66,11 @@ export const ProductsRecordTable = ({
         'unitPrice',
         'assignUserId',
       ]}
-      tableId="products_record_table"
+      tableId={
+        showAdvancedView
+          ? 'products_record_table_advanced'
+          : 'products_record_table'
+      }
     >
       {products.length === 0 ? (
         <Empty className="border-0 bg-transparent">

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/serializeDealProductMutation.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/serializeDealProductMutation.ts
@@ -1,23 +1,57 @@
-const dealProductMutationQueues = new Map<string, Promise<void>>();
+import type { ApolloClient } from '@apollo/client';
+import type { IProductData } from 'ui-modules';
 
-export const serializeDealProductMutation = <T>(
+import { updateDealProductsCache } from './updateDealProductsCache';
+
+interface DealProductMutationQueue {
+  tail: Promise<void>;
+  token: symbol;
+}
+
+const dealProductMutationQueues = new Map<string, DealProductMutationQueue>();
+
+export const withDealIdVariables = <TOptions extends { variables: object }>(
+  options: TOptions,
   dealId: string,
-  mutation: () => Promise<T>,
-): Promise<T> => {
-  const previous = dealProductMutationQueues.get(dealId) || Promise.resolve();
-  const result = previous.then(mutation);
-  const tail = result.then(
-    () => undefined,
-    () => undefined,
-  );
+) => ({
+  ...options,
+  variables: { ...options.variables, dealId },
+});
 
-  dealProductMutationQueues.set(dealId, tail);
+interface SerializeDealProductMutationOptions<TResult> {
+  client: ApolloClient<object>;
+  dealId: string;
+  mutation: () => Promise<TResult>;
+  selectProductsData: (result: TResult) => IProductData[] | undefined;
+}
 
-  void tail.then(() => {
-    if (dealProductMutationQueues.get(dealId) === tail) {
+export const serializeDealProductMutation = <TResult>({
+  client,
+  dealId,
+  mutation,
+  selectProductsData,
+}: SerializeDealProductMutationOptions<TResult>): Promise<TResult> => {
+  const previous =
+    dealProductMutationQueues.get(dealId)?.tail || Promise.resolve();
+  const result = previous.then(async () => {
+    const mutationResult = await mutation();
+    const productsData = selectProductsData(mutationResult);
+
+    if (productsData) {
+      updateDealProductsCache(client, dealId, productsData);
+    }
+
+    return mutationResult;
+  });
+  const token = Symbol(dealId);
+  const clearCompletedQueue = () => {
+    if (dealProductMutationQueues.get(dealId)?.token === token) {
       dealProductMutationQueues.delete(dealId);
     }
-  });
+  };
+  const tail = result.then(clearCompletedQueue, clearCompletedQueue);
+
+  dealProductMutationQueues.set(dealId, { tail, token });
 
   return result;
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/serializeDealProductMutation.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/serializeDealProductMutation.ts
@@ -1,0 +1,23 @@
+const dealProductMutationQueues = new Map<string, Promise<void>>();
+
+export const serializeDealProductMutation = <T>(
+  dealId: string,
+  mutation: () => Promise<T>,
+): Promise<T> => {
+  const previous = dealProductMutationQueues.get(dealId) || Promise.resolve();
+  const result = previous.then(mutation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  dealProductMutationQueues.set(dealId, tail);
+
+  void tail.then(() => {
+    if (dealProductMutationQueues.get(dealId) === tail) {
+      dealProductMutationQueues.delete(dealId);
+    }
+  });
+
+  return result;
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/updateDealProductsCache.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/updateDealProductsCache.ts
@@ -1,4 +1,6 @@
 import type { ApolloClient, Reference, StoreObject } from '@apollo/client';
+import { GET_DEAL_DETAIL } from '@/deals/graphql/queries/DealsQueries';
+import type { IDeal } from '@/deals/types/deals';
 import type { IProductData } from 'ui-modules';
 
 export const updateDealProductsCache = (
@@ -53,4 +55,24 @@ export const updateDealProductsCache = (
       },
     },
   });
+
+  client.cache.updateQuery<{ dealDetail: IDeal }>(
+    {
+      query: GET_DEAL_DETAIL,
+      variables: { _id: dealId },
+    },
+    (current) => {
+      if (!current?.dealDetail) {
+        return current;
+      }
+
+      return {
+        ...current,
+        dealDetail: {
+          ...current.dealDetail,
+          productsData,
+        },
+      };
+    },
+  );
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
@@ -81,15 +81,7 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
         throw apolloError;
       }
     },
-    [
-      client,
-      dealId,
-      mutateCreateProductsData,
-      onCompleted,
-      onError,
-      t,
-      toast,
-    ],
+    [client, dealId, mutateCreateProductsData, onCompleted, onError, t, toast],
   );
 
   return {

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
@@ -15,8 +15,10 @@ import { DEALS_CREATE_PRODUCT_DATA } from '@/deals/cards/components/detail/produ
 import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
-import { serializeDealProductMutation } from './serializeDealProductMutation';
-import { updateDealProductsCache } from './updateDealProductsCache';
+import {
+  serializeDealProductMutation,
+  withDealIdVariables,
+} from './serializeDealProductMutation';
 
 interface CreateProductsDataVariables {
   processId: string;
@@ -44,23 +46,15 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        const result = await serializeDealProductMutation(dealId, async () => {
-          const mutationResult = await mutateCreateProductsData({
-            ...executeOptions,
-            variables: {
-              ...executeOptions.variables,
-              dealId,
-            },
-          });
-
-          const productsData: IProductData[] | undefined =
-            mutationResult.data?.dealsCreateProductsData?.productsData;
-
-          if (productsData) {
-            updateDealProductsCache(client, dealId, productsData);
-          }
-
-          return mutationResult;
+        const result = await serializeDealProductMutation({
+          client,
+          dealId,
+          mutation: () =>
+            mutateCreateProductsData(
+              withDealIdVariables(executeOptions, dealId),
+            ),
+          selectProductsData: (mutationResult) =>
+            mutationResult.data?.dealsCreateProductsData?.productsData,
         });
 
         toast({

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
@@ -7,11 +7,12 @@ import {
   useApolloClient,
   useMutation,
 } from '@apollo/client';
-import { useQueryState, useToast } from 'erxes-ui';
+import { useToast } from 'erxes-ui';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEALS_CREATE_PRODUCT_DATA } from '@/deals/cards/components/detail/product/graphql/mutations/ProductsActions';
+import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
 import { updateDealProductsCache } from './updateDealProductsCache';
@@ -24,7 +25,7 @@ interface CreateProductsDataVariables {
 export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
   const { toast } = useToast();
   const { t } = useTranslation('sales');
-  const [salesItemId] = useQueryState<string>('salesItemId');
+  const dealId = useCurrentDealId();
   const client = useApolloClient();
 
   const { onCompleted, onError, ...hookOptions } = options || {};
@@ -42,13 +43,11 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        // dealId always comes from the URL, not the caller: it must match
-        // the id updateDealProductsCache writes into below.
         const result = await mutateCreateProductsData({
           ...executeOptions,
           variables: {
             ...executeOptions.variables,
-            dealId: salesItemId || '',
+            dealId,
           },
         });
 
@@ -62,7 +61,7 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
           result.data?.dealsCreateProductsData?.productsData;
 
         if (newDocs) {
-          updateDealProductsCache(client, salesItemId, newDocs);
+          updateDealProductsCache(client, dealId, newDocs);
         }
 
         onCompleted?.(result.data);
@@ -84,10 +83,10 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
     },
     [
       client,
+      dealId,
       mutateCreateProductsData,
       onCompleted,
       onError,
-      salesItemId,
       t,
       toast,
     ],

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsCreateProductsData.tsx
@@ -15,6 +15,7 @@ import { DEALS_CREATE_PRODUCT_DATA } from '@/deals/cards/components/detail/produ
 import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
+import { serializeDealProductMutation } from './serializeDealProductMutation';
 import { updateDealProductsCache } from './updateDealProductsCache';
 
 interface CreateProductsDataVariables {
@@ -43,12 +44,23 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        const result = await mutateCreateProductsData({
-          ...executeOptions,
-          variables: {
-            ...executeOptions.variables,
-            dealId,
-          },
+        const result = await serializeDealProductMutation(dealId, async () => {
+          const mutationResult = await mutateCreateProductsData({
+            ...executeOptions,
+            variables: {
+              ...executeOptions.variables,
+              dealId,
+            },
+          });
+
+          const productsData: IProductData[] | undefined =
+            mutationResult.data?.dealsCreateProductsData?.productsData;
+
+          if (productsData) {
+            updateDealProductsCache(client, dealId, productsData);
+          }
+
+          return mutationResult;
         });
 
         toast({
@@ -56,13 +68,6 @@ export const useDealsCreateProductsData = (options?: MutationHookOptions) => {
           variant: 'success',
           ...DEAL_TOAST_OPTIONS,
         });
-
-        const newDocs: IProductData[] | undefined =
-          result.data?.dealsCreateProductsData?.productsData;
-
-        if (newDocs) {
-          updateDealProductsCache(client, dealId, newDocs);
-        }
 
         onCompleted?.(result.data);
 

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
@@ -7,11 +7,12 @@ import {
   useApolloClient,
   useMutation,
 } from '@apollo/client';
-import { useQueryState, useToast } from 'erxes-ui';
+import { useToast } from 'erxes-ui';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEALS_EDIT_PRODUCT_DATA } from '@/deals/cards/components/detail/product/graphql/mutations/ProductsActions';
+import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
 import { updateDealProductsCache } from './updateDealProductsCache';
@@ -25,7 +26,7 @@ interface EditProductDataVariables {
 export const useDealsEditProductData = (options?: MutationHookOptions) => {
   const { toast } = useToast();
   const { t } = useTranslation('sales');
-  const [salesItemId] = useQueryState<string>('salesItemId');
+  const dealId = useCurrentDealId();
   const client = useApolloClient();
 
   const { onCompleted, onError, ...hookOptions } = options || {};
@@ -43,13 +44,11 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        // dealId always comes from the URL, not the caller: it must match
-        // the id updateDealProductsCache writes into below.
         const result = await mutateEditProductData({
           ...executeOptions,
           variables: {
             ...executeOptions.variables,
-            dealId: salesItemId || '',
+            dealId,
           },
         });
 
@@ -63,7 +62,7 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
           result.data?.dealsEditProductData?.productsData;
 
         if (nextProductsData) {
-          updateDealProductsCache(client, salesItemId, nextProductsData);
+          updateDealProductsCache(client, dealId, nextProductsData);
         }
 
         onCompleted?.(result.data);
@@ -85,10 +84,10 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
     },
     [
       client,
+      dealId,
       mutateEditProductData,
       onCompleted,
       onError,
-      salesItemId,
       t,
       toast,
     ],

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
@@ -82,15 +82,7 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
         throw apolloError;
       }
     },
-    [
-      client,
-      dealId,
-      mutateEditProductData,
-      onCompleted,
-      onError,
-      t,
-      toast,
-    ],
+    [client, dealId, mutateEditProductData, onCompleted, onError, t, toast],
   );
 
   return {

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
@@ -15,6 +15,7 @@ import { DEALS_EDIT_PRODUCT_DATA } from '@/deals/cards/components/detail/product
 import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
+import { serializeDealProductMutation } from './serializeDealProductMutation';
 import { updateDealProductsCache } from './updateDealProductsCache';
 
 interface EditProductDataVariables {
@@ -44,12 +45,23 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        const result = await mutateEditProductData({
-          ...executeOptions,
-          variables: {
-            ...executeOptions.variables,
-            dealId,
-          },
+        const result = await serializeDealProductMutation(dealId, async () => {
+          const mutationResult = await mutateEditProductData({
+            ...executeOptions,
+            variables: {
+              ...executeOptions.variables,
+              dealId,
+            },
+          });
+
+          const productsData: IProductData[] | undefined =
+            mutationResult.data?.dealsEditProductData?.productsData;
+
+          if (productsData) {
+            updateDealProductsCache(client, dealId, productsData);
+          }
+
+          return mutationResult;
         });
 
         toast({
@@ -57,13 +69,6 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
           variant: 'success',
           ...DEAL_TOAST_OPTIONS,
         });
-
-        const nextProductsData: IProductData[] | undefined =
-          result.data?.dealsEditProductData?.productsData;
-
-        if (nextProductsData) {
-          updateDealProductsCache(client, dealId, nextProductsData);
-        }
 
         onCompleted?.(result.data);
 

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useDealsEditProductData.tsx
@@ -15,8 +15,10 @@ import { DEALS_EDIT_PRODUCT_DATA } from '@/deals/cards/components/detail/product
 import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
-import { serializeDealProductMutation } from './serializeDealProductMutation';
-import { updateDealProductsCache } from './updateDealProductsCache';
+import {
+  serializeDealProductMutation,
+  withDealIdVariables,
+} from './serializeDealProductMutation';
 
 interface EditProductDataVariables {
   processId: string;
@@ -45,23 +47,13 @@ export const useDealsEditProductData = (options?: MutationHookOptions) => {
       },
     ) => {
       try {
-        const result = await serializeDealProductMutation(dealId, async () => {
-          const mutationResult = await mutateEditProductData({
-            ...executeOptions,
-            variables: {
-              ...executeOptions.variables,
-              dealId,
-            },
-          });
-
-          const productsData: IProductData[] | undefined =
-            mutationResult.data?.dealsEditProductData?.productsData;
-
-          if (productsData) {
-            updateDealProductsCache(client, dealId, productsData);
-          }
-
-          return mutationResult;
+        const result = await serializeDealProductMutation({
+          client,
+          dealId,
+          mutation: () =>
+            mutateEditProductData(withDealIdVariables(executeOptions, dealId)),
+          selectProductsData: (mutationResult) =>
+            mutationResult.data?.dealsEditProductData?.productsData,
         });
 
         toast({

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
@@ -9,11 +9,12 @@ import { useCallback } from 'react';
 import { productRemove } from '@/deals/cards/components/detail/product/graphql/mutations/ProductsActions';
 import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
-import { IProductData } from 'ui-modules';
 import { useToast } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
-import { serializeDealProductMutation } from './serializeDealProductMutation';
-import { updateDealProductsCache } from './updateDealProductsCache';
+import {
+  serializeDealProductMutation,
+  withDealIdVariables,
+} from './serializeDealProductMutation';
 
 interface RemoveProductsVariables {
   processId: string;
@@ -38,23 +39,13 @@ export const useRemoveProducts = () => {
       const { onCompleted, onError, ...executeOptions } = options;
 
       try {
-        const result = await serializeDealProductMutation(dealId, async () => {
-          const mutationResult = await mutateRemoveProducts({
-            ...executeOptions,
-            variables: {
-              ...executeOptions.variables,
-              dealId,
-            },
-          });
-
-          const productsData: IProductData[] | undefined =
-            mutationResult.data?.dealsDeleteProductData?.productsData;
-
-          if (productsData) {
-            updateDealProductsCache(client, dealId, productsData);
-          }
-
-          return mutationResult;
+        const result = await serializeDealProductMutation({
+          client,
+          dealId,
+          mutation: () =>
+            mutateRemoveProducts(withDealIdVariables(executeOptions, dealId)),
+          selectProductsData: (mutationResult) =>
+            mutationResult.data?.dealsDeleteProductData?.productsData,
         });
 
         toast({

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
@@ -12,6 +12,7 @@ import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
 import { useToast } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
+import { serializeDealProductMutation } from './serializeDealProductMutation';
 import { updateDealProductsCache } from './updateDealProductsCache';
 
 interface RemoveProductsVariables {
@@ -37,19 +38,24 @@ export const useRemoveProducts = () => {
       const { onCompleted, onError, ...executeOptions } = options;
 
       try {
-        const result = await mutateRemoveProducts({
-          ...executeOptions,
-          variables: {
-            ...executeOptions.variables,
-            dealId,
-          },
-        });
-        const remainingProductsData: IProductData[] | undefined =
-          result.data?.dealsDeleteProductData?.productsData;
+        const result = await serializeDealProductMutation(dealId, async () => {
+          const mutationResult = await mutateRemoveProducts({
+            ...executeOptions,
+            variables: {
+              ...executeOptions.variables,
+              dealId,
+            },
+          });
 
-        if (remainingProductsData) {
-          updateDealProductsCache(client, dealId, remainingProductsData);
-        }
+          const productsData: IProductData[] | undefined =
+            mutationResult.data?.dealsDeleteProductData?.productsData;
+
+          if (productsData) {
+            updateDealProductsCache(client, dealId, productsData);
+          }
+
+          return mutationResult;
+        });
 
         toast({
           title: t('products-deleted'),

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/mutations/useRemoveProduct.tsx
@@ -7,9 +7,10 @@ import {
 import { useCallback } from 'react';
 
 import { productRemove } from '@/deals/cards/components/detail/product/graphql/mutations/ProductsActions';
+import { useCurrentDealId } from '@/deals/cards/hooks/useCurrentDealId';
 import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
 import { IProductData } from 'ui-modules';
-import { useQueryState, useToast } from 'erxes-ui';
+import { useToast } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { updateDealProductsCache } from './updateDealProductsCache';
 
@@ -22,7 +23,7 @@ export const useRemoveProducts = () => {
   const [mutateRemoveProducts, { loading }] = useMutation(productRemove);
   const { toast } = useToast();
   const { t } = useTranslation('sales');
-  const [salesItemId] = useQueryState<string>('salesItemId');
+  const dealId = useCurrentDealId();
   const client = useApolloClient();
 
   // Callbacks run manually: passing onError to useMutation makes the mutate
@@ -36,20 +37,18 @@ export const useRemoveProducts = () => {
       const { onCompleted, onError, ...executeOptions } = options;
 
       try {
-        // dealId always comes from the URL, not the caller: it must match
-        // the id updateDealProductsCache writes into below.
         const result = await mutateRemoveProducts({
           ...executeOptions,
           variables: {
             ...executeOptions.variables,
-            dealId: salesItemId || '',
+            dealId,
           },
         });
         const remainingProductsData: IProductData[] | undefined =
           result.data?.dealsDeleteProductData?.productsData;
 
         if (remainingProductsData) {
-          updateDealProductsCache(client, salesItemId, remainingProductsData);
+          updateDealProductsCache(client, dealId, remainingProductsData);
         }
 
         toast({
@@ -74,7 +73,7 @@ export const useRemoveProducts = () => {
         return undefined;
       }
     },
-    [client, mutateRemoveProducts, salesItemId, t, toast],
+    [client, dealId, mutateRemoveProducts, t, toast],
   );
 
   return { removeProducts, loading };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealProductActions.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealProductActions.tsx
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useMemo,
-  useRef,
-} from 'react';
+import { Dispatch, SetStateAction, useCallback, useMemo, useRef } from 'react';
 import { IProduct, IProductData, currentUserState } from 'ui-modules';
 
 import { AdjustmentByCurrency } from './useProductCalculations';

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealProductActions.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useDealProductActions.tsx
@@ -125,7 +125,11 @@ export const useDealProductActions = ({
 
       // The server schema has no `product` field: send the stripped rows as
       // docs and keep the embedded product snapshot only for optimistic UI.
-      const docs = rows.map(({ product, ...doc }) => doc);
+      const docs = rows.map((row) => {
+        const doc = { ...row };
+        delete doc.product;
+        return doc;
+      });
 
       createProductsData(docs, rows);
     },
@@ -199,7 +203,7 @@ export const useDealProductActions = ({
       pendingProductDeletionsRef.current.add(productData._id);
       removeRows([productData._id]);
 
-      const processId = localStorage.getItem('processId') || '';
+      const processId = startProcess();
 
       void removeProducts({
         variables: {

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useProductRecord.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useProductRecord.tsx
@@ -28,7 +28,6 @@ export const useUpdateProductRecord = () => {
   const [productsEdit] = useMutation<ProductsEditData, ProductsEditVariables>(
     PRODUCTS_EDIT,
   );
-  const processId = localStorage.getItem('processId') || '';
   const onLocalChange = useAtomValue(onLocalChangeAtom);
   const { toast } = useToast();
   const { t } = useTranslation('sales');
@@ -39,6 +38,8 @@ export const useUpdateProductRecord = () => {
     patch: Partial<IProductData>,
   ) => {
     const doc = { ...product, ...patch };
+    const processId = crypto.randomUUID();
+    localStorage.setItem('processId', processId);
 
     if (onLocalChange && product._id) {
       onLocalChange(product._id, patch);

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/product-command-bar/ProductDelete.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/product-command-bar/ProductDelete.tsx
@@ -13,7 +13,6 @@ export const ProductsDelete = ({
 }) => {
   const { confirm } = useConfirm();
   const { removeProducts } = useRemoveProducts();
-  const processId = localStorage.getItem('processId') || '';
   const { t } = useTranslation('sales');
 
   return (
@@ -24,6 +23,9 @@ export const ProductsDelete = ({
         confirm({
           message: t('delete-products-confirm', { count: productIds.length }),
         }).then(() => {
+          const processId = crypto.randomUUID();
+          localStorage.setItem('processId', processId);
+
           removeProducts({
             variables: {
               dataIds: productIds,

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealDetail.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/deals/useDealDetail.tsx
@@ -47,20 +47,14 @@ export const useDealDetail = (
   });
 
   useEffect(() => {
-    if (!salesItemId) return;
+    if (!finalId) return;
 
     const unsubscribe = subscribeToMore<ISalesProductsDataChangedPayload>({
       document: PRODUCTS_DATA_CHANGED,
-      variables: { _id: salesItemId },
+      variables: { _id: finalId },
       updateQuery: (prev, { subscriptionData }) => {
         const payload = subscriptionData?.data?.salesProductsDataChanged;
         if (!payload) return prev;
-
-        const { processId } = payload;
-
-        if (processId === localStorage.getItem('processId')) {
-          return prev;
-        }
 
         refetch();
 
@@ -69,7 +63,7 @@ export const useDealDetail = (
     });
 
     return unsubscribe;
-  }, [refetch, salesItemId, subscribeToMore]);
+  }, [finalId, refetch, subscribeToMore]);
 
   useEffect(() => {
     if (!finalId) return;
@@ -159,7 +153,7 @@ export const useDealDetail = (
       return;
     }
 
-    if (currentDeal?._id === finalId && currentDeal.pipeline) {
+    if (currentDeal?._id === finalId && currentDeal?.pipeline) {
       lastCompleteDealRef.current = currentDeal;
       return;
     }

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useCurrentDealId.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useCurrentDealId.ts
@@ -1,0 +1,11 @@
+import { useQueryState } from 'erxes-ui';
+import { useAtomValue } from 'jotai';
+
+import { dealDetailSheetState } from '@/deals/states/dealDetailSheetState';
+
+export const useCurrentDealId = () => {
+  const [salesItemId] = useQueryState<string>('salesItemId');
+  const activeDealId = useAtomValue(dealDetailSheetState);
+
+  return salesItemId || activeDealId || '';
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStageItem.tsx
@@ -376,7 +376,7 @@ export const PipelineStageItem = (props: Props) => {
                     <Controller
                       name={`stages.${index}.defaultTick`}
                       control={control}
-                      defaultValue={stage?.defaultTick ?? false}
+                      defaultValue={stage?.defaultTick ?? true}
                       render={({ field }) => (
                         <Checkbox
                           id={`defaultTick-${index}`}

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineStages.tsx
@@ -44,6 +44,7 @@ export const PipelineStages = ({ form, stagesLoading }: Props) => {
       status: 'active',
       memberIds: [],
       departmentIds: [],
+      defaultTick: true,
     });
   };
 

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/hooks/usePipelineFormSync.ts
@@ -28,6 +28,7 @@ const mapPipelineStages = (
     probability: stage.probability || '',
     memberIds: stage.memberIds ?? [],
     departmentIds: stage.departmentIds ?? [],
+    defaultTick: stage.defaultTick ?? true,
   }));
 
 const getPipelineFormValues = (


### PR DESCRIPTION
## Summary

- resolve the active deal ID from either the URL or the deal detail sheet
- update both deal list and deal detail caches after product mutations
- refresh deal details for product subscription events and generate a fresh process ID per mutation
- isolate normal and advanced product table state
- default stage product ticking to enabled for new and existing stages without an explicit value

## Why

Deal details opened from sheet state do not always have a `salesItemId` query parameter. Product mutations and cache updates could therefore target an empty or stale deal ID, while ignored same-process subscription events could leave the detail view out of sync. Stage form defaults also differed from the product display fallback.

## Impact

Product create, edit, and delete actions now stay synchronized across deal views without a manual refresh. Product table modes retain independent state, and stages consistently enable product ticking unless explicitly disabled.

## Validation

- `git diff --check`
- `NX_DAEMON=false pnpm nx build sales_ui`

The `sales_ui` project does not define lint or test targets.

## Summary by Sourcery

Keep deal product data and ticking behavior consistent across deal views and pipeline stages.

New Features:
- Resolve the active deal ID from either the URL query or the deal detail sheet state via a shared hook.
- Maintain separate table state for normal and advanced product record views using distinct table IDs.

Bug Fixes:
- Synchronize product mutations across both deal list and deal detail caches so detail views reflect changes without manual refresh.
- Ensure product subscription events always target the correct deal by using the resolved deal ID instead of relying solely on the URL.
- Avoid stale subscription suppression by generating a new process ID for each product mutation and delete action.
- Guard deal detail state updates against missing pipeline data to prevent runtime issues.

Enhancements:
- Default stage product ticking to enabled for new and existing stages when no explicit value is set.
- Propagate defaultTick consistently through pipeline stage form mapping and stage creation.
- Simplify product mutation hooks to derive the deal ID centrally instead of from individual query state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more reliable deal identification across product actions.
  - Added separate product table views without state conflicts.
  - New pipeline stages default to enabling tick behavior.

- **Bug Fixes**
  - Improved consistency when creating, editing, and deleting products.
  - Ensured product and deal details stay synchronized after changes.
  - Each product update now uses a fresh processing identifier.
  - Improved deal-detail refresh behavior and handling when pipeline information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->