### PR TITLE
Fix(content): Show post submission loading state

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/hooks/usePostMutations.ts
+++ b/frontend/plugins/content_ui/src/modules/cms/hooks/usePostMutations.ts
@@ -52,8 +52,7 @@ export function usePostMutations({ websiteId }: UsePostMutationsOptions = {}) {
     createPost,
     editPost,
     removePost,
-    creating: createState.loading,
-    saving: editState.loading,
+    loading: createState.loading || editState.loading,
     removing: removeState.loading,
   };
 }

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostForm.tsx
@@ -23,8 +23,7 @@ interface AddPostFormProps {
   onFormReady?: (formState: {
     form: UseFormReturn<FieldValues>;
     onSubmit: (data?: FieldValues) => Promise<void>;
-    creating: boolean;
-    saving: boolean;
+    loading: boolean;
     handleLanguageChange: (lang: string) => void;
   }) => void;
 }
@@ -103,7 +102,7 @@ export const AddPostForm = ({
     [form],
   );
 
-  const { onSubmit, creating, saving } = usePostSubmission({
+  const { onSubmit, loading } = usePostSubmission({
     websiteId,
     editingPost: currentEditingPost,
     selectedLanguage,
@@ -123,8 +122,6 @@ export const AddPostForm = ({
       options: { silent: boolean },
     ) => Promise<void>,
   });
-
-  const formInitializedRef = useRef(false);
 
   const handleLanguageChangeRef = useRef<(lang: string) => void>(
     () => undefined,
@@ -157,25 +154,14 @@ export const AddPostForm = ({
   );
 
   useEffect(() => {
-    if (onFormReady && form && !formInitializedRef.current) {
-      // Same safe widening as formForColumns — consumers only read known fields.
-      onFormReady({
-        form: form as unknown as UseFormReturn<FieldValues>,
-        onSubmit: onSubmit as unknown as (data?: FieldValues) => Promise<void>,
-        creating,
-        saving,
-        handleLanguageChange: handleLanguageChangeStable,
-      });
-      formInitializedRef.current = true;
-    }
-  }, [
-    form,
-    onSubmit,
-    creating,
-    saving,
-    onFormReady,
-    handleLanguageChangeStable,
-  ]);
+    if (!onFormReady || !form) return;
+    onFormReady({
+      form: form as unknown as UseFormReturn<FieldValues>,
+      onSubmit: onSubmit as unknown as (data?: FieldValues) => Promise<void>,
+      loading,
+      handleLanguageChange: handleLanguageChangeStable,
+    });
+  }, [form, onSubmit, loading, onFormReady, handleLanguageChangeStable]);
 
   // Helper: apply translation (or clear) translatable fields and save default data
   const applyTranslationToForm = useCallback(

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostHeaderActions.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/AddPostHeaderActions.tsx
@@ -38,15 +38,13 @@ export interface PostFormData {
 interface AddPostHeaderActionsProps {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
 }
 
 export const AddPostHeaderActions = ({
   form,
   onSubmit,
-  creating,
-  saving,
+  loading,
 }: AddPostHeaderActionsProps) => {
   const { t } = useTranslation('content');
   const status = useWatch({
@@ -190,30 +188,27 @@ export const AddPostHeaderActions = ({
           />
         </div>
       </Form>
-      <Button
-        onClick={() => form.handleSubmit(onSubmit)()}
-        disabled={creating || saving}
-      >
-        {creating || saving ? (
+      <Button onClick={() => form.handleSubmit(onSubmit)()} disabled={loading}>
+        {loading ? (
           <>
             <Spinner size="sm" className="mr-2" />
             {status === 'published'
               ? t('publishing')
               : status === 'draft'
-                ? t('saving')
-                : status === 'scheduled'
-                  ? t('scheduling')
-                  : t('saving')}
+              ? t('saving')
+              : status === 'scheduled'
+              ? t('scheduling')
+              : t('saving')}
           </>
         ) : (
           <div>
             {status === 'published'
               ? t('publish')
               : status === 'draft'
-                ? t('save-draft')
-                : status === 'scheduled'
-                  ? t('schedule')
-                  : t('save')}
+              ? t('save-draft')
+              : status === 'scheduled'
+              ? t('schedule')
+              : t('save')}
           </div>
         )}
       </Button>

--- a/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/posts/components/add-post-form/hooks/usePostSubmission.tsx
@@ -368,7 +368,7 @@ export const usePostSubmission = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  const { createPost, editPost, creating, saving } = usePostMutations({
+  const { createPost, editPost, loading } = usePostMutations({
     websiteId,
   });
 
@@ -519,7 +519,6 @@ export const usePostSubmission = ({
 
   return {
     onSubmit,
-    creating,
-    saving,
+    loading,
   };
 };

--- a/frontend/plugins/content_ui/src/pages/cms/PostsAddPage.tsx
+++ b/frontend/plugins/content_ui/src/pages/cms/PostsAddPage.tsx
@@ -14,8 +14,7 @@ import {
 interface PostHeaderFormState {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
   handleLanguageChange: (lang: string) => void;
 }
 
@@ -65,8 +64,7 @@ export const PostsAddPage = ({
           <AddPostHeaderActions
             form={formState.form}
             onSubmit={formState.onSubmit}
-            creating={formState.creating}
-            saving={formState.saving}
+            loading={formState.loading}
           />
         )}
       </PostsHeader>

--- a/frontend/plugins/content_ui/src/pages/cms/posts-detail/PostsDetailPage.tsx
+++ b/frontend/plugins/content_ui/src/pages/cms/posts-detail/PostsDetailPage.tsx
@@ -14,8 +14,7 @@ import {
 interface PostHeaderFormState {
   form: UseFormReturn<FieldValues>;
   onSubmit: (data?: FieldValues) => void | Promise<void>;
-  creating: boolean;
-  saving: boolean;
+  loading: boolean;
   handleLanguageChange: (lang: string) => void;
 }
 
@@ -73,8 +72,7 @@ export const PostsDetailPage = ({
           <AddPostHeaderActions
             form={formState.form}
             onSubmit={formState.onSubmit}
-            creating={formState.creating}
-            saving={formState.saving}
+            loading={formState.loading}
           />
         )}
       </PostsHeader>


### PR DESCRIPTION
## Summary

- unify CMS post create and edit mutation loading state
- keep header actions synchronized so save, schedule, and publish show progress and cannot be submitted twice

## Validation

- pnpm nx build content_ui
- targeted Prettier check

## Summary by Sourcery

Unify CMS post submission loading feedback across creation and editing workflows.

Bug Fixes:
- Show a unified loading state while creating or editing CMS posts, preventing duplicate save, schedule, and publish submissions.

Enhancements:
- Keep post header actions synchronized with the active submission state and display the appropriate progress label for each action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved User Experience**
  * Consolidated post creation and editing activity into a single loading state.
  * Post action controls are now consistently disabled and display loading feedback while changes are being processed.
  * Improved form state updates when submission status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->