### PR TITLE
fix(operation): show related projects in conversation widget

### DIFF
--- a/backend/plugins/operation_api/src/modules/project/graphql/resolvers/queries/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/graphql/resolvers/queries/project.ts
@@ -84,7 +84,8 @@ export const projectQueries: Record<string, Resolver> = {
     if (
       !filter?._ids?.length &&
       filter.userId &&
-      (filter.teamIds?.length === 0 || (!filter.teamIds && !filter.memberId))
+      !filter.memberId &&
+      (!filter.teamIds || filter.teamIds.length === 0)
     ) {
       const teamIds = await models.TeamMember.find({
         memberId: filter.userId,

--- a/backend/plugins/operation_api/src/modules/project/graphql/resolvers/queries/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/graphql/resolvers/queries/project.ts
@@ -82,22 +82,19 @@ export const projectQueries: Record<string, Resolver> = {
     }
 
     if (
-      (filter.teamIds && filter.teamIds.length <= 0 && filter.userId) ||
-      (!filter.teamIds && !filter.memberId)
+      !filter?._ids?.length &&
+      filter.userId &&
+      (filter.teamIds?.length === 0 || (!filter.teamIds && !filter.memberId))
     ) {
       const teamIds = await models.TeamMember.find({
         memberId: filter.userId,
       }).distinct('teamId');
 
-      if (filter.userId) {
-        filterQuery.$or = [
-          { teamIds: { $in: teamIds } },
-          { leadId: filter.userId },
-          { memberIds: filter.userId },
-        ];
-      } else {
-        filterQuery.teamIds = { $in: teamIds };
-      }
+      filterQuery.$or = [
+        ...(teamIds.length ? [{ teamIds: { $in: teamIds } }] : []),
+        { leadId: filter.userId },
+        { memberIds: filter.userId },
+      ];
     }
 
     if (filter.active) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure project queries return projects related to the requesting user through team membership, leadership, or membership when no explicit project IDs or member/team filters are supplied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project list filtering for signed-in users.
  * Projects now reflect the user’s team memberships when no specific team or member filter is selected.
  * Explicit team and member filters continue to return all matching projects.
  * Improved handling for users who do not belong to any teams.
  * Updated project queries to avoid applying user-based team filtering where it is not relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->