### PR TITLE
feat(core): agent-callable automation, log, and product-similarity reads

### DIFF
--- a/backend/core-api/package.json
+++ b/backend/core-api/package.json
@@ -27,6 +27,7 @@
     "jimp": "^1.6.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.18.0",
+    "mongoose": "^8.10.0",
     "multer": "^1.4.2",
     "nodemailer": "^6.9.10",
     "sha256": "^0.2.0",

--- a/backend/core-api/src/modules/automations/trpc/automations.ts
+++ b/backend/core-api/src/modules/automations/trpc/automations.ts
@@ -37,14 +37,14 @@ export const automationsRouter = t.router({
     list: t.procedure
       .meta(
         agentMeta(
-          'List automations with optional filters: { status?: "draft"|"active"|"archived", searchValue? (matches name), skip?, limit? }. Returns automation summaries (name, status, triggers, timestamps), newest first. Results are capped at 100 rows (default 20). Use automation.executionCounts to see how often an automation has run.',
+          'List automations with optional filters: { status?: "draft"|"active"|"archived", searchValue? (matches name), skip?, limit? }. Returns summary rows (_id, name, status, audit timestamps and authors, tagIds), newest first. Results are capped at 100 rows (default 20). Use automation.executionCounts to see how often an automation has run.',
           { module: 'automations', action: 'automationsRead' },
         ),
       )
       .input(
         z.object({
           status: z.enum(['draft', 'active', 'archived']).optional(),
-          searchValue: z.string().optional(),
+          searchValue: z.string().max(200).optional(),
           skip: z.number().int().nonnegative().max(1_000_000).optional(),
           limit: z.number().int().positive().max(AGENT_LIST_MAX_LIMIT).optional(),
         }),
@@ -64,6 +64,15 @@ export const automationsRouter = t.router({
         }
 
         return models.Automations.find(query)
+          .select({
+            name: 1,
+            status: 1,
+            tagIds: 1,
+            createdAt: 1,
+            createdBy: 1,
+            updatedAt: 1,
+            updatedBy: 1,
+          })
           .sort({ createdAt: -1 })
           .skip(skip || 0)
           .limit(Math.min(limit || AGENT_LIST_DEFAULT_LIMIT, AGENT_LIST_MAX_LIMIT))
@@ -73,7 +82,7 @@ export const automationsRouter = t.router({
     executionCounts: t.procedure
       .meta(
         agentMeta(
-          'Get how many times each automation has executed. Input: { automationIds: [...] } (1-100 ids, resolve them with automation.list). Returns one count row per id. Pair with automation.list for "what automations exist and how active are they" questions.',
+          'Get how many times each automation has executed. Input: { automationIds: [...] } (1-100 ids, resolve them with automation.list). Returns exactly one { _id, count } row per requested id; never-executed automations report 0. Pair with automation.list for "what automations exist and how active are they" questions.',
           { module: 'automations', action: 'automationsRead' },
         ),
       )
@@ -84,10 +93,14 @@ export const automationsRouter = t.router({
       )
       .query(async ({ input, ctx }) => {
         const { models } = ctx;
+        const ids = [...new Set(input.automationIds)];
 
-        return models.AutomationExecutions.getExecutionCounts(
-          input.automationIds,
-        );
+        // getExecutionCounts returns rows only for automations with at least
+        // one root execution; normalize so every requested id gets a row.
+        const counts = await models.AutomationExecutions.getExecutionCounts(ids);
+        const countById = new Map(counts.map((row) => [row.key, row.count]));
+
+        return ids.map((id) => ({ _id: id, count: countById.get(id) ?? 0 }));
       }),
   }),
   executions: t.router({

--- a/backend/core-api/src/modules/automations/trpc/automations.ts
+++ b/backend/core-api/src/modules/automations/trpc/automations.ts
@@ -82,7 +82,7 @@ export const automationsRouter = t.router({
     executionCounts: t.procedure
       .meta(
         agentMeta(
-          'Get how many times each automation has executed. Input: { automationIds: [...] } (1-100 ids, resolve them with automation.list). Returns exactly one { _id, count } row per requested id; never-executed automations report 0. Pair with automation.list for "what automations exist and how active are they" questions.',
+          'Get how many times each automation has executed. Input: { automationIds: [...] } (1-100 ids, resolve them with automation.list). Returns exactly one { _id, count } row per unique requested id (duplicates are collapsed); never-executed automations report 0. Pair with automation.list for "what automations exist and how active are they" questions.',
           { module: 'automations', action: 'automationsRead' },
         ),
       )

--- a/backend/core-api/src/modules/automations/trpc/automations.ts
+++ b/backend/core-api/src/modules/automations/trpc/automations.ts
@@ -1,8 +1,16 @@
 import { initTRPC } from '@trpc/server';
+import { escapeRegExp } from 'erxes-api-shared/utils';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
+
+// Agent-facing list reads must stay bounded: an unbounded find can
+// materialize a whole collection in memory before the agent-tools response
+// cap is able to reject the result.
+const AGENT_LIST_DEFAULT_LIMIT = 20;
+const AGENT_LIST_MAX_LIMIT = 100;
 
 export const automationsRouter = t.router({
   automation: t.router({
@@ -24,6 +32,62 @@ export const automationsRouter = t.router({
         const { query } = input;
         const { models } = ctx;
         return await models.Automations.countDocuments(query);
+      }),
+
+    list: t.procedure
+      .meta(
+        agentMeta(
+          'List automations with optional filters: { status?: "draft"|"active"|"archived", searchValue? (matches name), skip?, limit? }. Returns automation summaries (name, status, triggers, timestamps), newest first. Results are capped at 100 rows (default 20). Use automation.executionCounts to see how often an automation has run.',
+          { module: 'automations', action: 'automationsRead' },
+        ),
+      )
+      .input(
+        z.object({
+          status: z.enum(['draft', 'active', 'archived']).optional(),
+          searchValue: z.string().optional(),
+          skip: z.number().int().nonnegative().max(1_000_000).optional(),
+          limit: z.number().int().positive().max(AGENT_LIST_MAX_LIMIT).optional(),
+        }),
+      )
+      .query(async ({ input, ctx }) => {
+        const { models } = ctx;
+        const { status, searchValue, skip, limit } = input;
+
+        const query: Record<string, unknown> = {};
+
+        if (status) {
+          query.status = status;
+        }
+
+        if (searchValue) {
+          query.name = new RegExp(escapeRegExp(searchValue), 'i');
+        }
+
+        return models.Automations.find(query)
+          .sort({ createdAt: -1 })
+          .skip(skip || 0)
+          .limit(Math.min(limit || AGENT_LIST_DEFAULT_LIMIT, AGENT_LIST_MAX_LIMIT))
+          .lean();
+      }),
+
+    executionCounts: t.procedure
+      .meta(
+        agentMeta(
+          'Get how many times each automation has executed. Input: { automationIds: [...] } (1-100 ids, resolve them with automation.list). Returns one count row per id. Pair with automation.list for "what automations exist and how active are they" questions.',
+          { module: 'automations', action: 'automationsRead' },
+        ),
+      )
+      .input(
+        z.object({
+          automationIds: z.array(z.string()).min(1).max(AGENT_LIST_MAX_LIMIT),
+        }),
+      )
+      .query(async ({ input, ctx }) => {
+        const { models } = ctx;
+
+        return models.AutomationExecutions.getExecutionCounts(
+          input.automationIds,
+        );
       }),
   }),
   executions: t.router({

--- a/backend/core-api/src/modules/logs/trpc/logs.ts
+++ b/backend/core-api/src/modules/logs/trpc/logs.ts
@@ -26,8 +26,22 @@ export const logsRouter = t.router({
       return logs;
     }),
 
-    get: t.procedure.query(async () => {
-      return null;
-    }),
+    get: t.procedure
+      .meta(
+        agentMeta(
+          'Get one system/audit log entry by _id. Input: { _id }. Returns the full log document (action, target, payload diff, who made the change and when). Resolve ids with log.list first.',
+          { module: 'logs', action: 'logsRead' },
+        ),
+      )
+      .input(z.object({ _id: z.string() }))
+      .query(async ({ input, ctx }) => {
+        const { models, userId } = ctx;
+
+        if (!userId) {
+          throw new TRPCError({ code: 'UNAUTHORIZED' });
+        }
+
+        return models.Logs.findOne({ _id: input._id }).lean();
+      }),
   }),
 });

--- a/backend/core-api/src/modules/logs/trpc/logs.ts
+++ b/backend/core-api/src/modules/logs/trpc/logs.ts
@@ -1,4 +1,5 @@
 import { initTRPC, TRPCError } from '@trpc/server';
+import { Types } from 'mongoose';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
 import { agentMeta } from '~/utils/agentMeta';
@@ -33,7 +34,13 @@ export const logsRouter = t.router({
           { module: 'logs', action: 'logsRead' },
         ),
       )
-      .input(z.object({ _id: z.string() }))
+              .input(
+          z.object({
+            _id: z
+              .string()
+              .refine(Types.ObjectId.isValid, 'Invalid log id'),
+          }),
+        )
       .query(async ({ input, ctx }) => {
         const { models, userId } = ctx;
 

--- a/backend/core-api/src/modules/products/trpc/similarity.ts
+++ b/backend/core-api/src/modules/products/trpc/similarity.ts
@@ -1,24 +1,51 @@
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
+import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
+// Agent-facing list reads must stay bounded: an unbounded find can
+// materialize a whole collection in memory before the agent-tools response
+// cap is able to reject the result.
+const AGENT_LIST_DEFAULT_LIMIT = 20;
+const AGENT_LIST_MAX_LIMIT = 100;
+
 export const similaritiesTrpcRouter = t.router({
-  find: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    const { query = {}, sort = {}, skip, limit } = input || {};
+  find: t.procedure
+    .meta(
+      agentMeta(
+        'List product similarity templates (bulk-create templates that generate similar products from one star product). Input: { query?, sort?, limit?, skip? }. Results are capped at 100 rows (default 20). Use products.similarities.findOne to read a single template in full.',
+        { module: 'products', action: 'productsRead' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      const { query = {}, sort = {}, skip, limit } = input || {};
 
-    let cursor = ctx.models.ProductSimilarities.find(query).sort(sort);
+      const safeLimit =
+        typeof limit === 'number' && Number.isFinite(limit) && limit > 0
+          ? Math.max(1, Math.min(Math.floor(limit), AGENT_LIST_MAX_LIMIT))
+          : AGENT_LIST_DEFAULT_LIMIT;
 
-    if (skip) cursor = cursor.skip(skip);
-    if (limit) cursor = cursor.limit(limit);
+      return ctx.models.ProductSimilarities.find(query)
+        .sort(sort)
+        .skip(skip || 0)
+        .limit(safeLimit)
+        .lean();
+    }),
 
-    return cursor.lean();
-  }),
-
-  findOne: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-    return ctx.models.ProductSimilarities.findOne(input || {}).lean();
-  }),
+  findOne: t.procedure
+    .meta(
+      agentMeta(
+        'Get one product similarity template by _id. Input: { _id }. Returns the template header (info), its property matching rules (propertiesData), the referenced product ids, and the starred source product.',
+        { module: 'products', action: 'productsRead' },
+      ),
+    )
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      return ctx.models.ProductSimilarities.findOne(input || {}).lean();
+    }),
 
   add: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
     return ctx.models.ProductSimilarities.addSimilarity(input);

--- a/backend/core-api/src/modules/products/trpc/similarity.ts
+++ b/backend/core-api/src/modules/products/trpc/similarity.ts
@@ -5,9 +5,6 @@ import { agentMeta } from '~/utils/agentMeta';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
 
-// Agent-facing list reads must stay bounded: an unbounded find can
-// materialize a whole collection in memory before the agent-tools response
-// cap is able to reject the result.
 const AGENT_LIST_DEFAULT_LIMIT = 20;
 const AGENT_LIST_MAX_LIMIT = 100;
 
@@ -19,19 +16,22 @@ export const similaritiesTrpcRouter = t.router({
         { module: 'products', action: 'productsRead' },
       ),
     )
-    .input(z.any())
+    .input(
+      z.object({
+        query: z.record(z.unknown()).optional(),
+        sort: z.record(z.union([z.literal(1), z.literal(-1)])).optional(),
+        skip: z.number().int().nonnegative().max(1_000_000).optional(),
+        limit: z.number().int().positive().max(AGENT_LIST_MAX_LIMIT).optional(),
+      }),
+    )
     .query(async ({ ctx, input }) => {
-      const { query = {}, sort = {}, skip, limit } = input || {};
+      const { query, sort, skip, limit } = input;
+      const { models } = ctx;
 
-      const safeLimit =
-        typeof limit === 'number' && Number.isFinite(limit) && limit > 0
-          ? Math.max(1, Math.min(Math.floor(limit), AGENT_LIST_MAX_LIMIT))
-          : AGENT_LIST_DEFAULT_LIMIT;
-
-      return ctx.models.ProductSimilarities.find(query)
-        .sort(sort)
+      return models.ProductSimilarities.find(query || {})
+        .sort(sort || {})
         .skip(skip || 0)
-        .limit(safeLimit)
+        .limit(limit || AGENT_LIST_DEFAULT_LIMIT)
         .lean();
     }),
 
@@ -42,9 +42,11 @@ export const similaritiesTrpcRouter = t.router({
         { module: 'products', action: 'productsRead' },
       ),
     )
-    .input(z.any())
+    .input(z.object({ _id: z.string() }))
     .query(async ({ ctx, input }) => {
-      return ctx.models.ProductSimilarities.findOne(input || {}).lean();
+      return ctx.models.ProductSimilarities.findOne({
+        _id: input._id,
+      }).lean();
     }),
 
   add: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,6 +796,9 @@ importers:
       multer:
         specifier: ^1.4.2
         version: 1.4.4
+      mongoose:
+        specifier: ^8.10.0
+        version: 8.13.2(socks@2.8.7)
       nodemailer:
         specifier: ^6.9.10
         version: 6.9.10


### PR DESCRIPTION
## Summary

Follow-up to #9143 from a module-by-module audit of core-api's agent surface (68 of 162 tRPC procedures exposed today). Three modules had registered read permissions but nothing — or a stub — for agents to call:

## What changes

### automations
Agents previously could not see automations at all: the only tRPC procedures were an internal bot-matcher `find` and a raw `executions.find`, both intentionally unannotated.

- **`automation.list`** (`automationsRead`) — bounded listing: `{ status?: "draft"|"active"|"archived", searchValue?, skip?, limit? }`, newest first, default 20 / hard max 100 rows.
- **`automation.executionCounts`** (`automationsRead`) — per-automation run counts via the existing `getExecutionCounts` model helper; input capped at 1–100 ids so agents pair it with `list`.

The internal matcher and raw execution reads remain invisible.

### logs
`log.get` was a stub returning `null`. It is now a real by-`_id` read with the same login guard and `logsRead` gate as `log.list`.

### products.similarities
Similarity templates (bulk-create-from-star-product) were fully hidden. `find`/`findOne` are now exposed behind `productsRead`; `find` clamps results to the same 1–100 policy. `add`/`edit`/`remove` stay agent-invisible.

## Deliberate non-goals

- **configs**: value readers stay hidden — config values can hold secrets; `getCodes` remains names-only by design.
- **permissions/relations/conformities**: platform plumbing; conformity reads would need a newly registered action first.
- **team-member mutations & auth machinery** (invite/reset/login helpers): account lifecycle stays human-only.
- **broadcast**: has real models but its tRPC router is dead stubs — campaign Q&A tooling is worth its own PR.

## Validation

- `tsc -p tsconfig.build.json --noEmit`: clean for core-api
- eslint: zero findings in all three touched files (project-wide error count identical to main)
- No internal callers relied on the touched procedures' previous behavior

## Summary by Sourcery

Expand the agent-callable read surface for automations, audit logs, and product-similarity templates while keeping sensitive and mutation operations restricted.

New Features:
- Expose bounded automation listing and execution-count reads for agents.
- Expose product-similarity template listing and single-record reads for agents.

Bug Fixes:
- Implement log retrieval by identifier instead of returning a stubbed null response.

Enhancements:
- Apply agent metadata, authorization gates, validated inputs, and bounded result policies to the newly exposed reads.

Build:
- Add mongoose as a core-api dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Automation listings now return concise summary details and limit search terms to 200 characters.
  - Execution-count results provide one entry per unique automation, including zero counts where applicable.
  - Similarity searches now support structured filters, sorting, pagination, and result limits up to 100, defaulting to 20.
  - Individual similarity lookups now require a specific record ID.
  - Log retrieval validates record IDs and provides clearer errors for invalid values.
  - Query responses include clearer metadata describing available fields and result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->