### PR TITLE
fix(posclient): resolve non-starred similarity searches

### DIFF
--- a/backend/plugins/posclient_api/AGENTS.md
+++ b/backend/plugins/posclient_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `posclient_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/posclient_api`
-- **Last synchronized:** `2026-08-23`
+- **Last synchronized:** `2026-08-24`
 
 ## Scope
 
@@ -23,6 +23,9 @@
 - Authenticates POS users against POS client context.
 - Serves POS client config, order, cover, user, and daily report GraphQL operations.
 - Serves POS product list and count queries with category, tag, price, remainder, discount, similarity, and product `propertiesData` filters.
+- Similarity-aware POS searches return the starred representative when any
+  product in that similarity group matches, while preserving standalone
+  product matches.
 - Calculates daily reports for authorized POS admins and cashiers with report permission.
 
 ## Architecture
@@ -59,6 +62,9 @@
 - POS client report queries must require a logged-in POS user.
 - Cashiers may access `dailyReport` only when `permissionConfig.cashiers.seeReport` is true; admins remain allowed by `adminIds`.
 - `poscProducts` and `poscProductsTotalCount` must share the same product filter builder so lists and counts stay consistent.
+- Similarity-aware searches must resolve groups from the ungrouped match set;
+  filtering to star product ids before searching hides groups whose non-starred
+  variant is the only match.
 
 ## Validation
 
@@ -69,6 +75,15 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-08-24` — `Preserve similarity groups in POS search`
+
+- **Summary:** POS product search now returns a group's starred representative
+  when any variant in that group matches the search.
+- **Affected areas:** `backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts`
+- **Contracts changed:** `poscProducts` and `poscProductsTotalCount`
+  similarity-search semantics now collapse matching groups to their starred
+  products.
 
 ### `2026-08-23` — `Filter POS products by properties`
 

--- a/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
+++ b/backend/plugins/posclient_api/src/modules/posclient/graphql/resolvers/queries/products.ts
@@ -346,7 +346,7 @@ const generateFilter = async (
     tokens: { $in: [token] },
   };
 
-  if (isSimilarity) {
+  if (isSimilarity && !searchValue) {
     const similarityGroups = await sendTRPCMessage({
       subdomain,
       pluginName: 'core',
@@ -543,17 +543,68 @@ const generateFilter = async (
 
   const lastFilter = { ...filter, $and };
 
-  if (isKiosk) {
+  const collapseSimilaritySearch = async (
+    searchFilter: Record<string, unknown>,
+  ) => {
+    const matchedProducts = await models.Products.find(searchFilter)
+      .select({ _id: 1, similarityId: 1 })
+      .lean();
+
+    const standaloneProductIds: string[] = [];
+    const similarityIds = new Set<string>();
+
+    for (const product of matchedProducts) {
+      if (product.similarityId) {
+        similarityIds.add(product.similarityId);
+      } else {
+        standaloneProductIds.push(product._id);
+      }
+    }
+
+    const similarityGroups = similarityIds.size
+      ? await sendTRPCMessage({
+          subdomain,
+          pluginName: 'core',
+          module: 'products',
+          action: 'similarities.find',
+          input: {
+            query: {
+              _id: { $in: [...similarityIds] },
+              status: { $ne: 'deleted' },
+            },
+          },
+          defaultValue: [],
+        })
+      : [];
+
+    const starProductIds = (similarityGroups || [])
+      .map((group) => group.starProductId)
+      .filter(Boolean);
+
     return {
+      status: { $ne: PRODUCT_STATUSES.DELETED },
+      tokens: { $in: [token] },
+      _id: { $in: [...standaloneProductIds, ...starProductIds] },
+    };
+  };
+
+  if (isKiosk) {
+    const kioskFilter = {
       $and: [
         lastFilter,
         { categoryId: { $nin: config.kioskExcludeCategoryIds } },
         { _id: { $nin: config.kioskExcludeProductIds } },
       ],
     };
+
+    return isSimilarity && searchValue
+      ? collapseSimilaritySearch(kioskFilter)
+      : kioskFilter;
   }
 
-  return lastFilter;
+  return isSimilarity && searchValue
+    ? collapseSimilaritySearch(lastFilter)
+    : lastFilter;
 };
 
 const generateFilterCat = async ({


### PR DESCRIPTION
## Summary
- resolve similarity groups from the complete ungrouped POS search result
- return a group’s starred representative when only a non-starred variant matches
- preserve standalone matches and apply the same resolved filter to list and count queries
- document the corrected search invariant in the posclient plugin guide

## Validation
- `pnpm nx build posclient_api`
- exact non-starred search `Implementation Sprint 2` returns starred `Implementation Sprint 1` and count 1
- broad search `Implementation` returns starred `Implementation Sprint 1` and count 1

## Context
Follow-up to #9134 for the CI-reported non-starred variant search case.

## Summary by Sourcery

Resolve POS similarity searches from the complete match set so grouped results consistently return starred representatives.

Bug Fixes:
- Correct similarity searches so matches on non-starred product variants return the starred representative of their group.
- Preserve standalone product matches while applying consistent resolved results to POS product lists and counts.

Documentation:
- Document the similarity-search invariant and updated POS search semantics in the plugin guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved similarity-based product search to return the appropriate representative product when variants match.
  * Preserved standalone product matches while consolidating grouped results.
* **Bug Fixes**
  * Excluded deleted products and unauthorized tokens from similarity-filtered results.
  * Ensured consistent behavior across kiosk and non-kiosk product searches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->