### PR TITLE
fix(blocknote): fix gallery images not loading

### DIFF
--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -6,10 +6,19 @@ import {
 import {
   createReactBlockSpec,
   ReactCustomBlockRenderProps,
+  useResolveUrl,
 } from '@blocknote/react';
-import { IconLayoutGrid, IconPhoto, IconPlus, IconX, IconLoader2 } from '@tabler/icons-react';
+import {
+  IconLayoutGrid,
+  IconPhoto,
+  IconPlus,
+  IconX,
+  IconLoader2,
+} from '@tabler/icons-react';
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
+import { readImage } from 'erxes-ui/utils';
+import { Button, Spinner } from 'erxes-ui/components';
 
 export interface GalleryImage {
   url: string;
@@ -47,6 +56,54 @@ const parseImages = (raw: string): GalleryImage[] => {
   }
 };
 
+const GalleryItem: FC<{
+  image: GalleryImage;
+  readonly: boolean;
+  onRemove: () => void;
+}> = ({ image, readonly, onRemove }) => {
+  const { loadingState, downloadUrl } = useResolveUrl(image.url);
+  const isResolving = loadingState === 'loading';
+  const src = downloadUrl ?? image.url;
+
+  return (
+    <div className="relative group aspect-square overflow-hidden rounded-md bg-muted">
+      {isResolving ? (
+        <div className="flex h-full w-full items-center justify-center">
+          <Spinner size="sm" />
+        </div>
+      ) : (
+        <img
+          src={src}
+          alt={image.caption ?? ''}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+          draggable={false}
+        />
+      )}
+      {!readonly && (
+        <Button
+          variant="ghost"
+          aria-label="Remove image"
+          className="absolute top-1 right-1 h-5 w-5 p-0 rounded-full bg-black/50 text-white opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity [&>svg]:size-3"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onRemove}
+        >
+          <IconX />
+        </Button>
+      )}
+      {image.caption && (
+        <div className="absolute bottom-0 inset-x-0 bg-black/50 text-white text-xs px-1.5 py-0.5 truncate">
+          {image.caption}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -77,12 +134,24 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
   };
 
   const removeImage = (index: number) => {
-    updateBlock({ images: JSON.stringify(images.filter((_, i) => i !== index)) });
+    updateBlock({
+      images: JSON.stringify(images.filter((_, i) => i !== index)),
+    });
   };
 
   const setColumns = (n: number) => {
     updateBlock({ columns: String(n) });
   };
+
+  let uploadButtonLabel = 'Add more';
+  let uploadButtonIcon = <IconPlus size={15} />;
+  if (uploading) {
+    uploadButtonLabel = 'Uploading...';
+    uploadButtonIcon = <IconLoader2 size={15} className="animate-spin" />;
+  } else if (images.length === 0) {
+    uploadButtonLabel = 'Add images to gallery';
+    uploadButtonIcon = <IconPhoto size={15} />;
+  }
 
   if (readonly && images.length === 0) return null;
 
@@ -94,34 +163,12 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
           style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
         >
           {images.map((img, i) => (
-            <div
-              key={i}
-              className="relative group aspect-square overflow-hidden rounded-md bg-muted"
-            >
-              <img
-                src={img.url}
-                alt={img.caption ?? ''}
-                className="w-full h-full object-cover"
-                draggable={false}
-              />
-              {!readonly && (
-                <button
-                  type="button"
-                  className="absolute top-1 right-1 flex items-center justify-center w-5 h-5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    removeImage(i);
-                  }}
-                >
-                  <IconX size={12} />
-                </button>
-              )}
-              {img.caption && (
-                <div className="absolute bottom-0 inset-x-0 bg-black/50 text-white text-xs px-1.5 py-0.5 truncate">
-                  {img.caption}
-                </div>
-              )}
-            </div>
+            <GalleryItem
+              key={`${img.url}-${i}`}
+              image={img}
+              readonly={readonly}
+              onRemove={() => removeImage(i)}
+            />
           ))}
         </div>
       )}
@@ -138,27 +185,16 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
           />
 
           {canUpload ? (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
               disabled={uploading}
-              className={cn(
-                'flex flex-1 items-center justify-center gap-1.5 text-sm text-muted-foreground border border-dashed rounded-md px-3 py-2 hover:bg-muted transition-colors',
-                uploading && 'opacity-50 cursor-not-allowed',
-              )}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                if (!uploading) inputRef.current?.click();
-              }}
+              className="flex-1 h-auto gap-1.5 py-2 text-muted-foreground border border-dashed rounded-md hover:bg-muted"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => inputRef.current?.click()}
             >
-              {uploading ? (
-                <IconLoader2 size={15} className="animate-spin" />
-              ) : images.length === 0 ? (
-                <IconPhoto size={15} />
-              ) : (
-                <IconPlus size={15} />
-              )}
-              <span>{uploading ? 'Uploading...' : images.length === 0 ? 'Add images to gallery' : 'Add more'}</span>
-            </button>
+              {uploadButtonIcon}
+              <span>{uploadButtonLabel}</span>
+            </Button>
           ) : (
             images.length === 0 && (
               <div className="flex flex-1 items-center justify-center gap-1.5 text-sm text-muted-foreground border border-dashed rounded-md px-3 py-2">
@@ -172,22 +208,22 @@ const GalleryBlockContent: FC<GalleryRenderProps> = ({ block, editor }) => {
             <div className="flex items-center gap-1 shrink-0">
               <IconLayoutGrid size={14} className="text-muted-foreground" />
               {COLUMN_OPTIONS.map((n) => (
-                <button
+                <Button
                   key={n}
-                  type="button"
+                  variant="ghost"
+                  aria-label={`${n} columns`}
+                  aria-pressed={columns === n}
                   className={cn(
-                    'w-6 h-6 text-xs rounded transition-colors',
+                    'h-6 w-6 p-0 text-xs',
                     columns === n
-                      ? 'bg-primary text-primary-foreground'
+                      ? 'bg-primary text-primary-foreground hover:bg-primary'
                       : 'text-muted-foreground hover:bg-muted',
                   )}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    setColumns(n);
-                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setColumns(n)}
                 >
                   {n}
-                </button>
+                </Button>
               ))}
             </div>
           )}
@@ -217,12 +253,31 @@ const GalleryExternalHTML: FC<GalleryRenderProps> = ({ block }) => {
     >
       {images.map((img, i) =>
         img.caption ? (
-          <figure key={i} style={{ margin: 0 }}>
-            <img src={img.url} alt={img.caption} style={{ width: '100%', height: 'auto', display: 'block' }} />
+          <figure key={`${img.url}-${i}`} style={{ margin: 0 }}>
+            <img
+              src={readImage(img.url)}
+              alt={img.caption}
+              style={{
+                width: '100%',
+                aspectRatio: '1 / 1',
+                objectFit: 'cover',
+                display: 'block',
+              }}
+            />
             <figcaption>{img.caption}</figcaption>
           </figure>
         ) : (
-          <img key={i} src={img.url} alt="" style={{ width: '100%', height: 'auto', display: 'block' }} />
+          <img
+            key={`${img.url}-${i}`}
+            src={readImage(img.url)}
+            alt=""
+            style={{
+              width: '100%',
+              aspectRatio: '1 / 1',
+              objectFit: 'cover',
+              display: 'block',
+            }}
+          />
         ),
       )}
     </div>

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/GalleryBlock.tsx
@@ -18,7 +18,7 @@ import {
 import { FC, useRef, useState } from 'react';
 import { cn } from 'erxes-ui/lib';
 import { readImage } from 'erxes-ui/utils';
-import { Button, Spinner } from 'erxes-ui/components';
+import { Button, Dialog, Spinner } from 'erxes-ui/components';
 
 export interface GalleryImage {
   url: string;
@@ -62,6 +62,7 @@ const GalleryItem: FC<{
   onRemove: () => void;
 }> = ({ image, readonly, onRemove }) => {
   const { loadingState, downloadUrl } = useResolveUrl(image.url);
+  const [previewOpen, setPreviewOpen] = useState(false);
   const isResolving = loadingState === 'loading';
   const src = downloadUrl ?? image.url;
 
@@ -72,18 +73,44 @@ const GalleryItem: FC<{
           <Spinner size="sm" />
         </div>
       ) : (
-        <img
-          src={src}
-          alt={image.caption ?? ''}
-          style={{
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-            display: 'block',
+        <Button
+          variant="ghost"
+          aria-label="Preview image"
+          className="h-full w-full p-0 rounded-none"
+          onDoubleClick={() => setPreviewOpen(true)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              setPreviewOpen(true);
+            }
           }}
-          draggable={false}
-        />
+        >
+          <img
+            src={src}
+            alt={image.caption ?? ''}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              display: 'block',
+            }}
+            draggable={false}
+          />
+        </Button>
       )}
+
+      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+        <Dialog.Content className="max-w-fit border-0 bg-transparent p-0 shadow-none">
+          <Dialog.Title className="sr-only">
+            {image.caption || 'Image preview'}
+          </Dialog.Title>
+          <img
+            src={src}
+            alt={image.caption ?? ''}
+            className="max-h-[85vh] max-w-[90vw] rounded object-contain shadow-2xl"
+          />
+        </Dialog.Content>
+      </Dialog>
       {!readonly && (
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary by Sourcery

Ensure gallery images load reliably while improving image preview and gallery interaction controls.

New Features:
- Enable gallery images to resolve protected URLs and open in an accessible full-size preview.

Bug Fixes:
- Fix gallery images not loading when their stored URLs require URL resolution.

Enhancements:
- Improve gallery image controls with loading states, removal actions, captions, and accessible column selectors.
- Use resolved image URLs and consistent square cropping in external gallery rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gallery images now load asynchronously with a visible spinner during loading.
  * Gallery items support captions, readonly-aware removal controls, and image previews opened by double-click or keyboard activation.
  * Upload and column controls provide clearer labels, familiar icons, and improved accessibility.
  * External gallery displays offer more reliable image rendering, including repeated image URLs and consistent square image styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->