### PR TITLE
track data

### DIFF
--- a/backend/core-api/src/modules/contacts/db/models/Customers.ts
+++ b/backend/core-api/src/modules/contacts/db/models/Customers.ts
@@ -522,14 +522,12 @@ export const loadCustomerClass = (
     }: ICreateMessengerCustomerParams) {
       doc = this.fixListFields(doc, customData);
 
-      const { propertiesData } = await models.Fields.generatePropertiesData(
-        customData,
-        'core:customer',
-      );
+      const { propertiesData, trackedData } =
+        await models.Fields.generatePropertiesData(customData, 'core:customer');
 
       return this.createCustomer({
         ...doc,
-        // trackedData: [], trackData note: trackedData is not used for now
+        trackedData,
         propertiesData,
         lastSeenAt: new Date(),
         isOnline: true,
@@ -549,10 +547,8 @@ export const loadCustomerClass = (
 
       doc = this.fixListFields(doc, customData, customer);
 
-      const { propertiesData } = await models.Fields.generatePropertiesData(
-        customData,
-        'core:customer',
-      );
+      const { propertiesData, trackedData } =
+        await models.Fields.generatePropertiesData(customData, 'core:customer');
 
       const modifier: any = {
         ...doc,
@@ -560,10 +556,9 @@ export const loadCustomerClass = (
         updatedAt: new Date(),
       };
 
-      // trackData note: trackedData is not used for now
-      // if (trackedData && trackedData.length > 0) {
-      //   modifier.trackedData = trackedData;
-      // }
+      if (trackedData.length > 0) {
+        modifier.trackedData = trackedData;
+      }
 
       if (Object.keys(propertiesData)?.length > 0) {
         // if use Customers.updateCustomer method then just pass propertiesData no spread neede

--- a/backend/core-api/src/modules/forms/trpc/fields.ts
+++ b/backend/core-api/src/modules/forms/trpc/fields.ts
@@ -173,6 +173,24 @@ export const fieldsTrpcRouter = t.router({
         const { subdomain, models } = ctx;
         return await fieldsCombinedByContentType(models, subdomain, input);
       }),
+    generatePropertiesData: t.procedure
+      .input(
+        z.object({
+          query: z.object({
+            customData: z.record(z.any()).optional(),
+            contentType: z.string(),
+          }),
+        }),
+      )
+      .query(async ({ ctx, input }) => {
+        const { customData, contentType } = input.query;
+        const { models } = ctx;
+
+        return await models.Fields.generatePropertiesData(
+          customData || {},
+          contentType,
+        );
+      }),
     validateFieldValues: t.procedure
       .input(z.any())
       .mutation(async ({ ctx, input }) => {

--- a/backend/core-api/src/modules/properties/db/models/Field.ts
+++ b/backend/core-api/src/modules/properties/db/models/Field.ts
@@ -11,6 +11,33 @@ import { fieldSchema } from '~/modules/properties/db/definitions/field';
 import { IField, IFieldDocument } from '../../@types';
 import { ORDER_GAP } from '../../constants';
 
+export type TrackedValue =
+  | string
+  | number
+  | boolean
+  | Date
+  | string[]
+  | ILocationOption;
+
+const isValidDate = (value: TrackedValue) => {
+  if (value instanceof Date) {
+    return true;
+  }
+
+  if (!value) {
+    return false;
+  }
+
+  const stringValue = value.toString();
+
+  return (
+    validator.isISO8601(stringValue) ||
+    /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/.test(
+      stringValue,
+    )
+  );
+};
+
 export interface IFieldModel extends Model<IFieldDocument> {
   getField({ _id }: { _id: string }): Promise<IFieldDocument>;
   createField(doc: IField, user: IUserDocument): Promise<IFieldDocument>;
@@ -24,10 +51,22 @@ export interface IFieldModel extends Model<IFieldDocument> {
   validateFieldValue(_id: string, value: any): Promise<any>;
   validateFieldValues(data: any): Promise<any>;
 
+  generateTypedItem(
+    fieldId: string,
+    value: TrackedValue,
+    type: string,
+    validation?: string,
+    extraValue?: string,
+  ): Promise<ICustomField>;
+
+  generateTypedListFromMap(data: {
+    [key: string]: TrackedValue;
+  }): Promise<ICustomField[]>;
+
   generatePropertiesData(
     data: { [key: string]: any },
     contentType: string,
-  ): Promise<{ propertiesData: IPropertyField }>;
+  ): Promise<{ propertiesData: IPropertyField; trackedData: ICustomField[] }>;
 
   syncFieldValues({
     customFieldsData,
@@ -244,6 +283,78 @@ export const loadFieldClass = (models: IModels) => {
       return result;
     }
 
+    public static async generateTypedItem(
+      fieldId: string,
+      value: TrackedValue,
+      type: string,
+      validation?: string,
+      extraValue?: string,
+    ): Promise<ICustomField> {
+      let typedValue: TrackedValue = value;
+      let stringValue: string | undefined;
+      let numberValue: number | undefined;
+      let dateValue: Date | undefined;
+      let locationValue: ILocationOption | undefined;
+
+      if (value) {
+        stringValue = value.toString();
+
+        if (type === 'input' && !validation) {
+          return {
+            field: fieldId,
+            value: stringValue,
+            stringValue,
+            numberValue,
+            dateValue,
+          };
+        }
+
+        if (type === 'map') {
+          const location = value as ILocationOption;
+
+          return {
+            field: fieldId,
+            value,
+            stringValue: `${location.lng},${location.lat}`,
+            locationValue: location,
+          };
+        }
+
+        if (type !== 'check' && validator.isFloat(stringValue)) {
+          numberValue = Number(value);
+          typedValue = numberValue;
+        }
+
+        if (isValidDate(typedValue)) {
+          const parsed = new Date(stringValue);
+
+          if (!isNaN(parsed.getTime())) {
+            dateValue = parsed;
+          }
+        }
+      }
+
+      return {
+        field: fieldId,
+        value: typedValue,
+        stringValue,
+        numberValue,
+        dateValue,
+        locationValue,
+        extraValue,
+      };
+    }
+
+    public static async generateTypedListFromMap(data: {
+      [key: string]: TrackedValue;
+    }): Promise<ICustomField[]> {
+      const keys = Object.keys(data || {});
+
+      return Promise.all(
+        keys.map((key) => this.generateTypedItem(key, data[key], '')),
+      );
+    }
+
     public static async generatePropertiesData(
       data: { [key: string]: any },
       contentType: string,
@@ -251,6 +362,7 @@ export const loadFieldClass = (models: IModels) => {
       const keys = Object.keys(data || {});
 
       let propertiesData: Record<string, any> = {};
+      const untrackedData: Record<string, TrackedValue> = { ...(data || {}) };
 
       for (const key of keys) {
         const field = await models.Fields.findOne({
@@ -262,12 +374,17 @@ export const loadFieldClass = (models: IModels) => {
 
         if (field) {
           propertiesData[field._id] = value;
+
+          delete untrackedData[key];
         }
       }
 
       propertiesData = await models.Fields.validateFieldValues(propertiesData);
 
-      return { propertiesData };
+      const trackedData =
+        await models.Fields.generateTypedListFromMap(untrackedData);
+
+      return { propertiesData, trackedData };
     }
 
     public static async syncFieldValues({

--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -94,6 +94,10 @@
   invisible to agents.
 - Contributes permissions, notifications, segments, references, and
   import/export handlers to the platform through `meta/`.
+- `widgetsMessengerConnect` stores messenger `companyData` on the core company
+  as both `propertiesData` (keys matching a `core:company` field) and
+  `trackedData` (every remaining key), so arbitrary messenger attributes are
+  preserved instead of dropped.
 
 ## Architecture
 
@@ -312,7 +316,10 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   `EXECUTE_WAIT_TYPES`, `attachmentSchema`.
 - `core` over tRPC — brands, tags, users, structure,
   `configs.getFileUploadConfigs`, `users.findOne`, `fields.find` (validating the
-  ticket property fields chosen in a ticket config).
+  ticket property fields chosen in a ticket config),
+  `fields.generatePropertiesData` (splitting messenger `companyData` into
+  `propertiesData` for keys that match a Core `core:company` field and
+  `trackedData` for every remaining key).
 - Facebook Graph API through `fbgraph` (`graphRequest` in
   `src/modules/integrations/facebook/utils.ts`).
 
@@ -868,6 +875,20 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-08-21` — Messenger company attributes are tracked again
+
+- **Summary:** `widgetsMessengerConnect` asked Core for
+  `fields.generatePropertiesData` but assigned only `propertiesData`, leaving
+  the company's `trackedData` permanently empty, so any messenger attribute
+  that did not match a defined `core:company` field was discarded. The company
+  branch now writes the `trackedData` Core returns alongside `propertiesData`.
+- **Affected areas:**
+  `src/modules/inbox/graphql/resolvers/mutations/widget.ts` (company branch of
+  `widgetsMessengerConnect`).
+- **Contracts changed:** None in this plugin. It now depends on Core's
+  `fields.generatePropertiesData` tRPC procedure returning
+  `{ propertiesData, trackedData }`.
+
 ### `2026-08-21` — A forwarded call stays one conversation
 
 - **Summary:** An inbound call that Follow Me forwarded to an agent's mobile
@@ -1036,21 +1057,3 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - **Contracts changed:** New `FacebookReportFilter` input, `ReportFacebook*`
   types, and five `reportFacebook*` queries; `TicketReportFilter`,
   `ReportChartFilters`, and the stored chart filters gained `pageIds`.
-
-### `2026-08-17` — IVR stops swallowing every call outcome
-
-- **Summary:** `deriveCallStatusFromLegs` checked `IVR` before the real
-  dispositions, and an IVR answers the line on every call it fronts, so every
-  call through a menu was labelled `IVR` — which `callHistoryList` then dropped
-  outright. On an IVR-fronted deployment the Call history was empty, phone
-  search found nothing, and the No answer / Busy / Failed filters returned
-  nothing while Total Calls read 259. `IVR` is now the last branch, so it only
-  labels a call that never left the menu, and the history no longer filters an
-  outcome class out of the list.
-- **Affected areas:**
-  `src/modules/integrations/call/services/cdrUtils.ts`
-  (`deriveCallStatusFromLegs`),
-  `src/modules/reports/graphql/resolvers/callQueries.ts` (`callHistoryList`).
-- **Contracts changed:** None. Values move: calls that entered an IVR and were
-  not answered now report `NO ANSWER` / `BUSY` / `FAILED` instead of `IVR`,
-  which also changes the conversation label `getConversationContent` renders.

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
@@ -426,9 +426,7 @@ export const widgetMutations: Record<string, Resolver> = {
       });
 
       companyData.propertiesData = fieldData?.propertiesData || {};
-
-      // trackData note: trackedData is not used for now
-      // companyData.trackedData = trackedData;
+      companyData.trackedData = fieldData?.trackedData || [];
 
       if (company) {
         company = await sendTRPCMessage({

--- a/frontend/core-ui/src/modules/widgets/constants/core-relations.ts
+++ b/frontend/core-ui/src/modules/widgets/constants/core-relations.ts
@@ -1,4 +1,4 @@
-import { IconBuilding, IconUser } from '@tabler/icons-react';
+import { IconBuilding, IconRadar, IconUser } from '@tabler/icons-react';
 
 export const CORE_RELATIONS = [
   {
@@ -12,5 +12,12 @@ export const CORE_RELATIONS = [
     name: 'company',
     icon: IconBuilding,
     label: 'Companies',
+  },
+  {
+    pluginName: 'core',
+    name: 'trackedData',
+    icon: IconRadar,
+    label: 'Tracked data',
+    contentTypes: ['core:customer'],
   },
 ];

--- a/frontend/core-ui/src/modules/widgets/core-widgets/CoreWidgets.tsx
+++ b/frontend/core-ui/src/modules/widgets/core-widgets/CoreWidgets.tsx
@@ -1,6 +1,7 @@
 import { IRelationWidgetProps } from 'ui-modules';
 import { CustomerWidgets } from './customer/CustomerWidgets';
 import { CompanyWidgets } from './company/CompanyWidgets';
+import { TrackedDataWidgets } from './tracked-data/TrackedDataWidgets';
 
 export const CoreWidgets = (props: IRelationWidgetProps) => {
   const { module } = props;
@@ -11,6 +12,10 @@ export const CoreWidgets = (props: IRelationWidgetProps) => {
 
   if (module === 'company') {
     return <CompanyWidgets {...props} />;
+  }
+
+  if (module === 'trackedData') {
+    return <TrackedDataWidgets {...props} />;
   }
 
   return null;

--- a/frontend/core-ui/src/modules/widgets/core-widgets/tracked-data/TrackedDataWidgets.tsx
+++ b/frontend/core-ui/src/modules/widgets/core-widgets/tracked-data/TrackedDataWidgets.tsx
@@ -1,0 +1,109 @@
+import { IconRadar } from '@tabler/icons-react';
+import {
+  Badge,
+  RelativeDateDisplay,
+  ScrollArea,
+  SideMenu,
+  Spinner,
+} from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+import {
+  ITrackedDataItem,
+  IRelationWidgetProps,
+  useCustomerDetail,
+} from 'ui-modules';
+
+const TrackedDataRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <li className="flex justify-between items-center gap-4 px-3 py-2 text-sm border-b last:border-b-0">
+    <span className="text-accent-foreground truncate">{label}</span>
+    <span className="font-medium text-foreground text-right truncate">
+      {children}
+    </span>
+  </li>
+);
+
+const renderTrackedValue = (item: ITrackedDataItem) => {
+  if (item.dateValue) {
+    return <RelativeDateDisplay.Value value={item.dateValue} />;
+  }
+
+  if (item.stringValue) {
+    return item.stringValue;
+  }
+
+  if (item.value === null || item.value === undefined) {
+    return '-';
+  }
+
+  return String(item.value);
+};
+
+export const TrackedDataWidgets = ({
+  contentId,
+  customerId,
+}: IRelationWidgetProps) => {
+  const { t } = useTranslation('contact', { keyPrefix: 'customer.detail' });
+  const _id = customerId || contentId;
+
+  const { customerDetail, loading } = useCustomerDetail({
+    variables: { _id },
+    skip: !_id,
+  });
+
+  const { isOnline, lastSeenAt, sessionCount, trackedData } =
+    customerDetail || {};
+  const items = trackedData ?? [];
+
+  return (
+    <SideMenu.Content value="trackedData" className="bg-sidebar">
+      <SideMenu.Header
+        label={t('tracked-data', 'Tracked data')}
+        Icon={IconRadar}
+      />
+      {loading ? (
+        <Spinner containerClassName="py-6" />
+      ) : (
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="p-3">
+            <ul className="bg-background rounded-lg shadow-xs">
+              <TrackedDataRow label={t('status', 'Status')}>
+                <Badge variant={isOnline ? 'success' : 'secondary'}>
+                  {isOnline ? t('online', 'Online') : t('offline', 'Offline')}
+                </Badge>
+              </TrackedDataRow>
+              <TrackedDataRow label={t('last-online', 'Last online')}>
+                {lastSeenAt ? (
+                  <RelativeDateDisplay.Value value={lastSeenAt} />
+                ) : (
+                  '-'
+                )}
+              </TrackedDataRow>
+              <TrackedDataRow label={t('session-count', 'Session count')}>
+                {sessionCount ?? 0}
+              </TrackedDataRow>
+              {items.map((item) => (
+                <TrackedDataRow key={item.field} label={item.field}>
+                  {renderTrackedValue(item)}
+                </TrackedDataRow>
+              ))}
+            </ul>
+            {items.length === 0 && (
+              <p className="px-3 pt-3 text-xs text-accent-foreground">
+                {t(
+                  'no-tracked-data',
+                  'No tracked data has been collected yet.',
+                )}
+              </p>
+            )}
+          </div>
+        </ScrollArea>
+      )}
+    </SideMenu.Content>
+  );
+};

--- a/frontend/libs/ui-modules/src/modules/contacts/graphql/queries/customerDetailQueries.ts
+++ b/frontend/libs/ui-modules/src/modules/contacts/graphql/queries/customerDetailQueries.ts
@@ -27,6 +27,10 @@ export const CUSTOMER_DETAIL = gql`
       primaryPhone
       score
       code
+      trackedData
+      isOnline
+      lastSeenAt
+      sessionCount
       companies {
         _id
         avatar

--- a/frontend/libs/ui-modules/src/modules/contacts/types/Customer.ts
+++ b/frontend/libs/ui-modules/src/modules/contacts/types/Customer.ts
@@ -3,6 +3,14 @@ import { CountryCode } from 'libphonenumber-js';
 import { ICompany } from './Company';
 import { IUser } from 'ui-modules/modules/team-members';
 
+export interface ITrackedDataItem {
+  field: string;
+  value?: string | number | boolean | null;
+  stringValue?: string;
+  numberValue?: number;
+  dateValue?: string;
+}
+
 export interface ICustomerInline {
   _id: string;
   firstName?: string;
@@ -31,6 +39,7 @@ export interface ICustomer extends ICustomerInline {
   sex?: SexCode;
   owner?: IUser;
   propertiesData?: Record<string, unknown>;
+  trackedData?: ITrackedDataItem[];
 }
 
 export interface ICustomerDetail extends ICustomer {
@@ -38,6 +47,9 @@ export interface ICustomerDetail extends ICustomer {
   position?: string;
   department?: string;
   state?: string;
+  isOnline?: boolean;
+  lastSeenAt?: string;
+  sessionCount?: number;
 }
 
 export enum CustomerType {

--- a/frontend/libs/ui-modules/src/modules/widget/components/RelationWidgetSideTabs.tsx
+++ b/frontend/libs/ui-modules/src/modules/widget/components/RelationWidgetSideTabs.tsx
@@ -24,8 +24,10 @@ export const RelationWidgetSideTabs = ({
   customerId?: string;
   companyId?: string;
 }) => {
-  const { RelationWidget, relationWidgetsModules } =
-    useRelationWidget(hookOptions);
+  const { RelationWidget, relationWidgetsModules } = useRelationWidget({
+    ...hookOptions,
+    contentType,
+  });
   return (
     <FocusSheet.SideTabs>
       {relationWidgetsModules.map((module) => (

--- a/frontend/libs/ui-modules/src/modules/widget/widget-provider/context/widgetContext.tsx
+++ b/frontend/libs/ui-modules/src/modules/widget/widget-provider/context/widgetContext.tsx
@@ -21,6 +21,7 @@ export interface IRelationModules {
   pluginName: string;
   icon: Icon;
   label?: string;
+  contentTypes?: string[];
 }
 
 export const RelationWidgetContext = createContext<{
@@ -55,10 +56,12 @@ export const useRelationWidget = (options?: {
   hiddenPlugins?: string[];
   hiddenModules?: string[];
   hideCoreRelations?: boolean;
+  contentType?: string;
 }) => {
   const context = useContext(RelationWidgetContext);
 
-  const { hiddenPlugins, hiddenModules, hideCoreRelations } = options || {};
+  const { hiddenPlugins, hiddenModules, hideCoreRelations, contentType } =
+    options || {};
 
   const hideCore = hideCoreRelations
     ? hideCoreRelations
@@ -66,7 +69,13 @@ export const useRelationWidget = (options?: {
     ? true
     : false;
 
-  let filteredModules = context.relationWidgetsModules;
+  let filteredModules = context.relationWidgetsModules || [];
+
+  filteredModules = filteredModules.filter(
+    (module) =>
+      !module.contentTypes ||
+      (!!contentType && module.contentTypes.includes(contentType)),
+  );
 
   if (hiddenPlugins) {
     filteredModules = filteredModules.filter(


### PR DESCRIPTION
## Summary by Sourcery

Preserve arbitrary messenger attributes as typed tracked data and make them available in customer details.

New Features:
- Expose a customer tracked-data relation widget showing captured attributes alongside online status, last-seen time, and session count.
- Add a fields API for generating typed property and tracked-data payloads from arbitrary custom data.

Bug Fixes:
- Preserve previously discarded messenger attributes by storing unmatched customer and company data in trackedData.

Enhancements:
- Filter relation widgets by content type so tracked-data navigation is available only for customers.
- Support typed tracked values including strings, numbers, dates, booleans, locations, and lists.

Documentation:
- Document the messenger company-data split between defined properties and preserved tracked attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Tracked Data panel for customer records.
  - View online status, last-seen time, session count, and captured customer fields.
  - Relation widgets can now be filtered by content type for more relevant options.

- **Bug Fixes**
  - Messenger-created and updated customers now retain generated tracked data.
  - Customer details reliably display tracked information and customer activity metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->