### PR TITLE
fix(posclient): keep similarity search grouped

### DIFF
--- a/apps/posclient-front/modules/products/hooks/useProducts.tsx
+++ b/apps/posclient-front/modules/products/hooks/useProducts.tsx
@@ -45,9 +45,8 @@ export const useProducts = (props?: {
   const mode = useAtomValue(modeAtom)
 
   const isKiosk = mode === "kiosk"
-  // main-family layouts and coffee-shop collapse bulk-similarity groups to
-  // their starred product; searching stays ungrouped so exact variant codes
-  // remain findable
+  // Main-family layouts and coffee-shop always collapse bulk-similarity groups
+  // to their starred product, including while searching.
   const isMainList = ["main", "restaurant", "mobile", "coffee-shop"].includes(
     mode
   )
@@ -66,7 +65,7 @@ export const useProducts = (props?: {
       sortDirection,
       searchValue: searchValue,
       page: 1,
-      isSimilarity: isMainList && !searchValue ? true : undefined,
+      isSimilarity: isMainList ? true : undefined,
       isKiosk: isKiosk ? true : undefined,
     },
     skip,
@@ -85,7 +84,7 @@ export const useProducts = (props?: {
       maxDiscountPercent,
       discountConditions,
       searchValue,
-      isSimilarity: isMainList && !searchValue ? true : undefined,
+      isSimilarity: isMainList ? true : undefined,
       isKiosk: isKiosk ? true : undefined,
     },
     onCompleted(data) {


### PR DESCRIPTION
## Summary
- keep bulk-similarity grouping enabled while searching POS products
- return only the starred product from each matching similarity group
- keep product-list and total-count query behavior aligned

## Validation
- `pnpm typecheck`
- verified `poscProducts(searchValue: "Implementation", isSimilarity: true)` returns one starred product and total count 1

## Lint
- `pnpm lint` opens the interactive Next.js ESLint setup prompt because this app has no ESLint configuration

## Summary by Sourcery

Keep POS product similarity results grouped while searching to return consistent starred-product results and counts.

Bug Fixes:
- Keep similarity grouping enabled during product searches so matching results return only the starred product from each group.

Enhancements:
- Align product-list and total-count queries to use consistent similarity grouping behavior across main product-list layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product searches in main-family and coffee-shop views now consistently group similar products.
  * Bulk-similarity groups remain collapsed to their starred product, including when searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->