### PR TITLE
fix(payment): redirect expired TDB invoices to failed page

### DIFF
--- a/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
+++ b/backend/plugins/payment_api/src/widget/src/pages/InvoiceDetail.tsx
@@ -68,7 +68,34 @@ const InvoiceDetail = () => {
       invoiceDetailQuery.refetch();
     }
   }, [invoiceSubscription.data, transactionSubscription.data]);
+  React.useEffect(() => {
+    if (!id || !invoiceDetail || invoiceDetail.status === 'paid') {
+      return;
+    }
+    const interval = setInterval(async () => {
+      try {
+        const { data } = await checkInvoice({
+          variables: { id },
+        });
 
+        const status = data?.invoicesCheck;
+
+        if (status === 'paid') {
+          clearInterval(interval);
+          return;
+        }
+
+        if (status === 'failed' || status === 'expired') {
+          clearInterval(interval);
+          window.location.href = `/pl:payment/widget/payment-failed/${id}`;
+        }
+      } catch (error) {
+        console.error('[Payment] Automatic invoice check failed:', error);
+      }
+    }, 15000);
+
+    return () => clearInterval(interval);
+  }, [id, invoiceDetail?.status, checkInvoice]);
   if (invoiceDetailQuery.loading || paymentsLoading) {
     return (
       <div className="py-12 flex items-center justify-center">


### PR DESCRIPTION
## Summary by Sourcery

Automatically monitor unpaid invoices and redirect expired or failed payments to the failure page.

Bug Fixes:
- Redirect users to the payment-failed page when an invoice becomes failed or expired during payment.

Enhancements:
- Periodically check unpaid invoice status and stop monitoring once the invoice is paid or reaches a terminal failure state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice payment statuses now update automatically every 15 seconds while payment is pending.
  * Successful payments stop status checks.
  * Failed or expired invoices automatically redirect to the payment-failed page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->