### PR TITLE
fix(content): allow 650 MiB custom field uploads

### DIFF
--- a/frontend/plugins/content_ui/AGENTS.md
+++ b/frontend/plugins/content_ui/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `content_ui`
 - **Layer:** `Frontend UI`
 - **Path:** `frontend/plugins/content_ui`
-- **Last synchronized:** `2026-08-13`
+- **Last synchronized:** `2026-08-17`
 
 ## Scope
 
@@ -25,7 +25,7 @@
 - Provides Web Builder configuration and editing surfaces.
 - Preserves blank lines and Tab-indented block structure when CMS posts are
   saved and reopened in the post editor.
-- Allows individual CMS custom-field file uploads up to 630 MiB through the
+- Allows individual CMS custom-field file uploads up to 650 MiB through the
   platform's chunked-upload contract.
 
 ## Architecture
@@ -176,7 +176,7 @@
 - Create or edit a CMS post with blank paragraphs and a Tab-indented paragraph,
   save it, reopen it, and verify the structure remains visible.
 - Directly select a CMS file custom field and verify a file no larger than
-  630 MiB is accepted while a larger file is rejected.
+  650 MiB is accepted while a larger file is rejected.
 
 ### Common Mistakes
 
@@ -192,6 +192,13 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-17` — Raise custom-field upload limit to 650 MiB
+
+- **Summary:** Raised the CMS custom-field file upload ceiling from 630 MiB to
+  650 MiB while preserving chunked upload behavior.
+- **Affected areas:** `src/modules/cms/posts/CustomFieldInput.tsx`
+- **Contracts changed:** None
 
 ### `2026-08-13` — Validate complete embedded block payloads
 

--- a/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/CustomFieldInput.tsx
@@ -18,7 +18,7 @@ import { SelectProduct } from 'ui-modules';
 import { SpreadsheetInput } from './SpreadsheetInput';
 import { GalleryUploader } from './GalleryUploader';
 
-const MAX_CUSTOM_FIELD_FILE_SIZE = 630 * 1024 * 1024;
+const MAX_CUSTOM_FIELD_FILE_SIZE = 650 * 1024 * 1024;
 
 export interface FieldDefinition {
   _id: string;
@@ -62,7 +62,7 @@ function FileFieldInput({
 
     if (file.size > MAX_CUSTOM_FIELD_FILE_SIZE) {
       setValidationError(
-        t('max-630mb', { defaultValue: 'Maximum file size: 630 MB' }),
+        t('max-650mb', { defaultValue: 'Maximum file size: 650 MB' }),
       );
       return;
     }
@@ -125,7 +125,7 @@ function FileFieldInput({
           {loading ? `${t('uploading')} ${progress}%` : buttonLabel}
         </Button>
         <p className="text-xs text-muted-foreground mt-1">
-          {t('max-630mb', { defaultValue: 'Maximum file size: 630 MB' })}
+          {t('max-650mb', { defaultValue: 'Maximum file size: 650 MB' })}
         </p>
       </div>
       {(validationError || error) && (


### PR DESCRIPTION
## Why

CMS custom fields using the `file` option need to accept files up to 650 MiB instead of the previous 630 MiB ceiling.

## What Changed

- raise the inclusive custom-field file limit to 650 MiB (`681,574,400` bytes)
- update the size helper and validation error text to 650 MB
- preserve the existing chunked-upload flow
- synchronize the `content_ui` plugin guide

## Summary by Sourcery

Raise the CMS custom-field file upload limit to 650 MiB and align UI messaging and plugin guide documentation with the new ceiling.

Enhancements:
- Increase the maximum allowed CMS custom-field file size from 630 MiB to 650 MiB and update validation messaging to reflect the new limit.

Documentation:
- Update the content_ui agent guide to document the new 650 MiB custom-field upload limit and add a changelog entry for the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the CMS custom-field file upload limit from 630 MB to 650 MB.
  * Updated validation messages to display the new upload limit.

* **Documentation**
  * Updated the CMS guide and recent-changes information to reflect the 650 MB limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->