### PR TITLE
feat(pos): ReturnDescription field added

### DIFF
--- a/backend/plugins/sales_api/src/modules/pos/@types/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/@types/orders.ts
@@ -32,6 +32,14 @@ export interface IMobileAmount {
   amount: number;
 }
 
+export interface IPosOrderReturnInfo {
+  cashAmount?: number;
+  paidAmounts?: IPaidAmount[];
+  returnAt?: Date;
+  returnBy?: string;
+  description?: string;
+}
+
 export interface IPosOrder {
   createdAt: Date;
   status: string;
@@ -69,7 +77,7 @@ export interface IPosOrder {
   origin?: string;
   taxInfo?: any;
   convertDealId?: string;
-  returnInfo?: any;
+  returnInfo?: IPosOrderReturnInfo;
   subscriptionInfo?: {
     subscriptionId: string;
     status: string;

--- a/backend/plugins/sales_api/src/modules/pos/@types/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/@types/orders.ts
@@ -33,10 +33,6 @@ export interface IMobileAmount {
 }
 
 export interface IPosOrderReturnInfo {
-  cashAmount?: number;
-  paidAmounts?: IPaidAmount[];
-  returnAt?: Date;
-  returnBy?: string;
   description?: string;
 }
 

--- a/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posOrder.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/resolvers/customResolvers/posOrder.ts
@@ -4,6 +4,9 @@ import { IPosOrderDocument } from '~/modules/pos/@types/orders';
 import { IPosDocument } from '~/modules/pos/@types/pos';
 
 const resolvers = {
+  returnDescription: (order: IPosOrderDocument) =>
+    order.returnInfo?.description ?? null,
+
   putResponses: async (order, _, { subdomain }) => {
     return sendTRPCMessage({
       subdomain,

--- a/backend/plugins/sales_api/src/modules/pos/graphql/schemas/orders.ts
+++ b/backend/plugins/sales_api/src/modules/pos/graphql/schemas/orders.ts
@@ -57,6 +57,7 @@ export const types = () => `
 
   type PosOrder {
     ${posOrderFields()}
+    returnDescription: String
   }
 
   type PosOrderDetail {


### PR DESCRIPTION
## Summary by Sourcery

Add support for returning POS order return descriptions through the GraphQL API.

New Features:
- Expose an optional return description on POS order GraphQL responses.

Enhancements:
- Strongly type POS order return information with an optional description field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying an order’s return description.
  * Return descriptions are available through the order API as an optional field.
  * Orders without a return description now return an empty value instead of an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->