### PR TITLE
feat(sales): enable deal checklists

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/Overview.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/Overview.tsx
@@ -1,4 +1,5 @@
 import { AttachmentProvider } from './attachments/AttachmentContext';
+import { Checklists } from './checklist/Checklists';
 import { Separator } from 'erxes-ui';
 import { IAttachment } from '@/deals/types/attachments';
 import { IDeal } from '@/deals/types/deals';
@@ -14,6 +15,7 @@ export const Overview = ({ deal }: { deal: IDeal }) => {
       <div className="w-full xl:max-w-6xl mx-auto p-6 flex flex-col gap-3">
         <SalesFormFields deal={deal} />
         <Separator className="mt-1" />
+        <Checklists dealId={deal._id} stageId={deal.stageId} />
         <SalesNoteAndComment dealId={deal._id} />
       </div>
     </AttachmentProvider>

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/SalesFormFields.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { AttachmentUploader } from './attachments/AttachmentUploader';
 import { Attachments } from './attachments/Attachments';
 import { DealsActions } from '@/deals/actionBar/components/DealsActions';
+import { ChecklistOverview } from './checklist/ChecklistOverview';
 import {
   areIdListsEqual,
   rejectOnMutationError,
@@ -242,6 +243,7 @@ export const SalesFormFields = ({ deal }: { deal: IDeal }) => {
           />
         )}
         <DealsActions deals={[deal]} variant="inline" />
+        <ChecklistOverview />
       </div>
       <div className="flex">
         <AttachmentUploader />

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistForm.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistForm.tsx
@@ -1,17 +1,16 @@
-import { Button, Form, Input, Popover, cn, toast } from 'erxes-ui';
+import { Button, Form, Input, Popover, Spinner, toast } from 'erxes-ui';
 import {
   ChecklistFormType,
   checklistFormSchema,
 } from './constants/checklistFormSchema';
 
-import { IconLoader } from '@tabler/icons-react';
 import { useChecklistsAdd } from '@/deals/cards/hooks/useChecklists';
 import { useForm } from 'react-hook-form';
 import { useRef } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 
-const ChecklistForm = () => {
+export const ChecklistForm = () => {
   const form = useForm<ChecklistFormType>({
     resolver: zodResolver(checklistFormSchema),
   });
@@ -47,7 +46,7 @@ const ChecklistForm = () => {
         onSubmit={form.handleSubmit(onSubmit)}
         className="flex flex-col h-full overflow-hidden"
       >
-        <h3 className="text-sm font-semibold text-gray-600 border-b pb-2">
+        <h3 className="text-sm font-semibold text-muted-foreground border-b pb-2">
           {t('add-checklist')}
         </h3>
         <div className="flex-auto overflow-hidden py-2 px-1">
@@ -58,7 +57,7 @@ const ChecklistForm = () => {
               <Form.Item>
                 <Form.Label>{t('name')}</Form.Label>
                 <Form.Control>
-                  <Input {...field} className="" />
+                  <Input {...field} />
                 </Form.Control>
                 <Form.Message />
               </Form.Item>
@@ -67,29 +66,16 @@ const ChecklistForm = () => {
         </div>
 
         <div className="flex justify-end shrink-0 gap-3">
-          <Popover.Close ref={closeRef}>
-            <Button
-              type="button"
-              variant="ghost"
-              className="bg-background hover:bg-background/90"
-            >
+          <Popover.Close asChild ref={closeRef}>
+            <Button type="button" variant="ghost">
               {t('cancel')}
             </Button>
           </Popover.Close>
-          <Button
-            type="submit"
-            className={cn(
-              loading
-                ? 'bg-primary/50 text-primary-foreground'
-                : 'bg-primary text-primary-foreground hover:bg-primary/90',
-            )}
-          >
-            {loading ? <IconLoader className="w-4 h-4 animate-spin" /> : t('save')}
+          <Button type="submit" disabled={loading}>
+            {loading ? <Spinner /> : t('save')}
           </Button>
         </div>
       </form>
     </Form>
   );
 };
-
-export default ChecklistForm;

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItem.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItem.tsx
@@ -1,37 +1,51 @@
-import { Button, Collapsible, Spinner, cn, useConfirm, toast } from 'erxes-ui';
+import {
+  Button,
+  Collapsible,
+  Input,
+  Spinner,
+  cn,
+  toast,
+  useConfirm,
+} from 'erxes-ui';
 import { IChecklist, IChecklistItem } from '@/deals/types/checklists';
 import {
   useChecklistItemsAdd,
   useChecklistItemsReorder,
+  useChecklistsEdit,
   useChecklistsRemove,
 } from '@/deals/cards/hooks/useChecklists';
 
-import ChecklistItemAdd from './ChecklistItemAdd';
-import ChecklistItemContent from './ChecklistItemContent';
-import CircularProgressbar from '@/deals/components/common/CircularProgressbar';
+import { ChecklistItemAdd } from './ChecklistItemAdd';
+import { ChecklistItemContent } from './ChecklistItemContent';
+import { CircularProgressBar } from '@/deals/components/common/CircularProgressbar';
 import { IconTrash } from '@tabler/icons-react';
-import SortableList from '@/deals/components/common/SortableList';
-import { useState, useEffect } from 'react';
+import {
+  SortableList,
+  SortableReorderMeta,
+} from '@/deals/components/common/SortableList';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const ChecklistItem = ({
+export const ChecklistItem = ({
   item,
   stageId,
-  dealId,
-}: {
+}: Readonly<{
   item: IChecklist;
   stageId?: string;
-  dealId?: string;
-}) => {
+}>) => {
   const [open, setOpen] = useState(false);
 
   const [items, setItems] = useState<IChecklistItem[]>(item.items ?? []);
   const [adding, setAdding] = useState(false);
   const [newItem, setNewItem] = useState('');
   const [hideChecked, setHideChecked] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [title, setTitle] = useState(item.title);
+  const savingTitleRef = useRef(false);
 
   const { salesChecklistItemsAdd } = useChecklistItemsAdd();
   const { salesChecklistItemsReorder } = useChecklistItemsReorder();
+  const { salesChecklistsEdit } = useChecklistsEdit();
   const { salesChecklistsRemove, salesChecklistsRemoveLoading, error } =
     useChecklistsRemove();
   const { confirm } = useConfirm();
@@ -47,6 +61,10 @@ const ChecklistItem = ({
   }, [item]);
 
   useEffect(() => {
+    setTitle(item.title);
+  }, [item.title]);
+
+  useEffect(() => {
     if (error) {
       toast({
         title: t('error'),
@@ -56,63 +74,158 @@ const ChecklistItem = ({
     }
   }, [error]);
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     const lines = newItem
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
 
-    if (lines.length > 0) {
-      setNewItem('');
-      setAdding(false);
+    if (lines.length === 0) return;
 
-      lines.forEach((content, index) => {
-        salesChecklistItemsAdd({
+    setNewItem('');
+    setAdding(false);
+
+    for (const [index, content] of lines.entries()) {
+      try {
+        const { data } = await salesChecklistItemsAdd({
           variables: {
             checklistId: item._id,
             content,
           },
-          onCompleted: (data) => {
-            if (data?.salesChecklistItemsAdd) {
-              setItems((prev) => [...prev, data.salesChecklistItemsAdd]);
-            }
-          },
         });
-      });
+
+        if (data?.salesChecklistItemsAdd) {
+          setItems((prev) => [...prev, data.salesChecklistItemsAdd]);
+        }
+      } catch (addError) {
+        setNewItem(lines.slice(index).join('\n'));
+        setAdding(true);
+        toast({
+          title: t('error'),
+          description:
+            addError instanceof Error ? addError.message : t('unknown-error'),
+          variant: 'destructive',
+        });
+        return;
+      }
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleAdd();
+      void handleAdd();
     }
   };
 
-  const onReorderItems = (reOrderedItems: IChecklistItem[]) => {
-    setItems(reOrderedItems);
+  const saveTitle = () => {
+    if (savingTitleRef.current) return;
 
-    const movedItem = reOrderedItems.find(
-      (_, index) => items[index]._id !== reOrderedItems[index]._id,
-    );
+    const trimmed = title.trim();
 
-    if (!movedItem) return;
+    if (!trimmed || trimmed === item.title) {
+      setTitle(item.title);
+      setIsEditingTitle(false);
+      return;
+    }
 
-    const destinationIndex = reOrderedItems.findIndex(
-      (i) => i._id === movedItem._id,
-    );
+    savingTitleRef.current = true;
+    setIsEditingTitle(false);
 
-    salesChecklistItemsReorder({
+    salesChecklistsEdit({
       variables: {
-        destinationIndex,
-        _id: movedItem._id,
+        _id: item._id,
+        title: trimmed,
+      },
+      onCompleted: () => {
+        savingTitleRef.current = false;
+      },
+      onError: (editError) => {
+        savingTitleRef.current = false;
+        setTitle(item.title);
+        toast({
+          title: t('error'),
+          description: editError.message,
+          variant: 'destructive',
+        });
       },
     });
   };
 
-  const onDeleteChecklist = (e: React.MouseEvent, id: string) => {
-    e.stopPropagation();
+  const cancelEditingTitle = () => {
+    setTitle(item.title);
+    setIsEditingTitle(false);
+  };
 
+  const onTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      saveTitle();
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelEditingTitle();
+    }
+  };
+
+  const onReorderItems = (
+    reOrderedVisibleItems: IChecklistItem[],
+    { item: movedItem, newIndex }: SortableReorderMeta<IChecklistItem>,
+  ) => {
+    const precedingId =
+      newIndex > 0 ? reOrderedVisibleItems[newIndex - 1]._id : null;
+
+    const remainingItems = items.filter(
+      (current) => current._id !== movedItem._id,
+    );
+
+    const destinationIndex = precedingId
+      ? remainingItems.findIndex((current) => current._id === precedingId) + 1
+      : 0;
+
+    const previousItems = items;
+    const nextItems = [...remainingItems];
+    nextItems.splice(destinationIndex, 0, movedItem);
+
+    setItems(nextItems);
+
+    const movedPositions = nextItems
+      .map((current, index) => ({ _id: current._id, order: index + 1 }))
+      .filter(
+        ({ _id, order }) =>
+          previousItems.find((current) => current._id === _id)?.order !== order,
+      );
+
+    if (!movedPositions.length) return;
+
+    Promise.all(
+      movedPositions.map(({ _id, order }) =>
+        salesChecklistItemsReorder({
+          variables: {
+            destinationIndex: order,
+            _id,
+          },
+        }),
+      ),
+    ).catch((reorderError) => {
+      setItems(previousItems);
+      toast({
+        title: t('error'),
+        description:
+          reorderError instanceof Error
+            ? reorderError.message
+            : t('unknown-error', 'Unknown error'),
+        variant: 'destructive',
+      });
+    });
+  };
+
+  const onDeleteChecklist = (id: string) => {
     confirm({
       message: t('delete-checklist-confirm', { title: item.title }),
     }).then(() => {
@@ -120,10 +233,10 @@ const ChecklistItem = ({
         variables: {
           _id: id,
         },
-        onError: (error) => {
+        onError: (removeError) => {
           if (
-            error.message?.includes('permission') ||
-            error.message?.includes('denied')
+            removeError.message?.includes('permission') ||
+            removeError.message?.includes('denied')
           ) {
             toast({
               title: t('permission-denied'),
@@ -138,15 +251,39 @@ const ChecklistItem = ({
 
   return (
     <Collapsible
-      className="checklists mb-4 bg-accent rounded-lg hover:rounded-lg"
+      className="checklists mb-2 overflow-hidden rounded-md"
       open={open}
       onOpenChange={setOpen}
     >
-      <Collapsible.TriggerButton className="flex items-center justify-between gap-2 h-full p-2">
-        <div className="flex items-center gap-2 flex-1">
-          <Collapsible.TriggerIcon className="group-data-[state=open]/checklists:rotate-180" />
-          <h4 className="text-sm">{item.title}</h4>
-          <CircularProgressbar
+      <div className="flex items-center justify-between gap-2 py-2">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <Collapsible.TriggerButton
+            className="size-6 w-auto shrink-0 justify-center p-0"
+            aria-label={item.title}
+          >
+            <Collapsible.TriggerIcon className="size-5 shrink-0" />
+          </Collapsible.TriggerButton>
+          {isEditingTitle ? (
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={onTitleKeyDown}
+              onBlur={saveTitle}
+              className="h-7 flex-1"
+              autoFocus
+            />
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto min-w-0 justify-start px-1 py-0.5 font-medium text-foreground"
+              title={t('edit')}
+              onClick={() => setIsEditingTitle(true)}
+            >
+              <span className="min-w-0 truncate">{item.title}</span>
+            </Button>
+          )}
+          <CircularProgressBar
             value={checkedCount}
             max={items.length || 1}
             size={20}
@@ -154,17 +291,13 @@ const ChecklistItem = ({
             strokeWidth={3}
           />
         </div>
+
         <div className="flex items-center gap-2">
           {open && (
             <Button
               variant="outline"
               size="sm"
-              onPointerDown={(e) => e.stopPropagation()}
-              onPointerUp={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                setHideChecked(!hideChecked);
-              }}
+              onClick={() => setHideChecked(!hideChecked)}
             >
               {hideChecked
                 ? t('show-checked-items', { count: checkedCount })
@@ -174,34 +307,35 @@ const ChecklistItem = ({
 
           <Button
             variant="destructive"
-            onClick={(e) => onDeleteChecklist(e, item._id)}
+            onClick={() => onDeleteChecklist(item._id)}
             title={t('delete-checklist')}
             size="sm"
-            onPointerDown={(e) => e.stopPropagation()}
-            onPointerUp={(e) => e.stopPropagation()}
-            className={cn(salesChecklistsRemoveLoading && 'opacity-50')}
+            disabled={salesChecklistsRemoveLoading}
           >
             <IconTrash />{' '}
             {salesChecklistsRemoveLoading ? <Spinner /> : t('delete')}
           </Button>
         </div>
-      </Collapsible.TriggerButton>
+      </div>
 
       <Collapsible.Content
-        className={cn(open && 'flex flex-col gap-1 py-1 pl-2 bg-white')}
+        className={cn(open && 'flex flex-col gap-1 py-1 pl-6')}
       >
         <SortableList
           items={hideChecked ? items.filter((i) => !i.isChecked) : items}
-          onReorder={(items) => onReorderItems(items)}
-          itemKey="_id"
+          onReorder={onReorderItems}
+          dragHandleLabel={t('reorder', 'Reorder')}
           className="flex flex-col gap-1"
-          renderItem={(item: IChecklistItem, index: number) => (
+          renderItem={(
+            checklistItem: IChecklistItem,
+            _index: number,
+            itemDragHandle: React.ReactNode,
+          ) => (
             <ChecklistItemContent
-              item={item}
-              index={index}
+              item={checklistItem}
               setItems={setItems}
               stageId={stageId}
-              dealId={dealId}
+              dragHandle={itemDragHandle}
             />
           )}
         />
@@ -218,5 +352,3 @@ const ChecklistItem = ({
     </Collapsible>
   );
 };
-
-export default ChecklistItem;

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItemAdd.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItemAdd.tsx
@@ -1,72 +1,67 @@
+import { Button, Textarea } from 'erxes-ui';
+
 import { IconPlus } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 
-
-const ChecklistItemAdd = ({
+export const ChecklistItemAdd = ({
   adding,
   setAdding,
   newItem,
   setNewItem,
   handleAdd,
   handleKeyDown,
-}: {
+}: Readonly<{
   adding: boolean;
   setAdding: React.Dispatch<React.SetStateAction<boolean>>;
   newItem: string;
   setNewItem: React.Dispatch<React.SetStateAction<string>>;
-  handleAdd: () => void;
+  handleAdd: () => void | Promise<void>;
   handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-}) => {
+}>) => {
   const { t } = useTranslation('sales');
+
   if (adding) {
     return (
       <div className="flex flex-col gap-2 p-2">
-        <textarea
-          className="border border-gray-300 rounded px-2 py-1 text-sm w-full resize-none focus:outline-hidden focus:ring-1 focus:ring-indigo-500"
+        <Textarea
           placeholder={t('enter-items-each-on-new-line')}
           value={newItem}
           onChange={(e) => setNewItem(e.target.value)}
           onKeyDown={handleKeyDown}
-          rows={3}
+          rows={1}
+          className="min-h-0 resize-none px-2 py-1.5 text-xs"
           autoFocus
         />
         <div className="flex gap-2">
-          <button
-            onClick={handleAdd}
-            className="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700"
-          >
+          <Button size="sm" onClick={handleAdd} disabled={!newItem.trim()}>
             {t('add')}
-          </button>
-          <button
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
             onClick={() => {
               setAdding(false);
               setNewItem('');
             }}
-            className="px-3 py-1 rounded border hover:bg-gray-100"
           >
             {t('cancel')}
-          </button>
+          </Button>
         </div>
       </div>
     );
   }
 
   return (
-    <div
-      className="flex items-center gap-1 p-2 text-xs cursor-pointer hover:bg-slate-100 transition select-none"
+    <Button
+      variant="ghost"
+      size="sm"
+      className="justify-start gap-2 p-1 text-xs font-normal"
       onClick={() => setAdding(true)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          setAdding(true);
-        }
-      }}
     >
-      <IconPlus size={14} />
+      <span className="flex size-5 shrink-0 items-center justify-center">
+        <IconPlus className="size-4" />
+      </span>
       {t('add-an-item')}
-    </div>
+    </Button>
   );
 };
-
-export default ChecklistItemAdd;

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItemContent.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistItemContent.tsx
@@ -1,4 +1,12 @@
-import { Checkbox, toast, useConfirm } from 'erxes-ui';
+import {
+  Button,
+  Checkbox,
+  DropdownMenu,
+  Textarea,
+  cn,
+  toast,
+  useConfirm,
+} from 'erxes-ui';
 import { IconDotsVertical, IconRefresh, IconTrash } from '@tabler/icons-react';
 import {
   useChecklistItemsEdit,
@@ -6,27 +14,25 @@ import {
 } from '@/deals/cards/hooks/useChecklists';
 import { useEffect, useRef, useState } from 'react';
 
-import { GET_CHECKLIST_DETAIL } from '~/modules/deals/graphql/queries/ChecklistQueries';
 import { GET_STAGE_DETAIL } from '~/modules/deals/graphql/queries/StagesQueries';
 import { IChecklistItem } from '@/deals/types/checklists';
 import { useDealsAdd } from '@/deals/cards/hooks/useDeals';
 import { useTranslation } from 'react-i18next';
 
-
-const ChecklistItemContent = ({
+export const ChecklistItemContent = ({
   item,
-  index,
   setItems,
   stageId,
-  dealId,
-}: {
+  dragHandle,
+}: Readonly<{
   item: IChecklistItem;
-  index: number;
   setItems: React.Dispatch<React.SetStateAction<IChecklistItem[]>>;
   stageId?: string;
-  dealId?: string;
-}) => {
-  const [activeMenuIndex, setActiveMenuIndex] = useState<number | null>(null);
+  dragHandle?: React.ReactNode;
+}>) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(item.content);
+  const savingContentRef = useRef(false);
   const { confirm } = useConfirm();
   const { t } = useTranslation('sales');
   const { salesChecklistItemsEdit } = useChecklistItemsEdit();
@@ -42,77 +48,135 @@ const ChecklistItemContent = ({
 
   const { addDeals } = useDealsAdd();
 
-  const menuRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        activeMenuIndex === index &&
-        menuRef.current &&
-        !menuRef.current.contains(e.target as Node)
-      ) {
-        setActiveMenuIndex(null);
-      }
-    };
+    setContent(item.content);
+  }, [item.content]);
 
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [activeMenuIndex, index]);
-
-  const toggleChecked = (id: string) => {
-    setItems((prev) =>
-      prev.map((item) =>
-        item._id === id ? { ...item, isChecked: !item.isChecked } : item,
-      ),
-    );
+  const removeItem = (id: string) => {
+    salesChecklistItemsRemove({
+      variables: { _id: id },
+      onCompleted: () => {
+        setItems((prev) => prev.filter((current) => current._id !== id));
+      },
+      onError: (error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+      },
+    });
   };
 
   const handleRemove = (id: string) => {
     confirm({
       message: t('are-you-sure'),
-    }).then(() => {
-      salesChecklistItemsRemove({
-        variables: {
-          _id: id,
-        },
-        refetchQueries: [
-          {
-            query: GET_CHECKLIST_DETAIL,
-            variables: {
-              _id: dealId,
-            },
-          },
-        ],
-        onCompleted: () => {
-          setItems((prev) => prev.filter((item) => item._id !== id));
-          setActiveMenuIndex(null);
-        },
-      });
-    });
+    }).then(() => removeItem(id));
   };
 
-  const onChangeChecked = (id: string) => {
-    toggleChecked(id);
+  const onChangeChecked = () => {
+    const isChecked = !item.isChecked;
+
+    setItems((prev) =>
+      prev.map((current) =>
+        current._id === item._id ? { ...current, isChecked } : current,
+      ),
+    );
 
     salesChecklistItemsEdit({
       variables: {
-        _id: id,
-        isChecked: !item.isChecked,
+        _id: item._id,
+        isChecked,
+      },
+      onError: (error) => {
+        setItems((prev) =>
+          prev.map((current) =>
+            current._id === item._id
+              ? { ...current, isChecked: !isChecked }
+              : current,
+          ),
+        );
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
       },
     });
   };
 
+  const saveContent = () => {
+    if (savingContentRef.current) return;
+
+    const trimmed = content.trim();
+
+    if (!trimmed || trimmed === item.content) {
+      setContent(item.content);
+      setIsEditing(false);
+      return;
+    }
+
+    savingContentRef.current = true;
+    setIsEditing(false);
+    setItems((prev) =>
+      prev.map((current) =>
+        current._id === item._id ? { ...current, content: trimmed } : current,
+      ),
+    );
+
+    salesChecklistItemsEdit({
+      variables: {
+        _id: item._id,
+        content: trimmed,
+      },
+      onCompleted: () => {
+        savingContentRef.current = false;
+      },
+      onError: (error) => {
+        savingContentRef.current = false;
+        setContent(item.content);
+        setItems((prev) =>
+          prev.map((current) =>
+            current._id === item._id
+              ? { ...current, content: item.content }
+              : current,
+          ),
+        );
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+      },
+    });
+  };
+
+  const cancelEditing = () => {
+    setContent(item.content);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      saveContent();
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelEditing();
+    }
+  };
+
   const onConvert = () => {
-    setActiveMenuIndex(null);
     addDeals({
       variables: {
         name: item.content,
-        stageId: stageId,
+        stageId,
       },
-      refetchQueries: dealId
+      refetchQueries: stageId
         ? [
             {
               query: GET_STAGE_DETAIL,
@@ -122,14 +186,12 @@ const ChecklistItemContent = ({
             },
           ]
         : [],
-
       onCompleted: () => {
         toast({
           title: t('success'),
           description: t('checklist-item-converted'),
-          variant: 'default',
         });
-        handleRemove(item._id);
+        removeItem(item._id);
       },
       onError: (error) => {
         toast({
@@ -141,73 +203,75 @@ const ChecklistItemContent = ({
     });
   };
 
-  return (
-    <div
-      key={item._id}
-      className="border-b border-gray-100 pointer-events-auto flex items-center justify-between p-1 gap-2 group relative"
-    >
-      <div className="flex items-center gap-2 text-xs">
-        <div
-          onPointerDown={(e) => e.stopPropagation()}
-          onPointerUp={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Checkbox
-            checked={item.isChecked || false}
-            onCheckedChange={() => onChangeChecked(item._id)}
-          />
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-2 p-1">
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          className="min-h-0 resize-none px-2 py-1.5 text-xs"
+          autoFocus
+        />
+        <div className="flex gap-2">
+          <Button size="sm" onClick={saveContent}>
+            {t('save')}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={cancelEditing}>
+            {t('cancel')}
+          </Button>
         </div>
-        <span
-          className={`text-xs ${
-            item.isChecked ? 'line-through text-gray-400' : ''
-          } select-none`}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between p-1 gap-2 relative rounded hover:bg-accent-foreground/10 transition-colors">
+      <div className="flex items-center gap-2 text-xs">
+        {dragHandle}
+        <Checkbox
+          checked={item.isChecked || false}
+          onCheckedChange={onChangeChecked}
+        />
+        <button
+          type="button"
+          title={t('edit')}
+          className={cn(
+            'text-xs text-left select-none',
+            item.isChecked && 'line-through text-muted-foreground',
+          )}
+          onClick={() => setIsEditing(true)}
         >
           {item.content}
-        </span>
-      </div>
-
-      <div
-        className="relative"
-        ref={menuRef}
-        onClick={(e) => e.stopPropagation()}
-        onPointerUp={(e) => e.stopPropagation()}
-        onPointerDown={(e) => e.stopPropagation()}
-      >
-        <button
-          onClick={(e) => {
-            setActiveMenuIndex(activeMenuIndex === index ? null : index);
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onPointerUp={(e) => e.stopPropagation()}
-          className="opacity-0 group-hover:opacity-100 transition"
-          aria-label={t('more-actions')}
-        >
-          <IconDotsVertical size={18} />
         </button>
-
-        {activeMenuIndex === index && (
-          <div className="absolute right-0 top-full mt-1 z-20 w-36 bg-white border rounded shadow-md">
-            <button
-              onClick={onConvert}
-              className="flex items-center gap-2 px- py-2 hover:bg-gray-100 w-full text-sm"
-            >
-              <IconRefresh size={16} className="ml-3" />
-              {t('convert-to-deal')}
-            </button>
-            <button
-              onClick={() => {
-                handleRemove(item._id);
-              }}
-              className="flex items-center gap-2 px-3 py-2 text-red-600 hover:bg-red-50 w-full text-sm"
-            >
-              <IconTrash size={16} />
-              {t('delete')}
-            </button>
-          </div>
-        )}
       </div>
+
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground"
+            aria-label={t('more-actions')}
+          >
+            <IconDotsVertical />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" className="w-44 min-w-fit!">
+          <DropdownMenu.Item onClick={onConvert} disabled={!stageId}>
+            <IconRefresh />
+            {t('convert-to-deal')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onClick={() => handleRemove(item._id)}
+            className="text-destructive focus:text-destructive"
+          >
+            <IconTrash className="text-destructive" />
+            {t('delete')}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
     </div>
   );
 };
-
-export default ChecklistItemContent;

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistOverview.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/ChecklistOverview.tsx
@@ -1,20 +1,19 @@
-import { Filter, Popover } from 'erxes-ui';
+import { Button, Popover } from 'erxes-ui';
 
-import ChecklistForm from './ChecklistForm';
+import { ChecklistForm } from './ChecklistForm';
 import { IconListCheck } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 
-const ChecklistOverview = () => {
+export const ChecklistOverview = ({ label }: Readonly<{ label?: string }>) => {
   const { t } = useTranslation('sales');
+
   return (
     <Popover>
-      <Popover.Trigger>
-        <Filter.BarButton filterKey="status">
-          <div className="flex items-center gap-1">
-            <IconListCheck size={16} />
-            {t('add-new-checklist')}
-          </div>
-        </Filter.BarButton>
+      <Popover.Trigger asChild>
+        <Button variant="outline" size="sm" className="h-7 gap-1.5 px-2">
+          <IconListCheck />
+          {label ?? t('checklist', 'Checklist')}
+        </Button>
       </Popover.Trigger>
       <Popover.Content>
         <ChecklistForm />
@@ -22,5 +21,3 @@ const ChecklistOverview = () => {
     </Popover>
   );
 };
-
-export default ChecklistOverview;

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/Checklists.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/overview/checklist/Checklists.tsx
@@ -1,27 +1,67 @@
-import ChecklistItem from './ChecklistItem';
+import { ChecklistItem } from './ChecklistItem';
+import { Empty, Separator, Spinner } from 'erxes-ui';
+import { IconListCheck } from '@tabler/icons-react';
 import { useChecklists } from '@/deals/cards/hooks/useChecklists';
+import { useTranslation } from 'react-i18next';
 
 export const Checklists = ({
   stageId,
   dealId,
-}: {
+}: Readonly<{
   stageId?: string;
   dealId?: string;
-}) => {
-  const { checklists } = useChecklists();
+}>) => {
+  const { t } = useTranslation('sales');
+  const { checklists, loading, error } = useChecklists({
+    variables: { contentTypeId: dealId },
+  });
 
-  if (!checklists || checklists.length === 0) return null;
+  if (loading && !checklists) {
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error && !checklists) {
+    return (
+      <>
+        <Empty className="border-0 bg-transparent py-4">
+          <Empty.Header>
+            <Empty.Media variant="icon">
+              <IconListCheck />
+            </Empty.Media>
+            <Empty.Title>
+              {t('failed-to-load-checklists', 'Failed to load checklists')}
+            </Empty.Title>
+            <Empty.Description>{error.message}</Empty.Description>
+          </Empty.Header>
+        </Empty>
+        <Separator className="mt-1" />
+      </>
+    );
+  }
+
+  if (!checklists || checklists.length === 0) {
+    return null;
+  }
 
   return (
-    <div className="py-2">
-      {checklists?.map((checklist) => (
-        <ChecklistItem
-          key={checklist._id}
-          item={checklist}
-          stageId={stageId}
-          dealId={dealId}
-        />
-      ))}
-    </div>
+    <>
+      <div className="flex flex-col gap-2">
+        <h4 className="text-sm font-medium">{t('checklists', 'Checklists')}</h4>
+        <div className="py-2">
+          {checklists.map((checklist) => (
+            <ChecklistItem
+              key={checklist._id}
+              item={checklist}
+              stageId={stageId}
+            />
+          ))}
+        </div>
+      </div>
+      <Separator className="mt-1" />
+    </>
   );
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useChecklists.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/hooks/useChecklists.tsx
@@ -4,6 +4,7 @@ import {
   CHECKLIST_ITEMS_EDIT,
   CHECKLIST_ITEMS_ORDER,
   CHECKLIST_ITEMS_REMOVE,
+  EDIT_CHECKLISTS,
   REMOVE_CHECKLISTS,
 } from '@/deals/graphql/mutations/ChecklistMutations';
 import { GET_CHECKLISTS } from '@/deals/graphql/queries/ChecklistQueries';
@@ -30,15 +31,37 @@ function useDealContentTypeId(passedContentTypeId?: string | null) {
   return passedContentTypeId || salesItemId || activeDealId;
 }
 
-type AddChecklistResult = {
-  checklistsAdd: IChecklist;
+type ChecklistAddResult = { salesChecklistsAdd: IChecklist };
+type ChecklistEditResult = { salesChecklistsEdit: IChecklist };
+type ChecklistRemoveResult = { salesChecklistsRemove: Pick<IChecklist, '_id'> };
+type ChecklistItemAddResult = { salesChecklistItemsAdd: IChecklistItem };
+type ChecklistItemEditResult = { salesChecklistItemsEdit: IChecklistItem };
+type ChecklistItemRemoveResult = {
+  salesChecklistItemsRemove: Pick<IChecklistItem, '_id'>;
 };
-type AddChecklistItemResult = {
-  checklistItemsAdd: IChecklistItem;
+type ChecklistItemOrderResult = {
+  salesChecklistItemsOrder: Pick<IChecklistItem, '_id'>;
 };
+type ChecklistVariables = Partial<{
+  _id: string;
+  contentTypeId: string | null;
+  title: string;
+}>;
+
+type ChecklistItemVariables = Partial<{
+  _id: string;
+  checklistId: string;
+  content: string;
+  isChecked: boolean;
+}>;
+
+type ChecklistItemOrderVariables = Partial<{
+  _id: string;
+  destinationIndex: number;
+}>;
 
 export function useChecklistsAdd(
-  options?: MutationHookOptions<AddChecklistResult, any>,
+  options?: MutationHookOptions<ChecklistAddResult, ChecklistVariables>,
 ) {
   const contentTypeId = useDealContentTypeId(options?.variables?.contentTypeId);
 
@@ -67,8 +90,25 @@ export function useChecklistsAdd(
   };
 }
 
+export function useChecklistsEdit(
+  options?: MutationHookOptions<ChecklistEditResult, ChecklistVariables>,
+) {
+  const [salesChecklistsEdit, { loading, error }] = useMutation(
+    EDIT_CHECKLISTS,
+    {
+      ...options,
+    },
+  );
+
+  return {
+    salesChecklistsEdit,
+    loading,
+    error,
+  };
+}
+
 export function useChecklistsRemove(
-  options?: MutationHookOptions<AddChecklistItemResult, any>,
+  options?: MutationHookOptions<ChecklistRemoveResult, ChecklistVariables>,
 ) {
   const contentTypeId = useDealContentTypeId(options?.variables?.contentTypeId);
 
@@ -97,14 +137,14 @@ export function useChecklistsRemove(
 }
 
 export function useChecklistItemsAdd(
-  options?: MutationHookOptions<AddChecklistItemResult, any>,
+  options?: MutationHookOptions<ChecklistItemAddResult, ChecklistItemVariables>,
 ) {
-  const [salesChecklistItemsAdd, { loading, error }] = useMutation(
-    CHECKLIST_ITEMS_ADD,
-    {
-      ...options,
-    },
-  );
+  const [salesChecklistItemsAdd, { loading, error }] = useMutation<
+    ChecklistItemAddResult,
+    ChecklistItemVariables
+  >(CHECKLIST_ITEMS_ADD, {
+    ...options,
+  });
 
   return {
     salesChecklistItemsAdd,
@@ -114,7 +154,10 @@ export function useChecklistItemsAdd(
 }
 
 export function useChecklistItemsEdit(
-  options?: MutationHookOptions<AddChecklistItemResult, any>,
+  options?: MutationHookOptions<
+    ChecklistItemEditResult,
+    ChecklistItemVariables
+  >,
 ) {
   const [salesChecklistItemsEdit, { loading, error }] = useMutation(
     CHECKLIST_ITEMS_EDIT,
@@ -131,7 +174,10 @@ export function useChecklistItemsEdit(
 }
 
 export function useChecklistItemsRemove(
-  options?: MutationHookOptions<AddChecklistItemResult, any>,
+  options?: MutationHookOptions<
+    ChecklistItemRemoveResult,
+    ChecklistItemVariables
+  >,
 ) {
   const [salesChecklistItemsRemove, { loading, error }] = useMutation(
     CHECKLIST_ITEMS_REMOVE,
@@ -148,7 +194,10 @@ export function useChecklistItemsRemove(
 }
 
 export function useChecklistItemsReorder(
-  options?: MutationHookOptions<AddChecklistItemResult, any>,
+  options?: MutationHookOptions<
+    ChecklistItemOrderResult,
+    ChecklistItemOrderVariables
+  >,
 ) {
   const [salesChecklistItemsReorder, { loading, error }] = useMutation(
     CHECKLIST_ITEMS_ORDER,
@@ -189,7 +238,8 @@ export const useChecklists = (
   });
 
   const checklistIds = useMemo(
-    () => data?.salesChecklists?.map((checklist) => checklist._id).join(',') ?? '',
+    () =>
+      data?.salesChecklists?.map((checklist) => checklist._id).join(',') ?? '',
     [data?.salesChecklists],
   );
 
@@ -217,12 +267,12 @@ export const useChecklists = (
   }, [contentTypeId, refetch, subscribeToMore]);
 
   useEffect(() => {
-    if (!contentTypeId || !data?.salesChecklists?.length) return;
+    if (!contentTypeId || !checklistIds) return;
 
-    const unsubscribes = data.salesChecklists.map((checklist) =>
+    const unsubscribes = checklistIds.split(',').map((_id) =>
       subscribeToMore<ISalesChecklistDetailChangedPayload>({
         document: CHECKLIST_DETAIL_CHANGED,
-        variables: { _id: checklist._id },
+        variables: { _id },
         updateQuery: (prev, { subscriptionData }) => {
           if (!subscriptionData.data?.salesChecklistDetailChanged) {
             return prev;
@@ -238,7 +288,7 @@ export const useChecklists = (
     return () => {
       unsubscribes.forEach((unsubscribe) => unsubscribe());
     };
-  }, [checklistIds, contentTypeId, data?.salesChecklists, refetch, subscribeToMore]);
+  }, [checklistIds, contentTypeId, refetch, subscribeToMore]);
 
-  return { checklists: data?.salesChecklists, loading, error };
+  return { checklists: data?.salesChecklists, loading, error, refetch };
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/components/common/CircularProgressbar.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/common/CircularProgressbar.tsx
@@ -13,15 +13,17 @@ interface CircularProgressBarProps {
   className?: string;
 }
 
-const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
+export const CircularProgressBar: React.FC<
+  Readonly<CircularProgressBarProps>
+> = ({
   value,
   max,
   size = 80,
   strokeWidth = 8,
   showText = true,
-  textColor = 'text-black',
-  progressColor = '#4f46e5',
-  trackColor = '#e5e7eb',
+  textColor = 'text-foreground',
+  progressColor = 'var(--primary)',
+  trackColor = 'var(--muted)',
   className,
 }) => {
   const radius = (size - strokeWidth) / 2;
@@ -63,5 +65,3 @@ const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
     </div>
   );
 };
-
-export default CircularProgressBar;

--- a/frontend/plugins/sales_ui/src/modules/deals/components/common/SortableList.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/common/SortableList.tsx
@@ -1,5 +1,6 @@
 import {
   DndContext,
+  DragEndEvent,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
@@ -12,45 +13,58 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+
 import { CSS } from '@dnd-kit/utilities';
 import React from 'react';
+import { DragHandle, cn } from 'erxes-ui';
 
-type SortableItemType = {
-  [key: string]: any;
+type SortableItemType = { _id: string };
+
+export type SortableReorderMeta<T> = {
+  item: T;
+  oldIndex: number;
+  newIndex: number;
 };
 
 type Props<T extends SortableItemType> = {
   items: T[];
-  onReorder: (items: T[]) => void;
-  renderItem: (item: T, index: number) => React.ReactNode;
+  onReorder: (items: T[], meta: SortableReorderMeta<T>) => void;
+  renderItem: (
+    item: T,
+    index: number,
+    dragHandle: React.ReactNode,
+  ) => React.ReactNode;
+  dragHandleLabel: string;
   className?: string;
-  itemKey?: keyof T;
 };
 
-export default function SortableList<T extends SortableItemType>({
+export function SortableList<T extends SortableItemType>({
   items,
   onReorder,
   renderItem,
+  dragHandleLabel,
   className = '',
-  itemKey = 'id',
-}: Props<T>) {
+}: Readonly<Props<T>>) {
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor),
   );
 
-  const handleDragEnd = (event: any) => {
+  const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
     if (!over || active.id === over.id) return;
 
-    const oldIndex = items.findIndex((i) => i[itemKey] === active.id);
-    const newIndex = items.findIndex((i) => i[itemKey] === over.id);
+    const oldIndex = items.findIndex((item) => item._id === active.id);
+    const newIndex = items.findIndex((item) => item._id === over.id);
 
     if (oldIndex === -1 || newIndex === -1) return;
 
-    const reordered = arrayMove(items, oldIndex, newIndex);
-    onReorder(reordered);
+    onReorder(arrayMove(items, oldIndex, newIndex), {
+      item: items[oldIndex],
+      oldIndex,
+      newIndex,
+    });
   };
 
   return (
@@ -60,14 +74,17 @@ export default function SortableList<T extends SortableItemType>({
       onDragEnd={handleDragEnd}
     >
       <SortableContext
-        items={items.map((item) => item[itemKey])}
+        items={items.map((item) => item._id)}
         strategy={verticalListSortingStrategy}
       >
         <div className={className}>
           {items.map((item, index) => (
-            <SortableItem key={item[itemKey]} id={item[itemKey]}>
-              {renderItem(item, index)}
-            </SortableItem>
+            <SortableItem
+              key={item._id}
+              id={item._id}
+              dragHandleLabel={dragHandleLabel}
+              renderItem={(dragHandle) => renderItem(item, index, dragHandle)}
+            />
           ))}
         </div>
       </SortableContext>
@@ -77,13 +94,21 @@ export default function SortableList<T extends SortableItemType>({
 
 function SortableItem({
   id,
-  children,
-}: {
+  dragHandleLabel,
+  renderItem,
+}: Readonly<{
   id: string;
-  children: React.ReactNode;
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id });
+  dragHandleLabel: string;
+  renderItem: (dragHandle: React.ReactNode) => React.ReactNode;
+}>) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -94,11 +119,16 @@ function SortableItem({
     <div
       ref={setNodeRef}
       style={style}
-      {...attributes}
-      {...listeners}
-      className="cursor-move"
+      className={cn('group', isDragging && 'opacity-60')}
     >
-      {children}
+      {renderItem(
+        <DragHandle
+          aria-label={dragHandleLabel}
+          className="opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+          {...attributes}
+          {...listeners}
+        />,
+      )}
     </div>
   );
 }

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/ChecklistMutations.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/mutations/ChecklistMutations.ts
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import gql from 'graphql-tag';
 
 export const commonVariables = `
   $contentTypeId: String,
@@ -22,7 +22,6 @@ const commonItemParams = `
   content: $content,
 `;
 
-
 export const checklistFields = `
   _id
   contentType
@@ -35,6 +34,7 @@ export const checklistFields = `
     checklistId
     isChecked
     content
+    order
   }
   percent
 `;
@@ -113,7 +113,7 @@ export const CHECKLIST_ITEMS_REMOVE = gql`
 
 export const CHECKLIST_ITEMS_ORDER = gql`
   mutation salesChecklistItemsOrder($_id: String!, $destinationIndex: Int) {
-    salesChecklistItemsOrder(_id: $_id destinationIndex: $destinationIndex) {
+    salesChecklistItemsOrder(_id: $_id, destinationIndex: $destinationIndex) {
       _id
     }
   }

--- a/frontend/plugins/sales_ui/src/modules/deals/types/checklists.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/types/checklists.ts
@@ -54,6 +54,7 @@ export interface IChecklistDoc {
   
   export interface IChecklistItem extends IChecklistItemDoc {
     _id: string;
+    order?: number;
   }
   
   export type AddItemMutationResponse = (args: {


### PR DESCRIPTION
## Summary by Sourcery

Integrate editable, reorderable checklists into the deal overview and wire them to updated checklist mutations and ordering logic.

New Features:
- Expose deal-specific checklists in the deal overview with controls to add new checklists and checklist items.
- Allow inline editing of checklist titles and item content, including converting checklist items into deals.
- Provide a checklist overview trigger in both the main sales form and deal overview to quickly add checklists.

Bug Fixes:
- Ensure checklist item reordering is calculated against the full sibling list and persisted consistently in the backend.
- Trigger checklist detail and list change notifications after checklist and checklist item mutations to keep clients in sync.

Enhancements:
- Refine the checklist and checklist item UI with dropdown menus, inline actions, and updated styling consistent with the design system.
- Improve sortable list behavior by exposing reorder metadata, simplifying item identity to _id, and updating drag cursor feedback.
- Extend checklist GraphQL hooks with stronger typing, edit support, and explicit contentTypeId usage for deal-scoped queries.
- Update circular progress bar colors to use theme variables for better visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checklists to deal overviews and sales forms.
  * Added checklist creation, editing, deletion, completion, reordering, and deal-conversion actions.
  * Added inline editing with save, cancel, validation, and error recovery.
  * Added loading and error states for checklist data.
* **UI Improvements**
  * Standardized checklist controls, buttons, inputs, drag handles, and progress colors.
  * Improved drag-and-drop feedback and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->