### PR TITLE
Fix frontline inbox filters and Facebook tagging

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
@@ -19,15 +19,15 @@ import {
 
 import { ConversationsHeader } from '@/inbox/conversations/components/ConversationsHeader';
 import { CONVERSATIONS_LIMIT } from '@/inbox/constants/conversationsConstants';
-import { ConversationItem } from './ConversationItem';
-import { ConversationThreadList } from './ConversationChannelSection';
+import { ConversationItem } from '@/inbox/conversations/components/ConversationItem';
+import { ConversationThreadList } from '@/inbox/conversations/components/ConversationChannelSection';
 import { isDiscordConversation } from '@/inbox/conversations/utils/channelGroups';
 import { useDiscordConversationChannels } from '@/integrations/discord/hooks/useDiscordSetup';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { refetchNewMessagesState } from '@/inbox/conversations/states/newMessagesCountState';
 import { conversationsContainerScrollState } from '@/inbox/conversations/states/conversationsContainerScrollState';
-import { ConversationActions } from './ConversationActions';
+import { ConversationActions } from '@/inbox/conversations/components/ConversationActions';
 
 const getBooleanFilterVariable = (
   value: boolean | null | undefined,

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
@@ -29,6 +29,10 @@ import { refetchNewMessagesState } from '@/inbox/conversations/states/newMessage
 import { conversationsContainerScrollState } from '@/inbox/conversations/states/conversationsContainerScrollState';
 import { ConversationActions } from './ConversationActions';
 
+const getBooleanFilterVariable = (
+  value: boolean | null | undefined,
+): string | undefined => (value ? 'true' : undefined);
+
 export const Conversations = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const refetchNewMessages = useAtomValue(refetchNewMessagesState);
@@ -73,6 +77,8 @@ export const Conversations = () => {
     integrationId,
     integrationType,
     unassigned,
+    awaitingResponse,
+    participated,
     status,
     created,
     brandId,
@@ -81,7 +87,9 @@ export const Conversations = () => {
     channelId: string;
     integrationId: string;
     integrationType: string;
-    unassigned: string;
+    unassigned: boolean;
+    awaitingResponse: boolean;
+    participated: boolean;
     status: string;
     conversationId: string;
     created: string;
@@ -92,6 +100,8 @@ export const Conversations = () => {
     'integrationId',
     'integrationType',
     'unassigned',
+    'awaitingResponse',
+    'participated',
     'status',
     'conversationId',
     'created',
@@ -108,7 +118,9 @@ export const Conversations = () => {
         channelId,
         integrationId,
         integrationType: integrationType,
-        unassigned,
+        unassigned: getBooleanFilterVariable(unassigned),
+        awaitingResponse: getBooleanFilterVariable(awaitingResponse),
+        participating: getBooleanFilterVariable(participated),
         status: status || '',
         startDate: parsedDate?.from,
         endDate: parsedDate?.to,

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsFilter.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsFilter.tsx
@@ -2,6 +2,9 @@ import {
   Combobox,
   Command,
   Filter,
+  Skeleton,
+  cn,
+  parseDateRangeFromString,
   useMultiQueryState,
   useNonNullMultiQueryState,
   useQueryState,
@@ -24,8 +27,23 @@ import {
   IntegrationTypeFilterItem,
   IntegrationTypeFilterView,
 } from '@/integrations/components/IntegrationTypeFilter';
-import { useInboxLayout } from '@/inbox/hooks/useInboxLayout';
 import { useTranslation } from 'react-i18next';
+import { useConversationFilterCounts } from '@/inbox/conversations/hooks/useConversationCounts';
+
+const FilterCount = ({
+  count,
+  loading,
+}: {
+  count?: number;
+  loading: boolean;
+}) =>
+  loading ? (
+    <Skeleton className="ml-auto size-4 rounded-full" />
+  ) : (
+    <span className="ml-auto tabular-nums text-xs text-muted-foreground">
+      {count ?? 0}
+    </span>
+  );
 
 export const FilterConversationsPopover = () => {
   const { t } = useTranslation('frontline');
@@ -35,8 +53,34 @@ export const FilterConversationsPopover = () => {
     awaitingResponse: boolean;
     participated: boolean;
     channelId: string;
-  }>(['status', 'unassigned', 'awaitingResponse', 'participated', 'channelId']);
+    integrationId: string;
+    integrationType: string;
+    brandId: string;
+    created: string;
+    searchValue: string;
+  }>([
+    'status',
+    'unassigned',
+    'awaitingResponse',
+    'participated',
+    'channelId',
+    'integrationId',
+    'integrationType',
+    'brandId',
+    'created',
+    'searchValue',
+  ]);
   const { status, unassigned, awaitingResponse, participated } = queries || {};
+  const parsedDate = parseDateRangeFromString(queries.created || '');
+  const { counts, loading } = useConversationFilterCounts({
+    channelId: queries.channelId,
+    integrationId: queries.integrationId,
+    integrationType: queries.integrationType,
+    brandId: queries.brandId,
+    startDate: parsedDate?.from,
+    endDate: parsedDate?.to,
+    searchValue: queries.searchValue,
+  });
 
   return (
     <Filter.Popover scope={InboxHotkeyScope.MainPage}>
@@ -55,7 +99,10 @@ export const FilterConversationsPopover = () => {
               <Filter.CommandItem onSelect={() => setQueries({ status: null })}>
                 <IconSquare />
                 {t('unresolved')}
-                {status === null && <IconCheck className="ml-auto" />}
+                <span className="ml-auto flex items-center gap-2">
+                  <FilterCount count={counts?.unresolved} loading={loading} />
+                  {status === null && <IconCheck />}
+                </span>
               </Filter.CommandItem>
               <Filter.CommandItem
                 onSelect={() =>
@@ -64,9 +111,10 @@ export const FilterConversationsPopover = () => {
               >
                 <IconCheckbox />
                 {t('resolved')}
-                {status === ConversationStatus.CLOSED && (
-                  <IconCheck className="ml-auto" />
-                )}
+                <span className="ml-auto flex items-center gap-2">
+                  <FilterCount count={counts?.resolved} loading={loading} />
+                  {status === ConversationStatus.CLOSED && <IconCheck />}
+                </span>
               </Filter.CommandItem>
               <Command.Separator className="my-1" />
               <Filter.CommandItem
@@ -78,7 +126,10 @@ export const FilterConversationsPopover = () => {
               >
                 <IconUserX />
                 {t('unassigned')}
-                {unassigned && <IconCheck className="ml-auto" />}
+                <span className="ml-auto flex items-center gap-2">
+                  <FilterCount count={counts?.unassigned} loading={loading} />
+                  {unassigned && <IconCheck />}
+                </span>
               </Filter.CommandItem>
               <Filter.CommandItem
                 onSelect={() => {
@@ -89,7 +140,13 @@ export const FilterConversationsPopover = () => {
               >
                 <IconUsersGroup />
                 {t('participated')}
-                {participated && <IconCheck className="ml-auto" />}
+                <span className="ml-auto flex items-center gap-2">
+                  <FilterCount
+                    count={counts?.participating}
+                    loading={loading}
+                  />
+                  {participated && <IconCheck />}
+                </span>
               </Filter.CommandItem>
               <Command.Separator className="my-1" />
               <Filter.CommandItem
@@ -101,7 +158,13 @@ export const FilterConversationsPopover = () => {
               >
                 <IconLoader />
                 {t('awaiting-response')}
-                {awaitingResponse && <IconCheck className="ml-auto" />}
+                <span className="ml-auto flex items-center gap-2">
+                  <FilterCount
+                    count={counts?.awaitingResponse}
+                    loading={loading}
+                  />
+                  {awaitingResponse && <IconCheck />}
+                </span>
               </Filter.CommandItem>
               <SelectChannel.FilterItem />
               <IntegrationTypeFilterItem />
@@ -128,12 +191,13 @@ export const FilterConversationsPopover = () => {
 
 export const ConversationFilterBar = ({
   children,
+  className,
 }: {
   children?: React.ReactNode;
+  className?: string;
 }) => {
   const { t } = useTranslation('frontline');
   const [status] = useQueryState<ConversationStatus>('status');
-  const inboxLayout = useInboxLayout();
   const filterStates = useNonNullMultiQueryState<{
     status: ConversationStatus;
     unassigned: boolean;
@@ -158,7 +222,10 @@ export const ConversationFilterBar = ({
 
   return (
     <Filter.Bar
-      className={inboxLayout === 'list' ? 'pl-2' : 'pt-1'}
+      className={cn(
+        'hide-scroll min-w-0 flex-nowrap overflow-x-auto overflow-y-hidden [&>div]:min-w-0 [&>div]:max-w-full [&>div]:shrink-0 [&>div]:overflow-hidden [&>div>button]:min-w-0 [&>div>button]:truncate [&>div>button:last-child]:shrink-0',
+        className,
+      )}
       id="conversations-filter-bar"
     >
       <Filter.SearchValueBarItem />

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsFilter.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsFilter.tsx
@@ -30,6 +30,33 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useConversationFilterCounts } from '@/inbox/conversations/hooks/useConversationCounts';
 
+type ConversationFilterQueries = {
+  status: ConversationStatus;
+  unassigned: boolean;
+  awaitingResponse: boolean;
+  participated: boolean;
+  channelId: string;
+  integrationId: string;
+  integrationType: string;
+  brandId: string;
+  created: string;
+  searchValue: string;
+};
+
+type ConversationFilterQueryValues = {
+  [Key in keyof ConversationFilterQueries]:
+    | ConversationFilterQueries[Key]
+    | null;
+};
+
+type ConversationFilterCounts = {
+  unresolved?: number;
+  resolved?: number;
+  unassigned?: number;
+  participating?: number;
+  awaitingResponse?: number;
+};
+
 const FilterCount = ({
   count,
   loading,
@@ -45,20 +72,119 @@ const FilterCount = ({
     </span>
   );
 
-export const FilterConversationsPopover = () => {
+const ConversationFilterCommandItem = ({
+  children,
+  count,
+  loading,
+  selected,
+  onSelect,
+}: {
+  children: React.ReactNode;
+  count?: number;
+  loading: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) => (
+  <Filter.CommandItem onSelect={onSelect}>
+    {children}
+    <span className="ml-auto flex items-center gap-2">
+      <FilterCount count={count} loading={loading} />
+      {selected && <IconCheck />}
+    </span>
+  </Filter.CommandItem>
+);
+
+const ConversationFilterCommand = ({
+  counts,
+  loading,
+  queries,
+  setQueries,
+}: {
+  counts?: ConversationFilterCounts;
+  loading: boolean;
+  queries: ConversationFilterQueryValues;
+  setQueries: (values: Partial<ConversationFilterQueryValues>) => void;
+}) => {
   const { t } = useTranslation('frontline');
-  const [queries, setQueries] = useMultiQueryState<{
-    status: ConversationStatus;
-    unassigned: boolean;
-    awaitingResponse: boolean;
-    participated: boolean;
-    channelId: string;
-    integrationId: string;
-    integrationType: string;
-    brandId: string;
-    created: string;
-    searchValue: string;
-  }>([
+  const { status, unassigned, awaitingResponse, participated } = queries;
+
+  return (
+    <Command>
+      <Filter.CommandInput
+        placeholder={t('filter')}
+        variant="secondary"
+        className="bg-background"
+      />
+      <Command.List className="max-h-none">
+        <Filter.SearchValueTrigger />
+        <Command.Separator className="my-1" />
+        <ConversationFilterCommandItem
+          count={counts?.unresolved}
+          loading={loading}
+          selected={status === null}
+          onSelect={() => setQueries({ status: null })}
+        >
+          <IconSquare />
+          {t('unresolved')}
+        </ConversationFilterCommandItem>
+        <ConversationFilterCommandItem
+          count={counts?.resolved}
+          loading={loading}
+          selected={status === ConversationStatus.CLOSED}
+          onSelect={() => setQueries({ status: ConversationStatus.CLOSED })}
+        >
+          <IconCheckbox />
+          {t('resolved')}
+        </ConversationFilterCommandItem>
+        <Command.Separator className="my-1" />
+        <ConversationFilterCommandItem
+          count={counts?.unassigned}
+          loading={loading}
+          selected={Boolean(unassigned)}
+          onSelect={() => setQueries({ unassigned: unassigned ? null : true })}
+        >
+          <IconUserX />
+          {t('unassigned')}
+        </ConversationFilterCommandItem>
+        <ConversationFilterCommandItem
+          count={counts?.participating}
+          loading={loading}
+          selected={Boolean(participated)}
+          onSelect={() =>
+            setQueries({ participated: participated ? null : true })
+          }
+        >
+          <IconUsersGroup />
+          {t('participated')}
+        </ConversationFilterCommandItem>
+        <Command.Separator className="my-1" />
+        <ConversationFilterCommandItem
+          count={counts?.awaitingResponse}
+          loading={loading}
+          selected={Boolean(awaitingResponse)}
+          onSelect={() =>
+            setQueries({
+              awaitingResponse: awaitingResponse ? null : true,
+            })
+          }
+        >
+          <IconLoader />
+          {t('awaiting-response')}
+        </ConversationFilterCommandItem>
+        <SelectChannel.FilterItem />
+        <IntegrationTypeFilterItem />
+        <Command.Separator className="my-1" />
+        <Filter.Item value="created">
+          <IconCalendarPlus />
+          {t('created-at')}
+        </Filter.Item>
+      </Command.List>
+    </Command>
+  );
+};
+
+export const FilterConversationsPopover = () => {
+  const [queries, setQueries] = useMultiQueryState<ConversationFilterQueries>([
     'status',
     'unassigned',
     'awaitingResponse',
@@ -70,7 +196,6 @@ export const FilterConversationsPopover = () => {
     'created',
     'searchValue',
   ]);
-  const { status, unassigned, awaitingResponse, participated } = queries || {};
   const parsedDate = parseDateRangeFromString(queries.created || '');
   const { counts, loading } = useConversationFilterCounts({
     channelId: queries.channelId,
@@ -87,94 +212,12 @@ export const FilterConversationsPopover = () => {
       <Filter.Trigger isFiltered />
       <Combobox.Content className="w-64">
         <Filter.View>
-          <Command>
-            <Filter.CommandInput
-              placeholder={t('filter')}
-              variant="secondary"
-              className="bg-background"
-            />
-            <Command.List className="max-h-none">
-              <Filter.SearchValueTrigger />
-              <Command.Separator className="my-1" />
-              <Filter.CommandItem onSelect={() => setQueries({ status: null })}>
-                <IconSquare />
-                {t('unresolved')}
-                <span className="ml-auto flex items-center gap-2">
-                  <FilterCount count={counts?.unresolved} loading={loading} />
-                  {status === null && <IconCheck />}
-                </span>
-              </Filter.CommandItem>
-              <Filter.CommandItem
-                onSelect={() =>
-                  setQueries({ status: ConversationStatus.CLOSED })
-                }
-              >
-                <IconCheckbox />
-                {t('resolved')}
-                <span className="ml-auto flex items-center gap-2">
-                  <FilterCount count={counts?.resolved} loading={loading} />
-                  {status === ConversationStatus.CLOSED && <IconCheck />}
-                </span>
-              </Filter.CommandItem>
-              <Command.Separator className="my-1" />
-              <Filter.CommandItem
-                onSelect={() => {
-                  setQueries({
-                    unassigned: unassigned ? null : true,
-                  });
-                }}
-              >
-                <IconUserX />
-                {t('unassigned')}
-                <span className="ml-auto flex items-center gap-2">
-                  <FilterCount count={counts?.unassigned} loading={loading} />
-                  {unassigned && <IconCheck />}
-                </span>
-              </Filter.CommandItem>
-              <Filter.CommandItem
-                onSelect={() => {
-                  setQueries({
-                    participated: participated ? null : true,
-                  });
-                }}
-              >
-                <IconUsersGroup />
-                {t('participated')}
-                <span className="ml-auto flex items-center gap-2">
-                  <FilterCount
-                    count={counts?.participating}
-                    loading={loading}
-                  />
-                  {participated && <IconCheck />}
-                </span>
-              </Filter.CommandItem>
-              <Command.Separator className="my-1" />
-              <Filter.CommandItem
-                onSelect={() =>
-                  setQueries({
-                    awaitingResponse: awaitingResponse ? null : true,
-                  })
-                }
-              >
-                <IconLoader />
-                {t('awaiting-response')}
-                <span className="ml-auto flex items-center gap-2">
-                  <FilterCount
-                    count={counts?.awaitingResponse}
-                    loading={loading}
-                  />
-                  {awaitingResponse && <IconCheck />}
-                </span>
-              </Filter.CommandItem>
-              <SelectChannel.FilterItem />
-              <IntegrationTypeFilterItem />
-              <Command.Separator className="my-1" />
-              <Filter.Item value="created">
-                <IconCalendarPlus />
-                {t('created-at')}
-              </Filter.Item>
-            </Command.List>
-          </Command>
+          <ConversationFilterCommand
+            counts={counts}
+            loading={loading}
+            queries={queries}
+            setQueries={setQueries}
+          />
         </Filter.View>
         <SelectMember.FilterView
           onValueChange={() => setQueries({ unassigned: null })}

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsHeader.tsx
@@ -1,6 +1,7 @@
 import { cn, Filter, Skeleton } from 'erxes-ui';
-import { useConversationListContext } from '../hooks/useConversationListContext';
+import { useConversationListContext } from '@/inbox/conversations/hooks/useConversationListContext';
 import { ConversationFilterBar } from '@/inbox/conversations/components/ConversationsFilter';
+import { useInboxLayout } from '@/inbox/hooks/useInboxLayout';
 import { useTranslation } from 'react-i18next';
 
 export const ConversationsHeader = ({
@@ -8,14 +9,24 @@ export const ConversationsHeader = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const inboxLayout = useInboxLayout();
+
   return (
     <Filter id="conversations-filter-bar">
-      <div className="pl-6 pr-4 py-2 space-y-1 bg-sidebar">
-        <div className="flex items-center justify-between gap-2 min-w-0">
-          {children}
-          <ConversationCount />
-        </div>
-        <ConversationFilterBar />
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 overflow-hidden bg-sidebar py-2 pl-6 pr-4">
+        <div className="order-1 flex shrink-0 items-center">{children}</div>
+        <ConversationFilterBar
+          className={cn(
+            'order-3 basis-full',
+            inboxLayout === 'list' && 'md:order-2 md:basis-0',
+          )}
+        />
+        <ConversationCount
+          className={cn(
+            'order-2 shrink-0',
+            inboxLayout === 'list' && 'md:order-3',
+          )}
+        />
         <Filter.Dialog>
           <Filter.View filterKey="searchValue" inDialog>
             <Filter.DialogStringView filterKey="searchValue" />

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationsHeader.tsx
@@ -4,6 +4,27 @@ import { ConversationFilterBar } from '@/inbox/conversations/components/Conversa
 import { useInboxLayout } from '@/inbox/hooks/useInboxLayout';
 import { useTranslation } from 'react-i18next';
 
+export const ConversationCount = ({ className }: { className?: string }) => {
+  const { t } = useTranslation('frontline');
+  const { totalCount, loading } = useConversationListContext();
+
+  return (
+    <span
+      className={cn(
+        'text-accent-foreground inline-flex items-center gap-1 text-sm font-medium ml-auto min-w-0',
+        className,
+      )}
+    >
+      {loading ? (
+        <Skeleton className="w-4 h-4 flex-none" />
+      ) : (
+        <span className="flex-none">{totalCount}</span>
+      )}
+      <span className="truncate">{t('conversations')}</span>
+    </span>
+  );
+};
+
 export const ConversationsHeader = ({
   children,
 }: {
@@ -37,26 +58,5 @@ export const ConversationsHeader = ({
         </Filter.Dialog>
       </div>
     </Filter>
-  );
-};
-
-export const ConversationCount = ({ className }: { className?: string }) => {
-  const { t } = useTranslation('frontline');
-  const { totalCount, loading } = useConversationListContext();
-
-  return (
-    <span
-      className={cn(
-        'text-accent-foreground inline-flex items-center gap-1 text-sm font-medium ml-auto min-w-0',
-        className,
-      )}
-    >
-      {loading ? (
-        <Skeleton className="w-4 h-4 flex-none" />
-      ) : (
-        <span className="flex-none">{totalCount}</span>
-      )}
-      <span className="truncate">{t('conversations')}</span>
-    </span>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -37,6 +37,7 @@ import {
 } from 'erxes-ui';
 import { useAtomValue } from 'jotai';
 import { CustomersInline, SelectMember, SelectTags } from 'ui-modules';
+import { ConversationActions } from '@/inbox/conversations/conversation-detail/components/ConversationActions';
 import { useTranslation } from 'react-i18next';
 import { type SyntheticEvent, useState } from 'react';
 
@@ -372,7 +373,12 @@ export const ConversationHeader = () => {
   const { loading } = useConversationContext();
   const [, setConversationId] = useQueryState<string>('conversationId');
   const view = useInboxLayout();
-  const { ref: headerRef, isCompact } = useOverflowCompact<HTMLDivElement>();
+  const {
+    ref: headerRef,
+    isCompact,
+    compactLevel,
+  } = useOverflowCompact<HTMLDivElement>();
+  const hideAssignee = compactLevel === 2;
 
   return (
     <div
@@ -397,11 +403,16 @@ export const ConversationHeader = () => {
         <Skeleton className="w-32 h-4 ml-2" />
       )}
       <Separator.Inline />
-      {!isCompact && <AssignConversation />}
+      {!hideAssignee && <AssignConversation />}
       <AutomatedReplyStatusBadge />
       <div className="flex items-center gap-3 ml-auto flex-none">
+        {!isCompact && <ConversationTags />}
         <IntegrationActions />
-        <ConversationActionsDropdown showAssignee={isCompact} />
+        {isCompact ? (
+          <ConversationActionsDropdown showAssignee={hideAssignee} />
+        ) : (
+          <ConversationActions />
+        )}
       </div>
     </div>
   );

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -133,9 +133,9 @@ const AutomatedReplyStatusBadge = () => {
   const label = isActive
     ? 'Automation active'
     : status === 'human_active' &&
-      automatedReplyControl?.reason === 'operator_reply'
-    ? 'Automation paused: operator active'
-    : 'Automation paused';
+        automatedReplyControl?.reason === 'operator_reply'
+      ? 'Automation paused: operator active'
+      : 'Automation paused';
   const nextStatus = isActive ? 'human_active' : 'active';
   const actionLabel = isActive ? 'Pause automation' : 'Resume automation';
   const Icon = isActive ? IconPlayerPlay : IconPlayerPause;

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -7,7 +7,7 @@ import { useChangeConversationStatus } from '@/inbox/conversations/hooks/useChan
 import { useConversationListVisibility } from '@/inbox/hooks/useConversationListVisibility';
 import { useInboxLayout } from '@/inbox/hooks/useInboxLayout';
 import { useOverflowCompact } from '@/inbox/hooks/useCompactWidth';
-import { refetchConversationsAtom } from '../../states/refetchConversationState';
+import { refetchConversationsAtom } from '@/inbox/conversations/states/refetchConversationState';
 import { ConversationStatus } from '@/inbox/types/Conversation';
 import { IntegrationActions } from '@/integrations/components/IntegrationActions';
 import {
@@ -133,9 +133,9 @@ const AutomatedReplyStatusBadge = () => {
   const label = isActive
     ? 'Automation active'
     : status === 'human_active' &&
-        automatedReplyControl?.reason === 'operator_reply'
-      ? 'Automation paused: operator active'
-      : 'Automation paused';
+      automatedReplyControl?.reason === 'operator_reply'
+    ? 'Automation paused: operator active'
+    : 'Automation paused';
   const nextStatus = isActive ? 'human_active' : 'active';
   const actionLabel = isActive ? 'Pause automation' : 'Resume automation';
   const Icon = isActive ? IconPlayerPlay : IconPlayerPause;

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/queries/getConversationCounts.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/queries/getConversationCounts.ts
@@ -15,3 +15,34 @@ export const CONVERSATION_COUNTS = gql`
     )
   }
 `;
+
+export const CONVERSATION_FILTER_COUNTS = gql`
+  query FrontlineInboxConversationFilterCounts(
+    $channelId: String
+    $integrationId: String
+    $integrationType: String
+    $brandId: String
+    $startDate: String
+    $endDate: String
+    $searchValue: String
+  ) {
+    unresolved: conversationsTotalCount(
+      channelId: $channelId
+      integrationId: $integrationId
+      integrationType: $integrationType
+      brandId: $brandId
+      startDate: $startDate
+      endDate: $endDate
+      searchValue: $searchValue
+    )
+    conversationCounts(
+      channelId: $channelId
+      integrationId: $integrationId
+      integrationType: $integrationType
+      brandId: $brandId
+      startDate: $startDate
+      endDate: $endDate
+      searchValue: $searchValue
+    )
+  }
+`;

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversationCounts.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversationCounts.tsx
@@ -1,12 +1,54 @@
 import { useQuery } from '@apollo/client';
 
-import { CONVERSATION_COUNTS } from '@/inbox/conversations/graphql/queries/getConversationCounts';
+import {
+  CONVERSATION_COUNTS,
+  CONVERSATION_FILTER_COUNTS,
+} from '@/inbox/conversations/graphql/queries/getConversationCounts';
 
 export type TConversationCounts = Record<string, number>;
 
 type TConversationCountsResponse = {
   conversationCounts: {
     byIntegrationTypes?: TConversationCounts;
+  };
+};
+
+type TConversationFilterCountsResponse = {
+  unresolved: number;
+  conversationCounts: {
+    unassigned?: number;
+    participating?: number;
+    awaitingResponse?: number;
+    resolved?: number;
+  };
+};
+
+type ConversationFilterCountVariables = {
+  channelId?: string | null;
+  integrationId?: string | null;
+  integrationType?: string | null;
+  brandId?: string | null;
+  startDate?: Date;
+  endDate?: Date;
+  searchValue?: string | null;
+};
+
+export const useConversationFilterCounts = (
+  variables: ConversationFilterCountVariables,
+) => {
+  const { data, loading } = useQuery<TConversationFilterCountsResponse>(
+    CONVERSATION_FILTER_COUNTS,
+    {
+      variables,
+      fetchPolicy: 'cache-and-network',
+    },
+  );
+
+  return {
+    counts: data
+      ? { ...data.conversationCounts, unresolved: data.unresolved }
+      : undefined,
+    loading,
   };
 };
 

--- a/frontend/plugins/frontline_ui/src/modules/inbox/hooks/useCompactWidth.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/hooks/useCompactWidth.tsx
@@ -46,16 +46,16 @@ export const useCompactWidth = <T extends HTMLElement>(
   return { ref, isCompact };
 };
 
-// Collapses on real overflow instead of a guessed breakpoint, and expands again
-// only once the width the full content needed is available, so it cannot flap.
+// Collapse secondary actions before the assignee.
 export const useOverflowCompact = <T extends HTMLElement>(): {
   ref: RefObject<T>;
   isCompact: boolean;
+  compactLevel: 0 | 1 | 2;
 } => {
   const ref = useRef<T>(null);
-  const requiredWidth = useRef(0);
-  const compactRef = useRef(false);
-  const [isCompact, setIsCompact] = useState(false);
+  const requiredWidths = useRef<[number, number]>([0, 0]);
+  const compactLevelRef = useRef<0 | 1 | 2>(0);
+  const [compactLevel, setCompactLevel] = useState<0 | 1 | 2>(0);
 
   const measure = useCallback(() => {
     const element = ref.current;
@@ -64,27 +64,38 @@ export const useOverflowCompact = <T extends HTMLElement>(): {
       return;
     }
 
-    const compact = compactRef.current;
-    const next = compact
-      ? element.clientWidth < requiredWidth.current
-      : element.scrollWidth > element.clientWidth;
+    const level = compactLevelRef.current;
+    let nextLevel = level;
 
-    if (!compact && next) {
-      requiredWidth.current = element.scrollWidth;
+    if (level === 0 && element.scrollWidth > element.clientWidth) {
+      requiredWidths.current[0] = element.scrollWidth;
+      nextLevel = 1;
+    } else if (level === 1) {
+      if (element.clientWidth >= requiredWidths.current[0]) {
+        nextLevel = 0;
+      } else if (element.scrollWidth > element.clientWidth) {
+        requiredWidths.current[1] = element.scrollWidth;
+        nextLevel = 2;
+      }
+    } else if (
+      level === 2 &&
+      element.clientWidth >= requiredWidths.current[1]
+    ) {
+      nextLevel = 1;
     }
 
     // Never dispatch while stable: this also runs on every render.
-    if (next === compact) {
+    if (nextLevel === level) {
       return;
     }
 
-    compactRef.current = next;
-    setIsCompact(next);
+    compactLevelRef.current = nextLevel;
+    setCompactLevel(nextLevel);
   }, []);
 
   // No dependency list: content can change without the element resizing.
   useLayoutEffect(measure);
   useResizeEffect(ref, measure);
 
-  return { ref, isCompact };
+  return { ref, isCompact: compactLevel > 0, compactLevel };
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/hooks/useCompactWidth.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/hooks/useCompactWidth.tsx
@@ -6,6 +6,8 @@ import {
   useState,
 } from 'react';
 
+type CompactLevel = 0 | 1 | 2;
+
 const useResizeEffect = (
   ref: RefObject<HTMLElement>,
   onResize: () => void,
@@ -50,12 +52,12 @@ export const useCompactWidth = <T extends HTMLElement>(
 export const useOverflowCompact = <T extends HTMLElement>(): {
   ref: RefObject<T>;
   isCompact: boolean;
-  compactLevel: 0 | 1 | 2;
+  compactLevel: CompactLevel;
 } => {
   const ref = useRef<T>(null);
   const requiredWidths = useRef<[number, number]>([0, 0]);
-  const compactLevelRef = useRef<0 | 1 | 2>(0);
-  const [compactLevel, setCompactLevel] = useState<0 | 1 | 2>(0);
+  const compactLevelRef = useRef<CompactLevel>(0);
+  const [compactLevel, setCompactLevel] = useState<CompactLevel>(0);
 
   const measure = useCallback(() => {
     const element = ref.current;

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { messageExtraInfoState } from '@/inbox/conversations/conversation-detail/states/messageExtraInfoState';
 import { EnumFacebookTag } from '@/integrations/facebook/types/FacebookTypes';
-import { useForm, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
+import {
+  useForm,
+  type SubmitHandler,
+  type UseFormReturn,
+} from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FACEBOOK_TAG_FORM_SCHEMA } from '../constants/FbTagSchema';
 import { z } from 'zod';

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
@@ -1,7 +1,6 @@
 import { differenceInHours } from 'date-fns';
 import { useFacebookConversationMessages } from '../hooks/useFacebookConversationMessages';
-import { Alert, Button, Form, ToggleGroup } from 'erxes-ui';
-import { IconExclamationCircle } from '@tabler/icons-react';
+import { Button, Dialog, Form, Select, Skeleton } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { messageExtraInfoState } from '@/inbox/conversations/conversation-detail/states/messageExtraInfoState';
@@ -27,44 +26,59 @@ export const FacebookTaggingForm = () => {
   };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-2">
-        <Form.Field
-          name="tag"
-          render={({ field }) => (
-            <Form.Item>
-              <Form.Control>
-                <ToggleGroup
-                  type="single"
-                  variant="outline"
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  className="gap-2"
-                >
-                  <ToggleGroup.Item
-                    value={EnumFacebookTag.CONFIRMED_EVENT_UPDATE}
-                  >
-                    {t('confirmed-event-update')}
-                  </ToggleGroup.Item>
-                  <ToggleGroup.Item
-                    value={EnumFacebookTag.POST_PURCHASE_UPDATE}
-                  >
-                    {t('post-purchase-update')}
-                  </ToggleGroup.Item>
-                  <ToggleGroup.Item value={EnumFacebookTag.ACCOUNT_UPDATE}>
-                    {t('account-update')}
-                  </ToggleGroup.Item>
-                </ToggleGroup>
-              </Form.Control>
-              <Form.Message />
-            </Form.Item>
-          )}
-        />
-        <Button variant="secondary" type="submit">
-          {t('submit')}
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button type="button" size="sm" variant="secondary">
+          {t('select-tag')}
         </Button>
-      </form>
-    </Form>
+      </Dialog.Trigger>
+      <Dialog.ContentCombined
+        title={t('select-tag')}
+        description={t('fb-24h-window-description')}
+        className="sm:max-w-sm"
+      >
+        <p className="text-sm text-muted-foreground">
+          {t('fb-24h-window-description')}
+        </p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <Form.Field
+              control={form.control}
+              name="tag"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t('tag')}</Form.Label>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <Form.Control>
+                      <Select.Trigger>
+                        <Select.Value placeholder={t('select-tag')} />
+                      </Select.Trigger>
+                    </Form.Control>
+                    <Select.Content>
+                      <Select.Item
+                        value={EnumFacebookTag.CONFIRMED_EVENT_UPDATE}
+                      >
+                        {t('confirmed-event-update')}
+                      </Select.Item>
+                      <Select.Item value={EnumFacebookTag.POST_PURCHASE_UPDATE}>
+                        {t('post-purchase-update')}
+                      </Select.Item>
+                      <Select.Item value={EnumFacebookTag.ACCOUNT_UPDATE}>
+                        {t('account-update')}
+                      </Select.Item>
+                    </Select.Content>
+                  </Select>
+                  <Form.Message />
+                </Form.Item>
+              )}
+            />
+            <Dialog.Footer>
+              <Button type="submit">{t('submit')}</Button>
+            </Dialog.Footer>
+          </form>
+        </Form>
+      </Dialog.ContentCombined>
+    </Dialog>
   );
 };
 
@@ -85,8 +99,8 @@ export const FacebookMessageInputWrapper = ({
 
   if (loading) {
     return (
-      <div className="flex-auto h-full px-6">
-        <div className="rounded-lg bg-sidebar h-full mx-auto max-w-2xl" />
+      <div className="flex h-full min-h-0 items-center justify-center p-4">
+        <Skeleton className="h-24 w-full max-w-lg rounded-lg" />
       </div>
     );
   }
@@ -97,17 +111,18 @@ export const FacebookMessageInputWrapper = ({
 
   if (lastMessageDate && isNotIn24Hours && !extraInfo?.tag) {
     return (
-      <div className="max-w-2xl mx-auto p-6">
-        <Alert className="">
-          <IconExclamationCircle />
-          <Alert.Title>
+      <div className="flex h-full min-h-0 items-center justify-center overflow-hidden p-4">
+        <div className="flex max-w-lg flex-col items-center gap-2 text-center">
+          <p className="text-sm font-medium text-foreground">
             {t('fb-24h-window-title')}
-          </Alert.Title>
-          <Alert.Description>
+          </p>
+          <p className="text-xs leading-5 text-muted-foreground">
             {t('fb-24h-window-description')}
+          </p>
+          <div className="pt-1">
             <FacebookTaggingForm />
-          </Alert.Description>
-        </Alert>
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
@@ -1,5 +1,5 @@
 import { differenceInHours } from 'date-fns';
-import { useFacebookConversationMessages } from '../hooks/useFacebookConversationMessages';
+import { useFacebookConversationMessages } from '@/integrations/facebook/hooks/useFacebookConversationMessages';
 import { Button, Dialog, Form, Select, Skeleton } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -11,7 +11,7 @@ import {
   type UseFormReturn,
 } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { FACEBOOK_TAG_FORM_SCHEMA } from '../constants/FbTagSchema';
+import { FACEBOOK_TAG_FORM_SCHEMA } from '@/integrations/facebook/constants/FbTagSchema';
 import { z } from 'zod';
 import { FACEBOOK_MESSAGE_WINDOW_HOURS } from '@/integrations/facebook/constants/FbMessageWindow';
 

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx
@@ -5,23 +5,102 @@ import { useTranslation } from 'react-i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { messageExtraInfoState } from '@/inbox/conversations/conversation-detail/states/messageExtraInfoState';
 import { EnumFacebookTag } from '@/integrations/facebook/types/FacebookTypes';
-import { useForm } from 'react-hook-form';
+import { useForm, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FACEBOOK_TAG_FORM_SCHEMA } from '../constants/FbTagSchema';
 import { z } from 'zod';
 import { FACEBOOK_MESSAGE_WINDOW_HOURS } from '@/integrations/facebook/constants/FbMessageWindow';
 
+type FacebookTagFormValues = z.infer<typeof FACEBOOK_TAG_FORM_SCHEMA>;
+
+const FacebookTagSelect = ({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+}) => {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <Form.Control>
+        <Select.Trigger>
+          <Select.Value placeholder={t('select-tag')} />
+        </Select.Trigger>
+      </Form.Control>
+      <Select.Content>
+        <Select.Item value={EnumFacebookTag.CONFIRMED_EVENT_UPDATE}>
+          {t('confirmed-event-update')}
+        </Select.Item>
+        <Select.Item value={EnumFacebookTag.POST_PURCHASE_UPDATE}>
+          {t('post-purchase-update')}
+        </Select.Item>
+        <Select.Item value={EnumFacebookTag.ACCOUNT_UPDATE}>
+          {t('account-update')}
+        </Select.Item>
+      </Select.Content>
+    </Select>
+  );
+};
+
+const FacebookTagField = ({
+  form,
+}: {
+  form: UseFormReturn<FacebookTagFormValues>;
+}) => {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <Form.Field
+      control={form.control}
+      name="tag"
+      render={({ field }) => (
+        <Form.Item>
+          <Form.Label>{t('tag')}</Form.Label>
+          <FacebookTagSelect
+            value={field.value}
+            onValueChange={field.onChange}
+          />
+          <Form.Message />
+        </Form.Item>
+      )}
+    />
+  );
+};
+
+const FacebookTagDialogForm = ({
+  form,
+  onSubmit,
+}: {
+  form: UseFormReturn<FacebookTagFormValues>;
+  onSubmit: SubmitHandler<FacebookTagFormValues>;
+}) => {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FacebookTagField form={form} />
+        <Dialog.Footer>
+          <Button type="submit">{t('submit')}</Button>
+        </Dialog.Footer>
+      </form>
+    </Form>
+  );
+};
+
 export const FacebookTaggingForm = () => {
   const { t } = useTranslation('frontline');
   const setExtraInfo = useSetAtom(messageExtraInfoState);
-  const form = useForm<z.infer<typeof FACEBOOK_TAG_FORM_SCHEMA>>({
+  const form = useForm<FacebookTagFormValues>({
     resolver: zodResolver(FACEBOOK_TAG_FORM_SCHEMA),
     defaultValues: {
       tag: EnumFacebookTag.CONFIRMED_EVENT_UPDATE,
     },
   });
 
-  const onSubmit = (data: z.infer<typeof FACEBOOK_TAG_FORM_SCHEMA>) => {
+  const onSubmit: SubmitHandler<FacebookTagFormValues> = (data) => {
     setExtraInfo((prev) => ({ ...prev, tag: data.tag }));
   };
 
@@ -40,43 +119,7 @@ export const FacebookTaggingForm = () => {
         <p className="text-sm text-muted-foreground">
           {t('fb-24h-window-description')}
         </p>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <Form.Field
-              control={form.control}
-              name="tag"
-              render={({ field }) => (
-                <Form.Item>
-                  <Form.Label>{t('tag')}</Form.Label>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <Form.Control>
-                      <Select.Trigger>
-                        <Select.Value placeholder={t('select-tag')} />
-                      </Select.Trigger>
-                    </Form.Control>
-                    <Select.Content>
-                      <Select.Item
-                        value={EnumFacebookTag.CONFIRMED_EVENT_UPDATE}
-                      >
-                        {t('confirmed-event-update')}
-                      </Select.Item>
-                      <Select.Item value={EnumFacebookTag.POST_PURCHASE_UPDATE}>
-                        {t('post-purchase-update')}
-                      </Select.Item>
-                      <Select.Item value={EnumFacebookTag.ACCOUNT_UPDATE}>
-                        {t('account-update')}
-                      </Select.Item>
-                    </Select.Content>
-                  </Select>
-                  <Form.Message />
-                </Form.Item>
-              )}
-            />
-            <Dialog.Footer>
-              <Button type="submit">{t('submit')}</Button>
-            </Dialog.Footer>
-          </form>
-        </Form>
+        <FacebookTagDialogForm form={form} onSubmit={onSubmit} />
       </Dialog.ContentCombined>
     </Dialog>
   );


### PR DESCRIPTION
## What changed

- show unresolved, resolved, unassigned, participated, and awaiting-response counts in the inbox filter menu
- pass the boolean inbox filters through to the conversation query correctly
- keep active filter chips usable in constrained and responsive inbox layouts
- restore the compact v2-style Facebook message-tag flow with a bordered prompt and a select dialog

## Why

The inbox filter menu did not expose category counts, and some boolean filter values were not forwarded to the conversation query. The Facebook 24-hour messaging-window prompt also rendered every tag inline, which made the composer area crowded and introduced unnecessary scrolling.

## Impact

Agents can see filter counts before selecting a filter, and the selected filters now affect the conversation list immediately. Facebook conversations outside the messaging window use a compact prompt and open tag selection in a dialog, leaving the composer surface uncluttered.

## Validation

- `npx eslint` on all six changed files
- `pnpm exec tsc -p frontend/plugins/frontline_ui/tsconfig.json --noEmit --pretty false`
- `pnpm nx build frontline_ui`

## Summary by Sourcery

Add inbox filter count querying and display while correctly wiring boolean filters into conversation queries, and restore a compact Facebook tagging flow for conversations outside the 24-hour window.

New Features:
- Show unresolved, resolved, unassigned, participated, and awaiting-response conversation counts in the inbox filter popover.
- Introduce a dialog-based Facebook tag selection flow with a compact prompt for conversations outside the 24-hour messaging window.

Bug Fixes:
- Ensure boolean inbox filters for unassigned, participated, and awaiting-response are passed correctly into the conversation query variables.

Enhancements:
- Improve the responsiveness and usability of the conversation filter bar across inbox layouts, keeping active filter chips usable in constrained widths.
- Refine Facebook message input loading and 24-hour window prompt UIs using skeletons and compact centered layouts for a less intrusive experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversation filters for awaiting response, participation, and assignment status.
  * Filter results now display filtered counts, including unresolved conversations.
  * Improved responsive layouts for inbox headers, filters, and conversation details.
  * Updated Facebook tagging with a dialog-based selector and clearer 24-hour window guidance.
  * Added adaptive conversation actions for compact screen layouts.
* **Bug Fixes**
  * Improved loading states and responsiveness while Facebook tagging options are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->