### PR TITLE
fix(frontline): show outbound calls in call reports

### DIFF
--- a/backend/gateway/src/locales/en/frontline.json
+++ b/backend/gateway/src/locales/en/frontline.json
@@ -785,7 +785,7 @@
   "kpi-service-level": "Service Level",
   "kpi-service-level-subtitle": "≤ 20 s answer target",
   "kpi-abandonment-rate": "Abandonment Rate",
-  "kpi-abandonment-rate-subtitle": "Inbound abandoned",
+  "kpi-abandonment-rate-subtitle": "Calls that never connected",
   "kpi-avg-speed-of-answer": "Avg Speed of Answer",
   "kpi-avg-speed-of-answer-subtitle": "Time before answer",
   "kpi-avg-handle-time": "Avg Handle Time",

--- a/backend/gateway/src/locales/mn/frontline.json
+++ b/backend/gateway/src/locales/mn/frontline.json
@@ -785,7 +785,7 @@
   "kpi-service-level": "Үйлчилгээний түвшин",
   "kpi-service-level-subtitle": "≤ 20 сек хариулах зорилт",
   "kpi-abandonment-rate": "Орхих хувь",
-  "kpi-abandonment-rate-subtitle": "Орхисон ирж буй дуудлага",
+  "kpi-abandonment-rate-subtitle": "Холбогдоогүй дуудлага",
   "kpi-avg-speed-of-answer": "Хариулах дундаж хурд",
   "kpi-avg-speed-of-answer-subtitle": "Хариулахаас өмнөх хугацаа",
   "kpi-avg-handle-time": "Дундаж боловсруулах хугацаа",

--- a/backend/plugins/frontline_api/src/modules/reports/callReportService.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/callReportService.ts
@@ -77,9 +77,27 @@ export const buildCdrFilter = ({
     filter.userfield = direction;
   }
 
-  if (queueId && queueId !== 'all') {
-    filter.actionType = { $regex: `QUEUE\\[${escapeRegExp(queueId)}\\]` };
+  if (!queueId || queueId === 'all') {
+    return filter;
   }
+
+  // An outbound call never enters a queue — the PBX files it as `DIAL`, not
+  // `QUEUE[...]` — so pairing a queue with outbound legs matches nothing at
+  // all, and pairing it with both directions silently drops every outbound
+  // call from the totals. The queue therefore narrows the inbound side only.
+  if (direction === 'Outbound') {
+    return filter;
+  }
+
+  const inQueue = {
+    actionType: { $regex: `QUEUE\\[${escapeRegExp(queueId)}\\]` },
+  };
+
+  if (direction === 'Inbound') {
+    return { ...filter, ...inQueue };
+  }
+
+  filter.$or = [inQueue, { userfield: 'Outbound' }];
 
   return filter;
 };

--- a/backend/plugins/frontline_api/src/modules/reports/callReportService.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/callReportService.ts
@@ -90,7 +90,7 @@ export const buildCdrFilter = ({
   }
 
   const inQueue = {
-    actionType: { $regex: `QUEUE\\[${escapeRegExp(queueId)}\\]` },
+    actionType: { $regex: String.raw`QUEUE\[${escapeRegExp(queueId)}\]` },
   };
 
   if (direction === 'Inbound') {

--- a/backend/plugins/frontline_api/src/modules/reports/callStatistics.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/callStatistics.ts
@@ -72,14 +72,37 @@ export const calculateFirstCallResolution = async (legs: IStatisticsLeg[]) => {
   return (resolvedFirstTime / callsPerCaller.size) * 100;
 };
 
+/**
+ * Share of the selected calls that connected.
+ *
+ * Counted straight from the calls rather than derived from the abandonment
+ * rate, so it survives a direction filter: an outbound call the customer
+ * picked up counts exactly like an inbound call an agent answered.
+ */
+export const calculateAnswerRate = async (legs: IStatisticsLeg[]) => {
+  const calls = groupLegsIntoCalls(legs);
+
+  if (!calls.length) return null;
+
+  return (calls.filter(wasAnswered).length / calls.length) * 100;
+};
+
+/**
+ * Share of the selected calls that never connected.
+ *
+ * The exact complement of {@link calculateAnswerRate}, and counted over the
+ * same population for that reason: scoping one to inbound and the other to
+ * every direction left the two cards sitting side by side without summing to
+ * 100 whenever both directions were in view.
+ */
 export const calculateAbandonmentRate = async (legs: IStatisticsLeg[]) => {
-  const inbound = inboundCalls(legs);
+  const calls = groupLegsIntoCalls(legs);
 
-  if (!inbound.length) return null;
+  if (!calls.length) return null;
 
-  const abandoned = inbound.filter((call) => !wasAnswered(call));
+  const abandoned = calls.filter((call) => !wasAnswered(call));
 
-  return (abandoned.length / inbound.length) * 100;
+  return (abandoned.length / calls.length) * 100;
 };
 
 export const calculateOccupancyRate = async (
@@ -109,8 +132,16 @@ export const calculateAverageSpeedOfAnswer = async (legs: IStatisticsLeg[]) => {
   return averageSpeedOfAnswer(inbound);
 };
 
+/**
+ * Mean talk time over the calls that connected, in either direction.
+ *
+ * Unlike the queue metrics above, handling time is not about what the caller
+ * waited through: an agent spends the same effort on a call they placed as on
+ * one they answered. Restricting it to inbound left an outbound-only report
+ * with nothing to show.
+ */
 export const calculateAverageHandlingTime = async (legs: IStatisticsLeg[]) => {
-  const answered = inboundCalls(legs).filter(wasAnswered);
+  const answered = groupLegsIntoCalls(legs).filter(wasAnswered);
 
   if (!answered.length) return null;
 

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/callQueries.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/callQueries.ts
@@ -427,11 +427,23 @@ export const reportCallQueries = {
   async callCarrierBreakdown(
     _args,
     { startDate, endDate, queueId, direction }: ICallReportArgs,
-    { models }: IContext,
+    { models, user, subdomain }: IContext,
   ) {
-    const cdrs = await models.CallCdrs.find(
-      buildCdrFilter({ startDate, endDate, queueId, direction }),
-    )
+    const integration = await findQueueIntegration(
+      models,
+      subdomain,
+      user,
+      queueId,
+    );
+
+    if (queueId && !integration) {
+      return [];
+    }
+
+    const cdrs = await models.CallCdrs.find({
+      ...buildCdrFilter({ startDate, endDate, queueId, direction }),
+      ...(integration ? { inboxIntegrationId: integration.inboxId } : {}),
+    })
       .select(CDR_REPORT_FIELDS)
       .lean<ICdrLeg[]>();
 
@@ -441,11 +453,23 @@ export const reportCallQueries = {
   async callHeatmap(
     _args,
     { startDate, endDate, queueId, direction }: ICallReportArgs,
-    { models }: IContext,
+    { models, user, subdomain }: IContext,
   ) {
-    const cdrs = await models.CallCdrs.find(
-      buildCdrFilter({ startDate, endDate, queueId, direction }),
-    )
+    const integration = await findQueueIntegration(
+      models,
+      subdomain,
+      user,
+      queueId,
+    );
+
+    if (queueId && !integration) {
+      return [];
+    }
+
+    const cdrs = await models.CallCdrs.find({
+      ...buildCdrFilter({ startDate, endDate, queueId, direction }),
+      ...(integration ? { inboxIntegrationId: integration.inboxId } : {}),
+    })
       .select(CDR_REPORT_FIELDS)
       .lean<ICdrLeg[]>();
 
@@ -461,11 +485,23 @@ export const reportCallQueries = {
       direction,
       limit = 12,
     }: ICallReportArgs & { limit?: number },
-    { models }: IContext,
+    { models, user, subdomain }: IContext,
   ) {
-    const cdrs = await models.CallCdrs.find(
-      buildCdrFilter({ startDate, endDate, queueId, direction }),
-    )
+    const integration = await findQueueIntegration(
+      models,
+      subdomain,
+      user,
+      queueId,
+    );
+
+    if (queueId && !integration) {
+      return [];
+    }
+
+    const cdrs = await models.CallCdrs.find({
+      ...buildCdrFilter({ startDate, endDate, queueId, direction }),
+      ...(integration ? { inboxIntegrationId: integration.inboxId } : {}),
+    })
       .select(CDR_REPORT_FIELDS)
       .lean<ICdrLeg[]>();
 

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/callQueries.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/resolvers/callQueries.ts
@@ -20,6 +20,7 @@ import {
 } from '@/reports/callHistoryService';
 import {
   calculateAbandonmentRate,
+  calculateAnswerRate,
   calculateAverageHandlingTime,
   calculateAverageSpeedOfAnswer,
   calculateFirstCallResolution,
@@ -78,6 +79,7 @@ const EMPTY_SCORECARD = {
   averageAnsweredTime: null,
   firstCallResolution: null,
   occupancy: null,
+  answerRate: null,
 };
 
 const findQueueIntegration = async (
@@ -349,6 +351,7 @@ export const reportCallQueries = {
       firstCallResolution,
       occupancy,
       averageSpeed,
+      answerRate,
     ] = await Promise.all([
       calculateServiceLevel(cdrs),
       calculateAbandonmentRate(cdrs),
@@ -356,6 +359,7 @@ export const reportCallQueries = {
       calculateFirstCallResolution(cdrs),
       calculateOccupancyRate(cdrs),
       calculateAverageSpeedOfAnswer(cdrs),
+      calculateAnswerRate(cdrs),
     ]);
 
     return {
@@ -366,6 +370,7 @@ export const reportCallQueries = {
       averageAnsweredTime,
       firstCallResolution,
       occupancy,
+      answerRate,
     };
   },
 

--- a/backend/plugins/frontline_api/src/modules/reports/graphql/schema/call.ts
+++ b/backend/plugins/frontline_api/src/modules/reports/graphql/schema/call.ts
@@ -18,6 +18,11 @@ export const types = `
     callstotal: Int
     abandonment: Float
     occupancy: Float
+    """
+    Share of the selected calls that connected, counted in either direction,
+    so it stays populated when the report is filtered to outbound only.
+    """
+    answerRate: Float
   }
 
   type AgentStats {

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/graphql/queries/callStatistics.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/graphql/queries/callStatistics.ts
@@ -53,6 +53,7 @@ export const CALL_KPI_SCORECARD = `
       averageAnsweredTime
       firstCallResolution
       occupancy
+      answerRate
     }
   }
 `;

--- a/frontend/plugins/frontline_ui/src/modules/report/call/components/KpiSection/KpiSection.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/call/components/KpiSection/KpiSection.tsx
@@ -30,8 +30,6 @@ export function KpiSection() {
     );
   }
 
-  const answerRate = kpi?.abandonment == null ? null : 100 - kpi.abandonment;
-
   const cards = [
     {
       title: t('kpi-total-calls'),
@@ -75,7 +73,7 @@ export function KpiSection() {
     },
     {
       title: t('kpi-answer-rate'),
-      value: fmtPctOrDash(answerRate),
+      value: fmtPctOrDash(kpi?.answerRate),
       subtitle:
         direction !== 'all'
           ? t('kpi-direction-only', { direction })

--- a/frontend/plugins/frontline_ui/src/modules/report/call/types.ts
+++ b/frontend/plugins/frontline_ui/src/modules/report/call/types.ts
@@ -9,6 +9,9 @@ export interface KpiScorecard {
   averageSpeed: number | null;
   firstCallResolution: number | null;
   occupancy: number | null;
+
+  /** Connected share of the selected calls, in either direction. */
+  answerRate: number | null;
 }
 
 export interface VolumePoint {


### PR DESCRIPTION
## Summary by Sourcery

Include outbound calls in frontline call reports and expose a direction-agnostic answer rate KPI.

New Features:
- Add an answer rate KPI calculated over all connected calls regardless of direction and expose it via GraphQL and the UI.

Bug Fixes:
- Ensure abandonment and handling time metrics are computed over all calls instead of inbound-only so outbound-only reports remain populated.
- Adjust CDR filtering so queue constraints only restrict inbound legs, allowing outbound calls to still appear in mixed-direction reports.

Enhancements:
- Refine KPI scorecard schema and translations wiring to support the new answer rate metric without deriving it from abandonment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an answer-rate KPI showing the percentage of selected calls that connected, including inbound and outbound calls.
  - Updated average handling time and abandonment metrics to account for calls in both directions.
- **Bug Fixes**
  - Improved queue filtering for inbound, outbound, and unspecified call directions.
  - Updated abandonment-rate labels for clearer English and Mongolian translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->