### PR TITLE
fix(frontline): load next conversation page on scroll

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx
@@ -1,4 +1,3 @@
-import { useInView } from 'react-intersection-observer';
 import { IconLoader } from '@tabler/icons-react';
 
 import { ConversationContext } from '@/inbox/conversations/context/ConversationContext';
@@ -6,133 +5,26 @@ import { ConversationListContext } from '@/inbox/conversations/context/Conversat
 import { IConversation } from '@/inbox/types/Conversation';
 import { useConversations } from '@/inbox/conversations/hooks/useConversations';
 
-import {
-  Button,
-  EnumCursorDirection,
-  EnumCursorMode,
-  Filter,
-  isUndefinedOrNull,
-  parseDateRangeFromString,
-  Separator,
-  useNonNullMultiQueryState,
-} from 'erxes-ui';
+import { Filter, Separator } from 'erxes-ui';
 
 import { ConversationsHeader } from '@/inbox/conversations/components/ConversationsHeader';
-import { CONVERSATIONS_LIMIT } from '@/inbox/constants/conversationsConstants';
 import { ConversationItem } from '@/inbox/conversations/components/ConversationItem';
 import { ConversationThreadList } from '@/inbox/conversations/components/ConversationChannelSection';
 import { isDiscordConversation } from '@/inbox/conversations/utils/channelGroups';
 import { useDiscordConversationChannels } from '@/integrations/discord/hooks/useDiscordSetup';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { refetchNewMessagesState } from '@/inbox/conversations/states/newMessagesCountState';
-import { conversationsContainerScrollState } from '@/inbox/conversations/states/conversationsContainerScrollState';
+import { useMemo } from 'react';
 import { ConversationActions } from '@/inbox/conversations/components/ConversationActions';
 
-const getBooleanFilterVariable = (
-  value: boolean | null | undefined,
-): string | undefined => (value ? 'true' : undefined);
-
 export const Conversations = () => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const refetchNewMessages = useAtomValue(refetchNewMessagesState);
-  const [conversationsContainerScroll, setConversationsContainerScroll] =
-    useAtom(conversationsContainerScrollState);
-  const [rerendered, setRerendered] = useState(false);
-
-  const [ref] = useInView({
-    onChange(inView) {
-      if (inView) {
-        handleFetchMore({
-          direction: EnumCursorDirection.FORWARD,
-        });
-      }
-    },
-  });
-
-  useEffect(() => {
-    if (
-      containerRef.current &&
-      !isUndefinedOrNull(conversationsContainerScroll) &&
-      !rerendered
-    ) {
-      containerRef.current.scrollTo({
-        top: conversationsContainerScroll,
-      });
-      setConversationsContainerScroll(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [conversationsContainerScroll]);
-
-  useEffect(() => {
-    if (refetchNewMessages) {
-      containerRef.current?.scrollTo({
-        top: 0,
-      });
-    }
-  }, [refetchNewMessages]);
-
   const {
-    channelId,
-    integrationId,
-    integrationType,
-    unassigned,
-    awaitingResponse,
-    automationStatus,
-    participated,
-    status,
-    created,
-    brandId,
-    searchValue,
-  } = useNonNullMultiQueryState<{
-    channelId: string;
-    integrationId: string;
-    integrationType: string;
-    unassigned: boolean;
-    awaitingResponse: boolean;
-    automationStatus: string;
-    participated: boolean;
-    status: string;
-    conversationId: string;
-    created: string;
-    brandId: string;
-    searchValue: string;
-  }>([
-    'channelId',
-    'integrationId',
-    'integrationType',
-    'unassigned',
-    'awaitingResponse',
-    'automationStatus',
-    'participated',
-    'status',
-    'conversationId',
-    'created',
-    'brandId',
-    'searchValue',
-  ]);
-
-  const parsedDate = parseDateRangeFromString(created || '');
-
-  const { totalCount, conversations, handleFetchMore, loading, pageInfo } =
-    useConversations({
-      variables: {
-        limit: CONVERSATIONS_LIMIT,
-        channelId,
-        integrationId,
-        integrationType: integrationType,
-        unassigned: getBooleanFilterVariable(unassigned),
-        awaitingResponse: getBooleanFilterVariable(awaitingResponse),
-        automationStatus,
-        participating: getBooleanFilterVariable(participated),
-        status: status || '',
-        startDate: parsedDate?.from,
-        endDate: parsedDate?.to,
-        brandId,
-        searchValue,
-        cursorMode: EnumCursorMode.INCLUSIVE,
-      },
-    });
+    totalCount,
+    conversations,
+    loading,
+    containerRef,
+    fetchingMore,
+    handleConversationSelect,
+    handleScroll,
+  } = useConversations();
 
   const conversationListContextValue = useMemo(
     () => ({ conversations, loading, totalCount }),
@@ -161,10 +53,7 @@ export const Conversations = () => {
           isDiscordConversation(conversation) &&
           !channelMap.has(conversation._id)
         }
-        onConversationSelect={() => {
-          setConversationsContainerScroll(containerRef.current?.scrollTop || 0);
-          setRerendered(true);
-        }}
+        onConversationSelect={handleConversationSelect}
       />
     </ConversationContext.Provider>
   );
@@ -178,24 +67,24 @@ export const Conversations = () => {
           </ConversationsHeader>
         </Filter>
         <Separator />
-        <div className="h-full w-full overflow-y-auto" ref={containerRef}>
-          <ConversationThreadList
-            conversations={conversations || []}
-            threadMap={channelMap}
-            renderItem={renderConversationItem}
-          />
-          {!loading && conversations?.length > 0 && pageInfo?.hasNextPage && (
-            <Button
-              variant="ghost"
-              ref={ref}
-              className="pl-6 h-8 w-full text-muted-foreground"
-              asChild
-            >
-              <div>
+        <div className="relative min-h-0 flex-1">
+          <div
+            className="h-full w-full overflow-y-auto pb-10"
+            ref={containerRef}
+            onScroll={handleScroll}
+          >
+            <ConversationThreadList
+              conversations={conversations || []}
+              threadMap={channelMap}
+              renderItem={renderConversationItem}
+            />
+          </div>
+          {fetchingMore && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
+              <div className="flex size-8 items-center justify-center rounded-full border bg-background/95 text-muted-foreground shadow-sm backdrop-blur-sm">
                 <IconLoader className="size-4 animate-spin" />
-                loading more...
               </div>
-            </Button>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/constants/useConversations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/constants/useConversations.ts
@@ -1,0 +1,20 @@
+import type { InboxConversationQueryState } from '@/inbox/conversations/types/useConversations';
+
+export const CONVERSATION_FETCH_MORE_THRESHOLD = 80;
+
+export const INBOX_CONVERSATION_QUERY_KEYS: (
+  keyof InboxConversationQueryState
+)[] = [
+  'channelId',
+  'integrationId',
+  'integrationType',
+  'unassigned',
+  'awaitingResponse',
+  'automationStatus',
+  'participated',
+  'status',
+  'conversationId',
+  'created',
+  'brandId',
+  'searchValue',
+];

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -107,6 +107,7 @@ export const useConversations = (
   const { toast } = useToast();
   const containerRef = useRef<HTMLDivElement>(null);
   const fetchingMoreRef = useRef(false);
+  const lastAutoFetchCursorRef = useRef<string | null>(null);
   const [fetchingMore, setFetchingMore] = useState(false);
   const [conversationSelected, setConversationSelected] = useState(false);
   const [storedScrollPosition, setStoredScrollPosition] = useAtom(
@@ -214,17 +215,31 @@ export const useConversations = (
   }, [playNotificationSound, setNewMessagesCount, subscribeToMore, userId]);
 
   useEffect(() => {
+    if (conversationSelected) {
+      setConversationSelected(false);
+      return;
+    }
+
+    const container = containerRef.current;
+
     if (
-      containerRef.current &&
-      !isUndefinedOrNull(storedScrollPosition) &&
-      !conversationSelected
+      container &&
+      !loading &&
+      sortedList.length > 0 &&
+      !isUndefinedOrNull(storedScrollPosition)
     ) {
-      containerRef.current.scrollTo({
+      container.scrollTo({
         top: storedScrollPosition,
       });
       setStoredScrollPosition(null);
     }
-  }, [conversationSelected, setStoredScrollPosition, storedScrollPosition]);
+  }, [
+    conversationSelected,
+    loading,
+    setStoredScrollPosition,
+    sortedList.length,
+    storedScrollPosition,
+  ]);
 
   useEffect(() => {
     if (refetchNewMessages) {
@@ -233,6 +248,19 @@ export const useConversations = (
       });
     }
   }, [refetchNewMessages]);
+
+  const isNearBottom = useCallback(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return false;
+    }
+
+    return (
+      container.scrollHeight - container.scrollTop - container.clientHeight <=
+      CONVERSATION_FETCH_MORE_THRESHOLD
+    );
+  }, []);
 
   const fetchNextPage = useCallback(async () => {
     if (fetchingMoreRef.current || loading || !pageInfo?.hasNextPage) {
@@ -258,20 +286,34 @@ export const useConversations = (
     }
   }, [handleFetchMore, loading, pageInfo?.hasNextPage, t, toast]);
 
-  const handleScroll = useCallback(() => {
-    const container = containerRef.current;
+  useEffect(() => {
+    const endCursor = pageInfo?.endCursor;
 
-    if (!container) {
+    if (
+      loading ||
+      !pageInfo?.hasNextPage ||
+      !endCursor ||
+      lastAutoFetchCursorRef.current === endCursor ||
+      !isNearBottom()
+    ) {
       return;
     }
 
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
+    lastAutoFetchCursorRef.current = endCursor;
+    void fetchNextPage();
+  }, [
+    fetchNextPage,
+    isNearBottom,
+    loading,
+    pageInfo?.endCursor,
+    pageInfo?.hasNextPage,
+  ]);
 
-    if (distanceFromBottom <= CONVERSATION_FETCH_MORE_THRESHOLD) {
+  const handleScroll = useCallback(() => {
+    if (isNearBottom()) {
       void fetchNextPage();
     }
-  }, [fetchNextPage]);
+  }, [fetchNextPage, isNearBottom]);
 
   const handleConversationSelect = useCallback(() => {
     setStoredScrollPosition(containerRef.current?.scrollTop || 0);

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx
@@ -1,41 +1,89 @@
 import { GET_CONVERSATIONS } from '@/inbox/conversations/graphql/queries/getConversations';
-import { QueryHookOptions, useQuery } from '@apollo/client';
-import { ConversationStatus, IConversation } from '../../types/Conversation';
+import { useQuery } from '@apollo/client';
+import type { QueryHookOptions } from '@apollo/client';
+import {
+  ConversationStatus,
+  type IConversation,
+} from '@/inbox/types/Conversation';
 import {
   EnumCursorDirection,
+  EnumCursorMode,
   ICursorListResponse,
+  isUndefinedOrNull,
   mergeCursorData,
+  parseDateRangeFromString,
+  useNonNullMultiQueryState,
+  useToast,
   validateFetchMore,
 } from 'erxes-ui';
 import { CONVERSATIONS_LIMIT } from '@/inbox/constants/conversationsConstants';
-import { useEffect, useMemo, useRef } from 'react';
-import { CONVERSATION_CLIENT_MESSAGE_INSERTED } from '../graphql/subscriptions/inboxSubscriptions';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CONVERSATION_CLIENT_MESSAGE_INSERTED } from '@/inbox/conversations/graphql/subscriptions/inboxSubscriptions';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { currentUserState } from 'ui-modules';
-import { useNotificationSound } from './useNotificationSound';
+import { useNotificationSound } from '@/inbox/conversations/hooks/useNotificationSound';
 import {
   newMessagesCountState,
   resetNewMessagesState,
 } from '@/inbox/conversations/states/newMessagesCountState';
-import { refetchConversationsAtom } from '../states/refetchConversationState';
-import { activeConversationState } from '../states/activeConversationState';
-
-const getRecency = (conversation: IConversation) => {
-  const time = Date.parse(conversation.updatedAt || conversation.createdAt);
-  return Number.isNaN(time) ? 0 : time;
-};
-
-// Live cache writes only patch fields, so re-apply the server's order
-// (updatedAt desc, ascending _id) to keep the newest conversation on top.
-const compareByRecency = (a: IConversation, b: IConversation) =>
-  getRecency(b) - getRecency(a) || a._id.localeCompare(b._id);
+import { refetchConversationsAtom } from '@/inbox/conversations/states/refetchConversationState';
+import { activeConversationState } from '@/inbox/conversations/states/activeConversationState';
+import { conversationsContainerScrollState } from '@/inbox/conversations/states/conversationsContainerScrollState';
+import { useTranslation } from 'react-i18next';
+import {
+  CONVERSATION_FETCH_MORE_THRESHOLD,
+  INBOX_CONVERSATION_QUERY_KEYS,
+} from '@/inbox/conversations/constants/useConversations';
+import type { InboxConversationQueryState } from '@/inbox/conversations/types/useConversations';
+import {
+  compareConversationsByRecency,
+  getBooleanFilterVariable,
+  getConversationRecency,
+} from '@/inbox/conversations/utils/useConversations';
 
 export const useConversations = (
   options?: QueryHookOptions<ICursorListResponse<IConversation>>,
 ) => {
+  const {
+    channelId,
+    integrationId,
+    integrationType,
+    unassigned,
+    awaitingResponse,
+    automationStatus,
+    participated,
+    status,
+    created,
+    brandId,
+    searchValue,
+  } = useNonNullMultiQueryState<InboxConversationQueryState>(
+    INBOX_CONVERSATION_QUERY_KEYS,
+  );
+  const parsedDate = parseDateRangeFromString(created || '');
+
   const { data, fetchMore, subscribeToMore, loading, refetch } = useQuery<
     ICursorListResponse<IConversation>
-  >(GET_CONVERSATIONS, options);
+  >(
+    GET_CONVERSATIONS,
+    options || {
+      variables: {
+        limit: CONVERSATIONS_LIMIT,
+        channelId,
+        integrationId,
+        integrationType,
+        unassigned: getBooleanFilterVariable(unassigned),
+        awaitingResponse: getBooleanFilterVariable(awaitingResponse),
+        automationStatus,
+        participating: getBooleanFilterVariable(participated),
+        status: status || '',
+        startDate: parsedDate?.from,
+        endDate: parsedDate?.to,
+        brandId,
+        searchValue,
+        cursorMode: EnumCursorMode.INCLUSIVE,
+      },
+    },
+  );
   const refetchRef = useRef(refetch);
   refetchRef.current = refetch;
   const { _id: userId } = useAtomValue(currentUserState) || {};
@@ -43,7 +91,7 @@ export const useConversations = (
   const { conversations } = data || {};
   const { totalCount = 0, pageInfo } = conversations || {};
   const sortedList = useMemo(
-    () => [...(conversations?.list ?? [])].sort(compareByRecency),
+    () => [...(conversations?.list ?? [])].sort(compareConversationsByRecency),
     [conversations?.list],
   );
   const setNewMessagesCount = useSetAtom(newMessagesCountState);
@@ -55,6 +103,15 @@ export const useConversations = (
   const activeConversation = useAtomValue(activeConversationState);
   const activeConversationRef = useRef(activeConversation);
   activeConversationRef.current = activeConversation;
+  const { t } = useTranslation('frontline');
+  const { toast } = useToast();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fetchingMoreRef = useRef(false);
+  const [fetchingMore, setFetchingMore] = useState(false);
+  const [conversationSelected, setConversationSelected] = useState(false);
+  const [storedScrollPosition, setStoredScrollPosition] = useAtom(
+    conversationsContainerScrollState,
+  );
 
   useEffect(() => {
     setRefetch(() => refetch);
@@ -65,38 +122,36 @@ export const useConversations = (
       refetch();
       resetNewMessagesStates();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetchNewMessages]);
+  }, [refetch, refetchNewMessages, resetNewMessagesStates]);
 
-  const handleFetchMore = ({
-    direction,
-  }: {
-    direction: EnumCursorDirection;
-  }) => {
-    if (!validateFetchMore({ direction, pageInfo })) {
-      return;
-    }
+  const handleFetchMore = useCallback(
+    async ({ direction }: { direction: EnumCursorDirection }) => {
+      if (!validateFetchMore({ direction, pageInfo })) {
+        return;
+      }
 
-    fetchMore({
-      variables: {
-        cursor:
-          direction === EnumCursorDirection.FORWARD
-            ? pageInfo?.endCursor
-            : pageInfo?.startCursor,
-        limit: CONVERSATIONS_LIMIT,
-      },
-      updateQuery: (prev, { fetchMoreResult }) => {
-        if (!fetchMoreResult) return prev;
-        return Object.assign({}, prev, {
-          conversations: mergeCursorData({
-            direction,
-            fetchMoreResult: fetchMoreResult.conversations,
-            prevResult: prev.conversations,
-          }),
-        });
-      },
-    });
-  };
+      await fetchMore({
+        variables: {
+          cursor:
+            direction === EnumCursorDirection.FORWARD
+              ? pageInfo?.endCursor
+              : pageInfo?.startCursor,
+          limit: CONVERSATIONS_LIMIT,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return Object.assign({}, prev, {
+            conversations: mergeCursorData({
+              direction,
+              fetchMoreResult: fetchMoreResult.conversations,
+              prevResult: prev.conversations,
+            }),
+          });
+        },
+      });
+    },
+    [fetchMore, pageInfo],
+  );
 
   useEffect(() => {
     const unsubscribe = subscribeToMore<{
@@ -143,7 +198,8 @@ export const useConversations = (
           content: newMessage.content,
           // Events can arrive out of order; recency must never move backwards.
           updatedAt:
-            Date.parse(newMessage.createdAt) >= getRecency(conversation)
+            Date.parse(newMessage.createdAt) >=
+            getConversationRecency(conversation)
               ? newMessage.createdAt
               : conversation.updatedAt,
         });
@@ -157,11 +213,80 @@ export const useConversations = (
     };
   }, [playNotificationSound, setNewMessagesCount, subscribeToMore, userId]);
 
+  useEffect(() => {
+    if (
+      containerRef.current &&
+      !isUndefinedOrNull(storedScrollPosition) &&
+      !conversationSelected
+    ) {
+      containerRef.current.scrollTo({
+        top: storedScrollPosition,
+      });
+      setStoredScrollPosition(null);
+    }
+  }, [conversationSelected, setStoredScrollPosition, storedScrollPosition]);
+
+  useEffect(() => {
+    if (refetchNewMessages) {
+      containerRef.current?.scrollTo({
+        top: 0,
+      });
+    }
+  }, [refetchNewMessages]);
+
+  const fetchNextPage = useCallback(async () => {
+    if (fetchingMoreRef.current || loading || !pageInfo?.hasNextPage) {
+      return;
+    }
+
+    fetchingMoreRef.current = true;
+    setFetchingMore(true);
+
+    try {
+      await handleFetchMore({
+        direction: EnumCursorDirection.FORWARD,
+      });
+    } catch (error) {
+      toast({
+        title: t('something-went-wrong'),
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      fetchingMoreRef.current = false;
+      setFetchingMore(false);
+    }
+  }, [handleFetchMore, loading, pageInfo?.hasNextPage, t, toast]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+
+    if (distanceFromBottom <= CONVERSATION_FETCH_MORE_THRESHOLD) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage]);
+
+  const handleConversationSelect = useCallback(() => {
+    setStoredScrollPosition(containerRef.current?.scrollTop || 0);
+    setConversationSelected(true);
+  }, [setStoredScrollPosition]);
+
   return {
     totalCount,
     conversations: sortedList,
     loading,
     handleFetchMore,
     pageInfo,
+    containerRef,
+    fetchingMore,
+    handleConversationSelect,
+    handleScroll,
   };
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/types/useConversations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/types/useConversations.ts
@@ -1,0 +1,14 @@
+export type InboxConversationQueryState = {
+  channelId: string;
+  integrationId: string;
+  integrationType: string;
+  unassigned: boolean;
+  awaitingResponse: boolean;
+  automationStatus: string;
+  participated: boolean;
+  status: string;
+  conversationId: string;
+  created: string;
+  brandId: string;
+  searchValue: string;
+};

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/utils/useConversations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/utils/useConversations.ts
@@ -1,0 +1,20 @@
+import type { IConversation } from '@/inbox/types/Conversation';
+
+export const getBooleanFilterVariable = (
+  value: boolean | null | undefined,
+): string | undefined => (value ? 'true' : undefined);
+
+export const getConversationRecency = (conversation: IConversation) => {
+  const time = Date.parse(conversation.updatedAt || conversation.createdAt);
+
+  return Number.isNaN(time) ? 0 : time;
+};
+
+// Live cache writes only patch fields, so re-apply the server's order
+// (updatedAt desc, ascending _id) to keep the newest conversation on top.
+export const compareConversationsByRecency = (
+  first: IConversation,
+  second: IConversation,
+) =>
+  getConversationRecency(second) - getConversationRecency(first) ||
+  first._id.localeCompare(second._id);


### PR DESCRIPTION
## Summary

- load the next conversation page when the inbox list approaches the bottom
- prevent concurrent `fetchMore` requests and show the loader only during an active request
- keep conversation query, pagination, and scroll state handling together in `useConversations`
- show an error toast when loading the next page fails

## Why

The conversation list relied on an intersection-observer sentinel at the end of the list. The sentinel did not reliably enter the viewport inside the scroll container, so `fetchMore` could remain uncalled and the list stopped at the first page. The old sentinel also displayed a loading state whenever another page existed, even when no request was running.

## Impact

Inbox users can continue scrolling through conversations without the list stopping after the first page, duplicate pagination requests are prevented, and loading/error feedback now reflects the actual request state.

## Validation

- `pnpm exec eslint frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/Conversations.tsx frontend/plugins/frontline_ui/src/modules/inbox/conversations/hooks/useConversations.tsx frontend/plugins/frontline_ui/src/modules/inbox/conversations/constants/useConversations.ts frontend/plugins/frontline_ui/src/modules/inbox/conversations/types/useConversations.ts frontend/plugins/frontline_ui/src/modules/inbox/conversations/utils/useConversations.ts`
- `pnpm nx build frontline_ui`

## Summary by Sourcery

Improve inbox conversation list pagination and scrolling behavior to load additional pages on scroll with accurate loading and error feedback.

New Features:
- Automatically load the next conversation page when the inbox list is scrolled near the bottom.
- Show a transient loader overlay while additional conversation pages are being fetched.
- Display an error toast if loading the next conversation page fails.

Enhancements:
- Centralize conversation query, filter, pagination, and scroll state management within the useConversations hook.
- Extract reusable conversation filter and recency comparison helpers into dedicated utility and type modules.
- Refine conversation sorting logic to keep the most recently updated conversations at the top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved conversation loading with automatic pagination as you scroll.
  * Added smoother scroll restoration and conversation selection behavior.
  * Added support for shared conversation filters and query-state handling.
  * Conversations are now sorted by most recent activity.
  * Added a bottom loading indicator when more conversations are being fetched.

* **Bug Fixes**
  * Improved loading and error feedback while fetching additional conversations.
  * Ensured conversations with missing or invalid dates are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->