### PR TITLE
Fix(content): Show post submission loading state

### DIFF
--- a/frontend/plugins/content_ui/AGENTS.md
+++ b/frontend/plugins/content_ui/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `content_ui`
 - **Layer:** `Frontend UI`
 - **Path:** `frontend/plugins/content_ui`
-- **Last synchronized:** `2026-08-17`
+- **Last synchronized:** `2026-08-19`
 
 ## Scope
 
@@ -27,6 +27,8 @@
   saved and reopened in the post editor.
 - Allows individual CMS custom-field file uploads up to 650 MiB through the
   platform's chunked-upload contract.
+- Shows the active CMS post create or edit mutation state in the header action
+  so save, schedule, and publish submissions cannot be triggered twice.
 
 ## Architecture
 
@@ -87,6 +89,8 @@
 - `src/widgets` is for plugin widget exports, not general shared CMS UI.
 - Keep hooks, GraphQL documents, states, constants, and types near the feature
   they support.
+- Keep the form-ready header state synchronized with post mutation loading so
+  header actions remain disabled and visible as loading until submission ends.
 
 ### UI Conventions
 
@@ -170,9 +174,9 @@
 
 ## Validation
 
-- `pnpm nx lint content_ui` (when a lint target is defined)
 - `pnpm nx build content_ui`
-- `pnpm nx test content_ui`
+- Create and edit a CMS post, submit each form, and verify the header action is
+  disabled with a status-specific loading label until the mutation completes.
 - Create or edit a CMS post with blank paragraphs and a Tab-indented paragraph,
   save it, reopen it, and verify the structure remains visible.
 - Directly select a CMS file custom field and verify a file no larger than
@@ -192,6 +196,14 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-19` — Synchronize post submission loading
+
+- **Summary:** Kept CMS post header actions synchronized with create and edit
+  mutation loading so submissions show feedback and cannot be duplicated.
+- **Affected areas:** `src/modules/cms/hooks/usePostMutations.ts`, post add form
+  submission and header actions, and CMS post add/detail pages
+- **Contracts changed:** None
 
 ### `2026-08-17` — Raise custom-field upload limit to 650 MiB
 

--- a/frontend/plugins/content_ui/src/modules/cms/hooks/usePostMutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/hooks/usePostMutations.ts
@@ -52,8 +52,7 @@ export function usePostMutations({ websiteId }: UsePostMutationsOptions = {}) {
     createPost,
     editPost,
     removePost,
-    creating: createState.loading,
-    saving: editState.loading,
+    loading: createState.loading || editState.loading,
     removing: removeState.loading,
   };
 }

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
@@ -23,8 +23,7 @@ interface AddPostFormProps {
   onFormReady?: (formState: {
     form: UseFormReturn<FieldValues>;
     onSubmit: (data?: FieldValues) => Promise<void>;
-    creating: boolean;
-    saving: boolean;
+    loading: boolean;
     handleLanguageChange: (lang: string) => void;
   }) => void;
 }
@@ -103,7 +102,7 @@ export const AddPostForm = ({
     [form],
   );
 
-  const { onSubmit, creating, saving } = usePostSubmission({
+  const { onSubmit, loading } = usePostSubmission({
     websiteId,
     editingPost: currentEditingPost,
     selectedLanguage,
@@ -123,8 +122,6 @@ export const AddPostForm = ({
       options: { silent: boolean },
     ) => Promise<void>,
   });
-
-  const formInitializedRef = useRef(false);
 
   const handleLanguageChangeRef = useRef<(lang: string) => void>(
     () => undefined,
@@ -157,25 +154,14 @@ export const AddPostForm = ({
   );
 
   useEffect(() => {
-    if (onFormReady && form && !formInitializedRef.current) {
-      // Same safe widening as formForColumns — consumers only read known fields.
-      onFormReady({
-        form: form as unknown as UseFormReturn<FieldValues>,
-        onSubmit: onSubmit as unknown as (data?: FieldValues) => Promise<void>,
-        creating,
-        saving,
-        handleLanguageChange: handleLanguageChangeStable,
-      });
-      formInitializedRef.current = true;
-    }
-  }, [
-    form,
-    onSubmit,
-    creating,
-    saving,
-    onFormReady,
-    handleLanguageChangeStable,
-  ]);
+    if (!onFormReady || !form) return;
+    onFormReady({
+      form: form as unknown as UseFormReturn<FieldValues>,
+      onSubmit: onSubmit as unknown as (data?: FieldValues) => Promise<void>,
+      loading,
+      handleLanguageChange: handleLanguageChangeStable,
+    });
+  }, [form, onSubmit, loading, onFormReady, handleLanguageChangeStable]);
 
   // Helper: apply translation (or clear) translatable fields and save default data
   const applyTranslationToForm = useCallback(

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostHeaderActions.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostHeaderActions.tsx
@@ -38,15 +38,13 @@ export interface PostFormData {
 interface AddPostHeaderActionsProps {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
 }
 
 export const AddPostHeaderActions = ({
   form,
   onSubmit,
-  creating,
-  saving,
+  loading,
 }: AddPostHeaderActionsProps) => {
   const { t } = useTranslation('content');
   const status = useWatch({
@@ -190,30 +188,27 @@ export const AddPostHeaderActions = ({
           />
         </div>
       </Form>
-      <Button
-        onClick={() => form.handleSubmit(onSubmit)()}
-        disabled={creating || saving}
-      >
-        {creating || saving ? (
+      <Button onClick={() => form.handleSubmit(onSubmit)()} disabled={loading}>
+        {loading ? (
           <>
             <Spinner size="sm" className="mr-2" />
             {status === 'published'
               ? t('publishing')
               : status === 'draft'
-                ? t('saving')
-                : status === 'scheduled'
-                  ? t('scheduling')
-                  : t('saving')}
+              ? t('saving')
+              : status === 'scheduled'
+              ? t('scheduling')
+              : t('saving')}
           </>
         ) : (
           <div>
             {status === 'published'
               ? t('publish')
               : status === 'draft'
-                ? t('save-draft')
-                : status === 'scheduled'
-                  ? t('schedule')
-                  : t('save')}
+              ? t('save-draft')
+              : status === 'scheduled'
+              ? t('schedule')
+              : t('save')}
           </div>
         )}
       </Button>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -368,7 +368,7 @@ export const usePostSubmission = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  const { createPost, editPost, creating, saving } = usePostMutations({
+  const { createPost, editPost, loading } = usePostMutations({
     websiteId,
   });
 
@@ -519,7 +519,6 @@ export const usePostSubmission = ({
 
   return {
     onSubmit,
-    creating,
-    saving,
+    loading,
   };
 };

--- a/frontend/plugins/content_ui/src/pages/cms/PostsAddPage.tsx
+++ b/frontend/plugins/content_ui/src/pages/cms/PostsAddPage.tsx
@@ -14,8 +14,7 @@ import {
 interface PostHeaderFormState {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
   handleLanguageChange: (lang: string) => void;
 }
 
@@ -65,8 +64,7 @@ export const PostsAddPage = ({
           <AddPostHeaderActions
             form={formState.form}
             onSubmit={formState.onSubmit}
-            creating={formState.creating}
-            saving={formState.saving}
+            loading={formState.loading}
           />
         )}
       </PostsHeader>

--- a/frontend/plugins/content_ui/src/pages/cms/posts-detail/PostsDetailPage.tsx
+++ b/frontend/plugins/content_ui/src/pages/cms/posts-detail/PostsDetailPage.tsx
@@ -14,8 +14,7 @@ import {
 interface PostHeaderFormState {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
   handleLanguageChange: (lang: string) => void;
 }
 
@@ -73,8 +72,7 @@ export const PostsDetailPage = ({
           <AddPostHeaderActions
             form={formState.form}
             onSubmit={formState.onSubmit}
-            creating={formState.creating}
-            saving={formState.saving}
+            loading={formState.loading}
           />
         )}
       </PostsHeader>


### PR DESCRIPTION
## Summary

- unify CMS post create and edit mutation loading state
- keep header actions synchronized so save, schedule, and publish show progress and cannot be submitted twice
- synchronize the content plugin guide

## Validation

- pnpm nx build content_ui
- targeted Prettier check

## Summary by Sourcery

Keep CMS post header actions synchronized with post mutation progress so submissions provide accurate feedback and cannot be triggered twice.

Bug Fixes:
- Prevent duplicate CMS post submissions by keeping header actions disabled throughout create and edit mutations.

Enhancements:
- Unify CMS post creation and editing into a single loading state with status-specific progress labels for save, schedule, and publish actions.

Documentation:
- Synchronize the content plugin guide with the post submission loading behavior and validation expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post creation and editing workflows by consistently showing loading feedback during submissions.
  * Submit actions are disabled while a post is being created or updated, helping prevent duplicate submissions.
* **Documentation**
  * Updated guidance for validating submission-loading behavior in the content management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->