### PR TITLE
fix: handle pipeline edits and invalid permission cache

### DIFF
--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -84,7 +84,26 @@ export const getGroupActionsMap = async (
 
   const cached = await redis.get(cacheKey);
 
-  if (cached) return JSON.parse(cached);
+  if (cached) {
+    try {
+      const cachedActions: unknown = JSON.parse(cached);
+
+      if (
+        cachedActions &&
+        typeof cachedActions === 'object' &&
+        !Array.isArray(cachedActions) &&
+        Object.values(cachedActions).every(
+          (isAllowed) => typeof isAllowed === 'boolean',
+        )
+      ) {
+        return cachedActions as Record<string, boolean>;
+      }
+    } catch {
+      // Rebuild malformed permission cache entries below.
+    }
+
+    await redis.del(cacheKey);
+  }
 
   const actionsMap: Record<string, boolean> = {};
   const groupIds = user.permissionGroupIds || [];

--- a/frontend/plugins/sales_ui/src/modules/SalesSubNavigation.tsx
+++ b/frontend/plugins/sales_ui/src/modules/SalesSubNavigation.tsx
@@ -125,7 +125,7 @@ function BoardItem({ board }: { board: IBoard }) {
                     onClick={() => handlePipelineClick(pipeline._id)}
                   >
                     <TextOverflowTooltip
-                      className="capitalize flex-1 min-w-0"
+                      className="flex-1 min-w-0"
                       value={pipeline.name}
                     />
                   </Sidebar.MenuButton>

--- a/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/PipelinesQueries.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/graphql/queries/PipelinesQueries.ts
@@ -96,6 +96,7 @@ export const GET_PIPELINES = gql`
         _id
         name
         boardId
+        visibility
         state
         startDate
         endDate

--- a/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/pipelines/components/PipelineRecordTable.tsx
@@ -194,7 +194,7 @@ const PipelineNameColumnCell = ({
   cell: Cell<IPipeline & { hasChildren: boolean; type?: string }, unknown>;
 }) => {
   const { pipelineEdit, loading } = usePipelineEdit();
-  const { _id, name, type } = cell.row.original;
+  const { _id, boardId, name, visibility } = cell.row.original;
   const [open, setOpen] = useState(false);
   const [editedName, setEditedName] = useState(name);
 
@@ -202,9 +202,10 @@ const PipelineNameColumnCell = ({
     if (name !== editedName) {
       pipelineEdit({
         variables: {
-          id: _id,
-          type,
+          _id,
+          boardId,
           name: editedName,
+          visibility: visibility || 'public',
         },
       });
     }


### PR DESCRIPTION
## Summary

- send the required pipeline ID, board ID, and visibility when renaming a pipeline inline
- load pipeline visibility in the pipeline list query and use a public fallback for legacy records
- preserve pipeline name casing in the Sales deals sidebar
- rebuild malformed or invalid cached permission action maps instead of failing JSON parsing

## Why

Inline pipeline name edits omitted required GraphQL variables and used `id` instead of `_id`, causing Apollo Router validation errors. Malformed Redis permission cache entries could also make deal updates fail with `Unexpected end of JSON input`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pipeline editing reliability by using the correct pipeline details when saving name changes.
  - Rebuilt permissions when stored permission data is invalid, preventing malformed cache entries from causing issues.

- **Improvements**
  - Pipeline visibility is now included when loading pipeline data.
  - Pipeline navigation labels preserve their original capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->