### PR TITLE
feat(erxes-api-shared): cap agent tool call responses at 64KB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,6 +427,12 @@ endpoints on every plugin that has a `trpcAppRouter`.
 3. The platform enforces five security layers automatically: procedure
    annotation → tenant curation (default-deny per plugin) → HMAC-signed
    service auth → user permission check → destructive-operation approval guard.
+4. Every `/agent-tools/call` result is capped at a serialized byte budget
+   (default 64KB, overridable with `AGENT_TOOLS_MAX_RESPONSE_BYTES`).
+   Oversized results are rejected with `413` and a `RESPONSE_TOO_LARGE`
+   error telling the agent to paginate, tighten the filter, project fewer
+   fields, or use the matching count/findOne tool — an unbounded payload
+   stalls the agent run and freezes the chat UI.
 
 #### Annotating a procedure
 

--- a/backend/erxes-api-shared/src/utils/agent-tools/endpoints.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/endpoints.ts
@@ -9,6 +9,11 @@ import { createPluginTRPCContext, err, ok, sendTRPCMessage } from '../trpc';
 import { decodeAgentToolsAuthHeader } from './auth';
 import { buildAgentToolManifest } from './manifest';
 import {
+  agentToolResponseTooLargeError,
+  getAgentToolMaxResponseBytes,
+  oversizedAgentToolResultBytes,
+} from './responseLimit';
+import {
   AgentToolManifest,
   AgentTrpcRouter,
   AgentTrpcToolDescriptor,
@@ -38,12 +43,7 @@ const manifestCache = new Map<
 const manifestCacheKey = (
   subdomain: string,
   options: AgentToolsOptions,
-): string =>
-  JSON.stringify([
-    options.plugin,
-    subdomain,
-    options.exclude || [],
-  ]);
+): string => JSON.stringify([options.plugin, subdomain, options.exclude || []]);
 
 const getManifest = async (
   subdomain: string,
@@ -239,6 +239,28 @@ export const mountAgentTools = (
         descriptor,
         input,
       );
+
+      // Oversized payloads stall the agent run and freeze the chat UI; reject
+      // them with guidance so the model retries with a narrower call.
+      const maxResponseBytes = getAgentToolMaxResponseBytes();
+      const resultBytes = oversizedAgentToolResultBytes(
+        result,
+        maxResponseBytes,
+      );
+
+      if (resultBytes !== null) {
+        return res
+          .status(413)
+          .json(
+            err(
+              agentToolResponseTooLargeError(
+                toolId,
+                resultBytes,
+                maxResponseBytes,
+              ),
+            ),
+          );
+      }
 
       return res.json(ok(result));
     } catch (error) {

--- a/backend/erxes-api-shared/src/utils/agent-tools/index.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './auth';
 export * from './manifest';
 export * from './endpoints';
+export * from './responseLimit';

--- a/backend/erxes-api-shared/src/utils/agent-tools/responseLimit.test.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/responseLimit.test.ts
@@ -1,0 +1,99 @@
+import {
+  AGENT_TOOL_DEFAULT_MAX_RESPONSE_BYTES,
+  agentToolResponseTooLargeError,
+  getAgentToolMaxResponseBytes,
+  oversizedAgentToolResultBytes,
+} from './responseLimit';
+
+describe('responseLimit', () => {
+  const ORIGINAL_ENV = process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES;
+    } else {
+      process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES = ORIGINAL_ENV;
+    }
+  });
+
+  describe('getAgentToolMaxResponseBytes', () => {
+    it('falls back to the 64KB default when the env var is unset', () => {
+      delete process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES;
+
+      expect(getAgentToolMaxResponseBytes()).toBe(
+        AGENT_TOOL_DEFAULT_MAX_RESPONSE_BYTES,
+      );
+    });
+
+    it('honors a positive numeric override', () => {
+      process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES = '1024';
+
+      expect(getAgentToolMaxResponseBytes()).toBe(1024);
+    });
+
+    it.each(['abc', '0', '-5'])(
+      'falls back to the default for invalid value "%s"',
+      (value) => {
+        process.env.AGENT_TOOLS_MAX_RESPONSE_BYTES = value;
+
+        expect(getAgentToolMaxResponseBytes()).toBe(
+          AGENT_TOOL_DEFAULT_MAX_RESPONSE_BYTES,
+        );
+      },
+    );
+  });
+
+  describe('oversizedAgentToolResultBytes', () => {
+    it('returns null when the serialized result fits', () => {
+      expect(oversizedAgentToolResultBytes({ ok: true }, 1024)).toBeNull();
+    });
+
+    it('returns null when the result fits exactly', () => {
+      const result = 'x'.repeat(100);
+
+      expect(oversizedAgentToolResultBytes(result, 102)).toBeNull();
+    });
+
+    it('returns the byte size when the result exceeds the budget', () => {
+      const result = { data: new Array(1000).fill('row') };
+
+      const bytes = oversizedAgentToolResultBytes(result, 1024);
+
+      expect(bytes).toBe(Buffer.byteLength(JSON.stringify(result), 'utf8'));
+    });
+
+    it('counts multi-byte characters by UTF-8 bytes, not string length', () => {
+      const result = 'үү'.repeat(100); // 2 bytes each in UTF-8
+
+      expect(oversizedAgentToolResultBytes(result, 50)).toBe(
+        Buffer.byteLength(JSON.stringify(result), 'utf8'),
+      );
+    });
+
+    it('returns null for unserializable results instead of throwing', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      expect(oversizedAgentToolResultBytes(circular, 1)).toBeNull();
+    });
+  });
+
+  describe('agentToolResponseTooLargeError', () => {
+    it('carries the code, sizes, and narrowing guidance', () => {
+      const error = agentToolResponseTooLargeError(
+        'sales.trpc.deal.find',
+        150_000,
+        65_536,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error & { code?: string }).code).toBe(
+        'RESPONSE_TOO_LARGE',
+      );
+      expect(error.message).toContain('sales.trpc.deal.find');
+      expect(error.message).toContain('150000');
+      expect(error.message).toContain('65536');
+      expect(error.message).toContain('limit');
+    });
+  });
+});

--- a/backend/erxes-api-shared/src/utils/agent-tools/responseLimit.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/responseLimit.ts
@@ -1,0 +1,66 @@
+import { getEnv } from '../utils';
+
+/**
+ * Response-size guard for agent tool calls.
+ *
+ * A tool that answers with an unbounded payload (an open-ended `find`, a fat
+ * aggregation) stalls the agent run and freezes the chat UI while the model
+ * ingests it. Every `/agent-tools/call` result is therefore capped at a
+ * serialized byte budget — mirroring the 64KB output cap code mode already
+ * enforces — and oversized results are rejected with actionable guidance so
+ * the model retries with a narrower call instead of the platform streaming an
+ * unbounded payload.
+ */
+export const AGENT_TOOL_DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024;
+
+/**
+ * Resolve the active byte budget. `AGENT_TOOLS_MAX_RESPONSE_BYTES` overrides
+ * the 64KB default; non-numeric or non-positive values fall back to it.
+ */
+export const getAgentToolMaxResponseBytes = (): number => {
+  const raw = getEnv({ name: 'AGENT_TOOLS_MAX_RESPONSE_BYTES' });
+  const parsed = Number(raw);
+
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : AGENT_TOOL_DEFAULT_MAX_RESPONSE_BYTES;
+};
+
+/**
+ * Returns the serialized UTF-8 byte size of `result` when it exceeds
+ * `maxBytes`, or null when it fits (or cannot be serialized — in which case
+ * the regular response path reports the serialization failure as before).
+ */
+export const oversizedAgentToolResultBytes = (
+  result: unknown,
+  maxBytes: number,
+): number | null => {
+  let serialized: string;
+
+  try {
+    serialized = JSON.stringify(result) ?? '';
+  } catch {
+    return null;
+  }
+
+  const bytes = Buffer.byteLength(serialized, 'utf8');
+
+  return bytes > maxBytes ? bytes : null;
+};
+
+/** Build the structured too-large error returned to the agent. */
+export const agentToolResponseTooLargeError = (
+  toolId: string,
+  resultBytes: number,
+  maxBytes: number,
+): Error =>
+  Object.assign(
+    new Error(
+      `Agent tool '${toolId}' returned ${resultBytes} bytes, exceeding the ` +
+        `${maxBytes}-byte agent tool response limit. Do not retry the same ` +
+        `call as-is: paginate with limit/skip or a cursor, tighten the ` +
+        `filter, project fewer fields, or use the matching count/findOne ` +
+        `tool instead.`,
+    ),
+    { code: 'RESPONSE_TOO_LARGE' },
+  );


### PR DESCRIPTION
## Summary

An agent tool that answers with an unbounded payload (an open-ended `deal.find`, a fat aggregation, a huge conversation list) stalls the agent run and **freezes the chat UI** while the model ingests megabytes of JSON. This caps every `/agent-tools/call` result at a serialized byte budget and rejects oversized results with actionable guidance, so the model retries with a narrower call instead of the platform streaming an unbounded payload.

- New `backend/erxes-api-shared/src/utils/agent-tools/responseLimit.ts` — `getAgentToolMaxResponseBytes()` (env `AGENT_TOOLS_MAX_RESPONSE_BYTES`, default **64KB**, mirroring the existing code-mode output cap), `oversizedAgentToolResultBytes()`, and the structured `RESPONSE_TOO_LARGE` error builder.
- `/agent-tools/call` measures the executed result before responding; oversized results return **413** with a `RESPONSE_TOO_LARGE` error: *"Do not retry the same call as-is: paginate with limit/skip or a cursor, tighten the filter, project fewer fields, or use the matching count/findOne tool instead."* The agent runtime already converts error envelopes into `ExpectedError(message)`, so this guidance reaches the model verbatim and it can self-correct (all annotated list tools document their pagination inputs).
- Manifest and permission checks are unaffected; unserializable results keep the previous behavior (the regular response path reports the failure).

## Validation

- `pnpm nx test erxes-api-shared` ✅ — 62 tests pass, including 11 new `responseLimit` tests (env override parsing, exact-fit boundary, byte-accurate multi-byte counting, circular-input safety, error shape)
- `pnpm nx build erxes-api-shared` ✅
- `pnpm nx lint erxes-api-shared` — changed files clean; the 2 remaining errors are pre-existing in untouched files (`mongo-connection.ts`, `utils.ts`)
- Root `AGENTS.md` agent-tools section documents the budget and the env override

## Notes

- No plugin changes required — the guard lives centrally in the platform endpoint and covers every current and future annotated tool.
- Follow-up for erxes-private: same commit, to keep the repos in sync like #9056/#9058/#9079.

## Summary by Sourcery

Cap serialized agent tool responses to prevent oversized payloads from stalling agent runs and freezing the chat interface.

Bug Fixes:
- Reject agent tool responses that exceed the serialized response budget with a structured `RESPONSE_TOO_LARGE` error and actionable guidance for narrowing the request.

Enhancements:
- Add a configurable 64KB default response limit for `/agent-tools/call`, including UTF-8 byte measurement and safe handling of unserializable results.

Documentation:
- Document the agent tool response budget, environment override, and remediation guidance in `AGENTS.md`.

Tests:
- Add coverage for response-limit configuration, exact-fit boundaries, UTF-8 byte sizing, circular inputs, and structured error details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable response-size limit for agent tool calls, defaulting to 64 KB.
  * Responses exceeding the limit now return HTTP 413 with guidance to narrow or paginate requests.
  * Limits account for serialized UTF-8 response size.

* **Bug Fixes**
  * Prevented oversized agent tool responses from being returned unexpectedly.
  * Preserved existing handling for results that cannot be serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->