### PR TITLE
feat(sales): add stage filter

### DIFF
--- a/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
+++ b/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
@@ -380,6 +380,7 @@ export const SelectCustomerFilterView = ({
 export const SelectCustomerFilterBar = ({
   mode = 'multiple',
   filterKey,
+  label,
   variant,
   scope,
   initialValue,
@@ -389,6 +390,7 @@ export const SelectCustomerFilterBar = ({
 }: {
   mode?: 'single' | 'multiple';
   filterKey: string;
+  label: string;
   variant?: `${SelectTriggerVariant}`;
   scope?: string;
   initialValue?: string[];
@@ -436,23 +438,52 @@ export const SelectCustomerFilterBar = ({
     }
   };
 
+  if (isCardVariant) {
+    return (
+      <SelectCustomerProvider
+        mode={mode}
+        value={query || []}
+        onValueChange={handleValueChange}
+        hideAvatar={hideAvatar}
+        loadSelectedCustomers={!isCardVariant || !hideAvatar || open}
+      >
+        <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
+          <SelectTriggerOperation variant={variant || 'filter'}>
+            <SelectCustomerValue />
+          </SelectTriggerOperation>
+          <SelectOperationContent variant={variant || 'filter'}>
+            <SelectCustomer.Content />
+          </SelectOperationContent>
+        </PopoverScoped>
+      </SelectCustomerProvider>
+    );
+  }
+
   return (
-    <SelectCustomerProvider
-      mode={mode}
-      value={query || []}
-      onValueChange={handleValueChange}
-      hideAvatar={hideAvatar}
-      loadSelectedCustomers={!isCardVariant || !hideAvatar || open}
-    >
-      <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
-        <SelectTriggerOperation variant={variant || 'filter'}>
-          <SelectCustomerValue />
-        </SelectTriggerOperation>
-        <SelectOperationContent variant={variant || 'filter'}>
-          <SelectCustomer.Content />
-        </SelectOperationContent>
-      </PopoverScoped>
-    </SelectCustomerProvider>
+    <Filter.BarItem queryKey={filterKey}>
+      <Filter.BarName>
+        <IconUser />
+        {label}
+      </Filter.BarName>
+      <SelectCustomerProvider
+        mode={mode}
+        value={query || []}
+        onValueChange={handleValueChange}
+        hideAvatar={hideAvatar}
+        loadSelectedCustomers
+      >
+        <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
+          <Popover.Trigger asChild>
+            <Filter.BarButton filterKey={filterKey}>
+              <SelectCustomerValue />
+            </Filter.BarButton>
+          </Popover.Trigger>
+          <Combobox.Content>
+            <SelectCustomer.Content />
+          </Combobox.Content>
+        </PopoverScoped>
+      </SelectCustomerProvider>
+    </Filter.BarItem>
   );
 };
 

--- a/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
+++ b/frontend/libs/ui-modules/src/modules/contacts/components/SelectCustomer.tsx
@@ -445,7 +445,7 @@ export const SelectCustomerFilterBar = ({
         value={query || []}
         onValueChange={handleValueChange}
         hideAvatar={hideAvatar}
-        loadSelectedCustomers={!isCardVariant || !hideAvatar || open}
+        loadSelectedCustomers={!hideAvatar || open}
       >
         <PopoverScoped scope={scope} open={open} onOpenChange={setOpen}>
           <SelectTriggerOperation variant={variant || 'filter'}>

--- a/frontend/libs/ui-modules/src/modules/sales/components/common/select/SelectStages.tsx
+++ b/frontend/libs/ui-modules/src/modules/sales/components/common/select/SelectStages.tsx
@@ -27,6 +27,7 @@ export const SelectStageProvider = ({
   onValueChange,
   stages,
   pipelineId,
+  autoSelectFirst = true,
 }: {
   children: React.ReactNode;
   mode?: 'single' | 'multiple';
@@ -34,6 +35,7 @@ export const SelectStageProvider = ({
   onValueChange?: (value: string[] | string, isAutoSelection?: boolean) => void;
   stages?: IStage[];
   pipelineId?: string;
+  autoSelectFirst?: boolean;
 }) => {
   const [_stages, setStages] = useState<IStage[]>(stages || []);
   const isSingleMode = mode === 'single';
@@ -51,17 +53,21 @@ export const SelectStageProvider = ({
       const currentStageId = Array.isArray(value) ? value[0] : value;
 
       const stage = availableStages.find((s) => s._id === currentStageId);
-      const selectedStage = stage || availableStages[0];
 
-      if (selectedStage) {
-        setStages([selectedStage]);
+      if (stage) {
+        setStages([stage]);
+        return;
+      }
 
-        if (!stage && selectedStage) {
+      if (autoSelectFirst) {
+        const selectedStage = availableStages[0];
+        if (selectedStage) {
+          setStages([selectedStage]);
           onValueChange?.(selectedStage._id, true);
         }
       }
     }
-  }, [pipelineId, availableStages, value, onValueChange]);
+  }, [pipelineId, availableStages, value, onValueChange, autoSelectFirst]);
 
   const onSelect = (stage: IStage) => {
     if (!stage) return;
@@ -216,6 +222,7 @@ export const SelectStageFilterView = ({
         mode={mode}
         value={stage || (mode === 'single' ? '' : [])}
         pipelineId={pipelineId}
+        autoSelectFirst={false}
         onValueChange={(value) => {
           setStage(value as string[] | string);
           resetFilterState();
@@ -258,6 +265,7 @@ export const SelectStageFilterBar = ({
         mode={mode}
         value={stage || (mode === 'single' ? '' : [])}
         pipelineId={pipelineId}
+        autoSelectFirst={false}
         onValueChange={(value) => {
           const hasValue = Array.isArray(value)
             ? value.length > 0

--- a/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/actionBar/components/SalesFilter.tsx
@@ -1,10 +1,11 @@
-import { Combobox, Command, Filter, useMultiQueryState } from 'erxes-ui';
+import { Combobox, Command, Filter, useMultiQueryState, useQueryState } from 'erxes-ui';
 import {
   IconCalendarBolt,
   IconCalendarClock,
   IconCalendarPlus,
   IconCalendarX,
   IconSearch,
+  IconStack2,
 } from '@tabler/icons-react';
 import {
   SelectBranches,
@@ -13,6 +14,7 @@ import {
   SelectDepartments,
   SelectMember,
   SelectProduct,
+  SelectStage,
 } from 'ui-modules';
 
 import { DealsTotalCount } from '@/deals/components/DealsTotalCount';
@@ -20,10 +22,14 @@ import { IDeal } from '@/deals/types/deals';
 import { SalesFilterState } from '@/deals/actionBar/types/actionBarTypes';
 import { SelectLabels } from '@/deals/components/common/filters/SelectLabel';
 import { SelectPriority } from '@/deals/components/common/filters/SelectPriority';
+import { dealsViewAtom } from '@/deals/states/dealsViewState';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 
 export const SalesFilter = () => {
   const { t } = useTranslation('sales');
+  const view = useAtomValue(dealsViewAtom);
+  const [pipelineId] = useQueryState<string>('pipelineId');
   const [queries] = useMultiQueryState<SalesFilterState>([
     'search',
     'companyIds',
@@ -59,7 +65,10 @@ export const SalesFilter = () => {
           <Filter.Popover scope={'sales-page'}>
             <Filter.Trigger isFiltered={hasFilters} />
             <Combobox.Content>
-              <SalesFilterView />
+              <SalesFilterView
+                view={view}
+                pipelineId={pipelineId || undefined}
+              />
             </Combobox.Content>
           </Filter.Popover>
           <Filter.Dialog>
@@ -95,7 +104,11 @@ export const SalesFilter = () => {
             </Filter.View>
           </Filter.Dialog>
         </div>
-        <SalesFilterBar queries={queries} />
+        <SalesFilterBar
+          queries={queries}
+          view={view}
+          pipelineId={pipelineId || undefined}
+        />
         <DealsTotalCount />
       </Filter.Bar>
     </Filter>
@@ -126,7 +139,15 @@ export const filterDeals = (deals: IDeal[], filters: SalesFilterState) => {
   return result;
 };
 
-const SalesFilterBar = ({ queries }: { queries: SalesFilterState }) => {
+const SalesFilterBar = ({
+  queries,
+  view,
+  pipelineId,
+}: {
+  queries: SalesFilterState;
+  view: 'list' | 'board';
+  pipelineId?: string;
+}) => {
   const { t } = useTranslation('sales');
   const {
     search,
@@ -247,11 +268,23 @@ const SalesFilterBar = ({ queries }: { queries: SalesFilterState }) => {
           label={t('by-product', 'By Product')}
         />
       )}
+      {view === 'list' && (
+        <SelectStage.FilterBar
+          queryKey="stageId"
+          pipelineId={pipelineId || undefined}
+        />
+      )}
     </>
   );
 };
 
-const SalesFilterView = () => {
+const SalesFilterView = ({
+  view,
+  pipelineId,
+}: {
+  view: 'list' | 'board';
+  pipelineId?: string;
+}) => {
   const { t } = useTranslation('sales');
   return (
     <>
@@ -301,6 +334,12 @@ const SalesFilterView = () => {
               value="labelIds"
               label={t('by-label', 'By Label')}
             />
+            {view === 'list' && (
+              <Filter.Item value="stageId">
+                <IconStack2 />
+                {t('by-stage', 'By Stage')}
+              </Filter.Item>
+            )}
             <Command.Separator className="my-1" />
             <Filter.Item value="createdStartDate">
               <IconCalendarPlus />
@@ -330,6 +369,12 @@ const SalesFilterView = () => {
       <SelectProduct.FilterView filterKey="productId" mode="multiple" />
       <SelectPriority.FilterView />
       <SelectLabels.FilterView filterKey="labelIds" mode="multiple" />
+      {view === 'list' && (
+        <SelectStage.FilterView
+          queryKey="stageId"
+          pipelineId={pipelineId || undefined}
+        />
+      )}
       <Filter.View filterKey="createdStartDate">
         <Filter.DateView
           filterKey="createdStartDate"

--- a/frontend/plugins/sales_ui/src/modules/deals/utils/queryVariables.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/utils/queryVariables.ts
@@ -7,6 +7,7 @@ const IGNORED_QUERY_VARIABLE_KEYS = [
   'tab',
   'archivedOnly',
   'archivedSort',
+  'stageId',
 ];
 
 const DATE_RANGE_MAP: Record<string, [string, string]> = {


### PR DESCRIPTION
## Summary by Sourcery

Add pipeline-aware stage filtering to the sales deals list.

New Features:
- Add stage filtering to the sales deals list, scoped to the selected pipeline.
- Expose stage filters in both the sales filter bar and filter dialog.

Bug Fixes:
- Prevent stage filters from automatically selecting the first stage when no stage is specified.
- Exclude stage filter state from the generated deal query variables.

Enhancements:
- Improve customer filter bar rendering across card and standard variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stage filtering to deal list views with pipeline-aware selection.
  * Added customer filtering with labeled filter buttons and combobox selection.
* **Bug Fixes**
  * Preserved existing stage selections during filtering.
  * Prevented unintended automatic stage selection in filter views.
  * Excluded stage filter values from deal queries when not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->