### PR TITLE
fix(content): return all client portal pages

### DIFF
--- a/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
+++ b/backend/plugins/content_api/src/modules/cms/graphql/queries/page.ts
@@ -78,17 +78,26 @@ class PageQueryResolver extends BaseQueryResolver {
     const { language } = args;
     const clientPortalId = clientPortal._id;
 
-    const query: any = { clientPortalId };
+    const pages = await models.Pages.getPages({ clientPortalId });
 
-    const { list } = await this.getListWithTranslations(
-      models.Pages,
-      query,
-      { ...args, clientPortalId, language },
-      FIELD_MAPPINGS.PAGE,
+    if (
+      !language ||
+      (await this.shouldSkipTranslation(clientPortalId, language))
+    ) {
+      return pages;
+    }
+
+    const translations = await this.getTranslations(
+      pages.map((page) => page._id.toString()),
+      language,
       'page',
     );
 
-    return list;
+    return this.applyTranslationsToList(
+      pages,
+      translations,
+      FIELD_MAPPINGS.PAGE,
+    );
   }
 
   async cpPageList(_parent: any, args: any, context: IContext) {


### PR DESCRIPTION
## Summary

- remove unintended cursor pagination from `cpPages`
- preserve client portal scoping and translated page fields
- keep `cpPageList` as the paginated page query

## Validation

- `pnpm nx build content_api`
- `pnpm nx lint content_api` (passes with pre-existing warnings)
- smoke-tested 25 portal pages and translated fields

## Summary by Sourcery

Return complete client portal page results while preserving translations and paginated list behavior.

Bug Fixes:
- Return all client portal pages from `cpPages` instead of applying unintended pagination.

Enhancements:
- Preserve client portal scoping and translated page fields while retaining pagination for `cpPageList`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-portal page retrieval for more reliable results.
  * Pages now display in their original language when no translation is requested or available.
  * Applied translations are fetched and displayed when a language is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->