### PR TITLE
fix(frontline): make messenger follow its online hours

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/db/models/Integrations.ts
@@ -72,6 +72,15 @@ export const isTimeInBetween = (
   const end = getHourAndMinute(closeTime);
   const closeDate = moment(now).hours(end.hour).minutes(end.minute);
 
+  if (!closeDate.isAfter(startDate)) {
+    closeDate.add(1, 'day');
+
+    if (now.isBefore(startDate)) {
+      startDate.subtract(1, 'day');
+      closeDate.subtract(1, 'day');
+    }
+  }
+
   return now.isBetween(startDate, closeDate);
 };
 
@@ -580,10 +589,12 @@ export const loadClass = (models: IModels, subdomain: string) => {
       /*
        * Auto
        */
-      const day = daysAsString[now.getDay()];
+      const day = daysAsString[moment(now).tz(timezoneString).day()];
 
       // check by everyday config
-      const everydayConf = onlineHours.find((c) => c.day === 'everyday');
+      const everydayConf = onlineHours.find(
+        (c) => c.day === 'everyday' && c.from && c.to,
+      );
 
       if (everydayConf) {
         return isTimeInBetween(


### PR DESCRIPTION
## Summary by Sourcery

Ensure messenger availability follows configured online hours across timezones and overnight schedules.

Bug Fixes:
- Make messenger online-hours checks correctly handle overnight schedules and evaluate hours using the configured timezone.
- Ignore incomplete everyday online-hours configurations when determining messenger availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved online status calculations for schedules that span midnight.
  * Correctly handles times carried over from the previous day.
  * Uses the configured timezone when determining schedule days.
  * Ignores incomplete schedule entries that are missing a start or end time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->