### PR TITLE
feat(frontline): convert conversation to ticket from inbox header

### DIFF
--- a/backend/gateway/src/locales/en/frontline.json
+++ b/backend/gateway/src/locales/en/frontline.json
@@ -1286,5 +1286,7 @@
   "facebook-last-synced": "Meta counts last synced {{time}}",
   "facebook-reports": "Facebook",
   "search-posts-placeholder": "Search post text or id",
-  "search-posts-title": "Filter by post text..."
+  "search-posts-title": "Filter by post text...",
+  "convert-to-ticket": "Convert to ticket",
+  "go-to-ticket": "Go to ticket"
 }

--- a/backend/gateway/src/locales/en/frontline.json
+++ b/backend/gateway/src/locales/en/frontline.json
@@ -1288,5 +1288,6 @@
   "search-posts-placeholder": "Search post text or id",
   "search-posts-title": "Filter by post text...",
   "convert-to-ticket": "Convert to ticket",
-  "go-to-ticket": "Go to ticket"
+  "open-linked-ticket": "Go to ticket",
+  "ticket-relation-failed": "The ticket was created but could not be linked to this conversation."
 }

--- a/backend/gateway/src/locales/mn/frontline.json
+++ b/backend/gateway/src/locales/mn/frontline.json
@@ -1287,5 +1287,6 @@
   "search-posts-placeholder": "Постын текст эсвэл id хайх",
   "search-posts-title": "Постын текстээр шүүх...",
   "convert-to-ticket": "Тикет болгох",
-  "go-to-ticket": "Тикет рүү очих"
+  "open-linked-ticket": "Тикет рүү очих",
+  "ticket-relation-failed": "Тикет үүссэн ч энэ харилцаатай холбогдож чадсангүй."
 }

--- a/backend/gateway/src/locales/mn/frontline.json
+++ b/backend/gateway/src/locales/mn/frontline.json
@@ -1285,5 +1285,7 @@
   "facebook-last-synced": "Meta-гийн тоог сүүлд {{time}}-д татсан",
   "facebook-reports": "Facebook",
   "search-posts-placeholder": "Постын текст эсвэл id хайх",
-  "search-posts-title": "Постын текстээр шүүх..."
+  "search-posts-title": "Постын текстээр шүүх...",
+  "convert-to-ticket": "Тикет болгох",
+  "go-to-ticket": "Тикет рүү очих"
 }

--- a/frontend/plugins/frontline_ui/AGENTS.md
+++ b/frontend/plugins/frontline_ui/AGENTS.md
@@ -63,6 +63,13 @@
   a multi-select over the selected channel's `ticketConfigs`.
 - Registers navigation, settings navigation, relation widgets, property inputs,
   and activity rows with the host via `CONFIG` in `src/config.tsx`.
+- A conversation converts to a ticket from its header. `ConvertToTicket` renders
+  `AddTicketSheet` with the conversation's channel, assignee, and content-derived
+  name as defaults, then links the ticket to the conversation and its customer.
+  It flips to a "Go to ticket" link once a `frontline:ticket` relation exists.
+  The ticket relation widget offers the same create-and-link flow from the side
+  menu; both write through `createMultipleRelations`, so either surface refreshes
+  the other.
 - Inbox navigation splits into **Me** — the integration types in use by the
   caller's personal channel, listed flat — and **Team inbox**, where every team
   channel is a collapsible row over the integration types in use inside it.
@@ -144,6 +151,7 @@
 | Channel settings   | `src/modules/channels`                                                                                                                       | Channel CRUD, members, GraphQL documents, form schemas                                                                                           |
 | Personal channel   | `src/modules/channels/components/settings/personal-channel`, `src/pages/PersonalChannelPage.tsx`                                             | Profile page for the user's private inbox                                                                                                        |
 | Inbox              | `src/modules/inbox/`                                                                                                                         | Conversations, messages, filters, channels, brands, integrations                                                                                 |
+| Convert to ticket  | `src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx`                                                          | Header action that creates a ticket from a conversation and links it, or links out to the ticket already linked                                  |
 | Integrations       | `src/modules/integrations/`                                                                                                                  | Per-provider connect forms and detail views                                                                                                      |
 | Ticket             | `src/modules/ticket/`, `src/modules/pipelines/`, `src/modules/status/`                                                                       | Ticket boards, pipelines, statuses                                                                                                               |
 | Ticket selects     | `src/modules/ticket/components/ticket-selects/`                                                                                              | Card/detail/form select-trigger components (status, priority, assignee, dates, tags) shared across the board card, detail sheet, and create form |
@@ -298,6 +306,13 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
   entry also carries the source property's `type` and `options`, taken from
   `useFields` when the property is toggled on; the API overwrites both from the
   current core definition on save, so never edit them in this UI.
+- `ticketCreateSheetState` is a single global atom, so two mounted
+  `AddTicketSheet` instances would open together. `ConvertToTicket` therefore
+  passes its own `open`/`onOpenChange` and keeps that state local, leaving the
+  atom to the ticket page and the relation widget. Prefilled values still travel
+  through `ticketCreateDefaultValuesState`, which `AddTicketForm` merges over its
+  own defaults and then clears — pass a key only when it has a value, or the
+  form's fallback for that field is lost.
 - React Hook Form + Zod for every form (`CHANNEL_SCHEMA`, `imapFormSchema`); the
   Facebook message action schema is in
   `src/widgets/automations/modules/facebook/components/action/states/replyMessageActionForm.tsx`.
@@ -535,6 +550,23 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-08-19` — Convert a conversation to a ticket from the inbox header
+
+- **Summary:** The conversation header opens the ticket create sheet prefilled
+  with the conversation's channel, assignee, and readable content as the ticket
+  name, then links the new ticket to `frontline:conversation` and
+  `core:customer`. Once a ticket is linked the button becomes "Go to ticket" and
+  routes to `/frontline/tickets?ticketId=<id>`; a failed relation write raises a
+  destructive toast, since the ticket already exists by then.
+- **Affected areas:**
+  `src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx`
+  (new),
+  `src/modules/inbox/conversations/conversation-detail/components/ConversationActions.tsx`,
+  `src/modules/ticket/components/add-ticket/AddTicketSheet.tsx`.
+- **Contracts changed:** `AddTicketSheet` gained optional `label`, `Icon`, and a
+  controlled `open`/`onOpenChange` pair; omitting them keeps the previous
+  `add-ticket` trigger and the `ticketCreateSheetState` atom behavior.
+
 ### `2026-08-19` — Facebook repair reports real failures
 
 - **Summary:** `integrationsRepair` answers a failed Facebook repair with a
@@ -665,11 +697,3 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
   other consumers of `TagsSelect` multi-select mode.
 - **Contracts changed:** None — `TagsSelectProps`/`TagsSelectContextType` are
   unchanged; only the popover's close timing in multi mode changed.
-
-### `2026-08-12` — Select ticket properties by group
-
-- **Summary:** Pipeline property configuration now selects an entire Core
-  ticket property group with one checkbox instead of selecting fields one by
-  one; the stored contract remains the group's field ids.
-- **Affected areas:** `src/modules/pipelines/components/PipelinePropertySelector.tsx`.
-- **Contracts changed:** None.

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationActions.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationActions.tsx
@@ -1,3 +1,4 @@
+import { ConvertToTicket } from '@/inbox/conversations/conversation-detail/components/ConvertToTicket';
 import { Toggle } from 'erxes-ui';
 import { useChangeConversationStatus } from '@/inbox/conversations/hooks/useChangeConversationStatus';
 import { useConversationContext } from '@/inbox/conversations/hooks/useConversationContext';
@@ -26,14 +27,17 @@ export const ConversationActions = () => {
   };
 
   return (
-    <Toggle
-      variant="outline"
-      className="flex-none"
-      pressed={status === ConversationStatus.CLOSED}
-      onPressedChange={handleChangeConversationStatus}
-      disabled={loading}
-    >
-      {status === ConversationStatus.CLOSED ? t('open-label') : t('resolve')}
-    </Toggle>
+    <>
+      <ConvertToTicket />
+      <Toggle
+        variant="outline"
+        className="flex-none"
+        pressed={status === ConversationStatus.CLOSED}
+        onPressedChange={handleChangeConversationStatus}
+        disabled={loading}
+      >
+        {status === ConversationStatus.CLOSED ? t('open-label') : t('resolve')}
+      </Toggle>
+    </>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx
@@ -5,9 +5,9 @@ import { AddTicketSheet } from '@/ticket/components/add-ticket/AddTicketSheet';
 import { ticketCreateDefaultValuesState } from '@/ticket/states/ticketCreateSheetState';
 import { TICKETS_DETAIL_QUERY_KEY } from '@/ticket/constants';
 import { IconTicket } from '@tabler/icons-react';
-import { Button, parseBlocks, stripHtml } from 'erxes-ui';
+import { Button, parseBlocks, stripHtml, useToast } from 'erxes-ui';
 import { useSetAtom } from 'jotai';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useCreateMultipleRelations, useRelations } from 'ui-modules';
@@ -33,7 +33,9 @@ export const ConvertToTicket = () => {
   const { t } = useTranslation('frontline');
   const { _id, content, customerId, assignedUserId, integration } =
     useConversationContext();
-  const { createMultipleRelations } = useCreateMultipleRelations();
+  const { toast } = useToast();
+  const { createMultipleRelations, error: relationError } =
+    useCreateMultipleRelations();
   const { ownEntities } = useRelations({
     variables: {
       contentId: _id,
@@ -48,6 +50,21 @@ export const ConvertToTicket = () => {
   const [open, setOpen] = useState(false);
 
   const linkedTicketId = ownEntities?.[ownEntities.length - 1]?.contentId;
+
+  useEffect(() => {
+    if (!relationError) {
+      return;
+    }
+
+    toast({
+      title: t('error'),
+      description: t(
+        'ticket-relation-failed',
+        'The ticket was created but could not be linked to this conversation.',
+      ),
+      variant: 'destructive',
+    });
+  }, [relationError, t, toast]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
@@ -92,7 +109,7 @@ export const ConvertToTicket = () => {
           to={`/frontline/tickets?${TICKETS_DETAIL_QUERY_KEY}=${linkedTicketId}`}
         >
           <IconTicket />
-          {t('go-to-ticket', 'Go to ticket')}
+          {t('open-linked-ticket', 'Go to ticket')}
         </Link>
       </Button>
     );

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConvertToTicket.tsx
@@ -1,0 +1,113 @@
+import { useConversationContext } from '@/inbox/conversations/hooks/useConversationContext';
+import { getPreviewText } from '@/inbox/types/inbox';
+import { parseCallConversationContent } from '@/integrations/call/utils/callContentUtils';
+import { AddTicketSheet } from '@/ticket/components/add-ticket/AddTicketSheet';
+import { ticketCreateDefaultValuesState } from '@/ticket/states/ticketCreateSheetState';
+import { TICKETS_DETAIL_QUERY_KEY } from '@/ticket/constants';
+import { IconTicket } from '@tabler/icons-react';
+import { Button, parseBlocks, stripHtml } from 'erxes-ui';
+import { useSetAtom } from 'jotai';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useCreateMultipleRelations, useRelations } from 'ui-modules';
+
+const TICKET_NAME_MAX_LENGTH = 100;
+
+const getTicketNameFromContent = (content?: string) => {
+  if (!content || parseCallConversationContent(content)) {
+    return undefined;
+  }
+
+  const text = parseBlocks(content)
+    ? getPreviewText(content)
+    : stripHtml(content);
+
+  return (
+    text.replace(/\s+/g, ' ').trim().slice(0, TICKET_NAME_MAX_LENGTH) ||
+    undefined
+  );
+};
+
+export const ConvertToTicket = () => {
+  const { t } = useTranslation('frontline');
+  const { _id, content, customerId, assignedUserId, integration } =
+    useConversationContext();
+  const { createMultipleRelations } = useCreateMultipleRelations();
+  const { ownEntities } = useRelations({
+    variables: {
+      contentId: _id,
+      contentType: 'frontline:conversation',
+      relatedContentType: 'frontline:ticket',
+    },
+    skip: !_id,
+  });
+  const setTicketCreateDefaultValues = useSetAtom(
+    ticketCreateDefaultValuesState,
+  );
+  const [open, setOpen] = useState(false);
+
+  const linkedTicketId = ownEntities?.[ownEntities.length - 1]?.contentId;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      const name = getTicketNameFromContent(content);
+
+      setTicketCreateDefaultValues({
+        ...(integration?.channelId ? { channelId: integration.channelId } : {}),
+        ...(name ? { name } : {}),
+        ...(assignedUserId ? { assigneeId: assignedUserId } : {}),
+      });
+    }
+
+    setOpen(nextOpen);
+  };
+
+  const handleComplete = (ticketId: string) => {
+    const entities: [string, string][] = [
+      ['frontline:conversation', _id],
+      ...(customerId
+        ? ([['core:customer', customerId]] as [string, string][])
+        : []),
+    ];
+
+    createMultipleRelations(
+      entities.map(([contentType, contentId]) => ({
+        entities: [
+          { contentType, contentId },
+          { contentType: 'frontline:ticket', contentId: ticketId },
+        ],
+      })),
+    );
+  };
+
+  if (!_id) {
+    return null;
+  }
+
+  if (linkedTicketId) {
+    return (
+      <Button variant="outline" className="flex-none" asChild>
+        <Link
+          to={`/frontline/tickets?${TICKETS_DETAIL_QUERY_KEY}=${linkedTicketId}`}
+        >
+          <IconTicket />
+          {t('go-to-ticket', 'Go to ticket')}
+        </Link>
+      </Button>
+    );
+  }
+
+  return (
+    <AddTicketSheet
+      open={open}
+      onOpenChange={handleOpenChange}
+      onComplete={handleComplete}
+      label={t('convert-to-ticket', 'Convert to ticket')}
+      Icon={IconTicket}
+      variant="outline"
+      className="flex-none"
+      isRelation
+    />
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/add-ticket/AddTicketSheet.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/add-ticket/AddTicketSheet.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from '@tabler/icons-react';
+import { Icon as TablerIcon, IconPlus } from '@tabler/icons-react';
 import { TicketHotKeyScope } from '@/ticket/types/ticketHotkeyScope';
 import {
   Button,
@@ -16,13 +16,23 @@ import { ticketCreateSheetState } from '@/ticket/states/ticketCreateSheetState';
 export const AddTicketSheet = ({
   onComplete,
   isRelation = false,
+  label,
+  Icon = IconPlus,
+  open: openProp,
+  onOpenChange,
   ...props
 }: {
   onComplete?: (ticketId: string) => void;
   isRelation?: boolean;
+  label?: string;
+  Icon?: TablerIcon;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 } & ButtonProps) => {
   const { t } = useTranslation('frontline');
-  const [open, setOpen] = useAtom(ticketCreateSheetState);
+  const [openState, setOpenState] = useAtom(ticketCreateSheetState);
+  const open = openProp ?? openState;
+  const setOpen = onOpenChange ?? setOpenState;
   const {
     setHotkeyScopeAndMemorizePreviousScope,
     goBackToPreviousHotkeyScope,
@@ -50,8 +60,8 @@ export const AddTicketSheet = ({
     <Sheet open={open} onOpenChange={(open) => (open ? onOpen() : onClose())}>
       <Sheet.Trigger asChild>
         <Button {...props}>
-          <IconPlus />
-          {t('add-ticket')}
+          <Icon />
+          {label ?? t('add-ticket')}
           {!isRelation && <Kbd>C</Kbd>}
         </Button>
       </Sheet.Trigger>


### PR DESCRIPTION
## Summary by Sourcery

Enable converting inbox conversations into linked tickets directly from the conversation header.

New Features:
- Add a conversation-header action to create a ticket prefilled from the conversation and link it to the conversation and customer.
- Show a direct link to the associated ticket after conversion.

Enhancements:
- Extend the ticket creation sheet with customizable labels, icons, and controlled open state while preserving existing usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to convert Frontline conversations into tickets.
  * Automatically pre-fills ticket details, including the title, channel, and assignee.
  * Links tickets to the conversation and customer.
  * Displays an option to open an associated ticket when one already exists.
  * Added customizable labels, icons, and open-state controls to the ticket creation dialog.
  * Added English and Mongolian translations for ticket actions and linking errors.

* **Bug Fixes**
  * Shows an error notification when ticket linking fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->