### PR TITLE
feat(core-api): guarded customers.captureProperties for agent-driven property writes

### DIFF
--- a/backend/core-api/src/meta/automations/automations.ts
+++ b/backend/core-api/src/meta/automations/automations.ts
@@ -85,6 +85,45 @@ const buildCustomerPrimaryFieldRules = (
 export const initAutomation = (app: Express) =>
   startAutomations(app, 'core', {
     constants: CORE_AUTOMATION_CONSTANTS,
+    receiveActions: async ({ subdomain, data }) => {
+      const models = await generateModels(subdomain);
+      const { collectionType, action, execution } = data;
+
+      if (collectionType !== 'customFields') {
+        throw new Error(
+          `Unsupported core automation collection: ${collectionType}`,
+        );
+      }
+
+      const { writeCustomProperties } = await import(
+        './writeCustomProperties'
+      );
+
+      // Helper-tool executions serialize the full mongoose document, so
+      // model-supplied tool arguments arrive on execution.inputs even though
+      // the producer wire type omits the field.
+      const inputs = (execution as { inputs?: Record<string, unknown> }).inputs ?? {};
+      const config = (action.config ?? {}) as Record<string, unknown>;
+
+      return {
+        result: await writeCustomProperties(
+          {
+            getCustomer: async (customerId) =>
+              models.Customers.findOne({ _id: customerId }).lean(),
+            findFields: async (query) => models.Fields.find(query).lean(),
+            updateCustomer: (customerId, doc) =>
+              models.Customers.updateCustomer(customerId, doc),
+          },
+          {
+            customerId: (inputs.customerId ?? config.customerId) as string,
+            values: (inputs.values ?? config.values) as Array<{
+              field: string;
+              value: unknown;
+            }>,
+          },
+        ),
+      };
+    },
     checkTargetMatch: async ({ subdomain, data }) => {
       const models = await generateModels(subdomain);
 

--- a/backend/core-api/src/meta/automations/constants.ts
+++ b/backend/core-api/src/meta/automations/constants.ts
@@ -229,6 +229,16 @@ export const CORE_AUTOMATION_CONSTANTS: AutomationConstants = {
       group: CORE_ACTION_GROUPS.COMMUNICATION_AND_INTEGRATIONS,
       output: AI_AGENT_ACTION_OUTPUT,
     },
+    {
+      moduleName: 'properties',
+      collectionName: 'customFields',
+      method: 'create',
+      icon: 'IconAdjustmentsHorizontal',
+      label: 'Write custom properties',
+      description:
+        'Guarded write of custom property values onto a customer: validates each value against its field definition, fills only missing fields, never overwrites or clears existing data. Designed for AI-agent helper tools.',
+      allowTargetFromActions: true,
+    },
     // Timing & Delays
     {
       type: AUTOMATION_CORE_ACTIONS.DELAY,

--- a/backend/core-api/src/meta/automations/writeCustomProperties.ts
+++ b/backend/core-api/src/meta/automations/writeCustomProperties.ts
@@ -1,0 +1,204 @@
+// Pure policy engine behind the core "Write custom properties" automation
+// action and the customers.captureProperties tRPC procedure. Persists custom
+// property values onto a customer's authoritative `propertiesData` object
+// with code-enforced guarantees:
+//
+//  - every value validated against its Field definition (type / options)
+//  - fill-only merge: already-set values are skipped, differing values are
+//    never silently overwritten, clearing filled fields is refused
+//  - at most one update call, preserving unrelated pre-existing entries
+//  - idempotent: repeating identical data saves nothing
+//
+// The deps object keeps the policy unit-testable and transport-agnostic:
+// the tRPC procedure injects mongoose models, the automation action injects
+// model-backed resolvers.
+
+interface FieldDef {
+  _id: string;
+  contentType?: string | null;
+  type?: string | null;
+  validation?: string | null;
+  options?: Array<{ value: string }> | null;
+}
+
+type PropertiesDataCarrier = {
+  propertiesData?: Record<string, unknown> | null;
+};
+
+export interface WriteCustomPropertiesDeps {
+  getCustomer(
+    customerId: string,
+  ): Promise<PropertiesDataCarrier | null>;
+  findFields(query: Record<string, unknown>): Promise<FieldDef[]>;
+  updateCustomer(
+    customerId: string,
+    doc: Record<string, unknown>,
+  ): Promise<unknown>;
+}
+
+export interface WriteCustomPropertiesInput {
+  customerId: string;
+  // zod's z.unknown() renders optional; empties are handled by policy.
+  values: Array<{ field: string; value?: unknown }>;
+}
+
+export interface WriteCustomPropertiesResult {
+  saved: boolean;
+  changedFields: string[];
+  skipped: Array<{ field: string; reason: string }>;
+}
+
+const CUSTOMERS_CONTENT_TYPE = 'core:customer';
+
+const isEmptyValue = (value: unknown) =>
+  value === null || value === undefined || value === '';
+
+const isEqualValue = (a: unknown, b: unknown) => {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+  }
+  return a === b;
+};
+
+const isValidNumber = (value: unknown) =>
+  typeof value === 'number'
+    ? Number.isFinite(value)
+    : typeof value === 'string' && value.trim() !== ''
+      ? Number.isFinite(Number(value))
+      : false;
+
+export const writeCustomProperties = async (
+  deps: WriteCustomPropertiesDeps,
+  input: WriteCustomPropertiesInput,
+): Promise<WriteCustomPropertiesResult> => {
+  const customer = await deps.getCustomer(input.customerId);
+
+  if (!customer) {
+    throw new Error('Customer not found');
+  }
+
+  const current: Record<string, unknown> = customer.propertiesData ?? {};
+
+  const submitted = input.values.map((v) => v.field);
+  const definitions =
+    (await deps.findFields({
+      $or: [{ _id: { $in: submitted } }, { code: { $in: submitted } }],
+    })) ?? [];
+
+  // Definitions resolve by both _id and code; submitted keys keep their
+  // original spelling so changedFields echoes what the caller sent.
+  const defByKey = new Map<string, FieldDef>();
+  for (const def of definitions) {
+    defByKey.set(String(def._id), def);
+    if (typeof (def as { code?: unknown }).code === 'string') {
+      defByKey.set((def as unknown as { code: string }).code, def);
+    }
+  }
+
+  const skipped: Array<{ field: string; reason: string }> = [];
+  const changedFields: string[] = [];
+  const writes: Record<string, unknown> = {};
+  const skip = (field: string, reason: string) =>
+    skipped.push({ field, reason });
+
+  for (const { field, value } of input.values) {
+    const def = defByKey.get(field);
+
+    if (!def || def.contentType !== CUSTOMERS_CONTENT_TYPE) {
+      skip(field, 'unknown-field');
+      continue;
+    }
+
+    const storageKey = String(def._id);
+    const hasCurrent =
+      Object.prototype.hasOwnProperty.call(current, storageKey) &&
+      !isEmptyValue(current[storageKey]);
+
+    if (hasCurrent && isEmptyValue(value)) {
+      skip(field, 'clear-not-allowed');
+      continue;
+    }
+
+    if (!hasCurrent && isEmptyValue(value)) {
+      skip(field, 'already-set');
+      continue;
+    }
+
+    let valid = false;
+
+    switch (def.type) {
+      case 'number': {
+        valid = isValidNumber(value);
+        break;
+      }
+      case 'date': {
+        valid =
+          value instanceof Date ||
+          (typeof value === 'string' && !Number.isNaN(Date.parse(value)));
+        break;
+      }
+      case 'select':
+      case 'radio': {
+        valid = Boolean(def.options?.some((option) => option.value === value));
+        break;
+      }
+      case 'check': {
+        const optionValues = new Set(
+          (def.options ?? []).map((option) => option.value),
+        );
+        valid =
+          Array.isArray(value) &&
+          value.length > 0 &&
+          value.every((member) => optionValues.has(String(member)));
+        break;
+      }
+      case 'text':
+      case 'textarea':
+      case 'input': {
+        valid =
+          def.validation === 'number'
+            ? isValidNumber(value)
+            : typeof value === 'string';
+        break;
+      }
+      default: {
+        valid = true;
+      }
+    }
+
+    if (!valid) {
+      const optionBased = ['select', 'radio', 'check'].includes(def.type ?? '');
+      skip(field, optionBased ? 'invalid-option' : 'invalid-value');
+      continue;
+    }
+
+    const normalized = def.type === 'number' ? Number(value) : value;
+
+    // Always compare and store under the canonical field _id so lookups by
+    // code cannot create duplicate keys.
+    const existing = current[storageKey];
+
+    if (existing !== undefined && existing !== null) {
+      skip(
+        field,
+        isEqualValue(existing, normalized) ? 'already-set' : 'conflict',
+      );
+      continue;
+    }
+
+    writes[storageKey] = normalized;
+    changedFields.push(field);
+  }
+
+  if (changedFields.length) {
+    await deps.updateCustomer(input.customerId, {
+      propertiesData: { ...current, ...writes },
+    });
+  }
+
+  return {
+    saved: changedFields.length > 0,
+    changedFields,
+    skipped,
+  };
+};

--- a/backend/core-api/src/meta/automations/writeCustomProperties.ts
+++ b/backend/core-api/src/meta/automations/writeCustomProperties.ts
@@ -58,7 +58,7 @@ const isEmptyValue = (value: unknown) =>
 
 const normalizeForCompare = (value: unknown) =>
   Array.isArray(value)
-    ? [...value].map(String).sort()
+    ? [...value].map(String).sort((a, b) => a.localeCompare(b))
     : value;
 
 const isEqualValue = (a: unknown, b: unknown) => {
@@ -147,6 +147,52 @@ const validateFieldValue = (
 const normalizeFieldValue = (def: FieldDef, value: unknown) =>
   def.type === 'number' ? Number(value) : value;
 
+
+type EntryOutcome =
+  | { reason: string; storageKey?: undefined; normalized?: undefined }
+  | { reason?: undefined; storageKey: string; normalized: unknown };
+
+/** Applies the full policy to one submitted pair against current state. */
+const evaluateEntry = (
+  defByKey: Map<string, FieldDef>,
+  current: Record<string, unknown>,
+  entry: { field: string; value?: unknown },
+): EntryOutcome => {
+  const { field, value } = entry;
+  const def = defByKey.get(field);
+
+  if (!def || def.contentType !== CUSTOMERS_CONTENT_TYPE) {
+    return { reason: 'unknown-field' };
+  }
+
+  const storageKey = String(def._id);
+  const existing = current[storageKey];
+
+  if (!isEmptyValue(existing) && isEmptyValue(value)) {
+    return { reason: 'clear-not-allowed' };
+  }
+
+  if (isEmptyValue(existing) && isEmptyValue(value)) {
+    return { reason: 'already-set' };
+  }
+
+  const validation = validateFieldValue(def, value);
+
+  if (!validation.ok) {
+    return { reason: validation.reason };
+  }
+
+  const normalized = normalizeFieldValue(def, value);
+
+  if (existing != null) {
+    return {
+      reason: isEqualValue(existing, normalized) ? 'already-set' : 'conflict',
+    };
+  }
+
+  return { storageKey, normalized };
+};
+
 export const writeCustomProperties = async (
   deps: WriteCustomPropertiesDeps,
   input: WriteCustomPropertiesInput,
@@ -180,48 +226,16 @@ export const writeCustomProperties = async (
   const changedFields: string[] = [];
   const writes: Record<string, unknown> = {};
 
-  for (const { field, value } of input.values) {
-    const def = defByKey.get(field);
+  for (const entry of input.values) {
+    const outcome = evaluateEntry(defByKey, current, entry);
 
-    if (!def || def.contentType !== CUSTOMERS_CONTENT_TYPE) {
-      skipped.push({ field, reason: 'unknown-field' });
+    if (outcome.reason) {
+      skipped.push({ field: entry.field, reason: outcome.reason });
       continue;
     }
 
-    const storageKey = String(def._id);
-    const existing = current[storageKey];
-
-    if (!isEmptyValue(existing) && isEmptyValue(value)) {
-      skipped.push({ field, reason: 'clear-not-allowed' });
-      continue;
-    }
-
-    if (isEmptyValue(existing) && isEmptyValue(value)) {
-      skipped.push({ field, reason: 'already-set' });
-      continue;
-    }
-
-    const validation = validateFieldValue(def, value);
-
-    if (!validation.ok) {
-      skipped.push({ field, reason: validation.reason });
-      continue;
-    }
-
-    const normalized = normalizeFieldValue(def, value);
-
-    if (existing !== undefined && existing !== null) {
-      skipped.push({
-        field,
-        reason: isEqualValue(existing, normalized)
-          ? 'already-set'
-          : 'conflict',
-      });
-      continue;
-    }
-
-    writes[storageKey] = normalized;
-    changedFields.push(field);
+    writes[outcome.storageKey as string] = outcome.normalized;
+    changedFields.push(entry.field);
   }
 
   if (changedFields.length) {

--- a/backend/core-api/src/meta/automations/writeCustomProperties.ts
+++ b/backend/core-api/src/meta/automations/writeCustomProperties.ts
@@ -16,6 +16,7 @@
 interface FieldDef {
   _id: string;
   contentType?: string | null;
+  code?: string | null;
   type?: string | null;
   validation?: string | null;
   options?: Array<{ value: string }> | null;
@@ -50,22 +51,101 @@ export interface WriteCustomPropertiesResult {
 
 const CUSTOMERS_CONTENT_TYPE = 'core:customer';
 
+const OPTION_BASED_TYPES = ['select', 'radio', 'check'];
+
 const isEmptyValue = (value: unknown) =>
   value === null || value === undefined || value === '';
 
+const normalizeForCompare = (value: unknown) =>
+  Array.isArray(value)
+    ? [...value].map(String).sort()
+    : value;
+
 const isEqualValue = (a: unknown, b: unknown) => {
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
-  }
-  return a === b;
+  const left = normalizeForCompare(a);
+  const right = normalizeForCompare(b);
+
+  return (
+    Array.isArray(left) === Array.isArray(right) &&
+    JSON.stringify(left) === JSON.stringify(right)
+  );
 };
 
-const isValidNumber = (value: unknown) =>
-  typeof value === 'number'
-    ? Number.isFinite(value)
-    : typeof value === 'string' && value.trim() !== ''
-      ? Number.isFinite(Number(value))
-      : false;
+const isValidNumber = (value: unknown) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+
+  return typeof value === 'string' && value.trim() !== ''
+    ? Number.isFinite(Number(value))
+    : false;
+};
+
+const isValidDate = (value: unknown) =>
+  value instanceof Date ||
+  (typeof value === 'string' && !Number.isNaN(Date.parse(value)));
+
+const isAllowedOption = (def: FieldDef, value: unknown) =>
+  Boolean(def.options?.some((option) => option.value === value));
+
+const isAllowedOptionArray = (def: FieldDef, value: unknown) => {
+  const optionValues = new Set((def.options ?? []).map((o) => o.value));
+
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((member) => optionValues.has(String(member)))
+  );
+};
+
+const isTextual = (value: unknown) => typeof value === 'string';
+
+/**
+ * Per-field definition validation. Returns 'valid' or the skip reason.
+ * Numeric coercion happens only at normalization time — booleans, arrays,
+ * and other non-numeric shapes never validate.
+ */
+const validateFieldValue = (
+  def: FieldDef,
+  value: unknown,
+): { ok: boolean; reason: string } => {
+  switch (def.type) {
+    case 'number': {
+      return { ok: isValidNumber(value), reason: 'invalid-value' };
+    }
+    case 'date': {
+      return { ok: isValidDate(value), reason: 'invalid-value' };
+    }
+    case 'select':
+    case 'radio': {
+      return {
+        ok: isAllowedOption(def, value),
+        reason: 'invalid-option',
+      };
+    }
+    case 'check': {
+      return {
+        ok: isAllowedOptionArray(def, value),
+        reason: 'invalid-option',
+      };
+    }
+    case 'text':
+    case 'textarea':
+    case 'input': {
+      const valid =
+        def.validation === 'number' ? isValidNumber(value) : isTextual(value);
+
+      return { ok: valid, reason: 'invalid-value' };
+    }
+    default: {
+      return { ok: true, reason: '' };
+    }
+  }
+};
+
+/** Normalizes validated values for storage (numeric strings -> numbers). */
+const normalizeFieldValue = (def: FieldDef, value: unknown) =>
+  def.type === 'number' ? Number(value) : value;
 
 export const writeCustomProperties = async (
   deps: WriteCustomPropertiesDeps,
@@ -86,103 +166,57 @@ export const writeCustomProperties = async (
     })) ?? [];
 
   // Definitions resolve by both _id and code; submitted keys keep their
-  // original spelling so changedFields echoes what the caller sent.
+  // original spelling so changedFields echoes what the caller sent, while
+  // storage always uses the canonical field _id.
   const defByKey = new Map<string, FieldDef>();
   for (const def of definitions) {
     defByKey.set(String(def._id), def);
-    if (typeof (def as { code?: unknown }).code === 'string') {
-      defByKey.set((def as unknown as { code: string }).code, def);
+    if (typeof def.code === 'string') {
+      defByKey.set(def.code, def);
     }
   }
 
   const skipped: Array<{ field: string; reason: string }> = [];
   const changedFields: string[] = [];
   const writes: Record<string, unknown> = {};
-  const skip = (field: string, reason: string) =>
-    skipped.push({ field, reason });
 
   for (const { field, value } of input.values) {
     const def = defByKey.get(field);
 
     if (!def || def.contentType !== CUSTOMERS_CONTENT_TYPE) {
-      skip(field, 'unknown-field');
+      skipped.push({ field, reason: 'unknown-field' });
       continue;
     }
 
     const storageKey = String(def._id);
-    const hasCurrent =
-      Object.prototype.hasOwnProperty.call(current, storageKey) &&
-      !isEmptyValue(current[storageKey]);
-
-    if (hasCurrent && isEmptyValue(value)) {
-      skip(field, 'clear-not-allowed');
-      continue;
-    }
-
-    if (!hasCurrent && isEmptyValue(value)) {
-      skip(field, 'already-set');
-      continue;
-    }
-
-    let valid = false;
-
-    switch (def.type) {
-      case 'number': {
-        valid = isValidNumber(value);
-        break;
-      }
-      case 'date': {
-        valid =
-          value instanceof Date ||
-          (typeof value === 'string' && !Number.isNaN(Date.parse(value)));
-        break;
-      }
-      case 'select':
-      case 'radio': {
-        valid = Boolean(def.options?.some((option) => option.value === value));
-        break;
-      }
-      case 'check': {
-        const optionValues = new Set(
-          (def.options ?? []).map((option) => option.value),
-        );
-        valid =
-          Array.isArray(value) &&
-          value.length > 0 &&
-          value.every((member) => optionValues.has(String(member)));
-        break;
-      }
-      case 'text':
-      case 'textarea':
-      case 'input': {
-        valid =
-          def.validation === 'number'
-            ? isValidNumber(value)
-            : typeof value === 'string';
-        break;
-      }
-      default: {
-        valid = true;
-      }
-    }
-
-    if (!valid) {
-      const optionBased = ['select', 'radio', 'check'].includes(def.type ?? '');
-      skip(field, optionBased ? 'invalid-option' : 'invalid-value');
-      continue;
-    }
-
-    const normalized = def.type === 'number' ? Number(value) : value;
-
-    // Always compare and store under the canonical field _id so lookups by
-    // code cannot create duplicate keys.
     const existing = current[storageKey];
 
+    if (!isEmptyValue(existing) && isEmptyValue(value)) {
+      skipped.push({ field, reason: 'clear-not-allowed' });
+      continue;
+    }
+
+    if (isEmptyValue(existing) && isEmptyValue(value)) {
+      skipped.push({ field, reason: 'already-set' });
+      continue;
+    }
+
+    const validation = validateFieldValue(def, value);
+
+    if (!validation.ok) {
+      skipped.push({ field, reason: validation.reason });
+      continue;
+    }
+
+    const normalized = normalizeFieldValue(def, value);
+
     if (existing !== undefined && existing !== null) {
-      skip(
+      skipped.push({
         field,
-        isEqualValue(existing, normalized) ? 'already-set' : 'conflict',
-      );
+        reason: isEqualValue(existing, normalized)
+          ? 'already-set'
+          : 'conflict',
+      });
       continue;
     }
 

--- a/backend/core-api/src/modules/contacts/trpc/customer.ts
+++ b/backend/core-api/src/modules/contacts/trpc/customer.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
 import { agentMeta } from '~/utils/agentMeta';
 import { createOrUpdate } from '../utils';
-import { writeCustomProperties } from '~/meta/automations/writeCustomProperties';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
@@ -147,38 +146,6 @@ export const customerRouter = t.router({
         const { _id, doc } = input;
         const { models } = ctx;
         return models.Customers.updateCustomer(_id, doc);
-      }),
-
-    captureProperties: t.procedure
-      .meta(
-        agentMeta(
-          "Save buyer-requirement custom property values onto a customer, guarded: unknown fields, wrong types and invalid options are rejected per field; already-set values are skipped; conflicting different values are never overwritten; clearing filled fields is refused. Input: { customerId, values: [{ field, value }] } where field is a custom field _id or code discovered via fields.fieldsCombinedByContentType (contentType core:customer). Call customers.findOne first to see current propertiesData. Returns { saved, changedFields, skipped[{field,reason}] }; repeat calls with identical data save nothing.",
-          { module: 'contacts', action: 'contactsUpdate' },
-        ),
-      )
-      .input(
-        z
-          .object({
-            customerId: z.string(),
-            values: z
-              .array(z.object({ field: z.string(), value: z.unknown() }))
-              .min(1),
-          })
-          .strict(),
-      )
-      .mutation(async ({ ctx, input }) => {
-        const { models } = ctx;
-
-        return writeCustomProperties(
-          {
-            getCustomer: (customerId) => models.Customers.findOne({ _id: customerId }),
-            findFields: async (query) =>
-              models.Fields.find(query).lean(),
-            updateCustomer: (customerId, doc) =>
-              models.Customers.updateCustomer(customerId, doc),
-          },
-          input,
-        );
       }),
 
     updateOne: t.procedure

--- a/backend/core-api/src/modules/contacts/trpc/customer.ts
+++ b/backend/core-api/src/modules/contacts/trpc/customer.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
 import { agentMeta } from '~/utils/agentMeta';
 import { createOrUpdate } from '../utils';
+import { writeCustomProperties } from '~/meta/automations/writeCustomProperties';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
@@ -151,7 +152,7 @@ export const customerRouter = t.router({
     captureProperties: t.procedure
       .meta(
         agentMeta(
-          "Save buyer-requirement custom property values onto a customer, guarded: unknown fields, wrong types, and invalid options are rejected per field; already-set values are skipped; conflicting different values are never overwritten. Input: { customerId, values: [{ field, value }] } where field is a custom field _id discovered via fields.fieldsCombinedByContentType (contentType core:customer). Call customers.findOne first to see current propertiesData. Returns { saved, changedFields, skipped[{field,reason}] }; repeat calls with identical data save nothing.",
+          "Save buyer-requirement custom property values onto a customer, guarded: unknown fields, wrong types and invalid options are rejected per field; already-set values are skipped; conflicting different values are never overwritten; clearing filled fields is refused. Input: { customerId, values: [{ field, value }] } where field is a custom field _id or code discovered via fields.fieldsCombinedByContentType (contentType core:customer). Call customers.findOne first to see current propertiesData. Returns { saved, changedFields, skipped[{field,reason}] }; repeat calls with identical data save nothing.",
           { module: 'contacts', action: 'contactsUpdate' },
         ),
       )
@@ -168,163 +169,16 @@ export const customerRouter = t.router({
       .mutation(async ({ ctx, input }) => {
         const { models } = ctx;
 
-        const customer = await models.Customers.findOne({
-          _id: input.customerId,
-        });
-
-        if (!customer) {
-          throw new Error('Customer not found');
-        }
-
-        // propertiesData is the authoritative custom-field store (see
-        // Customers.updateCustomer / migratePropertiesData); legacy
-        // customFieldsData is read-only history.
-        type PropertiesDataCarrier = {
-          propertiesData?: Record<string, unknown> | null;
-        };
-        const current: Record<string, unknown> =
-          (customer as unknown as PropertiesDataCarrier).propertiesData ?? {};
-
-        const definitions = await models.Fields.find({
-          _id: { $in: input.values.map((v) => v.field) },
-        });
-        const defById = new Map(
-          (definitions as Array<{
-            _id: unknown;
-            contentType?: string | null;
-            type?: string | null;
-            validation?: string | null;
-            options?: Array<{ value: string }> | null;
-          }>).map((def) => [String(def._id), def]),
+        return writeCustomProperties(
+          {
+            getCustomer: (customerId) => models.Customers.findOne({ _id: customerId }),
+            findFields: async (query) =>
+              models.Fields.find(query).lean(),
+            updateCustomer: (customerId, doc) =>
+              models.Customers.updateCustomer(customerId, doc),
+          },
+          input,
         );
-
-        const skipped: Array<{ field: string; reason: string }> = [];
-        const changedFields: string[] = [];
-        const writes: Record<string, unknown> = {};
-        const skip = (field: string, reason: string) =>
-          skipped.push({ field, reason });
-
-        const isEmptyValue = (value: unknown) =>
-          value === null || value === undefined || value === '';
-
-        const isEqualValue = (a: unknown, b: unknown) => {
-          if (Array.isArray(a) && Array.isArray(b)) {
-            return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
-          }
-          return a === b;
-        };
-
-        for (const { field, value } of input.values) {
-          const def = defById.get(field);
-
-          if (!def || def.contentType !== 'core:customer') {
-            skip(field, 'unknown-field');
-            continue;
-          }
-
-          const hasCurrent =
-            Object.prototype.hasOwnProperty.call(current, field) &&
-            !isEmptyValue(current[field]);
-
-          if (hasCurrent && isEmptyValue(value)) {
-            skip(field, 'clear-not-allowed');
-            continue;
-          }
-
-          if (!hasCurrent && isEmptyValue(value)) {
-            skip(field, 'already-set');
-            continue;
-          }
-
-          let valid = false;
-
-          switch (def.type) {
-            case 'number': {
-              valid =
-                typeof value === 'number'
-                  ? Number.isFinite(value)
-                  : typeof value === 'string' && value.trim() !== ''
-                    ? Number.isFinite(Number(value))
-                    : false;
-              break;
-            }
-            case 'date': {
-              valid =
-                value instanceof Date ||
-                (typeof value === 'string' && !Number.isNaN(Date.parse(value)));
-              break;
-            }
-            case 'select':
-            case 'radio': {
-              valid = Boolean(
-                def.options?.some((option) => option.value === value),
-              );
-              break;
-            }
-            case 'check': {
-              const optionValues = new Set(
-                (def.options ?? []).map((option) => option.value),
-              );
-              valid =
-                Array.isArray(value) &&
-                value.length > 0 &&
-                value.every((member) => optionValues.has(String(member)));
-              break;
-            }
-            case 'text':
-            case 'textarea':
-            case 'input': {
-              valid =
-                def.validation === 'number'
-                  ? typeof value === 'number' || Number.isFinite(Number(value))
-                  : typeof value === 'string';
-              break;
-            }
-            default: {
-              valid = true;
-            }
-          }
-
-          if (!valid) {
-            const optionBased = ['select', 'radio', 'check'].includes(
-              def.type ?? '',
-            );
-            skip(field, optionBased ? 'invalid-option' : 'invalid-value');
-            continue;
-          }
-
-          const normalized =
-            def.type === 'number' &&
-            (typeof value === 'string' || typeof value === 'number')
-              ? Number(value)
-              : value;
-
-          const existing = current[field];
-
-          if (existing !== undefined && existing !== null) {
-            if (isEqualValue(existing, normalized)) {
-              skip(field, 'already-set');
-            } else {
-              skip(field, 'conflict');
-            }
-            continue;
-          }
-
-          writes[field] = normalized;
-          changedFields.push(field);
-        }
-
-        if (changedFields.length) {
-          await models.Customers.updateCustomer(input.customerId, {
-            propertiesData: { ...current, ...writes },
-          });
-        }
-
-        return {
-          saved: changedFields.length > 0,
-          changedFields,
-          skipped,
-        };
       }),
 
     updateOne: t.procedure

--- a/backend/core-api/src/modules/contacts/trpc/customer.ts
+++ b/backend/core-api/src/modules/contacts/trpc/customer.ts
@@ -148,6 +148,185 @@ export const customerRouter = t.router({
         return models.Customers.updateCustomer(_id, doc);
       }),
 
+    captureProperties: t.procedure
+      .meta(
+        agentMeta(
+          "Save buyer-requirement custom property values onto a customer, guarded: unknown fields, wrong types, and invalid options are rejected per field; already-set values are skipped; conflicting different values are never overwritten. Input: { customerId, values: [{ field, value }] } where field is a custom field _id discovered via fields.fieldsCombinedByContentType (contentType core:customer). Call customers.findOne first to see current propertiesData. Returns { saved, changedFields, skipped[{field,reason}] }; repeat calls with identical data save nothing.",
+          { module: 'contacts', action: 'contactsUpdate' },
+        ),
+      )
+      .input(
+        z
+          .object({
+            customerId: z.string(),
+            values: z
+              .array(z.object({ field: z.string(), value: z.unknown() }))
+              .min(1),
+          })
+          .strict(),
+      )
+      .mutation(async ({ ctx, input }) => {
+        const { models } = ctx;
+
+        const customer = await models.Customers.findOne({
+          _id: input.customerId,
+        });
+
+        if (!customer) {
+          throw new Error('Customer not found');
+        }
+
+        // propertiesData is the authoritative custom-field store (see
+        // Customers.updateCustomer / migratePropertiesData); legacy
+        // customFieldsData is read-only history.
+        type PropertiesDataCarrier = {
+          propertiesData?: Record<string, unknown> | null;
+        };
+        const current: Record<string, unknown> =
+          (customer as unknown as PropertiesDataCarrier).propertiesData ?? {};
+
+        const definitions = await models.Fields.find({
+          _id: { $in: input.values.map((v) => v.field) },
+        });
+        const defById = new Map(
+          (definitions as Array<{
+            _id: unknown;
+            contentType?: string | null;
+            type?: string | null;
+            validation?: string | null;
+            options?: Array<{ value: string }> | null;
+          }>).map((def) => [String(def._id), def]),
+        );
+
+        const skipped: Array<{ field: string; reason: string }> = [];
+        const changedFields: string[] = [];
+        const writes: Record<string, unknown> = {};
+        const skip = (field: string, reason: string) =>
+          skipped.push({ field, reason });
+
+        const isEmptyValue = (value: unknown) =>
+          value === null || value === undefined || value === '';
+
+        const isEqualValue = (a: unknown, b: unknown) => {
+          if (Array.isArray(a) && Array.isArray(b)) {
+            return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+          }
+          return a === b;
+        };
+
+        for (const { field, value } of input.values) {
+          const def = defById.get(field);
+
+          if (!def || def.contentType !== 'core:customer') {
+            skip(field, 'unknown-field');
+            continue;
+          }
+
+          const hasCurrent =
+            Object.prototype.hasOwnProperty.call(current, field) &&
+            !isEmptyValue(current[field]);
+
+          if (hasCurrent && isEmptyValue(value)) {
+            skip(field, 'clear-not-allowed');
+            continue;
+          }
+
+          if (!hasCurrent && isEmptyValue(value)) {
+            skip(field, 'already-set');
+            continue;
+          }
+
+          let valid = false;
+
+          switch (def.type) {
+            case 'number': {
+              valid =
+                typeof value === 'number'
+                  ? Number.isFinite(value)
+                  : typeof value === 'string' && value.trim() !== ''
+                    ? Number.isFinite(Number(value))
+                    : false;
+              break;
+            }
+            case 'date': {
+              valid =
+                value instanceof Date ||
+                (typeof value === 'string' && !Number.isNaN(Date.parse(value)));
+              break;
+            }
+            case 'select':
+            case 'radio': {
+              valid = Boolean(
+                def.options?.some((option) => option.value === value),
+              );
+              break;
+            }
+            case 'check': {
+              const optionValues = new Set(
+                (def.options ?? []).map((option) => option.value),
+              );
+              valid =
+                Array.isArray(value) &&
+                value.length > 0 &&
+                value.every((member) => optionValues.has(String(member)));
+              break;
+            }
+            case 'text':
+            case 'textarea':
+            case 'input': {
+              valid =
+                def.validation === 'number'
+                  ? typeof value === 'number' || Number.isFinite(Number(value))
+                  : typeof value === 'string';
+              break;
+            }
+            default: {
+              valid = true;
+            }
+          }
+
+          if (!valid) {
+            const optionBased = ['select', 'radio', 'check'].includes(
+              def.type ?? '',
+            );
+            skip(field, optionBased ? 'invalid-option' : 'invalid-value');
+            continue;
+          }
+
+          const normalized =
+            def.type === 'number' &&
+            (typeof value === 'string' || typeof value === 'number')
+              ? Number(value)
+              : value;
+
+          const existing = current[field];
+
+          if (existing !== undefined && existing !== null) {
+            if (isEqualValue(existing, normalized)) {
+              skip(field, 'already-set');
+            } else {
+              skip(field, 'conflict');
+            }
+            continue;
+          }
+
+          writes[field] = normalized;
+          changedFields.push(field);
+        }
+
+        if (changedFields.length) {
+          await models.Customers.updateCustomer(input.customerId, {
+            propertiesData: { ...current, ...writes },
+          });
+        }
+
+        return {
+          saved: changedFields.length > 0,
+          changedFields,
+          skipped,
+        };
+      }),
+
     updateOne: t.procedure
       .input(z.object({ query: z.any(), doc: z.any() }))
       .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

Adds a tRPC procedure that persists custom property values onto a customer **with server-side guarantees** — designed as the write tool for AI agents (Automations AI-agent node / agent-tools), where prompt-only dedup is not trustworthy. The model decides *whether* to save; this code enforces *what* can be written.

## Contract

`customers.captureProperties({ customerId, values: [{ field, value }] })`
→ `{ saved, changedFields, skipped: [{ field, reason }] }`

Guarantees enforced server-side:
- **Validation** against Field definitions (contentType `core:customer`): number/date/text typing (numeric strings coerced), select/radio option membership, check-array membership → per-field skips `unknown-field` / `invalid-value` / `invalid-option`; nothing invalid reaches the DB
- **Fill-only merge policy**: missing → write; identical → `already-set`; different → `conflict` (never silently overwritten); clearing a filled field → `clear-not-allowed`
- **Single write** — one `updateCustomer` carrying only new entries into `propertiesData` (the authoritative store per `Customers.updateCustomer` / `migratePropertiesData`), preserving unrelated pre-existing entries
- **Idempotent** — identical repeat saves nothing
- Annotated `.meta(agentMeta(...))` (`contacts.contactsUpdate`) so it appears in /agent-tools with an agent-facing description of the discover→read→capture flow

Single-file change to `backend/core-api/src/modules/contacts/trpc/customer.ts`. (Behavior is covered by a 10-case suite — including red-first and mutation verification — maintained in our deployment repo where per-project jest infra already exists.)

## Summary by Sourcery

Enable safe AI-agent customer property writes with server-enforced validation and non-overwriting merge semantics.

New Features:
- Add a guarded custom-property write action for AI agents that validates values and persists only approved customer fields.
- Expose custom-property writes through the core automation action framework with agent-facing metadata.

Enhancements:
- Centralize custom-property write policy with fill-only, idempotent updates that preserve existing customer properties and report per-field outcomes.
- Support field lookup by identifier or code and normalize valid numeric values before storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for capturing customer custom properties through the customer API.
  * Added an automation action for writing custom fields to customer records.
  * Custom properties can be identified by field ID or code.
* **Validation**
  * Values are checked against field types and available options.
  * Invalid fields, conflicts, unsupported values, and prohibited clears are handled safely.
  * Numeric values are normalized, unchanged properties are preserved, and updates are applied efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->