### PR TITLE
feat(core): expose safe tRPC procedures as agent-callable tools

### DIFF
--- a/backend/core-api/src/modules/approval/trpc/approval.ts
+++ b/backend/core-api/src/modules/approval/trpc/approval.ts
@@ -5,6 +5,7 @@ import {
 } from 'erxes-api-shared/core-modules';
 import { ExpectedError } from 'erxes-api-shared/utils';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { IModels } from '~/connectionResolvers';
 
 type ApprovalTrpcUser = {
@@ -44,13 +45,12 @@ const getTrpcUser = async (
 export const approvalTrpcRouter = t.router({
   approval: t.router({
     state: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Check the approval-lock state of ONE record before editing it. Input: { contentType, contentId, action?, ownerId?, userId? } — contentType like "sales:deal", contentId is the record _id. Returns whether the current user has access and the lock reason. Always check this before mutating pipeline records (deals, tickets) so you do not fight an active approval lock. Use approval.states for multiple records at once.',
-          permission: { module: 'approval', action: 'approvalLocksManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Check the approval-lock state of ONE record before editing it. Input: { contentType, contentId, action?, ownerId?, userId? } — contentType like "sales:deal", contentId is the record _id. Returns whether the current user has access and the lock reason. Always check this before mutating pipeline records (deals, tickets) so you do not fight an active approval lock. Use approval.states for multiple records at once.',
+          { module: 'approval', action: 'approvalLocksManage' },
+        ),
+      )
       .input(approvalLockCheckInputSchema)
       .query(async ({ ctx, input }) => {
         const user = await getTrpcUser(ctx, input.userId);
@@ -65,13 +65,12 @@ export const approvalTrpcRouter = t.router({
       }),
 
     states: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Batch-check approval-lock states for MULTIPLE records of one content type. Input: { contentType, contentIds, ownerIdsByContentId?, action?, userId? }. Use instead of approval.state when working with a list of records.',
-          permission: { module: 'approval', action: 'approvalLocksManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Batch-check approval-lock states for MULTIPLE records of one content type. Input: { contentType, contentIds, ownerIdsByContentId?, action?, userId? }. Use instead of approval.state when working with a list of records.',
+          { module: 'approval', action: 'approvalLocksManage' },
+        ),
+      )
       .input(approvalLockStatesInputSchema)
       .query(async ({ ctx, input }) => {
         const user = await getTrpcUser(ctx, input.userId);

--- a/backend/core-api/src/modules/approval/trpc/approval.ts
+++ b/backend/core-api/src/modules/approval/trpc/approval.ts
@@ -44,6 +44,13 @@ const getTrpcUser = async (
 export const approvalTrpcRouter = t.router({
   approval: t.router({
     state: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Check the approval-lock state of ONE record before editing it. Input: { contentType, contentId, action?, ownerId?, userId? } — contentType like "sales:deal", contentId is the record _id. Returns whether the current user has access and the lock reason. Always check this before mutating pipeline records (deals, tickets) so you do not fight an active approval lock. Use approval.states for multiple records at once.',
+          permission: { module: 'approval', action: 'approvalLocksManage' },
+        },
+      })
       .input(approvalLockCheckInputSchema)
       .query(async ({ ctx, input }) => {
         const user = await getTrpcUser(ctx, input.userId);
@@ -58,6 +65,13 @@ export const approvalTrpcRouter = t.router({
       }),
 
     states: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Batch-check approval-lock states for MULTIPLE records of one content type. Input: { contentType, contentIds, ownerIdsByContentId?, action?, userId? }. Use instead of approval.state when working with a list of records.',
+          permission: { module: 'approval', action: 'approvalLocksManage' },
+        },
+      })
       .input(approvalLockStatesInputSchema)
       .query(async ({ ctx, input }) => {
         const user = await getTrpcUser(ctx, input.userId);

--- a/backend/core-api/src/modules/clientportal/trpc/cpUsers.ts
+++ b/backend/core-api/src/modules/clientportal/trpc/cpUsers.ts
@@ -18,6 +18,13 @@ const cpUserListFilterSchema = z.object({
 export const cpUsersTrpcRouter = t.router({
   cpUsers: t.router({
     list: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List client portal users (end customers with portal accounts): { erxesCustomerId?, clientPortalId?, type?, isVerified?, searchValue?, limit?, skip? }. Pass erxesCustomerId (from customers.findOne) to find the portal account linked to a customer. Returns { list, totalCount }.',
+          permission: { module: 'clientPortal', action: 'clientPortalRead' },
+        },
+      })
       .input(cpUserListFilterSchema)
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
@@ -61,6 +68,13 @@ export const cpUsersTrpcRouter = t.router({
         return { list, totalCount };
       }),
     get: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get one client portal user by { id } or by { erxesCustomerId, clientPortalId? }. Returns null when not found. Use cpUsers.list to search by name/email/phone instead.',
+          permission: { module: 'clientPortal', action: 'clientPortalRead' },
+        },
+      })
       .input(
         z.object({
           id: z.string().optional(),
@@ -88,6 +102,13 @@ export const cpUsersTrpcRouter = t.router({
   }),
   clientPortals: t.router({
     get: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a client portal configuration by { _id }. Returns portal settings (name, domain, features). The portal _id is needed for cpUsers.list and cpNotifications.create.',
+          permission: { module: 'clientPortal', action: 'clientPortalRead' },
+        },
+      })
       .input(z.object({ _id: z.string() }))
       .query(async ({ ctx, input }) => {
         const { models } = ctx;

--- a/backend/core-api/src/modules/clientportal/trpc/cpUsers.ts
+++ b/backend/core-api/src/modules/clientportal/trpc/cpUsers.ts
@@ -2,6 +2,7 @@ import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
@@ -18,13 +19,12 @@ const cpUserListFilterSchema = z.object({
 export const cpUsersTrpcRouter = t.router({
   cpUsers: t.router({
     list: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List client portal users (end customers with portal accounts): { erxesCustomerId?, clientPortalId?, type?, isVerified?, searchValue?, limit?, skip? }. Pass erxesCustomerId (from customers.findOne) to find the portal account linked to a customer. Returns { list, totalCount }.',
-          permission: { module: 'clientPortal', action: 'clientPortalRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List client portal users (end customers with portal accounts): { erxesCustomerId?, clientPortalId?, type?, isVerified?, searchValue?, limit?, skip? }. Pass erxesCustomerId (from customers.findOne) to find the portal account linked to a customer. Returns { list, totalCount }.',
+          { module: 'clientPortal', action: 'clientPortalRead' },
+        ),
+      )
       .input(cpUserListFilterSchema)
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
@@ -68,13 +68,12 @@ export const cpUsersTrpcRouter = t.router({
         return { list, totalCount };
       }),
     get: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get one client portal user by { id } or by { erxesCustomerId, clientPortalId? }. Returns null when not found. Use cpUsers.list to search by name/email/phone instead.',
-          permission: { module: 'clientPortal', action: 'clientPortalRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get one client portal user by { id } or by { erxesCustomerId, clientPortalId? }. Returns null when not found. Use cpUsers.list to search by name/email/phone instead.',
+          { module: 'clientPortal', action: 'clientPortalRead' },
+        ),
+      )
       .input(
         z.object({
           id: z.string().optional(),
@@ -102,13 +101,12 @@ export const cpUsersTrpcRouter = t.router({
   }),
   clientPortals: t.router({
     get: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a client portal configuration by { _id }. Returns portal settings (name, domain, features). The portal _id is needed for cpUsers.list and cpNotifications.create.',
-          permission: { module: 'clientPortal', action: 'clientPortalRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a client portal configuration by { _id }. Returns portal settings (name, domain, features). The portal _id is needed for cpUsers.list and cpNotifications.create.',
+          { module: 'clientPortal', action: 'clientPortalRead' },
+        ),
+      )
       .input(z.object({ _id: z.string() }))
       .query(async ({ ctx, input }) => {
         const { models } = ctx;

--- a/backend/core-api/src/modules/clientportal/trpc/notifications.ts
+++ b/backend/core-api/src/modules/clientportal/trpc/notifications.ts
@@ -21,6 +21,13 @@ const notificationDataSchema = z.object({
 export const cpNotificationTrpcRouter = t.router({
   cpNotifications: t.router({
     create: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Send a notification to client portal users (in-app in the customer portal). Input: { cpUserIds: [...], clientPortalId, data: { title, message, type?, priority?, contentType?, contentTypeId?, action? } } — type: "info"|"success"|"warning"|"error", priority: "low"|"medium"|"high"|"urgent". Workflow: customers.findOne → cpUsers.list (erxesCustomerId) to get cpUserIds → this tool. Use to notify end customers about updates to their tickets, orders, etc.',
+          permission: { module: 'clientPortal', action: 'clientPortalManage' },
+        },
+      })
       .input(
         z.object({
           cpUserIds: z.array(z.string()),
@@ -96,6 +103,13 @@ export const cpNotificationTrpcRouter = t.router({
       }),
 
     list: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List notifications previously sent to a portal user: { cpUserId, clientPortalId?, isRead?, limit?, skip? }. Returns { list, totalCount }. Get cpUserId from cpUsers.list.',
+          permission: { module: 'clientPortal', action: 'clientPortalRead' },
+        },
+      })
       .input(
         z.object({
           cpUserId: z.string(),

--- a/backend/core-api/src/modules/clientportal/trpc/notifications.ts
+++ b/backend/core-api/src/modules/clientportal/trpc/notifications.ts
@@ -1,6 +1,7 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { notificationService } from '@/clientportal/services';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
@@ -21,13 +22,12 @@ const notificationDataSchema = z.object({
 export const cpNotificationTrpcRouter = t.router({
   cpNotifications: t.router({
     create: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Send a notification to client portal users (in-app in the customer portal). Input: { cpUserIds: [...], clientPortalId, data: { title, message, type?, priority?, contentType?, contentTypeId?, action? } } — type: "info"|"success"|"warning"|"error", priority: "low"|"medium"|"high"|"urgent". Workflow: customers.findOne → cpUsers.list (erxesCustomerId) to get cpUserIds → this tool. Use to notify end customers about updates to their tickets, orders, etc.',
-          permission: { module: 'clientPortal', action: 'clientPortalManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Send a notification to client portal users (in-app in the customer portal). Input: { cpUserIds: [...], clientPortalId, data: { title, message, type?, priority?, contentType?, contentTypeId?, action? } } — type: "info"|"success"|"warning"|"error", priority: "low"|"medium"|"high"|"urgent". Workflow: customers.findOne → cpUsers.list (erxesCustomerId) to get cpUserIds → this tool. Use to notify end customers about updates to their tickets, orders, etc.',
+          { module: 'clientPortal', action: 'clientPortalManage' },
+        ),
+      )
       .input(
         z.object({
           cpUserIds: z.array(z.string()),
@@ -103,13 +103,12 @@ export const cpNotificationTrpcRouter = t.router({
       }),
 
     list: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List notifications previously sent to a portal user: { cpUserId, clientPortalId?, isRead?, limit?, skip? }. Returns { list, totalCount }. Get cpUserId from cpUsers.list.',
-          permission: { module: 'clientPortal', action: 'clientPortalRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List notifications previously sent to a portal user: { cpUserId, clientPortalId?, isRead?, limit?, skip? }. Returns { list, totalCount }. Get cpUserId from cpUsers.list.',
+          { module: 'clientPortal', action: 'clientPortalRead' },
+        ),
+      )
       .input(
         z.object({
           cpUserId: z.string(),

--- a/backend/core-api/src/modules/contacts/trpc/company.ts
+++ b/backend/core-api/src/modules/contacts/trpc/company.ts
@@ -7,14 +7,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const companyTrpcRouter = t.router({
   companies: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Search companies with a MongoDB-style filter: { query: {...} }, e.g. { query: { primaryName: "Acme" } } or { query: { industry: "Technology" } }. Returns full company documents. Use companies.findOne when you already know a unique key.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 
       return models.Companies.find(query).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single company by a unique key: { _id }, { name } or { companyPrimaryName }, { email } or { companyPrimaryEmail }, { phone } or { companyPrimaryPhone }, or { companyCode }. Deleted companies are excluded automatically. Returns {} when nothing matches. Call this before companies.updateCompany.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -78,6 +96,13 @@ export const companyTrpcRouter = t.router({
     }),
 
     findActiveCompanies: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List active (non-deleted) companies with optional projection and pagination: { query, fields, skip, limit }. Prefer companies.find unless you need field projection or pagination.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
       .input(z.any())
       .query(async ({ ctx, input }) => {
         const { query, fields, skip, limit } = input;
@@ -94,6 +119,13 @@ export const companyTrpcRouter = t.router({
     }),
 
     createCompany: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a company. Input: { doc: { primaryName?, names?, primaryEmail?, emails?, primaryPhone?, phones?, website?, industry?, size?, code?, tagIds?, customFieldsData?, ... } }. Check for duplicates first with companies.findOne by name or email. For custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.companies") and format values with fields.prepareCustomFieldsData.',
+          permission: { module: 'contacts', action: 'contactsCreate' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -105,6 +137,13 @@ export const companyTrpcRouter = t.router({
       }),
 
     updateCompany: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Update a company by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call companies.findOne first to get the _id and current values.',
+          permission: { module: 'contacts', action: 'contactsUpdate' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;

--- a/backend/core-api/src/modules/contacts/trpc/company.ts
+++ b/backend/core-api/src/modules/contacts/trpc/company.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { createOrUpdate } from '../utils';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const companyTrpcRouter = t.router({
   companies: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Search companies with a MongoDB-style filter: { query: {...} }, e.g. { query: { primaryName: "Acme" } } or { query: { industry: "Technology" } }. Returns full company documents. Use companies.findOne when you already know a unique key.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Search companies with a MongoDB-style filter: { query: {...} }, e.g. { query: { primaryName: "Acme" } } or { query: { industry: "Technology" } }. Returns full company documents. Use companies.findOne when you already know a unique key.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;
@@ -24,13 +24,12 @@ export const companyTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single company by a unique key: { _id }, { name } or { companyPrimaryName }, { email } or { companyPrimaryEmail }, { phone } or { companyPrimaryPhone }, or { companyCode }. Deleted companies are excluded automatically. Returns {} when nothing matches. Call this before companies.updateCompany.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single company by a unique key: { _id }, { name } or { companyPrimaryName }, { email } or { companyPrimaryEmail }, { phone } or { companyPrimaryPhone }, or { companyCode }. Deleted companies are excluded automatically. Returns {} when nothing matches. Call this before companies.updateCompany.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -96,13 +95,12 @@ export const companyTrpcRouter = t.router({
     }),
 
     findActiveCompanies: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List active (non-deleted) companies with optional projection and pagination: { query, fields, skip, limit }. Prefer companies.find unless you need field projection or pagination.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List active (non-deleted) companies with optional projection and pagination: { query, fields, skip, limit }. Prefer companies.find unless you need field projection or pagination.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
         const { query, fields, skip, limit } = input;
@@ -119,13 +117,12 @@ export const companyTrpcRouter = t.router({
     }),
 
     createCompany: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a company. Input: { doc: { primaryName?, names?, primaryEmail?, emails?, primaryPhone?, phones?, website?, industry?, size?, code?, tagIds?, customFieldsData?, ... } }. Check for duplicates first with companies.findOne by name or email. For custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.companies") and format values with fields.prepareCustomFieldsData.',
-          permission: { module: 'contacts', action: 'contactsCreate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a company. Input: { doc: { primaryName?, names?, primaryEmail?, emails?, primaryPhone?, phones?, website?, industry?, size?, code?, tagIds?, customFieldsData?, ... } }. Check for duplicates first with companies.findOne by name or email. For custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.companies") and format values with fields.prepareCustomFieldsData.',
+          { module: 'contacts', action: 'contactsCreate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -137,13 +134,12 @@ export const companyTrpcRouter = t.router({
       }),
 
     updateCompany: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Update a company by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call companies.findOne first to get the _id and current values.',
-          permission: { module: 'contacts', action: 'contactsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Update a company by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call companies.findOne first to get the _id and current values.',
+          { module: 'contacts', action: 'contactsUpdate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;

--- a/backend/core-api/src/modules/contacts/trpc/customer.ts
+++ b/backend/core-api/src/modules/contacts/trpc/customer.ts
@@ -1,6 +1,7 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { createOrUpdate } from '../utils';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
@@ -8,13 +9,12 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const customerRouter = t.router({
   customers: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Search customers (people) with a MongoDB-style filter. Input: { query: {...} }, e.g. { query: { primaryEmail: "a@b.com" } } or { query: { tagIds: ["tagId"] } }. Returns full customer documents. Use customers.findOne when you already know a unique key, and customers.count when you only need the total number.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Search customers (people) with a MongoDB-style filter. Input: { query: {...} }, e.g. { query: { primaryEmail: "a@b.com" } } or { query: { tagIds: ["tagId"] } }. Returns full customer documents. Use customers.findOne when you already know a unique key, and customers.count when you only need the total number.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;
@@ -24,13 +24,12 @@ export const customerRouter = t.router({
       }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single customer by a unique key: { _id }, { customerPrimaryEmail }, { customerPrimaryPhone }, or { customerCode }. Deleted customers are excluded automatically. Returns {} when nothing matches. Always call this before customers.updateCustomer to confirm the record and read its current values.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single customer by a unique key: { _id }, { customerPrimaryEmail }, { customerPrimaryPhone }, or { customerCode }. Deleted customers are excluded automatically. Returns {} when nothing matches. Always call this before customers.updateCustomer to confirm the record and read its current values.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -67,13 +66,12 @@ export const customerRouter = t.router({
     }),
 
     findActiveCustomers: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List active (non-deleted) customers with optional projection and pagination: { query, fields, skip, limit }, e.g. fields: { primaryEmail: 1, firstName: 1 } to return only those columns. Prefer customers.find unless you need field projection or pagination.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List active (non-deleted) customers with optional projection and pagination: { query, fields, skip, limit }, e.g. fields: { primaryEmail: 1, firstName: 1 } to return only those columns. Prefer customers.find unless you need field projection or pagination.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(
         z.object({
           query: z.any(),
@@ -107,13 +105,12 @@ export const customerRouter = t.router({
       }),
 
     count: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Count customers matching a MongoDB-style filter: { query: {...} }. Use this for "how many customers ..." questions instead of fetching full records.',
-          permission: { module: 'contacts', action: 'contactsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Count customers matching a MongoDB-style filter: { query: {...} }. Use this for "how many customers ..." questions instead of fetching full records.',
+          { module: 'contacts', action: 'contactsRead' },
+        ),
+      )
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;
@@ -123,13 +120,12 @@ export const customerRouter = t.router({
       }),
 
     createCustomer: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a customer (person). Input: { doc: { firstName?, lastName?, primaryEmail?, emails?, primaryPhone?, phones?, code?, tagIds?, customFieldsData?, ... } }. Workflow: (1) check for duplicates with customers.findOne by email or phone; (2) resolve tag IDs with tags.find (type "core:customer"); (3) for custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.customers") and format values with fields.prepareCustomFieldsData.',
-          permission: { module: 'contacts', action: 'contactsCreate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a customer (person). Input: { doc: { firstName?, lastName?, primaryEmail?, emails?, primaryPhone?, phones?, code?, tagIds?, customFieldsData?, ... } }. Workflow: (1) check for duplicates with customers.findOne by email or phone; (2) resolve tag IDs with tags.find (type "core:customer"); (3) for custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.customers") and format values with fields.prepareCustomFieldsData.',
+          { module: 'contacts', action: 'contactsCreate' },
+        ),
+      )
       .input(z.object({ doc: z.any() }))
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -139,13 +135,12 @@ export const customerRouter = t.router({
       }),
 
     updateCustomer: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Update a customer by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call customers.findOne first to get the _id and current values. For custom fields, build doc.customFieldsData with fields.prepareCustomFieldsData.',
-          permission: { module: 'contacts', action: 'contactsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Update a customer by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call customers.findOne first to get the _id and current values. For custom fields, build doc.customFieldsData with fields.prepareCustomFieldsData.',
+          { module: 'contacts', action: 'contactsUpdate' },
+        ),
+      )
       .input(z.object({ _id: z.string(), doc: z.any() }))
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -275,13 +270,12 @@ export const customerRouter = t.router({
       }),
 
     tag: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Attach tags to customers, or count tagged customers. Input: { action, _ids, tagIds, targetIds }. action "tagObject" sets tagIds on the customers listed in targetIds; action "count" counts customers carrying the tag IDs in _ids. Resolve tag IDs first with tags.find (type "core:customer").',
-          permission: { module: 'tags', action: 'tagsTag' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Attach tags to customers, or count tagged customers. Input: { action, _ids, tagIds, targetIds }. action "tagObject" sets tagIds on the customers listed in targetIds; action "count" counts customers carrying the tag IDs in _ids. Resolve tag IDs first with tags.find (type "core:customer").',
+          { module: 'tags', action: 'tagsTag' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
       const { action, _ids, tagIds, targetIds } = input;

--- a/backend/core-api/src/modules/contacts/trpc/customer.ts
+++ b/backend/core-api/src/modules/contacts/trpc/customer.ts
@@ -8,6 +8,13 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const customerRouter = t.router({
   customers: t.router({
     find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Search customers (people) with a MongoDB-style filter. Input: { query: {...} }, e.g. { query: { primaryEmail: "a@b.com" } } or { query: { tagIds: ["tagId"] } }. Returns full customer documents. Use customers.findOne when you already know a unique key, and customers.count when you only need the total number.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;
@@ -16,7 +23,16 @@ export const customerRouter = t.router({
         return models.Customers.find(query).lean();
       }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single customer by a unique key: { _id }, { customerPrimaryEmail }, { customerPrimaryPhone }, or { customerCode }. Deleted customers are excluded automatically. Returns {} when nothing matches. Always call this before customers.updateCustomer to confirm the record and read its current values.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -51,6 +67,13 @@ export const customerRouter = t.router({
     }),
 
     findActiveCustomers: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List active (non-deleted) customers with optional projection and pagination: { query, fields, skip, limit }, e.g. fields: { primaryEmail: 1, firstName: 1 } to return only those columns. Prefer customers.find unless you need field projection or pagination.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
       .input(
         z.object({
           query: z.any(),
@@ -84,6 +107,13 @@ export const customerRouter = t.router({
       }),
 
     count: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Count customers matching a MongoDB-style filter: { query: {...} }. Use this for "how many customers ..." questions instead of fetching full records.',
+          permission: { module: 'contacts', action: 'contactsRead' },
+        },
+      })
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;
@@ -93,6 +123,13 @@ export const customerRouter = t.router({
       }),
 
     createCustomer: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a customer (person). Input: { doc: { firstName?, lastName?, primaryEmail?, emails?, primaryPhone?, phones?, code?, tagIds?, customFieldsData?, ... } }. Workflow: (1) check for duplicates with customers.findOne by email or phone; (2) resolve tag IDs with tags.find (type "core:customer"); (3) for custom fields, discover field IDs via fields.fieldsCombinedByContentType (contentType "core:contacts.customers") and format values with fields.prepareCustomFieldsData.',
+          permission: { module: 'contacts', action: 'contactsCreate' },
+        },
+      })
       .input(z.object({ doc: z.any() }))
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -102,6 +139,13 @@ export const customerRouter = t.router({
       }),
 
     updateCustomer: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Update a customer by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call customers.findOne first to get the _id and current values. For custom fields, build doc.customFieldsData with fields.prepareCustomFieldsData.',
+          permission: { module: 'contacts', action: 'contactsUpdate' },
+        },
+      })
       .input(z.object({ _id: z.string(), doc: z.any() }))
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -230,7 +274,16 @@ export const customerRouter = t.router({
         });
       }),
 
-    tag: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    tag: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Attach tags to customers, or count tagged customers. Input: { action, _ids, tagIds, targetIds }. action "tagObject" sets tagIds on the customers listed in targetIds; action "count" counts customers carrying the tag IDs in _ids. Resolve tag IDs first with tags.find (type "core:customer").',
+          permission: { module: 'tags', action: 'tagsTag' },
+        },
+      })
+      .input(z.any())
+      .mutation(async ({ ctx, input }) => {
       const { action, _ids, tagIds, targetIds } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/documents/trpc/document.ts
+++ b/backend/core-api/src/modules/documents/trpc/document.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const documentTrpcRouter = t.router({
   documents: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List document templates (printable documents with placeholders): { query? }. Use to find the template _id before rendering with documents.print.',
-          permission: { module: 'documents', action: 'documentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List document templates (printable documents with placeholders): { query? }. Use to find the template _id before rendering with documents.print.',
+          { module: 'documents', action: 'documentsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;
@@ -23,13 +23,12 @@ export const documentTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single document template by { _id } or any MongoDB-style query. Returns {} when nothing matches. Inspect its content to see which placeholders documents.print will fill.',
-          permission: { module: 'documents', action: 'documentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single document template by { _id } or any MongoDB-style query. Returns {} when nothing matches. Inspect its content to see which placeholders documents.print will fill.',
+          { module: 'documents', action: 'documentsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -43,13 +42,12 @@ export const documentTrpcRouter = t.router({
     }),
 
     print: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Render a document template for specific records. Input: { _id, replacerIds?, config? } — _id is the template ID; replacerIds are the record IDs (e.g. customer IDs) whose data fills the template placeholders. Find the template first with documents.find. Read-only: generates content, changes nothing.',
-          permission: { module: 'documents', action: 'documentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Render a document template for specific records. Input: { _id, replacerIds?, config? } — _id is the template ID; replacerIds are the record IDs (e.g. customer IDs) whose data fills the template placeholders. Find the template first with documents.find. Read-only: generates content, changes nothing.',
+          { module: 'documents', action: 'documentsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { _id, replacerIds, config } = input;

--- a/backend/core-api/src/modules/documents/trpc/document.ts
+++ b/backend/core-api/src/modules/documents/trpc/document.ts
@@ -6,14 +6,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const documentTrpcRouter = t.router({
   documents: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List document templates (printable documents with placeholders): { query? }. Use to find the template _id before rendering with documents.print.',
+          permission: { module: 'documents', action: 'documentsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 
       return await models.Documents.find(query).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single document template by { _id } or any MongoDB-style query. Returns {} when nothing matches. Inspect its content to see which placeholders documents.print will fill.',
+          permission: { module: 'documents', action: 'documentsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -24,7 +42,16 @@ export const documentTrpcRouter = t.router({
       return await models.Documents.findOne(query);
     }),
 
-    print: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    print: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Render a document template for specific records. Input: { _id, replacerIds?, config? } — _id is the template ID; replacerIds are the record IDs (e.g. customer IDs) whose data fills the template placeholders. Find the template first with documents.find. Read-only: generates content, changes nothing.',
+          permission: { module: 'documents', action: 'documentsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { _id, replacerIds, config } = input;
       const { models } = ctx;
       return await models.Documents.processDocument({

--- a/backend/core-api/src/modules/forms/trpc/fields.ts
+++ b/backend/core-api/src/modules/forms/trpc/fields.ts
@@ -14,6 +14,13 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const fieldsTrpcRouter = t.router({
   fields: t.router({
     find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List custom field definitions: { query, projection?, sort? }, e.g. { query: { contentType: "core:contacts.customers" } }. Returns field metadata (name, label, type, validation, options). For a complete field list including built-in schema fields, use fields.fieldsCombinedByContentType instead.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(z.object({ query: z.any(), projection: z.any(), sort: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query, projection, sort } = input;
@@ -21,6 +28,13 @@ export const fieldsTrpcRouter = t.router({
         return await models.Fields.find(query, projection).sort(sort).lean();
       }),
     findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single custom field definition by { _id } or { query: {...} }. Returns the field metadata (type, validation, options) needed to format values for fields.prepareCustomFieldsData.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(
         z.object({
           _id: z.string().optional(),
@@ -65,6 +79,13 @@ export const fieldsTrpcRouter = t.router({
         return await models.Fields.updateOne(selector, modifier);
       }),
     prepareCustomFieldsData: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Format raw custom field values into typed customFieldsData entries. Input: [{ field, value }] where field is the custom field _id. Returns entries with the correct stringValue/numberValue/dateValue extras. Pure transformation — writes nothing to the database. Pass the result as doc.customFieldsData in customers.createCustomer / customers.updateCustomer / companies.createCompany / companies.updateCompany. Discover field IDs first via fields.fieldsCombinedByContentType.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(z.array(z.object({ field: z.string(), value: z.any() })))
       .mutation(async ({ ctx, input }) => {
         const { models } = ctx;
@@ -104,6 +125,13 @@ export const fieldsTrpcRouter = t.router({
       }),
 
     getFieldList: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get the full field list (built-in schema fields + custom fields) for a module. Input: { moduleType, collectionType?, usageType? } — moduleType is "contacts" (with collectionType "customers" or "companies"), "product", or "users". Use to discover which fields exist before building filters, imports, or create/update docs.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(
         z.object({
           moduleType: z.string(),
@@ -128,6 +156,13 @@ export const fieldsTrpcRouter = t.router({
         }
       }),
     fieldsCombinedByContentType: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get ALL fields (built-in schema fields + custom fields with select options) for one content type. Input: { contentType, usageType?, excludedNames? } — contentType format "plugin:module.collection", e.g. "core:contacts.customers", "core:contacts.companies", "core:products.product", "core:organization.users". Call this BEFORE writing customFieldsData on any create/update to learn the custom field IDs and their types, then format values with fields.prepareCustomFieldsData.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(
         z.object({
           contentType: z.string(),

--- a/backend/core-api/src/modules/forms/trpc/fields.ts
+++ b/backend/core-api/src/modules/forms/trpc/fields.ts
@@ -2,6 +2,7 @@ import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { fieldsCombinedByContentType } from '~/modules/forms/utils';
 import {
   generateContactsFields,
@@ -14,13 +15,12 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const fieldsTrpcRouter = t.router({
   fields: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List custom field definitions: { query, projection?, sort? }, e.g. { query: { contentType: "core:contacts.customers" } }. Returns field metadata (name, label, type, validation, options). For a complete field list including built-in schema fields, use fields.fieldsCombinedByContentType instead.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List custom field definitions: { query, projection?, sort? }, e.g. { query: { contentType: "core:contacts.customers" } }. Returns field metadata (name, label, type, validation, options). For a complete field list including built-in schema fields, use fields.fieldsCombinedByContentType instead.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(z.object({ query: z.any(), projection: z.any(), sort: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query, projection, sort } = input;
@@ -28,13 +28,12 @@ export const fieldsTrpcRouter = t.router({
         return await models.Fields.find(query, projection).sort(sort).lean();
       }),
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single custom field definition by { _id } or { query: {...} }. Returns the field metadata (type, validation, options) needed to format values for fields.prepareCustomFieldsData.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single custom field definition by { _id } or { query: {...} }. Returns the field metadata (type, validation, options) needed to format values for fields.prepareCustomFieldsData.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(
         z.object({
           _id: z.string().optional(),
@@ -79,13 +78,12 @@ export const fieldsTrpcRouter = t.router({
         return await models.Fields.updateOne(selector, modifier);
       }),
     prepareCustomFieldsData: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Format raw custom field values into typed customFieldsData entries. Input: [{ field, value }] where field is the custom field _id. Returns entries with the correct stringValue/numberValue/dateValue extras. Pure transformation — writes nothing to the database. Pass the result as doc.customFieldsData in customers.createCustomer / customers.updateCustomer / companies.createCompany / companies.updateCompany. Discover field IDs first via fields.fieldsCombinedByContentType.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Format raw custom field values into typed customFieldsData entries. Input: [{ field, value }] where field is the custom field _id. Returns entries with the correct stringValue/numberValue/dateValue extras. Pure transformation — writes nothing to the database. Pass the result as doc.customFieldsData in customers.createCustomer / customers.updateCustomer / companies.createCompany / companies.updateCompany. Discover field IDs first via fields.fieldsCombinedByContentType.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(z.array(z.object({ field: z.string(), value: z.any() })))
       .mutation(async ({ ctx, input }) => {
         const { models } = ctx;
@@ -125,13 +123,12 @@ export const fieldsTrpcRouter = t.router({
       }),
 
     getFieldList: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get the full field list (built-in schema fields + custom fields) for a module. Input: { moduleType, collectionType?, usageType? } — moduleType is "contacts" (with collectionType "customers" or "companies"), "product", or "users". Use to discover which fields exist before building filters, imports, or create/update docs.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get the full field list (built-in schema fields + custom fields) for a module. Input: { moduleType, collectionType?, usageType? } — moduleType is "contacts" (with collectionType "customers" or "companies"), "product", or "users". Use to discover which fields exist before building filters, imports, or create/update docs.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(
         z.object({
           moduleType: z.string(),
@@ -156,13 +153,12 @@ export const fieldsTrpcRouter = t.router({
         }
       }),
     fieldsCombinedByContentType: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get ALL fields (built-in schema fields + custom fields with select options) for one content type. Input: { contentType, usageType?, excludedNames? } — contentType format "plugin:module.collection", e.g. "core:contacts.customers", "core:contacts.companies", "core:products.product", "core:organization.users". Call this BEFORE writing customFieldsData on any create/update to learn the custom field IDs and their types, then format values with fields.prepareCustomFieldsData.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get ALL fields (built-in schema fields + custom fields with select options) for one content type. Input: { contentType, usageType?, excludedNames? } — contentType format "plugin:module.collection", e.g. "core:contacts.customers", "core:contacts.companies", "core:products.product", "core:organization.users". Call this BEFORE writing customFieldsData on any create/update to learn the custom field IDs and their types, then format values with fields.prepareCustomFieldsData.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(
         z.object({
           contentType: z.string(),

--- a/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
+++ b/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const fieldsGroupsTrpcRouter = t.router({
   fieldsGroups: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List custom field groups (sections that custom fields belong to): { query? }. Use with fields.find to understand how custom fields are organized.',
-          permission: { module: 'properties', action: 'propertiesRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List custom field groups (sections that custom fields belong to): { query? }. Use with fields.find to understand how custom fields are organized.',
+          { module: 'properties', action: 'propertiesRead' },
+        ),
+      )
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;

--- a/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
+++ b/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
@@ -8,6 +8,13 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const fieldsGroupsTrpcRouter = t.router({
   fieldsGroups: t.router({
     find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List custom field groups (sections that custom fields belong to): { query? }. Use with fields.find to understand how custom fields are organized.',
+          permission: { module: 'properties', action: 'propertiesRead' },
+        },
+      })
       .input(z.object({ query: z.any() }))
       .query(async ({ ctx, input }) => {
         const { query } = input;

--- a/backend/core-api/src/modules/import-export/trpc/import.ts
+++ b/backend/core-api/src/modules/import-export/trpc/import.ts
@@ -1,6 +1,7 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { saveErrorFile } from '~/modules/import-export/workers/utils/errorFileHandler';
 import { importTemplates } from './templates';
 
@@ -109,13 +110,12 @@ export const importRouter = t.router({
       }),
 
     getTemplate: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get the CSV import template (filename + required column headers) for an entity type. Input: { entityType } — e.g. "core:contacts.customers", "core:contacts.companies", "core:product.product", "core:organization.users". Use to prepare import data with the exact expected columns. For the full field list of an entity also see fields.getFieldList.',
-          permission: { module: 'importExport', action: 'importsManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get the CSV import template (filename + required column headers) for an entity type. Input: { entityType } — e.g. "core:contacts.customers", "core:contacts.companies", "core:product.product", "core:organization.users". Use to prepare import data with the exact expected columns. For the full field list of an entity also see fields.getFieldList.',
+          { module: 'importExport', action: 'importsManage' },
+        ),
+      )
       .input(
         z.object({
           entityType: z.string(),

--- a/backend/core-api/src/modules/import-export/trpc/import.ts
+++ b/backend/core-api/src/modules/import-export/trpc/import.ts
@@ -109,6 +109,13 @@ export const importRouter = t.router({
       }),
 
     getTemplate: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get the CSV import template (filename + required column headers) for an entity type. Input: { entityType } — e.g. "core:contacts.customers", "core:contacts.companies", "core:product.product", "core:organization.users". Use to prepare import data with the exact expected columns. For the full field list of an entity also see fields.getFieldList.',
+          permission: { module: 'importExport', action: 'importsManage' },
+        },
+      })
       .input(
         z.object({
           entityType: z.string(),

--- a/backend/core-api/src/modules/logs/trpc/logs.ts
+++ b/backend/core-api/src/modules/logs/trpc/logs.ts
@@ -1,19 +1,19 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const logsRouter = t.router({
   log: t.router({
     list: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List system/audit logs with a MongoDB-style filter, e.g. { targetId: "recordId" } to see what happened to one record, or { processId: "..." } to see every change made by one operation/request. Use to audit history and trace what changed, when, and by whom.',
-          permission: { module: 'logs', action: 'logsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List system/audit logs with a MongoDB-style filter, e.g. { targetId: "recordId" } to see what happened to one record, or { processId: "..." } to see every change made by one operation/request. Use to audit history and trace what changed, when, and by whom.',
+          { module: 'logs', action: 'logsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ input, ctx }) => {
       const { ...query } = input;

--- a/backend/core-api/src/modules/logs/trpc/logs.ts
+++ b/backend/core-api/src/modules/logs/trpc/logs.ts
@@ -6,7 +6,16 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const logsRouter = t.router({
   log: t.router({
-    list: t.procedure.input(z.any()).query(async ({ input, ctx }) => {
+    list: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List system/audit logs with a MongoDB-style filter, e.g. { targetId: "recordId" } to see what happened to one record, or { processId: "..." } to see every change made by one operation/request. Use to audit history and trace what changed, when, and by whom.',
+          permission: { module: 'logs', action: 'logsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ input, ctx }) => {
       const { ...query } = input;
       const { models, userId } = ctx;
       if (!userId) {

--- a/backend/core-api/src/modules/organization/brand/trpc/brand.ts
+++ b/backend/core-api/src/modules/organization/brand/trpc/brand.ts
@@ -6,13 +6,31 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const brandTrpcRouter = t.router({
   brands: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List brands: { query? }. Brands group channels/integrations (messenger, forms, etc.). Use to resolve a brand name to its _id.',
+          permission: { module: 'brands', action: 'brandsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 
       return await models.Brands.find(query);
     }),
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single brand by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before brands.updateOne.',
+          permission: { module: 'brands', action: 'brandsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -22,13 +40,31 @@ export const brandTrpcRouter = t.router({
 
       return await models.Brands.findOne(query);
     }),
-    create: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    create: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a brand. Input: { data: { name, code, description? } } — code must be unique. Check for an existing brand with brands.find first.',
+          permission: { module: 'brands', action: 'brandsCreate' },
+        },
+      })
+      .input(z.any())
+      .mutation(async ({ ctx, input }) => {
       const { data } = input;
       const { models } = ctx;
 
       return await models.Brands.createBrand(data);
     }),
-    updateOne: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    updateOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Update a brand by ID. Input: { _id, fields: { name?, code?, description?, ... } }. Call brands.findOne first to get the _id.',
+          permission: { module: 'brands', action: 'brandsUpdate' },
+        },
+      })
+      .input(z.any())
+      .mutation(async ({ ctx, input }) => {
       const { _id, fields } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/organization/brand/trpc/brand.ts
+++ b/backend/core-api/src/modules/organization/brand/trpc/brand.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const brandTrpcRouter = t.router({
   brands: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List brands: { query? }. Brands group channels/integrations (messenger, forms, etc.). Use to resolve a brand name to its _id.',
-          permission: { module: 'brands', action: 'brandsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List brands: { query? }. Brands group channels/integrations (messenger, forms, etc.). Use to resolve a brand name to its _id.',
+          { module: 'brands', action: 'brandsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;
@@ -22,13 +22,12 @@ export const brandTrpcRouter = t.router({
       return await models.Brands.find(query);
     }),
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single brand by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before brands.updateOne.',
-          permission: { module: 'brands', action: 'brandsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single brand by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before brands.updateOne.',
+          { module: 'brands', action: 'brandsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -41,13 +40,12 @@ export const brandTrpcRouter = t.router({
       return await models.Brands.findOne(query);
     }),
     create: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a brand. Input: { data: { name, code, description? } } — code must be unique. Check for an existing brand with brands.find first.',
-          permission: { module: 'brands', action: 'brandsCreate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a brand. Input: { data: { name, code, description? } } — code must be unique. Check for an existing brand with brands.find first.',
+          { module: 'brands', action: 'brandsCreate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
       const { data } = input;
@@ -56,13 +54,12 @@ export const brandTrpcRouter = t.router({
       return await models.Brands.createBrand(data);
     }),
     updateOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Update a brand by ID. Input: { _id, fields: { name?, code?, description?, ... } }. Call brands.findOne first to get the _id.',
-          permission: { module: 'brands', action: 'brandsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Update a brand by ID. Input: { _id, fields: { name?, code?, description?, ... } }. Call brands.findOne first to get the _id.',
+          { module: 'brands', action: 'brandsUpdate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
       const { _id, fields } = input;

--- a/backend/core-api/src/modules/organization/structure/trpc/branch.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/branch.ts
@@ -7,14 +7,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const branchTrpcRouter = t.router({
   branches: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List branches (physical/logical locations): { query?, fields? }. Branch IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a branch name/code to its _id.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { models } = ctx;
       const { query, fields } = input;
 
       return await models.Branches.find(query, fields).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single branch by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -25,7 +43,16 @@ export const branchTrpcRouter = t.router({
       return await models.Branches.findOne(query).lean();
     }),
 
-    findWithChild: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findWithChild: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get branches matching { query?, fields? } plus all their descendant branches (branches nest via parentId/order).',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query, fields } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/organization/structure/trpc/branch.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/branch.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const branchTrpcRouter = t.router({
   branches: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List branches (physical/logical locations): { query?, fields? }. Branch IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a branch name/code to its _id.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List branches (physical/logical locations): { query?, fields? }. Branch IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a branch name/code to its _id.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { models } = ctx;
@@ -24,13 +24,12 @@ export const branchTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single branch by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single branch by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -44,13 +43,12 @@ export const branchTrpcRouter = t.router({
     }),
 
     findWithChild: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get branches matching { query?, fields? } plus all their descendant branches (branches nest via parentId/order).',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get branches matching { query?, fields? } plus all their descendant branches (branches nest via parentId/order).',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query, fields } = input;

--- a/backend/core-api/src/modules/organization/structure/trpc/department.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/department.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const departmentTrpcRouter = t.router({
   departments: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List departments: { query?, fields? }. Department IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a department name/code to its _id.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List departments: { query?, fields? }. Department IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a department name/code to its _id.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { models } = ctx;
@@ -24,13 +24,12 @@ export const departmentTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single department by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single department by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -44,13 +43,12 @@ export const departmentTrpcRouter = t.router({
     }),
 
     findWithChild: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get departments matching { query?, fields? } plus all their descendant departments (departments nest via parentId/order).',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get departments matching { query?, fields? } plus all their descendant departments (departments nest via parentId/order).',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query, fields } = input;

--- a/backend/core-api/src/modules/organization/structure/trpc/department.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/department.ts
@@ -7,14 +7,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const departmentTrpcRouter = t.router({
   departments: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List departments: { query?, fields? }. Department IDs are needed for inventory operations (products.setInventories / products.increaseInventories) and team member assignment. Use to resolve a department name/code to its _id.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { models } = ctx;
       const { query, fields } = input;
 
       return await models.Departments.find(query, fields).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single department by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -25,7 +43,16 @@ export const departmentTrpcRouter = t.router({
       return await models.Departments.findOne(query).lean();
     }),
 
-    findWithChild: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findWithChild: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get departments matching { query?, fields? } plus all their descendant departments (departments nest via parentId/order).',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query, fields } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/organization/structure/trpc/unit.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/unit.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const unitTrpcRouter = t.router({
   units: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List units (cross-department organizational groupings): { query?, fields? }. Use to resolve a unit name/code to its _id.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List units (cross-department organizational groupings): { query?, fields? }. Use to resolve a unit name/code to its _id.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { models } = ctx;
@@ -23,13 +23,12 @@ export const unitTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single unit by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'organization', action: 'organizationRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single unit by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'organization', action: 'organizationRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;

--- a/backend/core-api/src/modules/organization/structure/trpc/unit.ts
+++ b/backend/core-api/src/modules/organization/structure/trpc/unit.ts
@@ -6,14 +6,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const unitTrpcRouter = t.router({
   units: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List units (cross-department organizational groupings): { query?, fields? }. Use to resolve a unit name/code to its _id.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { models } = ctx;
       const { query, fields } = input;
 
       return await models.Units.find(query, fields).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single unit by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'organization', action: 'organizationRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/organization/team-member/trpc/user.ts
+++ b/backend/core-api/src/modules/organization/team-member/trpc/user.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const userTrpcRouter = t.router({
   users: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List team members (staff users): { query, fields? }, e.g. { query: { email: "a@b.com" } } or { query: { isActive: true } }. Use fields to limit columns, e.g. { _id: 1, email: 1, "detail.fullName": 1 }. Use to resolve a person\'s name/email to their user _id (needed for ownerId, assignee, etc.).',
-          permission: { module: 'teamMembers', action: 'teamMembersRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List team members (staff users): { query, fields? }, e.g. { query: { email: "a@b.com" } } or { query: { isActive: true } }. Use fields to limit columns, e.g. { _id: 1, email: 1, "detail.fullName": 1 }. Use to resolve a person\'s name/email to their user _id (needed for ownerId, assignee, etc.).',
+          { module: 'teamMembers', action: 'teamMembersRead' },
+        ),
+      )
       .input(
         z.object({
           query: z.record(z.any()),
@@ -27,13 +27,12 @@ export const userTrpcRouter = t.router({
         return models.Users.find(query, fields);
       }),
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single team member by { _id }, { email }, { username }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'teamMembers', action: 'teamMembersRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single team member by { _id }, { email }, { username }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'teamMembers', action: 'teamMembersRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -81,13 +80,12 @@ export const userTrpcRouter = t.router({
       }),
 
     getCount: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Count team members matching a filter: { query? }, e.g. { query: { isActive: true } }.',
-          permission: { module: 'teamMembers', action: 'teamMembersRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Count team members matching a filter: { query? }, e.g. { query: { isActive: true } }.',
+          { module: 'teamMembers', action: 'teamMembersRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;

--- a/backend/core-api/src/modules/organization/team-member/trpc/user.ts
+++ b/backend/core-api/src/modules/organization/team-member/trpc/user.ts
@@ -7,6 +7,13 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 export const userTrpcRouter = t.router({
   users: t.router({
     find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List team members (staff users): { query, fields? }, e.g. { query: { email: "a@b.com" } } or { query: { isActive: true } }. Use fields to limit columns, e.g. { _id: 1, email: 1, "detail.fullName": 1 }. Use to resolve a person\'s name/email to their user _id (needed for ownerId, assignee, etc.).',
+          permission: { module: 'teamMembers', action: 'teamMembersRead' },
+        },
+      })
       .input(
         z.object({
           query: z.record(z.any()),
@@ -19,7 +26,16 @@ export const userTrpcRouter = t.router({
 
         return models.Users.find(query, fields);
       }),
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single team member by { _id }, { email }, { username }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'teamMembers', action: 'teamMembersRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -64,7 +80,16 @@ export const userTrpcRouter = t.router({
         return models.Users.setUserActiveOrInactive(_id);
       }),
 
-    getCount: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    getCount: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Count team members matching a filter: { query? }, e.g. { query: { isActive: true } }.',
+          permission: { module: 'teamMembers', action: 'teamMembersRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/products/trpc/category.ts
+++ b/backend/core-api/src/modules/products/trpc/category.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const productCategoryTrpcRouter = t.router({
   productCategories: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List product categories: { query?, sort? }. Categories form a tree via parentId/order. Use this to resolve a category name or code to its _id before creating/updating products or filtering products by categoryId.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List product categories: { query?, sort? }. Categories form a tree via parentId/order. Use this to resolve a category name or code to its _id before creating/updating products or filtering products by categoryId.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query, sort, regData } = input;
@@ -31,13 +31,12 @@ export const productCategoryTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single product category by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before productCategories.updateProductCategory.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single product category by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before productCategories.updateProductCategory.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -54,13 +53,12 @@ export const productCategoryTrpcRouter = t.router({
     }),
 
     withChilds: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get categories plus ALL their descendants. Input: { ids: ["categoryId", ...] }. Use to gather every subcategory under a parent, e.g. before bulk product operations across a whole category tree. (products.find/count already expand a single categoryId automatically.)',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get categories plus ALL their descendants. Input: { ids: ["categoryId", ...] }. Use to gather every subcategory under a parent, e.g. before bulk product operations across a whole category tree. (products.find/count already expand a single categoryId automatically.)',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { ids } = input;
@@ -73,13 +71,12 @@ export const productCategoryTrpcRouter = t.router({
     }),
 
     createProductCategory: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a product category. Input: { doc: { name, code, parentId?, description?, status?, ... } } — code must be unique; pass parentId to nest under an existing category (find it with productCategories.find).',
-          permission: { module: 'products', action: 'productCategoriesManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a product category. Input: { doc: { name, code, parentId?, description?, status?, ... } } — code must be unique; pass parentId to nest under an existing category (find it with productCategories.find).',
+          { module: 'products', action: 'productCategoriesManage' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -89,13 +86,12 @@ export const productCategoryTrpcRouter = t.router({
       }),
 
     updateProductCategory: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Update a product category by ID. Input: { _id, doc: { ...fields to change } }. Call productCategories.findOne first to get the _id and current values.',
-          permission: { module: 'products', action: 'productCategoriesManage' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Update a product category by ID. Input: { _id, doc: { ...fields to change } }. Call productCategories.findOne first to get the _id and current values.',
+          { module: 'products', action: 'productCategoriesManage' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -114,13 +110,12 @@ export const productCategoryTrpcRouter = t.router({
       }),
 
     count: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Count product categories matching a filter: { query? }.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Count product categories matching a filter: { query? }.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;

--- a/backend/core-api/src/modules/products/trpc/category.ts
+++ b/backend/core-api/src/modules/products/trpc/category.ts
@@ -7,7 +7,16 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const productCategoryTrpcRouter = t.router({
   productCategories: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List product categories: { query?, sort? }. Categories form a tree via parentId/order. Use this to resolve a category name or code to its _id before creating/updating products or filtering products by categoryId.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query, sort, regData } = input;
       const { models } = ctx;
 
@@ -21,7 +30,16 @@ export const productCategoryTrpcRouter = t.router({
       return models.ProductCategories.find(query).sort(sort).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single product category by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call before productCategories.updateProductCategory.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
       if (!query || !Object.keys(query).length) {
@@ -35,7 +53,16 @@ export const productCategoryTrpcRouter = t.router({
       return productCategory;
     }),
 
-    withChilds: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    withChilds: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get categories plus ALL their descendants. Input: { ids: ["categoryId", ...] }. Use to gather every subcategory under a parent, e.g. before bulk product operations across a whole category tree. (products.find/count already expand a single categoryId automatically.)',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { ids } = input;
       const { models } = ctx;
 
@@ -46,6 +73,13 @@ export const productCategoryTrpcRouter = t.router({
     }),
 
     createProductCategory: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a product category. Input: { doc: { name, code, parentId?, description?, status?, ... } } — code must be unique; pass parentId to nest under an existing category (find it with productCategories.find).',
+          permission: { module: 'products', action: 'productCategoriesManage' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -55,6 +89,13 @@ export const productCategoryTrpcRouter = t.router({
       }),
 
     updateProductCategory: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Update a product category by ID. Input: { _id, doc: { ...fields to change } }. Call productCategories.findOne first to get the _id and current values.',
+          permission: { module: 'products', action: 'productCategoriesManage' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -72,7 +113,16 @@ export const productCategoryTrpcRouter = t.router({
         return models.ProductCategories.removeProductCategory(_id);
       }),
 
-    count: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    count: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Count product categories matching a filter: { query? }.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/products/trpc/config.ts
+++ b/backend/core-api/src/modules/products/trpc/config.ts
@@ -6,7 +6,16 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const productConfigTrpcRouter = t.router({
   productConfigs: t.router({
-    getConfig: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    getConfig: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Read a product module configuration value by code: { code, defaultValue? }. Returns defaultValue when the config is not set. Product-related settings only.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { code, defaultValue } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/products/trpc/config.ts
+++ b/backend/core-api/src/modules/products/trpc/config.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const productConfigTrpcRouter = t.router({
   productConfigs: t.router({
     getConfig: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Read a product module configuration value by code: { code, defaultValue? }. Returns defaultValue when the config is not set. Product-related settings only.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Read a product module configuration value by code: { code, defaultValue? }. Returns defaultValue when the config is not set. Product-related settings only.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { code, defaultValue } = input;

--- a/backend/core-api/src/modules/products/trpc/product.ts
+++ b/backend/core-api/src/modules/products/trpc/product.ts
@@ -2,6 +2,7 @@ import { initTRPC } from '@trpc/server';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { similaritiesTrpcRouter } from '@/products/trpc/similarity';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
@@ -79,13 +80,12 @@ export const productsTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single product by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call this before products.updateProduct to confirm the record and read current values.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single product by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call this before products.updateProduct to confirm the record and read current values.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -98,13 +98,12 @@ export const productsTrpcRouter = t.router({
     }),
 
     createProduct: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a product. Input: { doc: { name, code?, unitPrice?, categoryId?, uom?, type?, status?, sku?, barcodes?, tagIds?, customFieldsData?, ... } } — name is required; code should be unique. Resolve categoryId via productCategories.find and uom via productUoms.find first. For custom fields use fields.fieldsCombinedByContentType (contentType "core:products.product") + fields.prepareCustomFieldsData.',
-          permission: { module: 'products', action: 'productsCreate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a product. Input: { doc: { name, code?, unitPrice?, categoryId?, uom?, type?, status?, sku?, barcodes?, tagIds?, customFieldsData?, ... } } — name is required; code should be unique. Resolve categoryId via productCategories.find and uom via productUoms.find first. For custom fields use fields.fieldsCombinedByContentType (contentType "core:products.product") + fields.prepareCustomFieldsData.',
+          { module: 'products', action: 'productsCreate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -114,13 +113,12 @@ export const productsTrpcRouter = t.router({
       }),
 
     updateProduct: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Update a product by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call products.findOne first to get the _id and current values.',
-          permission: { module: 'products', action: 'productsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Update a product by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call products.findOne first to get the _id and current values.',
+          { module: 'products', action: 'productsUpdate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -148,13 +146,12 @@ export const productsTrpcRouter = t.router({
       }),
 
     count: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Count products matching a filter: { query?, categoryId? } — categoryId automatically includes all child categories. Use for "how many products ..." questions instead of fetching records.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Count products matching a filter: { query?, categoryId? } — categoryId automatically includes all child categories. Use for "how many products ..." questions instead of fetching records.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query: rawQuery, categoryId } = input;
@@ -180,13 +177,12 @@ export const productsTrpcRouter = t.router({
     }),
     rules: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Search products with a MongoDB-style filter plus pagination: { query?, sort?, skip?, limit?, fields?, categoryId?, categoryIds? }. categoryId/categoryIds automatically expand to include all child categories. Use products.findOne for a single known product and products.count for totals.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Search products with a MongoDB-style filter plus pagination: { query?, sort?, skip?, limit?, fields?, categoryId?, categoryIds? }. categoryId/categoryIds automatically expand to include all child categories. Use products.findOne for a single known product and products.count for totals.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
@@ -201,13 +197,12 @@ export const productsTrpcRouter = t.router({
     }),
 
     setInventories: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Set ABSOLUTE inventory numbers per branch/department. Input: { branchId?, departmentId?, productsInfo: [{ productId, remainder?, cost?, soonIn?, soonOut? }] }. WARNING: fields you omit are cleared to 0 — for relative stock in/out adjustments use products.increaseInventories instead. Resolve branchId/departmentId via branches.find / departments.find and productId via products.findOne.',
-          permission: { module: 'products', action: 'productsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Set ABSOLUTE inventory numbers per branch/department. Input: { branchId?, departmentId?, productsInfo: [{ productId, remainder?, cost?, soonIn?, soonOut? }] }. WARNING: fields you omit are cleared to 0 — for relative stock in/out adjustments use products.increaseInventories instead. Resolve branchId/departmentId via branches.find / departments.find and productId via products.findOne.',
+          { module: 'products', action: 'productsUpdate' },
+        ),
+      )
       .input(
         z.object({
           branchId: z.string().optional(),
@@ -275,13 +270,12 @@ export const productsTrpcRouter = t.router({
       }),
 
     increaseInventories: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Adjust inventory by DELTA amounts per branch/department (stock in/out). Input: { branchId?, departmentId?, productsInfo: [{ productId, diffCount?, diffCost?, diffSoonIn?, diffSoonOut? }] } — use negative numbers to decrease stock. Prefer this over products.setInventories for everyday stock movements. Resolve branchId/departmentId via branches.find / departments.find.',
-          permission: { module: 'products', action: 'productsUpdate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Adjust inventory by DELTA amounts per branch/department (stock in/out). Input: { branchId?, departmentId?, productsInfo: [{ productId, diffCount?, diffCost?, diffSoonIn?, diffSoonOut? }] } — use negative numbers to decrease stock. Prefer this over products.setInventories for everyday stock movements. Resolve branchId/departmentId via branches.find / departments.find.',
+          { module: 'products', action: 'productsUpdate' },
+        ),
+      )
       .input(
         z.object({
           branchId: z.string().optional(),

--- a/backend/core-api/src/modules/products/trpc/product.ts
+++ b/backend/core-api/src/modules/products/trpc/product.ts
@@ -78,7 +78,16 @@ export const productsTrpcRouter = t.router({
         .lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single product by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches. Call this before products.updateProduct to confirm the record and read current values.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
       if (!query || !Object.keys(query).length) {
@@ -89,6 +98,13 @@ export const productsTrpcRouter = t.router({
     }),
 
     createProduct: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a product. Input: { doc: { name, code?, unitPrice?, categoryId?, uom?, type?, status?, sku?, barcodes?, tagIds?, customFieldsData?, ... } } — name is required; code should be unique. Resolve categoryId via productCategories.find and uom via productUoms.find first. For custom fields use fields.fieldsCombinedByContentType (contentType "core:products.product") + fields.prepareCustomFieldsData.',
+          permission: { module: 'products', action: 'productsCreate' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { doc } = input;
@@ -98,6 +114,13 @@ export const productsTrpcRouter = t.router({
       }),
 
     updateProduct: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Update a product by ID. Input: { _id, doc: { ...fields to change } } — only provided fields are modified. Call products.findOne first to get the _id and current values.',
+          permission: { module: 'products', action: 'productsUpdate' },
+        },
+      })
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
         const { _id, doc } = input;
@@ -124,7 +147,16 @@ export const productsTrpcRouter = t.router({
         return models.Products.removeProducts(_ids);
       }),
 
-    count: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    count: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Count products matching a filter: { query?, categoryId? } — categoryId automatically includes all child categories. Use for "how many products ..." questions instead of fetching records.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query: rawQuery, categoryId } = input;
       const { models } = ctx;
 
@@ -147,7 +179,16 @@ export const productsTrpcRouter = t.router({
       return models.Products.find(query).countDocuments();
     }),
     rules: t.router({
-      find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Search products with a MongoDB-style filter plus pagination: { query?, sort?, skip?, limit?, fields?, categoryId?, categoryIds? }. categoryId/categoryIds automatically expand to include all child categories. Use products.findOne for a single known product and products.count for totals.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
         const { models } = ctx;
         const { _ids = [] } = input || {};
 
@@ -160,6 +201,13 @@ export const productsTrpcRouter = t.router({
     }),
 
     setInventories: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Set ABSOLUTE inventory numbers per branch/department. Input: { branchId?, departmentId?, productsInfo: [{ productId, remainder?, cost?, soonIn?, soonOut? }] }. WARNING: fields you omit are cleared to 0 — for relative stock in/out adjustments use products.increaseInventories instead. Resolve branchId/departmentId via branches.find / departments.find and productId via products.findOne.',
+          permission: { module: 'products', action: 'productsUpdate' },
+        },
+      })
       .input(
         z.object({
           branchId: z.string().optional(),
@@ -227,6 +275,13 @@ export const productsTrpcRouter = t.router({
       }),
 
     increaseInventories: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Adjust inventory by DELTA amounts per branch/department (stock in/out). Input: { branchId?, departmentId?, productsInfo: [{ productId, diffCount?, diffCost?, diffSoonIn?, diffSoonOut? }] } — use negative numbers to decrease stock. Prefer this over products.setInventories for everyday stock movements. Resolve branchId/departmentId via branches.find / departments.find.',
+          permission: { module: 'products', action: 'productsUpdate' },
+        },
+      })
       .input(
         z.object({
           branchId: z.string().optional(),

--- a/backend/core-api/src/modules/products/trpc/uom.ts
+++ b/backend/core-api/src/modules/products/trpc/uom.ts
@@ -6,7 +6,16 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const uomTrpcRouter = t.router({
   productUoms: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List units of measure (UOM): { query? }. Use to resolve a UOM code/name to the exact value expected in products.createProduct doc.uom.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
 
       const { models } = ctx;
@@ -14,7 +23,16 @@ export const uomTrpcRouter = t.router({
       return models.Uoms.find(query).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single unit of measure by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'products', action: 'productsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
 
       const { models } = ctx;

--- a/backend/core-api/src/modules/products/trpc/uom.ts
+++ b/backend/core-api/src/modules/products/trpc/uom.ts
@@ -1,19 +1,19 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const uomTrpcRouter = t.router({
   productUoms: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List units of measure (UOM): { query? }. Use to resolve a UOM code/name to the exact value expected in products.createProduct doc.uom.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List units of measure (UOM): { query? }. Use to resolve a UOM code/name to the exact value expected in products.createProduct doc.uom.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;
@@ -24,13 +24,12 @@ export const uomTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single unit of measure by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'products', action: 'productsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single unit of measure by { _id }, { code }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'products', action: 'productsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;

--- a/backend/core-api/src/modules/segments/trpc/segments.ts
+++ b/backend/core-api/src/modules/segments/trpc/segments.ts
@@ -2,6 +2,7 @@ import { initTRPC } from '@trpc/server';
 import { generateElkId } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 import { fetchSegment } from '../utils/fetchSegment';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
@@ -30,13 +31,12 @@ export const optionsSchema = z
 export const segmentsRouter = t.router({
   segment: t.router({
     isInSegment: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Check whether ONE record belongs to a segment. Input: { segmentId, idToCheck } — idToCheck is the record _id (e.g. a customer _id). Returns true/false. Use segment.fetchSegment instead when you need the full member list.',
-          permission: { module: 'segments', action: 'segmentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Check whether ONE record belongs to a segment. Input: { segmentId, idToCheck } — idToCheck is the record _id (e.g. a customer _id). Returns true/false. Use segment.fetchSegment instead when you need the full member list.',
+          { module: 'segments', action: 'segmentsRead' },
+        ),
+      )
       .input(
         z.object({
           segmentId: z.string(),
@@ -72,13 +72,12 @@ export const segmentsRouter = t.router({
         return count > 0;
       }),
     fetchSegment: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Fetch the records that belong to a segment. Input: { segmentId?, options? } — options.returnCount=true returns only the count; options.returnFields limits columns; options.page/perPage paginate; options.returnFullDoc=true returns full documents. Call segment.findOne first to confirm the segment exists and see what content type and conditions it filters.',
-          permission: { module: 'segments', action: 'segmentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Fetch the records that belong to a segment. Input: { segmentId?, options? } — options.returnCount=true returns only the count; options.returnFields limits columns; options.page/perPage paginate; options.returnFullDoc=true returns full documents. Call segment.findOne first to confirm the segment exists and see what content type and conditions it filters.',
+          { module: 'segments', action: 'segmentsRead' },
+        ),
+      )
       .input(
         z.object({
           segmentId: z.string().optional(),
@@ -98,13 +97,12 @@ export const segmentsRouter = t.router({
         return await fetchSegment(models, subdomain, segment, options);
       }),
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a segment definition by ID: { _id }. Returns the segment name, contentType (what entity it filters, e.g. "core:contacts.customers"), and its conditions. Call this before segment.fetchSegment or segment.isInSegment to understand what the segment contains.',
-          permission: { module: 'segments', action: 'segmentsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a segment definition by ID: { _id }. Returns the segment name, contentType (what entity it filters, e.g. "core:contacts.customers"), and its conditions. Call this before segment.fetchSegment or segment.isInSegment to understand what the segment contains.',
+          { module: 'segments', action: 'segmentsRead' },
+        ),
+      )
       .input(z.object({ _id: z.string() }))
       .query(async ({ input, ctx }) => {
         const { models } = ctx;

--- a/backend/core-api/src/modules/segments/trpc/segments.ts
+++ b/backend/core-api/src/modules/segments/trpc/segments.ts
@@ -30,6 +30,13 @@ export const optionsSchema = z
 export const segmentsRouter = t.router({
   segment: t.router({
     isInSegment: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Check whether ONE record belongs to a segment. Input: { segmentId, idToCheck } — idToCheck is the record _id (e.g. a customer _id). Returns true/false. Use segment.fetchSegment instead when you need the full member list.',
+          permission: { module: 'segments', action: 'segmentsRead' },
+        },
+      })
       .input(
         z.object({
           segmentId: z.string(),
@@ -65,6 +72,13 @@ export const segmentsRouter = t.router({
         return count > 0;
       }),
     fetchSegment: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Fetch the records that belong to a segment. Input: { segmentId?, options? } — options.returnCount=true returns only the count; options.returnFields limits columns; options.page/perPage paginate; options.returnFullDoc=true returns full documents. Call segment.findOne first to confirm the segment exists and see what content type and conditions it filters.',
+          permission: { module: 'segments', action: 'segmentsRead' },
+        },
+      })
       .input(
         z.object({
           segmentId: z.string().optional(),
@@ -84,6 +98,13 @@ export const segmentsRouter = t.router({
         return await fetchSegment(models, subdomain, segment, options);
       }),
     findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a segment definition by ID: { _id }. Returns the segment name, contentType (what entity it filters, e.g. "core:contacts.customers"), and its conditions. Call this before segment.fetchSegment or segment.isInSegment to understand what the segment contains.',
+          permission: { module: 'segments', action: 'segmentsRead' },
+        },
+      })
       .input(z.object({ _id: z.string() }))
       .query(async ({ input, ctx }) => {
         const { models } = ctx;

--- a/backend/core-api/src/modules/tags/trpc/tag.ts
+++ b/backend/core-api/src/modules/tags/trpc/tag.ts
@@ -7,14 +7,32 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const tagTrpcRouter = t.router({
   tags: t.router({
-    find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    find: t.procedure
+      .meta({
+        agent: {
+          description:
+            'List tags: { query? }. Tags are scoped per entity type — filter with { type: "core:customer" } for customer tags, "core:company" for companies, "core:product" for products. Use to resolve tag names to _ids before tagging records via customers.tag or setting tagIds in create/update docs.',
+          permission: { module: 'tags', action: 'tagsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query } = input;
       const { models } = ctx;
 
       return await models.Tags.find(query).lean();
     }),
 
-    findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findOne: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get a single tag by { _id }, { name, type }, or any MongoDB-style query. Returns {} when nothing matches.',
+          permission: { module: 'tags', action: 'tagsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
       const { models } = ctx;
 
@@ -25,7 +43,16 @@ export const tagTrpcRouter = t.router({
       return await models.Tags.findOne(query);
     }),
 
-    findWithChild: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+    findWithChild: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Get tags matching { query?, fields? } plus all their child tags (tags nest via parentId). Use when a tagging or filtering operation should include sub-tags.',
+          permission: { module: 'tags', action: 'tagsRead' },
+        },
+      })
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
       const { query, fields } = input;
       const { models } = ctx;
 
@@ -51,7 +78,16 @@ export const tagTrpcRouter = t.router({
         .sort({ order: 1 })
         .lean();
     }),
-    create: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    create: t.procedure
+      .meta({
+        agent: {
+          description:
+            'Create a tag. Input: { data: { name, type, colorCode?, parentId? } } — type scopes the tag, e.g. "core:customer", "core:company", "core:product". Check for an existing tag with tags.find (by name + type) before creating a duplicate. Then attach it with customers.tag or doc.tagIds.',
+          permission: { module: 'tags', action: 'tagsCreate' },
+        },
+      })
+      .input(z.any())
+      .mutation(async ({ ctx, input }) => {
       const { data } = input;
       const { models } = ctx;
 

--- a/backend/core-api/src/modules/tags/trpc/tag.ts
+++ b/backend/core-api/src/modules/tags/trpc/tag.ts
@@ -2,19 +2,19 @@ import { initTRPC } from '@trpc/server';
 import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
 export const tagTrpcRouter = t.router({
   tags: t.router({
     find: t.procedure
-      .meta({
-        agent: {
-          description:
-            'List tags: { query? }. Tags are scoped per entity type — filter with { type: "core:customer" } for customer tags, "core:company" for companies, "core:product" for products. Use to resolve tag names to _ids before tagging records via customers.tag or setting tagIds in create/update docs.',
-          permission: { module: 'tags', action: 'tagsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'List tags: { query? }. Tags are scoped per entity type — filter with { type: "core:customer" } for customer tags, "core:company" for companies, "core:product" for products. Use to resolve tag names to _ids before tagging records via customers.tag or setting tagIds in create/update docs.',
+          { module: 'tags', action: 'tagsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query } = input;
@@ -24,13 +24,12 @@ export const tagTrpcRouter = t.router({
     }),
 
     findOne: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get a single tag by { _id }, { name, type }, or any MongoDB-style query. Returns {} when nothing matches.',
-          permission: { module: 'tags', action: 'tagsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get a single tag by { _id }, { name, type }, or any MongoDB-style query. Returns {} when nothing matches.',
+          { module: 'tags', action: 'tagsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const query = input?.query || input?.selector || input;
@@ -44,13 +43,12 @@ export const tagTrpcRouter = t.router({
     }),
 
     findWithChild: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Get tags matching { query?, fields? } plus all their child tags (tags nest via parentId). Use when a tagging or filtering operation should include sub-tags.',
-          permission: { module: 'tags', action: 'tagsRead' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Get tags matching { query?, fields? } plus all their child tags (tags nest via parentId). Use when a tagging or filtering operation should include sub-tags.',
+          { module: 'tags', action: 'tagsRead' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
       const { query, fields } = input;
@@ -79,13 +77,12 @@ export const tagTrpcRouter = t.router({
         .lean();
     }),
     create: t.procedure
-      .meta({
-        agent: {
-          description:
-            'Create a tag. Input: { data: { name, type, colorCode?, parentId? } } — type scopes the tag, e.g. "core:customer", "core:company", "core:product". Check for an existing tag with tags.find (by name + type) before creating a duplicate. Then attach it with customers.tag or doc.tagIds.',
-          permission: { module: 'tags', action: 'tagsCreate' },
-        },
-      })
+      .meta(
+        agentMeta(
+          'Create a tag. Input: { data: { name, type, colorCode?, parentId? } } — type scopes the tag, e.g. "core:customer", "core:company", "core:product". Check for an existing tag with tags.find (by name + type) before creating a duplicate. Then attach it with customers.tag or doc.tagIds.',
+          { module: 'tags', action: 'tagsCreate' },
+        ),
+      )
       .input(z.any())
       .mutation(async ({ ctx, input }) => {
       const { data } = input;

--- a/backend/core-api/src/utils/agentMeta.ts
+++ b/backend/core-api/src/utils/agentMeta.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds the `.meta()` payload that exposes a tRPC procedure as an
+ * agent-callable tool in the /agent-tools manifest.
+ *
+ * @param description - Agent-facing guidance: when to use the tool, its
+ *   input shape, and which other tools it chains with.
+ * @param permission - A permission the plugin registers in its
+ *   meta/permissions config; checked against the acting user on every call.
+ */
+export const agentMeta = (
+  description: string,
+  permission: { module: string; action: string },
+) => ({
+  agent: { description, permission },
+});


### PR DESCRIPTION
## Summary

Annotates **68 core tRPC procedures** with `.meta({ agent: { description, permission } })`, making them discoverable via `/agent-tools/manifest` and callable through `/agent-tools/call` under the platform's admit-only protocol. Every tool is gated by a permission action that core actually registers (`meta/permissions.ts`), checked against the acting user at call time.

No behavior changes for existing callers — this only adds metadata. Unannotated procedures remain invisible to agents.

## What's exposed

| Module | Tools | Permissions |
|---|---|---|
| Contacts (customers) | find, findOne, findActiveCustomers, count, createCustomer, updateCustomer, tag | contactsRead/Create/Update, tagsTag |
| Contacts (companies) | find, findOne, findActiveCompanies, createCompany, updateCompany | contactsRead/Create/Update |
| Products | find, findOne, count, createProduct, updateProduct, setInventories, increaseInventories | productsRead/Create/Update |
| Product categories / UOM / config | find, findOne, withChilds, count, category create/update, UOM find/findOne, getConfig | productsRead, productCategoriesManage |
| Tags / Brands | find, findOne, findWithChild, create / find, findOne, create, updateOne | tagsRead/Create, brandsRead/Create/Update |
| Organization | branches/departments/units find, findOne, findWithChild | organizationRead |
| Team members | users.find, findOne, getCount | teamMembersRead |
| Segments | findOne, fetchSegment, isInSegment | segmentsRead |
| Fields (properties) | find, findOne, getFieldList, fieldsCombinedByContentType, prepareCustomFieldsData, fieldsGroups.find | propertiesRead |
| Documents | find, findOne, print | documentsRead |
| Client portal | cpUsers.list/get, clientPortals.get, cpNotifications.list/create | clientPortalRead/Manage |
| Approval | state, states | approvalLocksManage |
| Logs / Import | log.list / import.getTemplate | logsRead / importsManage |

## Description design

Each description is written for runtime agent consumption — when to use the tool, the input shape (most inputs are free-form `z.any()`, so field guidance lives in the description), and how tools chain:

- **Safe mutation:** `findOne` → `update*` (confirm record + current values first)
- **Customer create:** dedupe via `findOne` → resolve tags via `tags.find` → custom fields via `fields.fieldsCombinedByContentType` + `fields.prepareCustomFieldsData` → `createCustomer`
- **Product create:** `productCategories.find` + `productUoms.find` → `createProduct`
- **Inventory:** `branches.find`/`departments.find` → `increaseInventories` (delta, preferred) vs `setInventories` (absolute, warns that omitted fields reset to 0)
- **Segments:** `segment.findOne` → `fetchSegment` / `isInSegment`
- **Portal notify:** `customers.findOne` → `cpUsers.list(erxesCustomerId)` → `cpNotifications.create`
- **Approval-aware edits:** check `approval.state` before mutating locked records

## Deliberately NOT exposed

Auth internals (`comparePassword`, `checkLoginAuth`), raw selector/modifier bulk ops (`updateMany`, `updateOne`, `updateProducts`), all delete/remove procedures, `branches.aggregate` (raw pipeline), `configs.*` (secret-bearing), `notifications.sendEmail`/`sendMobileNotification` (abuse vector), messenger/widget session internals, import/export job progress workers, automation trigger matching, `activityLog.*`, `revert.applyWrite` (internal revert engine).

## Verification

- `tsc --noEmit` on core-api: **0 errors** (whole project, incl. all 21 touched files)
- eslint: clean on all touched files (the repo's remaining lint errors are pre-existing on `main`, confirmed on the stashed tree)
- `nx build core-api`: `build:packageJson` failure is pre-existing infrastructure (resolves `erxes-api-shared/*` to stale dist types; tsconfig.build.json drops the src path mapping) — unrelated to this change; dev/serve typecheck passes

## Summary by Sourcery

Expose approved core tRPC procedures to agents through the agent-tools manifest and call protocol with permission-gated metadata.

New Features:
- Expose 68 selected core tRPC procedures as discoverable, agent-callable tools with runtime descriptions and permission metadata.

Enhancements:
- Provide agent-facing guidance for tool inputs, safe mutation workflows, and chaining related procedures.
- Restrict agent exposure to explicitly annotated procedures while preserving existing caller behavior and enforcing registered permissions at call time.

Tests:
- Verify whole-project TypeScript compilation and linting for all touched core-api files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized operation metadata and permission requirements across approvals, contacts, documents, forms, client portals, products, organization structure, teams, tags, segments, logs, imports, and brands.
  * Improved consistency for integrations and assistants when discovering supported operations and access requirements.
* **Bug Fixes**
  * No changes were made to operation behavior, validation, inputs, outputs, or permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->