### PR TITLE
fix(core-ui): property options frozen after removing one

### DIFF
--- a/frontend/core-ui/src/modules/properties/components/PropertyFormSelectFields.tsx
+++ b/frontend/core-ui/src/modules/properties/components/PropertyFormSelectFields.tsx
@@ -20,7 +20,10 @@ export const PropertyFormSelectFields = ({
     : 0;
 
   const setOptions = (next: NonNullable<IPropertyForm['options']>) =>
-    form.setValue('options', next, { shouldDirty: true });
+    form.setValue('options', next, {
+      shouldDirty: true,
+      shouldValidate: form.formState.isSubmitted,
+    });
 
   if (!['multiSelect', 'select', 'check', 'radio'].includes(type)) {
     return <></>;

--- a/frontend/core-ui/src/modules/properties/components/PropertyFormSelectFields.tsx
+++ b/frontend/core-ui/src/modules/properties/components/PropertyFormSelectFields.tsx
@@ -1,5 +1,5 @@
 import { Button, Form, InfoCard, Input } from 'erxes-ui';
-import { useFieldArray, UseFormReturn } from 'react-hook-form';
+import { UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { IPropertyForm } from '../types/Properties';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
@@ -13,12 +13,14 @@ export const PropertyFormSelectFields = ({
 }) => {
   const { t } = useTranslation('settings', { keyPrefix: 'properties' });
   const type = form.watch('type');
-  const options = (form.formState.defaultValues?.options as unknown[])?.length ?? 0;
+  const options = form.watch('options') || [];
 
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: 'options' as never,
-  });
+  const savedOptionCount = isEdit
+    ? form.formState.defaultValues?.options?.length ?? 0
+    : 0;
+
+  const setOptions = (next: NonNullable<IPropertyForm['options']>) =>
+    form.setValue('options', next, { shouldDirty: true });
 
   if (!['multiSelect', 'select', 'check', 'radio'].includes(type)) {
     return <></>;
@@ -28,10 +30,10 @@ export const PropertyFormSelectFields = ({
     <InfoCard title={t('select-options', 'Select options')}>
       <InfoCard.Content>
         <div className="flex flex-col gap-3">
-          {fields.map((field, index) => {
-            const isExisting = !!isEdit && index < options;
+          {options.map((_, index) => {
+            const isExisting = index < savedOptionCount;
             return (
-            <div className="flex gap-2" key={field.id}>
+            <div className="flex gap-2" key={index}>
               <Form.Field
                 control={form.control}
                 name={`options.${index}.label`}
@@ -59,7 +61,9 @@ export const PropertyFormSelectFields = ({
                 )}
               />
               <Button
-                onClick={() => remove(index)}
+                onClick={() =>
+                  setOptions(options.filter((_, i) => i !== index))
+                }
                 variant="secondary"
                 size="icon"
                 className="mt-auto size-8"
@@ -71,7 +75,7 @@ export const PropertyFormSelectFields = ({
             );
           })}
           <Button
-            onClick={() => append({ label: '', value: '' })}
+            onClick={() => setOptions([...options, { label: '', value: '' }])}
             variant="secondary"
           >
             <IconPlus /> {t('add-option', 'Add option')}


### PR DESCRIPTION
## Summary by Sourcery

Fix dynamic property option management after an option is removed.

Bug Fixes:
- Fix property option fields so removing an option does not freeze or prevent subsequent option edits.

Enhancements:
- Track current option values directly through the form while preserving saved-option handling for edit forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option management in property forms.
  * Added more reliable dirty-state tracking when adding or removing options.
  * Preserved saved options more consistently while editing existing properties.
  * Improved validation updates after changing options in submitted forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->