### PR TITLE
fix(posclient): restore service charge handling

### DIFF
--- a/apps/posclient-front/modules/auth/graphql/queries.ts
+++ b/apps/posclient-front/modules/auth/graphql/queries.ts
@@ -58,6 +58,8 @@ const currentConfig = gql`
         isCleanTaxPrice
       }
       saveRemainder
+      serviceCharge
+      serviceChargeApplicableProductId
     }
   }
 `

--- a/backend/plugins/posclient_api/src/modules/posclient/@types/configs.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/@types/configs.ts
@@ -62,6 +62,8 @@ export interface IConfig {
   name: string;
   description?: string;
   orderPassword?: string;
+  serviceCharge?: number;
+  serviceChargeApplicableProductId?: string;
   pdomain?: string;
   productDetails?: string[];
   adminIds: string[];

--- a/backend/plugins/posclient_api/src/modules/posclient/db/definitions/configs.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/db/definitions/configs.ts
@@ -64,6 +64,12 @@ export const configSchema = new Schema({
     optional: true,
     label: ' OrderPassword',
   }),
+  serviceCharge: field({ type: Number, optional: true }),
+  serviceChargeApplicableProductId: field({
+    type: String,
+    optional: true,
+    label: 'Service charge applicable product id',
+  }),
   pdomain: field({ type: String, optional: true, label: 'Domain' }),
   userId: field({ type: String, optional: true, label: 'Created by' }),
   createdAt: getDateFieldDefinition('Created at'),

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/schemas/configs.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/schemas/configs.ts
@@ -65,6 +65,8 @@ export const types = `
     name: String
     description: String
     orderPassword: String
+    serviceCharge: Float
+    serviceChargeApplicableProductId: String
     pdomain: String
     userId: String
     createdAt: Date

--- a/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/orderUtils.ts
@@ -670,12 +670,32 @@ export const prepareOrderDoc = async (
     }
   }
 
-  return await checkPrices(
+  const result = await checkPrices(
     subdomain,
     { ...doc, items, subscriptionInfo },
     config,
     posUser,
   );
+
+  if (!config.serviceCharge || !config.serviceChargeApplicableProductId) {
+    return result;
+  }
+
+  const serviceChargeAmount = doc.totalAmount * (config.serviceCharge / 100);
+
+  return {
+    ...result,
+    totalAmount: result.totalAmount + serviceChargeAmount,
+    items: [
+      ...result.items,
+      {
+        productId: config.serviceChargeApplicableProductId,
+        count: 1,
+        unitPrice: serviceChargeAmount,
+        isPackage: true,
+      },
+    ],
+  };
 };
 
 export const checkOrderStatus = (order: IOrderDocument) => {

--- a/backend/plugins/posclient_api/src/modules/posclient/utils/syncUtils.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/utils/syncUtils.ts
@@ -282,6 +282,8 @@ export const extractConfig = async (subdomain, doc) => {
   return {
     name: doc.name,
     description: doc.description,
+    serviceCharge: doc.serviceCharge,
+    serviceChargeApplicableProductId: doc.serviceChargeApplicableProductId,
     pdomain: doc.pdomain,
     productDetails: doc.productDetails,
     adminIds: doc.adminIds,


### PR DESCRIPTION
## Summary by Sourcery

Restore POS service charge handling and propagate its configuration across the POS client.

Bug Fixes:
- Restore POS service charge application by adding the configured charge to order totals and recording it as an applicable product item.

Enhancements:
- Expose service charge settings throughout POS client configuration storage, synchronization, GraphQL APIs, and client configuration queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional service charge configuration for point-of-sale orders.
  * Orders now automatically include the configured service charge when both the percentage and applicable product are set.
  * Service charge settings are available through POS configuration data and APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->