### PR TITLE
fix(frontline): colored conversation tags with paginated tag select fix

### DIFF
--- a/backend/gateway/src/locales/en/frontline.json
+++ b/backend/gateway/src/locales/en/frontline.json
@@ -221,6 +221,7 @@
   "conversations-resolved": "Conversations resolved",
   "resolve-all": "Resolve All",
   "select-assignee": "Select assignee",
+  "add-tags": "Add tags",
   "tag-updated": "Tag updated",
   "failed-to-update-tags": "Failed to update tags",
   "open-label": "Open",

--- a/backend/gateway/src/locales/mn/frontline.json
+++ b/backend/gateway/src/locales/mn/frontline.json
@@ -221,6 +221,7 @@
   "conversations-resolved": "Харилцаа шийдвэрлэгдлээ",
   "resolve-all": "Бүгдийг шийдвэрлэх",
   "select-assignee": "Хариуцагч сонгох",
+  "add-tags": "Шошго нэмэх",
   "tag-updated": "Шошго шинэчлэгдлээ",
   "failed-to-update-tags": "Шошго шинэчлэхэд алдаа гарлаа",
   "open-label": "Нээлттэй",

--- a/frontend/libs/ui-modules/src/modules/tags/components/SelectTags.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags/components/SelectTags.tsx
@@ -227,7 +227,11 @@ export const SelectTagsCommand = ({
           {search ? (
             <>
               {tags
-                ?.filter((tag) => !tag.parentId && !tag.isGroup)
+                ?.filter(
+                  (tag) =>
+                    !tag.isGroup &&
+                    !tags.some((t) => t._id === tag.parentId && t.isGroup),
+                )
                 ?.map((tag) => (
                   <SelectTagsItem
                     key={tag._id}
@@ -260,27 +264,15 @@ export const SelectTagsCommand = ({
                       ))}
                   </Command.Group>
                 ))}
-              {tags
-                ?.filter(
-                  (tag) =>
-                    tag.parentId &&
-                    !tags.some((t) => t._id === tag.parentId) &&
-                    !tag.isGroup,
-                )
-                .map((tag) => (
-                  <SelectTagsItem
-                    key={tag._id}
-                    tag={{
-                      ...tag,
-                      hasChildren: false,
-                    }}
-                  />
-                ))}
             </>
           ) : (
             <>
               {tags
-                ?.filter((tag) => !tag.parentId && !tag.isGroup)
+                ?.filter(
+                  (tag) =>
+                    !tag.isGroup &&
+                    !tags.some((t) => t._id === tag.parentId && t.isGroup),
+                )
                 ?.map((tag) => (
                   <SelectTagsItem
                     key={tag._id}

--- a/frontend/libs/ui-modules/src/modules/tags/components/SelectTags.tsx
+++ b/frontend/libs/ui-modules/src/modules/tags/components/SelectTags.tsx
@@ -224,89 +224,43 @@ export const SelectTagsCommand = ({
             show={!disableCreateOption && !loading && !tags?.length}
           />
           <Combobox.Empty loading={loading} error={error} />
-          {search ? (
-            <>
-              {tags
-                ?.filter(
-                  (tag) =>
-                    !tag.isGroup &&
-                    !tags.some((t) => t._id === tag.parentId && t.isGroup),
-                )
-                ?.map((tag) => (
-                  <SelectTagsItem
-                    key={tag._id}
-                    tag={{
-                      ...tag,
-                      hasChildren: false,
-                    }}
-                  />
-                ))}
+          {tags
+            ?.filter(
+              (tag) =>
+                !tag.isGroup &&
+                !tags.some((t) => t._id === tag.parentId && t.isGroup),
+            )
+            ?.map((tag) => (
+              <SelectTagsItem
+                key={tag._id}
+                tag={{
+                  ...tag,
+                  hasChildren: false,
+                }}
+              />
+            ))}
 
-              {tags
-                ?.filter(
-                  (tag) =>
-                    tag.isGroup && tags.some((t) => t.parentId === tag._id),
-                )
-                ?.map((tag) => (
-                  <Command.Group key={tag._id} heading={tag.name}>
-                    {tags
-                      .filter((t) => t.parentId === tag._id)
-                      .map((childTag) => (
-                        <SelectTagsItem
-                          key={childTag._id}
-                          tag={{
-                            ...childTag,
-                            hasChildren: tags.some(
-                              (t) => t.parentId === childTag._id,
-                            ),
-                          }}
-                        />
-                      ))}
-                  </Command.Group>
-                ))}
-            </>
-          ) : (
-            <>
-              {tags
-                ?.filter(
-                  (tag) =>
-                    !tag.isGroup &&
-                    !tags.some((t) => t._id === tag.parentId && t.isGroup),
-                )
-                ?.map((tag) => (
-                  <SelectTagsItem
-                    key={tag._id}
-                    tag={{
-                      ...tag,
-                      hasChildren: false,
-                    }}
-                  />
-                ))}
-
-              {tags
-                ?.filter(
-                  (tag) =>
-                    tag.isGroup && tags.some((t) => t.parentId === tag._id),
-                )
-                ?.map((tag) => (
-                  <Command.Group key={tag._id} heading={tag.name}>
-                    {tags
-                      .filter((t) => t.parentId === tag._id)
-                      .map((childTag) => (
-                        <SelectTagsItem
-                          key={childTag._id}
-                          tag={{
-                            ...childTag,
-                            hasChildren: tags.some(
-                              (t) => t.parentId === childTag._id,
-                            ),
-                          }}
-                        />
-                      ))}
-                  </Command.Group>
-                ))}
-            </>
-          )}
+          {tags
+            ?.filter(
+              (tag) => tag.isGroup && tags.some((t) => t.parentId === tag._id),
+            )
+            ?.map((tag) => (
+              <Command.Group key={tag._id} heading={tag.name}>
+                {tags
+                  .filter((t) => t.parentId === tag._id)
+                  .map((childTag) => (
+                    <SelectTagsItem
+                      key={childTag._id}
+                      tag={{
+                        ...childTag,
+                        hasChildren: tags.some(
+                          (t) => t.parentId === childTag._id,
+                        ),
+                      }}
+                    />
+                  ))}
+              </Command.Group>
+            ))}
           <Combobox.FetchMore
             fetchMore={handleFetchMore}
             currentLength={tags?.length || 0}

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationTagChips.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationTagChips.tsx
@@ -1,20 +1,24 @@
-import { Badge, Tooltip } from 'erxes-ui';
+import { Badge, Skeleton, TextOverflowTooltip, cn } from 'erxes-ui';
 import { useGetTags } from 'ui-modules';
 
-const MAX_VISIBLE_TAGS = 3;
+const MAX_VISIBLE_TAGS = 2;
 
 export const ConversationTagChips = ({
   tagIds,
-  max = MAX_VISIBLE_TAGS,
+  showAll,
   onRemove,
 }: {
   tagIds: string[];
-  max?: number;
+  showAll?: boolean;
   onRemove?: (tagId: string) => void;
 }) => {
-  const { tags } = useGetTags({
+  const { tags, loading } = useGetTags({
     variables: { type: 'frontline:conversation' },
   });
+
+  if (loading) {
+    return tagIds.map((tagId) => <Skeleton key={tagId} className="w-8 h-4" />);
+  }
 
   const selectedTags = tagIds
     .map((tagId) => tags?.find((tag) => tag._id === tagId))
@@ -24,49 +28,38 @@ export const ConversationTagChips = ({
     return null;
   }
 
-  const visibleTags = selectedTags.slice(0, max);
-  const remainingCount = selectedTags.length - visibleTags.length;
+  const visibleTags = showAll
+    ? selectedTags
+    : selectedTags.slice(0, MAX_VISIBLE_TAGS);
+  const overflowCount = selectedTags.length - visibleTags.length;
 
   return (
-    <Tooltip.Provider>
-      <div className="flex items-center gap-1 min-w-0">
-        {visibleTags.map((tag) => (
-          <Tooltip key={tag._id} delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="secondary"
-                className="h-5 max-w-32 px-1.5 font-normal"
-                onClose={onRemove ? () => onRemove(tag._id) : undefined}
-              >
-                <span
-                  className="size-1.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: tag.colorCode }}
-                />
-                <span className="truncate">{tag.name}</span>
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>{tag.name}</Tooltip.Content>
-          </Tooltip>
-        ))}
-        {remainingCount > 0 && (
-          <Tooltip delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="secondary"
-                className="h-5 shrink-0 px-1.5 font-normal"
-              >
-                +{remainingCount}
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>
-              {selectedTags
-                .slice(max)
-                .map((tag) => tag.name)
-                .join(', ')}
-            </Tooltip.Content>
-          </Tooltip>
-        )}
-      </div>
-    </Tooltip.Provider>
+    <div
+      className={cn(
+        showAll
+          ? 'flex flex-wrap gap-2 w-full'
+          : 'flex items-center gap-1 min-w-0',
+      )}
+    >
+      {visibleTags.map((tag) => (
+        <Badge
+          key={tag._id}
+          variant="secondary"
+          className={cn(!showAll && 'max-w-24 shrink truncate')}
+          onClose={onRemove ? () => onRemove(tag._id) : undefined}
+        >
+          <span
+            className="size-1.5 shrink-0 rounded-full"
+            style={{ backgroundColor: tag.colorCode }}
+          />
+          <TextOverflowTooltip value={tag.name} />
+        </Badge>
+      ))}
+      {overflowCount > 0 && (
+        <Badge variant="secondary" className="shrink-0 text-xs">
+          +{overflowCount}
+        </Badge>
+      )}
+    </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationTagChips.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/ConversationTagChips.tsx
@@ -1,0 +1,72 @@
+import { Badge, Tooltip } from 'erxes-ui';
+import { useGetTags } from 'ui-modules';
+
+const MAX_VISIBLE_TAGS = 3;
+
+export const ConversationTagChips = ({
+  tagIds,
+  max = MAX_VISIBLE_TAGS,
+  onRemove,
+}: {
+  tagIds: string[];
+  max?: number;
+  onRemove?: (tagId: string) => void;
+}) => {
+  const { tags } = useGetTags({
+    variables: { type: 'frontline:conversation' },
+  });
+
+  const selectedTags = tagIds
+    .map((tagId) => tags?.find((tag) => tag._id === tagId))
+    .filter((tag): tag is NonNullable<typeof tag> => Boolean(tag));
+
+  if (!selectedTags.length) {
+    return null;
+  }
+
+  const visibleTags = selectedTags.slice(0, max);
+  const remainingCount = selectedTags.length - visibleTags.length;
+
+  return (
+    <Tooltip.Provider>
+      <div className="flex items-center gap-1 min-w-0">
+        {visibleTags.map((tag) => (
+          <Tooltip key={tag._id} delayDuration={200}>
+            <Tooltip.Trigger asChild>
+              <Badge
+                variant="secondary"
+                className="h-5 max-w-32 px-1.5 font-normal"
+                onClose={onRemove ? () => onRemove(tag._id) : undefined}
+              >
+                <span
+                  className="size-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: tag.colorCode }}
+                />
+                <span className="truncate">{tag.name}</span>
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{tag.name}</Tooltip.Content>
+          </Tooltip>
+        ))}
+        {remainingCount > 0 && (
+          <Tooltip delayDuration={200}>
+            <Tooltip.Trigger asChild>
+              <Badge
+                variant="secondary"
+                className="h-5 shrink-0 px-1.5 font-normal"
+              >
+                +{remainingCount}
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              {selectedTags
+                .slice(max)
+                .map((tag) => tag.name)
+                .join(', ')}
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+      </div>
+    </Tooltip.Provider>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -36,7 +36,13 @@ import {
   useQueryState,
 } from 'erxes-ui';
 import { useAtomValue } from 'jotai';
-import { CustomersInline, SelectMember, SelectTags } from 'ui-modules';
+import {
+  CustomersInline,
+  SelectMember,
+  SelectTags,
+  useGiveTags,
+} from 'ui-modules';
+import { ConversationTagChips } from '@/inbox/conversations/components/ConversationTagChips';
 import { ConversationActions } from '@/inbox/conversations/conversation-detail/components/ConversationActions';
 import { useTranslation } from 'react-i18next';
 import { type SyntheticEvent, useState } from 'react';
@@ -250,11 +256,26 @@ export const ConversationTags = ({
 }) => {
   const { t } = useTranslation('frontline');
   const { _id, tagIds, setTagIds } = useConversationContext();
-  const TagSelector = showAllTags
-    ? SelectTags.Detail
-    : SelectTags.ConversationDetail;
+  const { giveTags } = useGiveTags();
+  const [open, setOpen] = useState(false);
 
   if (!_id) return null;
+
+  const mutationOptions = () => ({
+    onCompleted: () => {
+      toast({
+        title: t('tag-updated'),
+        variant: 'default',
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: t('failed-to-update-tags'),
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
 
   const handleTagChange = (newTagIds: string[] | string) => {
     const ids = Array.isArray(newTagIds) ? newTagIds : [newTagIds];
@@ -262,33 +283,53 @@ export const ConversationTags = ({
     setTagIds?.(ids);
   };
 
+  const handleRemoveTag = (tagId: string) => {
+    const ids = tagIds.filter((id) => id !== tagId);
+
+    setTagIds?.(ids);
+    giveTags({
+      variables: {
+        tagIds: ids,
+        targetIds: [_id],
+        type: 'frontline:conversation',
+      },
+      ...mutationOptions(),
+    });
+  };
+
   return (
     <div className="flex-none">
-      <TagSelector
+      <SelectTags.Provider
         tagType="frontline:conversation"
         mode="multiple"
         value={tagIds}
         targetIds={[_id]}
         onValueChange={handleTagChange}
-        options={() => ({
-          onCompleted: () => {
-            toast({
-              title: t('tag-updated'),
-              variant: 'default',
-            });
-          },
-          onError: (error: Error) => {
-            toast({
-              title: t('failed-to-update-tags'),
-              description: error.message,
-              variant: 'destructive',
-            });
-          },
-        })}
-        onPointerDown={withinDropdown ? stopEventPropagation : undefined}
-        onClick={withinDropdown ? stopEventPropagation : undefined}
-        onKeyDown={withinDropdown ? stopEventPropagation : undefined}
-      />
+        options={mutationOptions}
+      >
+        <div className="flex gap-2 items-center">
+          <PopoverScoped open={open} onOpenChange={setOpen}>
+            <Combobox.Trigger
+              className="text-foreground shadow-none px-2"
+              variant="outline"
+              onPointerDown={withinDropdown ? stopEventPropagation : undefined}
+              onClick={withinDropdown ? stopEventPropagation : undefined}
+              onKeyDown={withinDropdown ? stopEventPropagation : undefined}
+            >
+              <IconTags className="size-4" />
+              {t('add-tags')}
+            </Combobox.Trigger>
+            <Combobox.Content>
+              <SelectTags.Content />
+            </Combobox.Content>
+          </PopoverScoped>
+          <ConversationTagChips
+            tagIds={tagIds}
+            max={showAllTags ? tagIds.length : 2}
+            onRemove={handleRemoveTag}
+          />
+        </div>
+      </SelectTags.Provider>
     </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -27,6 +27,7 @@ import {
   Button,
   Combobox,
   DropdownMenu,
+  Popover,
   PopoverScoped,
   Separator,
   Skeleton,
@@ -39,7 +40,7 @@ import { useAtomValue } from 'jotai';
 import {
   CustomersInline,
   SelectMember,
-  SelectTags,
+  TagsSelect,
   useGiveTags,
 } from 'ui-modules';
 import { ConversationTagChips } from '@/inbox/conversations/components/ConversationTagChips';
@@ -257,7 +258,6 @@ export const ConversationTags = ({
   const { t } = useTranslation('frontline');
   const { _id, tagIds, setTagIds } = useConversationContext();
   const { giveTags } = useGiveTags();
-  const [open, setOpen] = useState(false);
 
   if (!_id) return null;
 
@@ -277,12 +277,6 @@ export const ConversationTags = ({
     },
   });
 
-  const handleTagChange = (newTagIds: string[] | string) => {
-    const ids = Array.isArray(newTagIds) ? newTagIds : [newTagIds];
-
-    setTagIds?.(ids);
-  };
-
   const handleRemoveTag = (tagId: string) => {
     const ids = tagIds.filter((id) => id !== tagId);
 
@@ -299,37 +293,37 @@ export const ConversationTags = ({
 
   return (
     <div className="flex-none">
-      <SelectTags.Provider
-        tagType="frontline:conversation"
+      <TagsSelect.Provider
+        type="frontline:conversation"
         mode="multiple"
         value={tagIds}
         targetIds={[_id]}
-        onValueChange={handleTagChange}
+        onValueChange={(newTagIds) => setTagIds?.(newTagIds)}
         options={mutationOptions}
       >
         <div className="flex gap-2 items-center">
-          <PopoverScoped open={open} onOpenChange={setOpen}>
-            <Combobox.Trigger
-              className="text-foreground shadow-none px-2"
+          <Popover.Trigger asChild>
+            <Button
+              className="shrink-0 w-min text-sm font-medium shadow-xs"
               variant="outline"
               onPointerDown={withinDropdown ? stopEventPropagation : undefined}
               onClick={withinDropdown ? stopEventPropagation : undefined}
               onKeyDown={withinDropdown ? stopEventPropagation : undefined}
             >
-              <IconTags className="size-4" />
-              {t('add-tags')}
-            </Combobox.Trigger>
-            <Combobox.Content>
-              <SelectTags.Content />
-            </Combobox.Content>
-          </PopoverScoped>
+              <IconTags className="text-lg" />
+              {t('add-tags', 'Add tags')}
+            </Button>
+          </Popover.Trigger>
           <ConversationTagChips
             tagIds={tagIds}
-            max={showAllTags ? tagIds.length : 2}
+            showAll={showAllTags}
             onRemove={handleRemoveTag}
           />
         </div>
-      </SelectTags.Provider>
+        <Combobox.Content>
+          <TagsSelect.Content />
+        </Combobox.Content>
+      </TagsSelect.Provider>
     </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/conversation-detail/components/ConversationHeader.tsx
@@ -387,7 +387,7 @@ const ConversationActionsDropdown = ({
           <IconTags className="size-4" />
           {t('tags')}
         </DropdownMenu.Label>
-        <div className="px-1 pb-2 [&>div]:flex-col [&>div]:items-stretch [&>div>button]:order-last [&>div>button]:mt-2 [&>div>button]:w-full [&>div>button]:justify-between [&>div>button]:border-dashed [&>div>button]:bg-muted/30 [&>div>div]:max-h-28 [&>div>div]:w-full [&>div>div]:overflow-y-auto [&>div>div]:pr-1">
+        <div className="px-1 pb-2 [&>div>div]:flex-col [&>div>div]:items-stretch [&>div>div>button]:order-last [&>div>div>button]:mt-2 [&>div>div>button]:w-full [&>div>div>button]:justify-between [&>div>div>button]:border-dashed [&>div>div>button]:bg-muted/30 [&>div>div>div]:max-h-28 [&>div>div>div]:w-full [&>div>div>div]:overflow-y-auto [&>div>div>div]:pr-1">
           <ConversationTags showAllTags withinDropdown />
         </div>
         <DropdownMenu.Separator />


### PR DESCRIPTION
## Summary by Sourcery

Improve frontline conversation tag management with colored tag chips and reliable paginated tag selection.

New Features:
- Display conversation tags as colored, removable chips with compact overflow handling or a full expanded view.
- Provide a unified tag selection experience for frontline conversations with add-tags controls and paginated results.

Bug Fixes:
- Fix tag selection rendering so paginated and searched results consistently display standalone tags and grouped child tags.

Enhancements:
- Refactor conversation tag management to use the shared TagsSelect provider and tag mutation flow with update and error notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manage conversation tags directly from conversation details.
  - Display tags as colored chips, with options to show all tags, view additional tag counts, and remove tags.
  - Added English and Mongolian translations for the “Add tags” action.

- **Bug Fixes**
  - Tag selection now consistently displays root-level, orphaned, and grouped tags in filtered and unfiltered views.
  - Search results now include all applicable tags for a more predictable selection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->