### PR TITLE
feat(oauth): delegate user permissions to OpenClaw

### DIFF
--- a/backend/core-api/src/modules/auth/routes/oauth/routes.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/routes.ts
@@ -189,11 +189,14 @@ router.post('/oauth/device/approve', async (req: Request, res: Response) => {
       return sendOAuthError(res, 400, 'invalid_request', 'Missing userCode');
     }
 
-    const deviceCode = await models.OAuthDeviceCodes.findOne({
-      userCodeHash: hashToken(userCode),
-      status: 'pending',
-      expiresAt: { $gt: new Date() },
-    });
+    const [deviceCode, user] = await Promise.all([
+      models.OAuthDeviceCodes.findOne({
+        userCodeHash: hashToken(userCode),
+        status: 'pending',
+        expiresAt: { $gt: new Date() },
+      }),
+      models.Users.findOne({ _id: userId, isActive: true }),
+    ]);
 
     if (!deviceCode) {
       return sendOAuthError(res, 404, 'invalid_grant', 'Invalid device code');
@@ -209,11 +212,35 @@ router.post('/oauth/device/approve', async (req: Request, res: Response) => {
       );
     }
 
-    const grantedScopes: string[] = Array.isArray(req.body?.grantedScopes)
-      ? req.body.grantedScopes.filter(
-          (s: unknown) => typeof s === 'string' && s.trim(),
-        )
+    if (!user) {
+      return sendOAuthError(res, 401, 'invalid_grant', 'User not found');
+    }
+
+    const availableScopes = await getAvailableOAuthScopesForUser({
+      subdomain,
+      user,
+    });
+    const availableScopeNames = new Set(
+      availableScopes.map(({ scope }) => scope),
+    );
+    const submittedScopes: string[] = Array.isArray(req.body?.grantedScopes)
+      ? req.body.grantedScopes
+          .filter(
+            (scope: unknown): scope is string => typeof scope === 'string',
+          )
+          .map((scope) => scope.trim())
+          .filter(Boolean)
       : [];
+    const grantedScopes = [...new Set(submittedScopes)];
+
+    if (grantedScopes.some((scope) => !availableScopeNames.has(scope))) {
+      return sendOAuthError(
+        res,
+        400,
+        'invalid_scope',
+        'One or more requested permissions are not available to this user',
+      );
+    }
 
     const [oauthClientApp] = await Promise.all([
       getOAuthClientApp(models, deviceCode.clientId),

--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -44,16 +44,6 @@ export const getAvailableOAuthScopesForUser = async ({
 
     for (const module of modules) {
       for (const action of module.actions || []) {
-        const actionScopes = action.oauthScopes?.length
-          ? action.oauthScopes
-          : action.oauthScope
-          ? [action.oauthScope]
-          : [];
-
-        if (actionScopes.length === 0) {
-          continue;
-        }
-
         const allowed =
           user.isOwner || (await canGroup(subdomain, action.name, user));
 
@@ -61,13 +51,15 @@ export const getAvailableOAuthScopesForUser = async ({
           continue;
         }
 
-        for (const actionScope of actionScopes) {
-          if (!scopeMap.has(actionScope)) {
-            scopeMap.set(actionScope, {
-              scope: actionScope,
-              description: action.description || action.title || actionScope,
-            });
-          }
+        // OAuth delegates the existing permission action directly. No plugin
+        // needs a second OAuth-specific permission catalog.
+        if (!scopeMap.has(action.name)) {
+          scopeMap.set(action.name, {
+            scope: action.name,
+            description: `${pluginName} / ${
+              module.description || module.name
+            }: ${action.description || action.title || action.name}`,
+          });
         }
       }
     }

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -183,15 +183,15 @@ const getOAuthActionScopeMap = async () => {
 
     for (const module of modules) {
       for (const action of module.actions || []) {
-        const actionScopes = action.oauthScopes?.length
-          ? action.oauthScopes
-          : action.oauthScope
-            ? [action.oauthScope]
-            : [];
+        const actionScopes = [
+          action.name,
+          ...(action.oauthScopes || []),
+          ...(action.oauthScope ? [action.oauthScope] : []),
+        ];
 
-        if (actionScopes.length) {
-          scopeMap[action.name] = actionScopes;
-        }
+        scopeMap[action.name] = [
+          ...new Set([...(scopeMap[action.name] || []), ...actionScopes]),
+        ];
       }
     }
   }
@@ -206,7 +206,9 @@ const checkOAuthScope = async (action: string, user?: IUserDocument) => {
     }
   ).oauthScopes;
 
-  if (!oauthScopes?.length) {
+  // A normal erxes session has no oauthScopes property. OAuth identities do,
+  // including an explicit empty array, which must fail closed.
+  if (!Array.isArray(oauthScopes)) {
     return;
   }
 

--- a/backend/erxes-api-shared/src/utils/agent-tools/auth.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/auth.ts
@@ -10,6 +10,8 @@ const AUTH_TTL_MS = 5 * 60 * 1000;
 export interface AgentToolsAuthPayload {
   subdomain: string;
   userId: string | null;
+  oauthClientId?: string;
+  oauthScopes?: string[];
 }
 
 /**
@@ -48,9 +50,19 @@ const signPayload = (payloadBase64: string): string =>
 export const encodeAgentToolsAuthHeader = (
   subdomain: string,
   userId?: string,
+  oauth?: { clientId?: string; scopes?: string[] },
 ): string => {
+  const scopes = [...new Set(oauth?.scopes || [])].filter(
+    (scope) => typeof scope === 'string' && scope.length <= 256,
+  );
   const payloadBase64 = Buffer.from(
-    JSON.stringify({ subdomain, userId: userId || null, at: Date.now() }),
+    JSON.stringify({
+      subdomain,
+      userId: userId || null,
+      at: Date.now(),
+      ...(oauth?.clientId ? { oauthClientId: oauth.clientId } : {}),
+      ...(scopes.length ? { oauthScopes: scopes } : {}),
+    }),
     'utf8',
   ).toString('base64url');
 
@@ -122,6 +134,16 @@ export const decodeAgentToolsAuthHeader = (
     return {
       subdomain: payload.subdomain,
       userId: typeof payload.userId === 'string' ? payload.userId : null,
+      ...(typeof payload.oauthClientId === 'string'
+        ? { oauthClientId: payload.oauthClientId }
+        : {}),
+      ...(Array.isArray(payload.oauthScopes) &&
+      payload.oauthScopes.length <= 512 &&
+      payload.oauthScopes.every(
+        (scope: unknown) => typeof scope === 'string' && scope.length <= 256,
+      )
+        ? { oauthScopes: payload.oauthScopes }
+        : {}),
     };
   } catch {
     return null;

--- a/backend/erxes-api-shared/src/utils/agent-tools/endpoints.ts
+++ b/backend/erxes-api-shared/src/utils/agent-tools/endpoints.ts
@@ -67,6 +67,60 @@ const getManifest = async (
   return manifest;
 };
 
+const getActingUser = async (
+  subdomain: string,
+  userId: string,
+  oauth?: { clientId?: string; scopes?: string[] },
+): Promise<IUserDocument | null> => {
+  const user = (await sendTRPCMessage({
+    subdomain,
+    pluginName: 'core',
+    module: 'users',
+    action: 'findOne',
+    method: 'query',
+    input: { query: { _id: userId } },
+    defaultValue: null,
+  })) as IUserDocument | null;
+
+  if (!user) return null;
+
+  return {
+    ...user,
+    ...(oauth?.clientId
+      ? {
+          oauthClientId: oauth.clientId,
+          oauthScopes: oauth.scopes || [],
+        }
+      : {}),
+  } as IUserDocument;
+};
+
+const filterManifestForUser = async (
+  manifest: AgentToolManifest,
+  subdomain: string,
+  user: IUserDocument,
+): Promise<AgentToolManifest> => {
+  const tools = await Promise.all(
+    manifest.tools.map(async (tool) => {
+      if (!tool.permission) return null;
+
+      try {
+        await checkPermissionGroup(subdomain, user)(tool.permission.action);
+        return tool;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return {
+    ...manifest,
+    tools: tools.filter((tool): tool is AgentTrpcToolDescriptor =>
+      Boolean(tool),
+    ),
+  };
+};
+
 /** Execute a tRPC tool in-process through the plugin's context factory. */
 const executeTrpcTool = async (
   options: AgentToolsOptions,
@@ -140,7 +194,27 @@ export const mountAgentTools = (
       }
 
       try {
-        const manifest = await getManifest(auth.subdomain, options);
+        const rawManifest = await getManifest(auth.subdomain, options);
+        let manifest = rawManifest;
+
+        if (auth.userId) {
+          const user = await getActingUser(auth.subdomain, auth.userId, {
+            clientId: auth.oauthClientId,
+            scopes: auth.oauthScopes,
+          });
+
+          if (!user) {
+            return res
+              .status(403)
+              .json(err(new Error('Forbidden: user not found')));
+          }
+
+          manifest = await filterManifestForUser(
+            rawManifest,
+            auth.subdomain,
+            user,
+          );
+        }
 
         return res.json(ok(manifest));
       } catch (error) {
@@ -207,15 +281,10 @@ export const mountAgentTools = (
           );
       }
 
-      const user = (await sendTRPCMessage({
-        subdomain,
-        pluginName: 'core',
-        module: 'users',
-        action: 'findOne',
-        method: 'query',
-        input: { query: { _id: userId } },
-        defaultValue: null,
-      })) as IUserDocument | null;
+      const user = await getActingUser(subdomain, userId, {
+        clientId: auth.oauthClientId,
+        scopes: auth.oauthScopes,
+      });
 
       if (!user) {
         return res

--- a/backend/gateway/src/agent-tools/routes.ts
+++ b/backend/gateway/src/agent-tools/routes.ts
@@ -1,0 +1,315 @@
+import crypto from 'node:crypto';
+import express, { Request, Response, Router } from 'express';
+import fetch from 'node-fetch';
+
+import {
+  AgentToolDescriptor,
+  AgentToolManifest,
+  encodeAgentToolsAuthHeader,
+  getSubdomain,
+  redis,
+} from 'erxes-api-shared/utils';
+import { ErxesProxyTarget } from '~/proxy/targets';
+
+type OAuthUser = {
+  _id?: string;
+  oauthClientId?: string;
+  oauthScopes?: string[];
+};
+
+type AgentRequest = Request & { user?: OAuthUser };
+type InternalResponse<T> = {
+  status: 'success' | 'error';
+  data?: T;
+  error?: { code?: string; message?: string };
+};
+
+const router: Router = Router();
+const targets = (): ErxesProxyTarget[] => global.currentTargets || [];
+
+const requireOAuth = (req: AgentRequest, res: Response): OAuthUser | null => {
+  if (!req.user?._id || !req.user.oauthClientId) {
+    res.status(401).json({
+      error: {
+        code: 'OAUTH_REQUIRED',
+        message: 'A valid erxes OAuth access token is required',
+      },
+    });
+    return null;
+  }
+
+  return req.user;
+};
+
+const signedHeaders = (req: AgentRequest, user: OAuthUser) => ({
+  'Content-Type': 'application/json',
+  'x-erxes-agent-auth': encodeAgentToolsAuthHeader(
+    getSubdomain(req),
+    user._id,
+    {
+      clientId: user.oauthClientId,
+      scopes: user.oauthScopes || [],
+    },
+  ),
+});
+
+const fetchInternal = async <T>({
+  target,
+  path,
+  method = 'GET',
+  headers,
+  body,
+}: {
+  target: ErxesProxyTarget;
+  path: string;
+  method?: 'GET' | 'POST';
+  headers: Record<string, string>;
+  body?: unknown;
+}): Promise<{ status: number; payload: InternalResponse<T> }> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60_000);
+
+  try {
+    const response = await fetch(`${target.address}${path}`, {
+      method,
+      headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: controller.signal,
+    });
+
+    return {
+      status: response.status,
+      payload: (await response.json()) as InternalResponse<T>,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const pluginFromToolId = (toolId: string) =>
+  /^([a-zA-Z0-9_-]+)\.trpc\./.exec(toolId)?.[1] || null;
+
+const confirmationKey = (id: string) => `agent_tool_confirmation:${id}`;
+const inputDigest = (toolId: string, input: unknown) =>
+  crypto
+    .createHash('sha256')
+    .update(JSON.stringify({ toolId, input: input || {} }))
+    .digest('hex');
+
+const createConfirmation = async (
+  req: AgentRequest,
+  user: OAuthUser,
+  tool: AgentToolDescriptor,
+  input: unknown,
+) => {
+  const id = crypto.randomUUID();
+
+  await redis.set(
+    confirmationKey(id),
+    JSON.stringify({
+      subdomain: getSubdomain(req),
+      userId: user._id,
+      clientId: user.oauthClientId,
+      toolId: tool.id,
+      digest: inputDigest(tool.id, input),
+    }),
+    'EX',
+    300,
+  );
+
+  return { id, toolId: tool.id, summary: tool.description, expiresIn: 300 };
+};
+
+const consumeConfirmation = async (
+  req: AgentRequest,
+  user: OAuthUser,
+  toolId: string,
+  input: unknown,
+  confirmationId: string,
+) => {
+  const raw = (await redis.eval(
+    "local v=redis.call('GET',KEYS[1]); if v then redis.call('DEL',KEYS[1]) end; return v",
+    1,
+    confirmationKey(confirmationId),
+  )) as string | null;
+
+  if (!raw) return false;
+
+  try {
+    const saved = JSON.parse(raw);
+    return (
+      saved.subdomain === getSubdomain(req) &&
+      saved.userId === user._id &&
+      saved.clientId === user.oauthClientId &&
+      saved.toolId === toolId &&
+      saved.digest === inputDigest(toolId, input)
+    );
+  } catch {
+    return false;
+  }
+};
+
+router.get('/agent-tools/manifest', async (req: AgentRequest, res) => {
+  const user = requireOAuth(req, res);
+  if (!user) return;
+
+  const headers = signedHeaders(req, user);
+  const targetList = targets();
+  const settled = await Promise.allSettled(
+    targetList.map(async (target) => ({
+      target,
+      result: await fetchInternal<AgentToolManifest>({
+        target,
+        path: '/agent-tools/manifest',
+        headers,
+      }),
+    })),
+  );
+  const tools: AgentToolDescriptor[] = [];
+  const unavailablePlugins: string[] = [];
+
+  settled.forEach((result, index) => {
+    const plugin = targetList[index]?.name || 'unknown';
+    const manifest =
+      result.status === 'fulfilled' && result.value.result.status < 400
+        ? result.value.result.payload.data
+        : undefined;
+
+    if (!manifest) {
+      unavailablePlugins.push(plugin);
+      return;
+    }
+
+    tools.push(...manifest.tools);
+  });
+
+  const search = String(req.query.query || '')
+    .trim()
+    .toLowerCase();
+  const plugin = String(req.query.plugin || '').trim();
+  const module = String(req.query.module || '').trim();
+  const offset = Math.max(0, Number(req.query.cursor) || 0);
+  const limit = Math.min(100, Math.max(1, Number(req.query.limit) || 50));
+  const filtered = tools.filter((tool) => {
+    if (plugin && tool.plugin !== plugin) return false;
+    if (module && tool.module !== module) return false;
+    if (!search) return true;
+
+    return `${tool.id} ${tool.plugin} ${tool.module} ${tool.description}`
+      .toLowerCase()
+      .includes(search);
+  });
+
+  return res.json({
+    tools: filtered.slice(offset, offset + limit),
+    total: filtered.length,
+    nextCursor:
+      offset + limit < filtered.length ? String(offset + limit) : null,
+    unavailablePlugins: [...new Set(unavailablePlugins)],
+  });
+});
+
+router.post(
+  '/agent-tools/call',
+  express.json({ limit: '256kb' }),
+  async (req: AgentRequest, res) => {
+    const user = requireOAuth(req, res);
+    if (!user) return;
+
+    const { toolId, input, confirmationId } = req.body || {};
+
+    if (typeof toolId !== 'string' || !toolId) {
+      return res.status(400).json({
+        error: { code: 'INVALID_INPUT', message: 'toolId is required' },
+      });
+    }
+
+    if (
+      input !== undefined &&
+      (!input || typeof input !== 'object' || Array.isArray(input))
+    ) {
+      return res.status(400).json({
+        error: { code: 'INVALID_INPUT', message: 'input must be an object' },
+      });
+    }
+
+    const plugin = pluginFromToolId(toolId);
+    const target = plugin
+      ? targets().find((candidate) => candidate.name === plugin)
+      : undefined;
+
+    if (!target) {
+      return res.status(404).json({
+        error: { code: 'UNKNOWN_TOOL', message: 'Unknown erxes tool' },
+      });
+    }
+
+    try {
+      const headers = signedHeaders(req, user);
+      const manifestResult = await fetchInternal<AgentToolManifest>({
+        target,
+        path: '/agent-tools/manifest',
+        headers,
+      });
+      const tool = manifestResult.payload.data?.tools.find(
+        (candidate) => candidate.id === toolId,
+      );
+
+      if (!tool) {
+        return res.status(403).json({
+          error: {
+            code: 'TOOL_NOT_GRANTED',
+            message: 'This tool was not delegated during OAuth',
+          },
+        });
+      }
+
+      if (tool.destructive) {
+        const confirmed =
+          typeof confirmationId === 'string' &&
+          (await consumeConfirmation(req, user, toolId, input, confirmationId));
+
+        if (!confirmed) {
+          return res.status(409).json({
+            error: {
+              code: 'CONFIRMATION_REQUIRED',
+              message: 'Explicit user confirmation is required',
+            },
+            confirmation: await createConfirmation(req, user, tool, input),
+          });
+        }
+      }
+
+      const result = await fetchInternal<unknown>({
+        target,
+        path: '/agent-tools/call',
+        method: 'POST',
+        headers,
+        body: { toolId, input },
+      });
+
+      console.log(
+        JSON.stringify({
+          scope: 'agent-tools',
+          event: 'call',
+          subdomain: getSubdomain(req),
+          userId: user._id,
+          oauthClientId: user.oauthClientId,
+          toolId,
+          status: result.status,
+        }),
+      );
+
+      return res.status(result.status).json(result.payload);
+    } catch {
+      return res.status(502).json({
+        error: {
+          code: 'PLUGIN_UNAVAILABLE',
+          message: 'The erxes plugin is temporarily unavailable',
+        },
+      });
+    }
+  },
+);
+
+export default router;

--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -41,6 +41,7 @@ import {
   stopSubscriptionServer,
 } from './subscription';
 import { isValidLocaleParams, resolveLocale } from '~/util/locales';
+import agentToolsRouter from '~/agent-tools/routes';
 
 dotenv.config();
 
@@ -150,6 +151,7 @@ app.use(async (req, res, next) => {
 });
 
 app.use(userMiddleware);
+app.use(agentToolsRouter);
 
 app.use('/bullmq-board', serverAdapter.getRouter());
 


### PR DESCRIPTION
## Why

OpenClaw should only receive permissions that the authorizing erxes user already has and explicitly delegates during OAuth. Previously, OAuth scope discovery depended on a separate opt-in scope catalog, so most existing plugin permissions could not be delegated consistently.

## What Changed

- Expose each existing permission action available to the current user as an OAuth scope, and reject approval requests containing unavailable scopes.
- Treat OAuth identities with an empty scope list as denied while leaving normal erxes sessions unchanged.
- Forward the OAuth client and selected scopes through signed internal agent-tool requests.
- Filter tool manifests and enforce permissions again when a tool is called.
- Add OAuth-only gateway endpoints for tool discovery and execution, including one-time confirmation for destructive tools.

## Summary by Sourcery

Delegate existing erxes permissions through OAuth and enforce them across OpenClaw agent-tool discovery and execution.

New Features:
- Expose the current user’s existing permission actions as delegable OAuth scopes and validate requested scopes during device approval.
- Add OAuth-only agent-tool manifest and execution endpoints with filtering, pagination, and confirmation for destructive tools.

Bug Fixes:
- Fail closed for OAuth identities with no delegated scopes while preserving authorization behavior for regular erxes sessions.
- Recheck delegated permissions during agent-tool discovery and execution to prevent unauthorized access.

Enhancements:
- Propagate OAuth client identity and delegated scopes through signed internal agent-tool requests for end-to-end authorization.