### PR TITLE
fix(sales): add POS order search filter

### DIFF
--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/queries/orders.ts
@@ -58,9 +58,12 @@ const generateFilterPosQuery = async (models, params, currentUserId) => {
   }
 
   if (search) {
+    const searchRegex = new RegExp(escapeRegExp(search), 'i');
+
     query.$or = [
-      { number: { $regex: new RegExp(search) } },
-      { origin: { $regex: new RegExp(search) } },
+      { number: { $regex: searchRegex } },
+      { origin: { $regex: searchRegex } },
+      { description: { $regex: searchRegex } },
     ];
   }
 

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
@@ -174,7 +174,10 @@ export const PosOrderFilterPopover = () => {
       </Filter.Popover>
       <Filter.Dialog>
         <Filter.View filterKey="searchValue" inDialog>
-          <Filter.DialogStringView filterKey="searchValue" />
+          <Filter.DialogStringView
+            filterKey="searchValue"
+            label={t('search')}
+          />
         </Filter.View>
         <Filter.View filterKey="number" inDialog>
           <Filter.DialogStringView filterKey="number" />

--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/PosOrderFilter.tsx
@@ -34,6 +34,7 @@ import { SelectExcludeStatus } from './selects/SelectExcludeStatus';
 export const PosOrderFilterPopover = () => {
   const { t } = useTranslation('sales');
   const [queries] = useMultiQueryState<{
+    searchValue: string;
     number: string;
     types: string;
     user: string;
@@ -43,6 +44,7 @@ export const PosOrderFilterPopover = () => {
     paidDateRange: string;
     createdDateRange: string;
   }>([
+    'searchValue',
     'number',
     'types',
     'status',
@@ -73,6 +75,7 @@ export const PosOrderFilterPopover = () => {
                 className="bg-background"
               />
               <Command.List className="p-1 max-h-none">
+                <Filter.SearchValueTrigger />
                 <Filter.Item value="number" inDialog>
                   <IconHash />
                   {t('number')}
@@ -118,7 +121,7 @@ export const PosOrderFilterPopover = () => {
               mode="single"
               value={customer || ''}
               onValueChange={(value) => {
-                setCustomer(value as any);
+                setCustomer(value);
                 setCustomerName(null);
                 resetFilterState();
               }}
@@ -131,7 +134,7 @@ export const PosOrderFilterPopover = () => {
               mode="single"
               value={company || ''}
               onValueChange={(value) => {
-                setCompany(value as any);
+                setCompany(value);
                 resetFilterState();
               }}
             >
@@ -144,7 +147,7 @@ export const PosOrderFilterPopover = () => {
               mode="single"
               value={user || ''}
               onValueChange={(value) => {
-                setUser(value as any);
+                setUser(value);
                 resetFilterState();
               }}
             >
@@ -170,6 +173,9 @@ export const PosOrderFilterPopover = () => {
         </Combobox.Content>
       </Filter.Popover>
       <Filter.Dialog>
+        <Filter.View filterKey="searchValue" inDialog>
+          <Filter.DialogStringView filterKey="searchValue" />
+        </Filter.View>
         <Filter.View filterKey="number" inDialog>
           <Filter.DialogStringView filterKey="number" />
         </Filter.View>
@@ -195,7 +201,7 @@ export const PosOrderFilter = () => {
   const [open, setOpen] = useState<boolean>(false);
 
   const handleCustomerChange = (value: string) => {
-    setCustomer(value as string);
+    setCustomer(value);
     setCustomerName(null);
     setOpen(false);
   };
@@ -204,6 +210,7 @@ export const PosOrderFilter = () => {
     <Filter id="pos-orders-filter" sessionKey={sessionKey}>
       <Filter.Bar>
         <PosOrderFilterPopover />
+        <Filter.SearchValueBarItem />
         <Filter.BarItem queryKey="number">
           <Filter.BarName>
             <IconHash />
@@ -246,7 +253,7 @@ export const PosOrderFilter = () => {
             mode="single"
             value={company || ''}
             onValueChange={(value) => {
-              setCompany(value as any);
+              setCompany(value);
               setOpen(false);
             }}
           >
@@ -271,7 +278,7 @@ export const PosOrderFilter = () => {
             mode="single"
             value={user || ''}
             onValueChange={(value) => {
-              setUser(value as any);
+              setUser(value);
               setOpen(false);
             }}
           >


### PR DESCRIPTION
## Summary

- add the standard Search control to the Sales POS orders filter
- search order number, origin, and description with case-insensitive literal matching
- keep existing POS, customer, user, status, type, and date filters applied

## Validation

- sales_ui production build passed
- sales_api production build passed
- no test files added

## Summary by Sourcery

Add a text search filter to POS orders and extend backend search to support case-insensitive, escaped matching across order number, origin, and description.

New Features:
- Introduce a generic search value filter in the POS orders UI, integrated into the filter popover, bar, and dialog views.

Bug Fixes:
- Use correctly typed values for customer, company, and user selection handlers in POS order filters to avoid unnecessary type casting.

Enhancements:
- Update POS orders backend query to perform case-insensitive, escaped regex search across number, origin, and description fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added order search across order numbers, origins, and descriptions.
  * Added search controls to the POS order filter interface.
  * Search results are matched without regard to letter case.

* **Bug Fixes**
  * Improved search accuracy by treating special characters as literal text.
  * Standardized search behavior across order fields.
  * Improved consistency when updating customer, company, and user filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->