### PR TITLE
feat(frontline): expose safe tRPC procedures as agent-callable tools

### DIFF
--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `frontline_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/frontline_api`
-- **Last synchronized:** `2026-08-19`
+- **Last synchronized:** `2026-08-20`
 
 ## Scope
 
@@ -87,6 +87,10 @@
   `onServerInit`.
 - Ticket boards/pipelines, response templates, forms, knowledgebase articles,
   and report aggregations.
+- Read-only inbox, integration, and form-submission tRPC procedures are
+  exposed to AI agents through `/agent-tools/manifest` and `/agent-tools/call`
+  via `.meta(agentMeta(...))` annotations; every other procedure remains
+  invisible to agents.
 - Contributes permissions, notifications, segments, references, and
   import/export handlers to the platform through `meta/`.
 
@@ -98,6 +102,7 @@
 | Models               | `src/connectionResolvers.ts`                                                | Per-subdomain model container for all modules                                                           |
 | GraphQL              | `src/apollo/`                                                               | Aggregated `typeDefs` and `resolvers` across modules                                                    |
 | tRPC                 | `src/init-trpc.ts`                                                          | `appRouter` for service-to-service calls                                                                |
+| Agent tool metadata  | `src/trpc/agentMeta.ts`                                                     | Local `agentMeta` helper for agent-callable tRPC annotations                                            |
 | HTTP                 | `src/routes.ts`                                                             | Mounts `/facebook` and `/instagram` webhook routers                                                     |
 | Platform extensions  | `src/meta/`                                                                 | automations, permissions, notifications, segments, references, import/export                            |
 | Channels             | `src/modules/channel/`                                                      | Channel + ChannelMember models, schema, resolvers, role checks                                          |
@@ -178,6 +183,16 @@ accountId, brandId, data)` — `channelId` is **nullable** for every kind;
 - tRPC `appRouter` consumed by other services, including
   `inbox.updateUserChannels({ channelIds, userId })` — replaces a user's team
   channel memberships; never touches their personal channel.
+- Agent-callable tRPC tools (admit-only via `.meta({ agent })`), each gated by
+  the listed frontline permission action:
+  - `inbox.conversations.findOne`, `inbox.conversations.count`,
+    `inbox.getConversationsList`, `inbox.conversationMessages.findOne`,
+    `inbox.conversationMessages.find` — `showConversations`
+  - `inbox.conversations.changeStatus` — `conversationsChangeStatus`
+  - `inbox.integrations.findOne`, `inbox.integrations.find`,
+    `inbox.integrations.count`, `inbox.getIntegrationKinds` —
+    `showIntegrations`
+  - `form.submissionsByConversation` — `showFormSubmissions`
 - HTTP routes in `src/routes.ts` and provider webhooks under
   `src/modules/integrations/*`: Express webhook routes `/facebook/*` and
   `/instagram/*`, including the OAuth entry points `/facebook/fblogin`,
@@ -690,6 +705,23 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   drill-down) rather than the chart. Widening the stored filter set means adding
   the field to the `filters` subschema, the `ReportChartFilters` output type,
   and that key list together, or it will be silently dropped on save.
+- Agent tool annotations are admit-only: never annotate webhook ingestion or
+  notification plumbing (`inbox.integrations.receive`,
+  `inbox.integrationsNotification`, `inbox.sendNotifications`,
+  `inbox.conversationClientMessageInserted`), raw-mongo helpers
+  (`inbox.conversationMessages.updateOne`, `inbox.updateConversationMessage`),
+  bulk or destructive operations (`inbox.integrations.remove`,
+  `inbox.removeConversation`, `inbox.removeCustomersConversations`,
+  `inbox.changeCustomer`, `conversation.tag`), procedures that trust a
+  caller-supplied `userId` (`inbox.createConversationAndMessage`,
+  `inbox.createOnlyMessage`, `inbox.integrations.copyLeadIntegration`,
+  `ticket.create`), widget-facing endpoints
+  (`inbox.widgetsGetUnreadMessagesCount`), internal membership or relation
+  plumbing (`inbox.updateUserChannels`, `inbox.getModuleRelation`,
+  `relation.onRelationAdded`, `fields.getFieldList`), or the raw
+  `inbox.channels.find`, which bypasses `visibleChannelsFilter` and would
+  expose other users' personal channels. New procedures are agent-invisible
+  unless explicitly annotated.
 - Every resolver, model call, worker, and route resolves models from the request
   `subdomain`.
 - Schemas are defined with `new Schema(...)` and explicit fields; do not
@@ -717,10 +749,34 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   range covering `calls_cdrs` documents whose `actionType` contains
   `QUEUE[<queue>]`. Every tab must show numbers; an empty `calls_cdrs` renders
   every tab blank, which is expected, not a bug.
+- Smoke: `GET /agent-tools/manifest` on the frontline service lists only the
+  annotated procedures above; `ticket.create`, `inbox.removeConversation`,
+  `inbox.conversationMessages.updateOne`, and `inbox.channels.find` never
+  appear.
 
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-20` — Agent-callable tRPC tools
+
+- **Summary:** Read-only inbox conversation/message, integration, and form
+  submission tRPC procedures — plus the well-scoped
+  `inbox.conversations.changeStatus` action — are now exposed to AI agents
+  through the platform agent-tools manifest, each gated by a frontline
+  permission the plugin registers.
+- **Affected areas:** `src/trpc/agentMeta.ts` (new local helper mirroring
+  core-api), `src/modules/inbox/trpc/inbox.ts`,
+  `src/modules/form/trpc/form.ts`.
+- **Contracts changed:** New agent-tool manifest entries
+  `inbox.conversations.findOne`, `inbox.conversations.count`,
+  `inbox.getConversationsList`, `inbox.conversations.changeStatus`,
+  `inbox.conversationMessages.findOne`, `inbox.conversationMessages.find`,
+  `inbox.integrations.findOne`, `inbox.integrations.find`,
+  `inbox.integrations.count`, `inbox.getIntegrationKinds`, and
+  `form.submissionsByConversation`, gated by `showConversations`,
+  `conversationsChangeStatus`, `showIntegrations`, and `showFormSubmissions`.
+  No existing GraphQL or tRPC behavior changed.
 
 ### `2026-08-19` — Call history reports the ring on unanswered calls
 
@@ -854,16 +910,3 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - **Affected areas:** `src/modules/ticket/utils/permissionValidator.ts`.
 - **Contracts changed:** None — `updateTicket` can now fail with
   `You do not have permission to move tickets out of this status`.
-
-### `2026-08-17` — Status management moved onto the frontline permission
-
-- **Summary:** `addTicketStatus`, `updateTicketStatus` and `deleteTicketStatus`
-  now require the new `ticketStatusesManage` action via
-  `context.checkPermission` instead of asserting pipeline ownership; the local
-  `assertPipelineOwner` helper is gone.
-- **Affected areas:** `src/meta/permissions.ts`,
-  `src/modules/ticket/graphql/resolvers/mutations/status.ts`.
-- **Contracts changed:** The `ticket` permission module gained the
-  `ticketStatusesManage` action, granted to the `frontline:admin` default
-  group; the three status mutations now fail with `Permission required`
-  (`FORBIDDEN`) for users without it.

--- a/backend/plugins/frontline_api/src/modules/form/trpc/form.ts
+++ b/backend/plugins/frontline_api/src/modules/form/trpc/form.ts
@@ -1,6 +1,7 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { FrontlineTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/trpc/agentMeta';
 import { getConversationFormSubmissions } from '@/form/utils';
 
 const t = initTRPC.context<FrontlineTRPCContext>().create();
@@ -8,6 +9,12 @@ const t = initTRPC.context<FrontlineTRPCContext>().create();
 export const formTrpcRouter = t.router({
   form: t.router({
     submissionsByConversation: t.procedure
+      .meta(
+        agentMeta(
+          'Get the form submissions attached to an inbox conversation: { conversationId }. Returns { formId, formTitle, submissions: [{ label, value }] }, or null when the conversation has no submission.',
+          { module: 'form', action: 'showFormSubmissions' },
+        ),
+      )
       .input(z.object({ conversationId: z.string() }))
       .query(async ({ ctx, input }) => {
         const { models } = ctx;

--- a/backend/plugins/frontline_api/src/modules/inbox/trpc/inbox.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/trpc/inbox.ts
@@ -11,6 +11,7 @@ import { cursorPaginate } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { IModels } from '~/connectionResolvers';
 import { FrontlineTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/trpc/agentMeta';
 import { IConversationDocument } from '../@types/conversations';
 
 const t = initTRPC.context<FrontlineTRPCContext>().create();
@@ -140,40 +141,48 @@ export const integrationsRouter = t.router({
     }
   }),
 
-  find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    const { query = {}, options } = input;
-    const { models } = ctx;
-    try {
-      const integrations = await models.Integrations.findIntegrations(
-        query,
-        options,
-      );
+  find: t.procedure
+    .meta(
+      agentMeta(
+        'Search active integrations (messenger, lead, webhook, or external kinds): { query?: {...}, options?: projection }, e.g. { query: { kind: "messenger" } } or { query: { channelId: "..." } }. Inactive integrations are excluded automatically. Use inbox.getIntegrationKinds to see valid kind values.',
+        { module: 'integration', action: 'showIntegrations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      const { query = {}, options } = input;
+      const { models } = ctx;
+      try {
+        const integrations = await models.Integrations.findIntegrations(
+          query,
+          options,
+        );
 
-      return {
-        status: 'success',
-        data: integrations,
-        meta: {
-          count: integrations.length,
-        },
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      console.error('Failed to fetch integrations:', error);
+        return {
+          status: 'success',
+          data: integrations,
+          meta: {
+            count: integrations.length,
+          },
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        console.error('Failed to fetch integrations:', error);
 
-      return {
-        status: 'error',
-        error: {
-          code: 'INTEGRATIONS_FETCH_FAILED',
-          message: 'Failed to retrieve integrations',
-          details: error instanceof Error ? error.message : undefined,
-          ...(process.env.NODE_ENV === 'development' && {
-            stack: error instanceof Error ? error.stack : undefined,
-          }),
-        },
-        timestamp: new Date().toISOString(),
-      };
-    }
-  }),
+        return {
+          status: 'error',
+          error: {
+            code: 'INTEGRATIONS_FETCH_FAILED',
+            message: 'Failed to retrieve integrations',
+            details: error instanceof Error ? error.message : undefined,
+            ...(process.env.NODE_ENV === 'development' && {
+              stack: error instanceof Error ? error.stack : undefined,
+            }),
+          },
+          timestamp: new Date().toISOString(),
+        };
+      }
+    }),
 
   copyLeadIntegration: t.procedure
     .input(z.any())
@@ -211,165 +220,197 @@ export const integrationsRouter = t.router({
       }
     }),
 
-  count: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    const { models } = ctx;
-    const { selector = {}, filters } = input;
-
-    try {
-      const query = {
-        ...selector,
-        ...(filters && { ...filters }),
-      };
-
-      const count = await models.Integrations.countDocuments(query);
-
-      return {
-        status: 'success',
-        data: count,
-        meta: {
-          filteredBy:
-            Object.keys(query).length > 0 ? Object.keys(query) : ['all'],
-          timestamp: new Date().toISOString(),
-        },
-      };
-    } catch (error) {
-      console.error('Count operation failed:', error);
-
-      return {
-        status: 'error',
-        error: {
-          code: 'COUNT_OPERATION_FAILED',
-          message: 'Failed to count documents',
-          details: error instanceof Error ? error.message : 'Database error',
-          ...(process.env.NODE_ENV === 'development' && {
-            stack: error instanceof Error ? error.stack : undefined,
-          }),
-        },
-        timestamp: new Date().toISOString(),
-      };
-    }
-  }),
-
-  findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    const { models } = ctx;
-    try {
-      const result = await models.Integrations.findOne(input).lean();
-
-      if (!result) {
-        return {
-          status: 'error',
-          error: {
-            code: 'NOT_FOUND',
-            message: 'Integration not found',
-            suggestion: 'Please verify the search criteria',
-          },
-          timestamp: new Date().toISOString(),
-        };
-      }
-
-      return {
-        status: 'success',
-        data: result,
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      console.error('FindOne operation failed:', error);
-
-      return {
-        status: 'error',
-        error: {
-          code: 'FIND_ONE_FAILED',
-          message: 'Failed to find integration',
-          details: error instanceof Error ? error.message : 'Database error',
-          ...(process.env.NODE_ENV === 'development' && {
-            stack: error instanceof Error ? error.stack : undefined,
-          }),
-        },
-        timestamp: new Date().toISOString(),
-      };
-    }
-  }),
-});
-
-export const conversationMessagesRouter = t.router({
-  findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    const { models } = ctx;
-    try {
-      // Build the query from validated input
-      const message = await models.ConversationMessages.findOne(input).lean();
-
-      if (!message) {
-        return {
-          status: 'error',
-          error: {
-            code: 'MESSAGE_NOT_FOUND',
-            message: 'Conversation message not found',
-            suggestion: 'Verify the message identifiers and try again',
-          },
-          timestamp: new Date().toISOString(),
-        };
-      }
-
-      return {
-        status: 'success',
-        data: message,
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      console.error('Failed to find conversation message:', error);
-
-      return {
-        status: 'error',
-        error: {
-          code: 'MESSAGE_FIND_FAILED',
-          message: 'Failed to retrieve message',
-          details: error instanceof Error ? error.message : 'Database error',
-          ...(process.env.NODE_ENV === 'development' && {
-            stack: error instanceof Error ? error.stack : undefined,
-          }),
-        },
-        timestamp: new Date().toISOString(),
-      };
-    }
-  }),
-
-  find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    try {
-      const { skip, limit } = input;
+  count: t.procedure
+    .meta(
+      agentMeta(
+        'Count integrations matching a filter: { selector?: {...}, filters?: {...} }, merged into one Mongo query, e.g. { selector: { kind: "lead" } }. Use for "how many integrations ..." questions instead of inbox.integrations.find.',
+        { module: 'integration', action: 'showIntegrations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
       const { models } = ctx;
+      const { selector = {}, filters } = input;
 
-      if (skip || limit) {
-        const queryParams = { ...input };
-        delete queryParams.skip;
-        delete queryParams.limit;
+      try {
+        const query = {
+          ...selector,
+          ...(filters && { ...filters }),
+        };
 
-        const result = await models.ConversationMessages.find(queryParams)
-          .skip(skip || 0)
-          .limit(limit || 20)
-          .lean();
+        const count = await models.Integrations.countDocuments(query);
+
+        return {
+          status: 'success',
+          data: count,
+          meta: {
+            filteredBy:
+              Object.keys(query).length > 0 ? Object.keys(query) : ['all'],
+            timestamp: new Date().toISOString(),
+          },
+        };
+      } catch (error) {
+        console.error('Count operation failed:', error);
+
+        return {
+          status: 'error',
+          error: {
+            code: 'COUNT_OPERATION_FAILED',
+            message: 'Failed to count documents',
+            details: error instanceof Error ? error.message : 'Database error',
+            ...(process.env.NODE_ENV === 'development' && {
+              stack: error instanceof Error ? error.stack : undefined,
+            }),
+          },
+          timestamp: new Date().toISOString(),
+        };
+      }
+    }),
+
+  findOne: t.procedure
+    .meta(
+      agentMeta(
+        'Get a single integration by any MongoDB-style query, e.g. { _id } or { kind: "messenger", brandId: "..." }. Returns a NOT_FOUND error when nothing matches.',
+        { module: 'integration', action: 'showIntegrations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      const { models } = ctx;
+      try {
+        const result = await models.Integrations.findOne(input).lean();
+
+        if (!result) {
+          return {
+            status: 'error',
+            error: {
+              code: 'NOT_FOUND',
+              message: 'Integration not found',
+              suggestion: 'Please verify the search criteria',
+            },
+            timestamp: new Date().toISOString(),
+          };
+        }
 
         return {
           status: 'success',
           data: result,
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        console.error('FindOne operation failed:', error);
+
+        return {
+          status: 'error',
+          error: {
+            code: 'FIND_ONE_FAILED',
+            message: 'Failed to find integration',
+            details: error instanceof Error ? error.message : 'Database error',
+            ...(process.env.NODE_ENV === 'development' && {
+              stack: error instanceof Error ? error.stack : undefined,
+            }),
+          },
+          timestamp: new Date().toISOString(),
         };
       }
+    }),
+});
 
-      const result = await models.ConversationMessages.find(input).lean();
-      return {
-        status: 'success',
-        data: result,
-      };
-    } catch (error) {
-      console.error('Error fetching conversation messages:', error);
+export const conversationMessagesRouter = t.router({
+  findOne: t.procedure
+    .meta(
+      agentMeta(
+        'Get a single conversation message by any MongoDB-style query, e.g. { _id } or { conversationId: "..." }. Returns a MESSAGE_NOT_FOUND error when nothing matches. Use inbox.conversationMessages.find to list a conversation\'s messages.',
+        { module: 'inbox', action: 'showConversations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      const { models } = ctx;
+      try {
+        // Build the query from validated input
+        const message = await models.ConversationMessages.findOne(input).lean();
 
-      return {
-        status: 'error',
-        message: 'Failed to fetch conversation messages',
-        error:
-          process.env.NODE_ENV === 'development' ? error.message : undefined,
-      };
-    }
-  }),
+        if (!message) {
+          return {
+            status: 'error',
+            error: {
+              code: 'MESSAGE_NOT_FOUND',
+              message: 'Conversation message not found',
+              suggestion: 'Verify the message identifiers and try again',
+            },
+            timestamp: new Date().toISOString(),
+          };
+        }
+
+        return {
+          status: 'success',
+          data: message,
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        console.error('Failed to find conversation message:', error);
+
+        return {
+          status: 'error',
+          error: {
+            code: 'MESSAGE_FIND_FAILED',
+            message: 'Failed to retrieve message',
+            details: error instanceof Error ? error.message : 'Database error',
+            ...(process.env.NODE_ENV === 'development' && {
+              stack: error instanceof Error ? error.stack : undefined,
+            }),
+          },
+          timestamp: new Date().toISOString(),
+        };
+      }
+    }),
+
+  find: t.procedure
+    .meta(
+      agentMeta(
+        'List conversation messages matching a MongoDB-style filter, e.g. { conversationId: "...", skip?: number, limit?: number }. When skip or limit is present the result is paged (default limit 20); otherwise every matching message is returned.',
+        { module: 'inbox', action: 'showConversations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      try {
+        const { skip, limit } = input;
+        const { models } = ctx;
+
+        if (skip || limit) {
+          const queryParams = { ...input };
+          delete queryParams.skip;
+          delete queryParams.limit;
+
+          const result = await models.ConversationMessages.find(queryParams)
+            .skip(skip || 0)
+            .limit(limit || 20)
+            .lean();
+
+          return {
+            status: 'success',
+            data: result,
+          };
+        }
+
+        const result = await models.ConversationMessages.find(input).lean();
+        return {
+          status: 'success',
+          data: result,
+        };
+      } catch (error) {
+        console.error('Error fetching conversation messages:', error);
+
+        return {
+          status: 'error',
+          message: 'Failed to fetch conversation messages',
+          error:
+            process.env.NODE_ENV === 'development' ? error.message : undefined,
+        };
+      }
+    }),
 
   updateOne: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
     const { filter, updateDoc } = input;
@@ -382,110 +423,134 @@ export const conversationMessagesRouter = t.router({
 });
 
 export const conversationsRouter = t.router({
-  count: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    try {
-      const { query = {}, options } = input;
-      const { models } = ctx;
+  count: t.procedure
+    .meta(
+      agentMeta(
+        'Count inbox conversations matching a filter: { query?: {...}, options?: { skip?, limit? } }, e.g. { query: { status: "new", integrationId: "..." } }. Use for "how many conversations ..." questions instead of inbox.getConversationsList.',
+        { module: 'inbox', action: 'showConversations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      try {
+        const { query = {}, options } = input;
+        const { models } = ctx;
 
-      const count = await models.Conversations.find(query)
-        .skip(options?.skip || 0)
-        .limit(options?.limit || 0) // 0 means no limit
-        .countDocuments();
+        const count = await models.Conversations.find(query)
+          .skip(options?.skip || 0)
+          .limit(options?.limit || 0) // 0 means no limit
+          .countDocuments();
 
-      return {
-        status: 'success',
-        data: count,
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      console.error('Count documents error:', error);
-
-      return {
-        status: 'error',
-        message: 'Failed to count documents',
-        ...(process.env.NODE_ENV === 'development' && {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          stack: error instanceof Error ? error.stack : undefined,
-        }),
-      };
-    }
-  }),
-
-  findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    try {
-      const { query } = input;
-      const { models } = ctx;
-
-      if (!query) {
-        return {
-          status: 'error',
-          message: 'Query parameter is required',
-        };
-      }
-
-      const conversation = await models.Conversations.findOne(query).lean();
-
-      if (!conversation) {
         return {
           status: 'success',
-          data: null,
-          message: 'No conversation found',
+          data: count,
+          timestamp: new Date().toISOString(),
         };
-      }
+      } catch (error) {
+        console.error('Count documents error:', error);
 
-      return {
-        status: 'success',
-        data: conversation,
-      };
-    } catch (error) {
-      console.error('Error finding conversation:', error);
-      return {
-        status: 'error',
-        message: 'Failed to find conversation',
-        error:
-          process.env.NODE_ENV === 'development' ? error.message : undefined,
-      };
-    }
-  }),
-
-  changeStatus: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    try {
-      const { id, status } = input;
-      const { models } = ctx;
-
-      if (!id || !status) {
         return {
           status: 'error',
-          message: `Both id and status are required. Received id: ${id}, status: ${status}`,
+          message: 'Failed to count documents',
+          ...(process.env.NODE_ENV === 'development' && {
+            error: error instanceof Error ? error.message : 'Unknown error',
+            stack: error instanceof Error ? error.stack : undefined,
+          }),
         };
       }
+    }),
 
-      const result = await models.Conversations.updateOne(
-        { _id: id },
-        { status: status },
-      );
+  findOne: t.procedure
+    .meta(
+      agentMeta(
+        'Get a single inbox conversation by a MongoDB-style query: { query: { _id } } or { query: { customerId: "...", integrationId: "..." } }. Returns data null when nothing matches. Use inbox.getConversationsList to browse many conversations.',
+        { module: 'inbox', action: 'showConversations' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      try {
+        const { query } = input;
+        const { models } = ctx;
 
-      if (result.matchedCount === 0) {
+        if (!query) {
+          return {
+            status: 'error',
+            message: 'Query parameter is required',
+          };
+        }
+
+        const conversation = await models.Conversations.findOne(query).lean();
+
+        if (!conversation) {
+          return {
+            status: 'success',
+            data: null,
+            message: 'No conversation found',
+          };
+        }
+
         return {
-          status: 'not_found',
-          message: 'No conversation found with the provided ID',
+          status: 'success',
+          data: conversation,
+        };
+      } catch (error) {
+        console.error('Error finding conversation:', error);
+        return {
+          status: 'error',
+          message: 'Failed to find conversation',
+          error:
+            process.env.NODE_ENV === 'development' ? error.message : undefined,
         };
       }
+    }),
 
-      return {
-        status: 'success',
-        data: result,
-      };
-    } catch (error) {
-      console.error('Update error:', error);
-      return {
-        status: 'error',
-        message: 'Update failed',
-        error:
-          process.env.NODE_ENV === 'development' ? error.message : undefined,
-      };
-    }
-  }),
+  changeStatus: t.procedure
+    .meta(
+      agentMeta(
+        'Open, close, or resolve an inbox conversation: { id, status } where status is one of "new", "open", "closed", "resolved". Both fields are required.',
+        { module: 'inbox', action: 'conversationsChangeStatus' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      try {
+        const { id, status } = input;
+        const { models } = ctx;
+
+        if (!id || !status) {
+          return {
+            status: 'error',
+            message: `Both id and status are required. Received id: ${id}, status: ${status}`,
+          };
+        }
+
+        const result = await models.Conversations.updateOne(
+          { _id: id },
+          { status: status },
+        );
+
+        if (result.matchedCount === 0) {
+          return {
+            status: 'not_found',
+            message: 'No conversation found with the provided ID',
+          };
+        }
+
+        return {
+          status: 'success',
+          data: result,
+        };
+      } catch (error) {
+        console.error('Update error:', error);
+        return {
+          status: 'error',
+          message: 'Update failed',
+          error:
+            process.env.NODE_ENV === 'development' ? error.message : undefined,
+        };
+      }
+    }),
 });
 
 export const visitorRouter = t.router({});
@@ -858,26 +923,40 @@ export const inboxTrpcRouter = t.router({
         }
       }),
 
-    getIntegrationKinds: t.procedure.input(z.any()).query(async () => {
-      try {
-        const data = await getIntegrationsKinds();
-        return {
-          status: 'success',
-          data,
-        };
-      } catch (error) {
-        console.error('Error fetching integration kinds:', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return {
-          status: 'error',
-          message: 'Failed to fetch integration kinds',
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    }),
+    getIntegrationKinds: t.procedure
+      .meta(
+        agentMeta(
+          'List the integration kinds available on this workspace as a kind to label map (e.g. messenger, lead, webhook, imap, facebook-messenger). Call this before filtering integrations by kind with inbox.integrations.find.',
+          { module: 'integration', action: 'showIntegrations' },
+        ),
+      )
+      .input(z.any())
+      .query(async () => {
+        try {
+          const data = await getIntegrationsKinds();
+          return {
+            status: 'success',
+            data,
+          };
+        } catch (error) {
+          console.error('Error fetching integration kinds:', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return {
+            status: 'error',
+            message: 'Failed to fetch integration kinds',
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }),
 
     getConversationsList: t.procedure
+      .meta(
+        agentMeta(
+          'List inbox conversations with cursor pagination: { query: {...}, listParams: { limit?, cursor?, direction?, orderBy? } }, e.g. { query: { status: "new" }, listParams: { limit: 20, orderBy: { updatedAt: -1 } } }. Returns { list, totalCount, pageInfo }; pass pageInfo.endCursor back as listParams.cursor for the next page.',
+          { module: 'inbox', action: 'showConversations' },
+        ),
+      )
       .input(z.any())
       .query(async ({ ctx, input }) => {
         const { query, listParams } = input;

--- a/backend/plugins/frontline_api/src/trpc/agentMeta.ts
+++ b/backend/plugins/frontline_api/src/trpc/agentMeta.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the `.meta()` payload that exposes a tRPC procedure as an
+ * agent-callable tool in the /agent-tools manifest.
+ *
+ * Local copy of the core-api helper (`core-api/src/utils/agentMeta.ts`);
+ * plugin isolation forbids importing core-api source.
+ *
+ * @param description - Agent-facing guidance: when to use the tool, its
+ *   input shape, and which other tools it chains with.
+ * @param permission - A permission the plugin registers in its
+ *   meta/permissions config; checked against the acting user on every call.
+ */
+export const agentMeta = (
+  description: string,
+  permission: { module: string; action: string },
+) => ({
+  agent: { description, permission },
+});


### PR DESCRIPTION
## Summary

Follow-up to #9056 (core agent tools) and #9058 (sales agent tools). Annotates 11 frontline tRPC procedures with `.meta(agentMeta(...))` so they appear in the frontline plugin's `/agent-tools/manifest` and become callable through `/agent-tools/call`, subject to the platform's five security layers (annotation → tenant curation → HMAC auth → permission check → destructive-op approval).

### Agent-callable after this PR

| Procedure | Permission action |
|---|---|
| `inbox.conversations.findOne`, `inbox.conversations.count`, `inbox.getConversationsList`, `inbox.conversationMessages.findOne`, `inbox.conversationMessages.find` | `showConversations` |
| `inbox.conversations.changeStatus` | `conversationsChangeStatus` |
| `inbox.integrations.findOne`, `inbox.integrations.find`, `inbox.integrations.count`, `inbox.getIntegrationKinds` | `showIntegrations` |
| `form.submissionsByConversation` | `showFormSubmissions` |

### Deliberately NOT exposed (admit-only rules)

- **Webhook ingestion / notification plumbing** — `inbox.integrations.receive`, `inbox.integrationsNotification`, `inbox.sendNotifications`, `inbox.conversationClientMessageInserted`
- **Raw-mongo helpers** — `inbox.conversationMessages.updateOne`, `inbox.updateConversationMessage`
- **Bulk or destructive operations** — `inbox.integrations.remove` (cascades into conversations/messages), `inbox.removeConversation`, `inbox.removeCustomersConversations`, `inbox.changeCustomer`, `conversation.tag`
- **Procedures trusting a caller-supplied `userId`** — `inbox.createConversationAndMessage`, `inbox.createOnlyMessage`, `inbox.integrations.copyLeadIntegration`, `ticket.create`. The agent path authenticates only `userId` via HMAC header; annotating as-is would allow impersonation. Ticket/message creation for agents needs a follow-up that reads the acting user from `ctx`.
- **Widget-facing endpoints** — `inbox.widgetsGetUnreadMessagesCount`
- **`inbox.channels.find`** — raw channel read that bypasses `visibleChannelsFilter`; exposing it would reveal other users' personal channels
- **Internal plumbing** — `inbox.updateUserChannels`, `inbox.getModuleRelation`, `relation.onRelationAdded`, `fields.getFieldList`
- **Redundant reads** — `conversation.find`, `inbox.getConversations`, `integration.find` (covered by the annotated `inbox.*` set)

## Implementation

- New `backend/plugins/frontline_api/src/trpc/agentMeta.ts` — local copy of the core-api helper; plugin isolation forbids importing core-api source and `erxes-api-shared` doesn't export it
- Descriptions follow the #9056 style: input shape, when to use, chaining hints
- All changes scoped to `backend/plugins/frontline_api`; no GraphQL or tRPC behavior changes for existing callers (annotations are metadata-only)
- `frontline_api/AGENTS.md` updated: agent-tool contracts, never-annotate invariant list, manifest smoke scenario, recent-change entry

## Validation

- `npx tsc -p backend/plugins/frontline_api/tsconfig.json --noEmit` ✅
- `pnpm nx build frontline_api` ✅
- `pnpm nx lint frontline_api` — touched files have 0 errors; remaining repo errors are pre-existing in untouched files (`messengerWidget.bundle.js`, ticket/report files)
- Manifest smoke (in-process `buildAgentToolManifest` over the real `appRouter`) emits exactly the 11 annotated tools with the permissions above; `ticket.create`, `inbox.removeConversation`, `inbox.conversationMessages.updateOne`, and `inbox.channels.find` do not appear
- No `test` target defined in `project.json`

## Summary by Sourcery

Expose approved, permission-gated frontline tRPC procedures as callable agent tools without changing behavior for existing callers.

New Features:
- Expose 11 approved frontline tRPC procedures for agent discovery and invocation, covering conversation and message reads, integration queries, form submissions, and conversation status changes.
- Associate each agent-callable procedure with agent-facing usage guidance and the appropriate frontline permission.

Enhancements:
- Add a local helper for defining agent-tool metadata while preserving existing procedure behavior.
- Document the admit-only agent-tool contract, permission mappings, excluded procedures, and manifest smoke checks for the frontline plugin.

Documentation:
- Update frontline plugin guidance with the new agent-tool contracts, security boundaries, validation scenario, and change history.

Tests:
- Validate the agent-tool manifest exposes exactly the approved procedures and excludes unsafe or unscoped endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only agent tools for retrieving inboxes, conversations, messages, integrations, conversation statuses, and form submissions.
  * Added clear tool descriptions and permission checks to support safe, authorized access.

* **Documentation**
  * Documented the Call Pro webhook integration, routes, operations, customer resolution, recordings, configuration requirements, and smoke-test coverage.
  * Updated architecture and ownership guidance, including answering-agent assignment changes and removal of obsolete entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->