### PR TITLE
fix(ui): restore plugin config integrations

### DIFF
--- a/frontend/core-ui/src/modules/search/hooks/useSettingsNavigationSearchItems.ts
+++ b/frontend/core-ui/src/modules/search/hooks/useSettingsNavigationSearchItems.ts
@@ -22,13 +22,22 @@ const toSettingsSearchItem = (
   destination: TSettingsDestination,
   section: string,
   settingsPrefix: string,
-): TNavigationSearchItem => ({
-  id: `go-to:settings:${destination.path.replace(/^\/+/, '')}`,
-  title: destination.name,
-  description: `${settingsPrefix} › ${section}`,
-  icon: destination.icon,
-  path: `/${AppPath.Settings}/${destination.path.replace(/^\/+/, '')}`,
-});
+): TNavigationSearchItem => {
+  const normalizedPath = destination.path.replace(/^\/+/, '');
+  const path =
+    normalizedPath === AppPath.Settings ||
+    normalizedPath.startsWith(`${AppPath.Settings}/`)
+      ? normalizedPath
+      : `${AppPath.Settings}/${normalizedPath}`;
+
+  return {
+    id: `go-to:settings:${normalizedPath}`,
+    title: destination.name,
+    description: `${settingsPrefix} › ${section}`,
+    icon: destination.icon,
+    path: `/${path}`,
+  };
+};
 
 export const useSettingsNavigationSearchItems = () => {
   const version = useVersion();

--- a/frontend/plugins/sales_ui/src/config.tsx
+++ b/frontend/plugins/sales_ui/src/config.tsx
@@ -64,6 +64,7 @@ export const CONFIG: IUIConfig = {
     {
       name: 'deals',
       path: 'sales/deals',
+      hasAutomation: true,
     },
     {
       name: 'pos',


### PR DESCRIPTION
## Summary

- restore the Sales automation capability flag on the Deals module
- allow core automation components to detect and load the Sales automation remote
- avoid duplicating the `/settings` prefix for settings-only plugin search destinations

## Validation

- `pnpm exec eslint frontend/plugins/sales_ui/src/config.tsx`
- `pnpm nx build sales_ui`
- `pnpm exec eslint frontend/core-ui/src/modules/search/hooks/useSettingsNavigationSearchItems.ts`
- `pnpm nx test core-ui --runInBand`
- `pnpm nx build core-ui`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automation capabilities for the Deals module.

* **Bug Fixes**
  * Improved Settings search navigation so results consistently open the correct destination without duplicated path prefixes.
  * Updated search result identifiers and links to accurately reflect normalized Settings paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->