### PR TITLE
fix: prevent POS payment amounts from doubling

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
+++ b/frontend/plugins/sales_ui/src/modules/pos/orders/components/OrderColumns.tsx
@@ -45,8 +45,12 @@ const getPaidAmountsMap = (
 
   return paidAmounts.reduce<Record<string, number>>((acc, item) => {
     const amount = Number(item?.amount || 0);
-    if (item?.title) acc[item.title] = (acc[item.title] || 0) + amount;
-    if (item?.type) acc[item.type] = (acc[item.type] || 0) + amount;
+    const key = item?.title || item?.type;
+
+    if (key) {
+      acc[key] = (acc[key] || 0) + amount;
+    }
+
     return acc;
   }, {});
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent POS payment amounts from being counted twice when a payment has both a title and a type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payment amount aggregation in order displays.
  * Prevented payment amounts from being counted twice when payment titles and types differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->