### PR TITLE
fix(sales): bound and strictly validate agent-facing deal reads

### DIFF
--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `sales_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/sales_api`
-- **Last synchronized:** `2026-08-19`
+- **Last synchronized:** `2026-08-21`
 
 ## Scope
 
@@ -69,7 +69,11 @@
   `salesPipelinesAdd`, and `salesPipelinesEdit`.
 - Agent-callable tRPC tools (admit-only via `.meta({ agent })`), each gated by
   the listed sales permission action:
-  - `deal.findOne`, `deal.find`, `deal.count`, `deal.getLink` — `showDeals`
+  - `deal.findOne`, `deal.getLink` — `showDeals`
+  - `deal.find` — `showDeals`; strict input `{ query?, skip?, limit?, sort?, fields? }`
+    (unknown keys rejected by name), always bounded (`limit` defaults to 20,
+    hard max 100), `fields` drives a real projection
+  - `deal.count` — `showDeals`; strict input `{ filter? }` (`{}` counts all)
   - `stage.findOne`, `stage.find` — `showDeals`
   - `pipeline.findOne` — `pipelinesWatch`
   - `pos.findOne`, `pos.find` — `posRead`
@@ -116,6 +120,11 @@
   the full total amount.
 - Deal amount fallbacks should preserve the existing `tickUsed` semantics used
   by sales totals.
+- Agent-facing deal reads are always bounded and strictly shaped: `deal.find`
+  clamps `limit` to 1–100 (default 20) on every path and rejects unknown input
+  keys by name, `deal.count` takes `{ filter? }` — an agent's unbounded
+  `deal.find {}` over 1.27M deals crash-looped this service (exit 139) on
+  2026-08-20, and wrapper-shaped input silently matched nothing.
 - Do not introduce new `schemaWrapper` usage in backend schemas.
 - Agent tool annotations are admit-only: never annotate raw-mongo helpers
   (`deal.aggregate`, `deal.updateOne`, `orders.updateOne`), system-user
@@ -146,6 +155,25 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-21` — Bounded, strict agent-facing deal reads
+
+- **Summary:** `deal.find` can no longer execute unbounded or mis-shaped
+  queries: input is now a strict zod object (`{ query?, skip?, limit?, sort?, fields? }`
+  — unknown keys such as an invented `arg` wrapper are rejected by name
+  instead of silently matching nothing), results are always bounded (`limit`
+  defaults to 20 and is hard-capped at 100, including the no-query path — an
+  agent's `deal.find {}` over 1.27M deals crash-looped this service with
+  exit 139 on 2026-08-20), and `fields` now drives a real projection so
+  agents stay under the 64KB agent-tools response budget. `deal.count` takes
+  an explicit `{ filter? }` object for the same reason (a `{ query: ... }`
+  wrapper previously counted 0 silently). No cross-plugin tRPC callers of
+  either procedure exist, so the tightened contracts break no consumers.
+- **Affected areas:** `src/modules/sales/trpc/deal.ts`.
+- **Contracts changed:** `deal.find` input is now strict
+  `{ query?, skip?, limit?, sort?, fields? }` (the bare top-level filter form
+  is rejected) with `limit` clamped to 1–100 (default 20); `deal.count` input
+  is now strict `{ filter? }` instead of a bare filter object.
 
 ### `2026-08-19` — Agent-callable tRPC tools
 

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -1,5 +1,6 @@
 import { initTRPC } from '@trpc/server';
 import { ITRPCContext, sendTRPCMessage } from 'erxes-api-shared/utils';
+import type { SortOrder } from 'mongoose';
 import { z } from 'zod';
 import { IModels } from '~/connectionResolvers';
 import { agentMeta } from '~/trpc/agentMeta';
@@ -65,6 +66,33 @@ const updateDealProcedure = t.procedure
     });
   });
 
+// Agent-facing reads are ALWAYS bounded. An unbounded find serializes the
+// whole deals collection (observed 2026-08-20: an agent's `deal.find {}` call
+// over 1.27M deals crash-looped the service — exit 139 — taking every
+// subsequent agent call down with it). Defaults also keep a full-document
+// page inside the 64KB agent-tools response budget.
+const AGENT_FIND_DEFAULT_LIMIT = 20;
+const AGENT_FIND_MAX_LIMIT = 100;
+
+// Strict input objects: unknown top-level keys are rejected by name instead
+// of being silently treated as document filters (an invented "arg"/"query"
+// wrapper used to match 0 records and the agent reported "no data" as fact).
+const dealFindInput = z
+  .object({
+    query: z.record(z.unknown()).optional(),
+    skip: z.number().int().min(0).optional(),
+    limit: z.number().int().min(1).optional(),
+    sort: z.record(z.unknown()).optional(),
+    fields: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const dealCountInput = z
+  .object({
+    filter: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
 export const dealTrpcRouter = t.router({
   deal: {
     findOne: t.procedure
@@ -83,24 +111,29 @@ export const dealTrpcRouter = t.router({
     find: t.procedure
       .meta(
         agentMeta(
-          'Search deals with a MongoDB-style filter: { query: {...}, skip?, limit?, sort? }, e.g. { query: { stageId: "..." } } or { query: { assignedUserIds: { $in: ["userId"] } } }. Pass a plain filter object without query to match directly. Resolve stage names to stageId with stage.find and pipeline names with pipeline.findOne first.',
+          'Search deals: { query: {...}, skip?, limit?, sort?, fields? }, e.g. { query: { stageId: "..." } } or { query: { assignedUserIds: { $in: ["userId"] } } }. Only the listed fields are accepted. Results are always bounded: limit defaults to 20 and is capped at 100 — paginate with skip, and pass fields to project only the attributes you need. Resolve stage names to stageId with stage.find and pipeline names with pipeline.findOne first.',
           { module: 'deal', action: 'showDeals' },
         ),
       )
-      .input(z.any())
+      .input(dealFindInput)
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
+        const { query = {}, skip = 0, limit, sort = {}, fields } = input;
 
-        const { query, skip, limit, sort = {} } = input;
+        const boundedLimit = Math.min(
+          limit ?? AGENT_FIND_DEFAULT_LIMIT,
+          AGENT_FIND_MAX_LIMIT,
+        );
+        const projection = fields?.length
+          ? Object.fromEntries(fields.map((field) => [field, 1]))
+          : undefined;
 
-        if (!query) {
-          return await models.Deals.find(input).lean();
-        }
-
-        return await models.Deals.find(query)
-          .skip(skip || 0)
-          .limit(limit || 0)
-          .sort(sort)
+        return await models.Deals.find(query, projection)
+          .skip(skip)
+          .limit(boundedLimit)
+          // Sort directions arrive as plain JSON; mongoose validates the
+          // values at query time (external-library boundary cast).
+          .sort(sort as Record<string, SortOrder>)
           .lean();
       }),
 
@@ -113,15 +146,15 @@ export const dealTrpcRouter = t.router({
     count: t.procedure
       .meta(
         agentMeta(
-          'Count deals matching a filter, e.g. { stageId: "..." }. Use for "how many deals ..." questions instead of deal.find.',
+          'Count deals matching a MongoDB-style filter: { filter: {...} }, e.g. { filter: { stageId: "..." } }; {} counts every deal. Use for "how many deals ..." questions instead of deal.find.',
           { module: 'deal', action: 'showDeals' },
         ),
       )
-      .input(z.any())
+      .input(dealCountInput)
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
 
-        return await models.Deals.find(input).countDocuments();
+        return await models.Deals.find(input.filter ?? {}).countDocuments();
       }),
 
     getLink: t.procedure


### PR DESCRIPTION
## Summary

Agent-facing deal reads could crash the sales service and silently return wrong answers:

- **Unbounded reads:** `deal.find` with `{}` (or no `limit`) serialized the entire deals collection. Observed on a tenant with 1.27M deals: the sales service crash-looped (exit 139) and every subsequent agent tool call failed with "service could not be reached".
- **Silent wrong answers:** wrapper-shaped input — `{ arg: {...} }` on `deal.find`, `{ query: {...} }` on `deal.count` — was silently treated as a document filter, matched 0 records, and the agent presented "no data exists" to the user as fact.
- **64KB budget errors:** `fields` was accepted by the documented contract but never applied as a projection, so full-document pages kept blowing the 64KB agent-tools response limit.

## Changes (`src/modules/sales/trpc/deal.ts` only)

- `deal.find` input is now a strict zod object `{ query?, skip?, limit?, sort?, fields? }` — unknown top-level keys are rejected by name (BAD_REQUEST) before any DB call.
- Results are always bounded: `limit` defaults to **20** and is hard-capped at **100**, including the no-query path.
- `fields` becomes a real Mongo projection.
- `deal.count` takes an explicit `{ filter? }` object (`{}` counts all); a `{ query: ... }` wrapper is rejected by name instead of counting 0 silently.
- Agent-facing descriptions updated to state the exact contract.

## Compatibility

Verified no cross-plugin `sendTRPCMessage` callers of `deal.find`/`deal.count` exist (other plugins call `deal.updateOne`/`generateAmounts`/`generateProducts` only), so the tightened contracts break no consumers. `deal.findOne` is unchanged (single-doc, naturally bounded).

## Test plan

- Validated against a contract suite covering: no-query path bounded, default limit applied, excessive limit clamped, valid limit + skip/sort honored, fields projection applied, `arg`/bare-filter keys rejected without a DB call, `count` filter key honored, `{query}` wrapper rejected, manifest exposes typed `inputFields` for exactly the 7 annotated read-only procedures (all 13 cases pass).
- `pnpm nx build sales_api` ✅ · `pnpm nx lint sales_api` ✅ (only the documented pre-existing `ecommerce/routes.ts` errors)

## Summary by Sourcery

Harden agent-facing deal reads with strict contracts, bounded results, and effective projections.

Bug Fixes:
- Prevent unbounded agent-facing deal searches by applying default and maximum result limits on every path.
- Reject malformed or wrapper-shaped deal read inputs instead of silently returning incorrect results.
- Apply requested field projections to keep deal search responses within agent-tool size limits.

Enhancements:
- Align deal.find and deal.count contracts and agent-facing descriptions with their strict input shapes.

Documentation:
- Document the bounded and strict deal read contracts and their compatibility considerations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deal search now supports filtering, pagination, sorting, and field selection.
  - Search results are consistently limited to 1–100 records, with a default of 20.
  - Deal counting now supports optional filters for more accurate result totals.

- **Bug Fixes**
  - Improved validation prevents unsupported search inputs from causing errors.
  - Search results are returned in a consistent, bounded format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->