### PR TITLE
fix/frontline show properties on ticket cards

### DIFF
--- a/frontend/libs/ui-modules/src/modules/properties/propertyUtils.ts
+++ b/frontend/libs/ui-modules/src/modules/properties/propertyUtils.ts
@@ -20,6 +20,42 @@ export const hasFieldValue = (value: unknown): boolean => {
   return true;
 };
 
+export const formatFieldValue = (field: IField, value: unknown): string => {
+  if (Array.isArray(value)) {
+    if (field.options?.length) {
+      return value
+        .map(
+          (item) =>
+            field.options?.find((option) => option.value === item)?.label ??
+            String(item),
+        )
+        .join(', ');
+    }
+
+    return value.join(', ');
+  }
+
+  if (field.options?.length) {
+    return (
+      field.options.find((option) => option.value === value)?.label ??
+      String(value)
+    );
+  }
+
+  if (field.type === 'boolean' || field.type === 'check') {
+    return value ? 'Yes' : 'No';
+  }
+
+  if (field.type === 'date') {
+    const date = new Date(value as string);
+    return Number.isNaN(date.getTime())
+      ? String(value)
+      : date.toLocaleDateString();
+  }
+
+  return String(value);
+};
+
 export const isFieldVisibleByLogic = (
   field: Pick<IField, 'logics'>,
   valuesByFieldId: Record<string, unknown>,

--- a/frontend/libs/ui-modules/src/modules/shared/components/CardDetailBadges.tsx
+++ b/frontend/libs/ui-modules/src/modules/shared/components/CardDetailBadges.tsx
@@ -1,0 +1,97 @@
+import { Badge, Button, Tooltip } from 'erxes-ui';
+
+export type CardDetailBadgeItem = {
+  _id?: string;
+  name: string;
+  colorCode?: string;
+};
+
+type CardDetailBadgesProps = {
+  items: CardDetailBadgeItem[];
+  color: string;
+  maxVisibleItems: number;
+  onOverflowClick?: () => void;
+};
+
+const TooltipItemList = ({ items }: { items: string[] }) => (
+  <div className="flex max-w-64 flex-col gap-1">
+    {items.map((item, index) => (
+      <span key={`${item}-${index}`} className="wrap-break-word">
+        {item}
+      </span>
+    ))}
+  </div>
+);
+
+export const CardDetailBadges = ({
+  items,
+  color,
+  maxVisibleItems,
+  onOverflowClick,
+}: CardDetailBadgesProps) => {
+  if (!items.length) {
+    return null;
+  }
+
+  const visibleItems = items.slice(0, maxVisibleItems);
+  const remainingItems = items.slice(maxVisibleItems);
+
+  return (
+    <Tooltip.Provider>
+      <div className="flex flex-wrap gap-1">
+        {visibleItems.map((item, index) => (
+          <Tooltip
+            key={`${item._id ?? item.name}-${index}`}
+            delayDuration={200}
+          >
+            <Tooltip.Trigger asChild>
+              <Badge
+                variant="secondary"
+                className="h-5 max-w-full cursor-default px-1.5 font-normal"
+              >
+                <span
+                  className="size-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: item.colorCode || color }}
+                />
+                <span className="truncate">{item.name}</span>
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{item.name}</Tooltip.Content>
+          </Tooltip>
+        ))}
+        {remainingItems.length > 0 && (
+          <Tooltip delayDuration={200}>
+            <Tooltip.Trigger asChild>
+              {onOverflowClick ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 px-1.5 text-xs"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOverflowClick();
+                  }}
+                >
+                  +{remainingItems.length}
+                </Button>
+              ) : (
+                <Badge
+                  variant="ghost"
+                  className="h-5 cursor-default px-1.5 hover:bg-muted"
+                >
+                  +{remainingItems.length}
+                </Badge>
+              )}
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <TooltipItemList
+                items={remainingItems.map((item) => item.name)}
+              />
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+      </div>
+    </Tooltip.Provider>
+  );
+};

--- a/frontend/libs/ui-modules/src/modules/shared/index.ts
+++ b/frontend/libs/ui-modules/src/modules/shared/index.ts
@@ -1,1 +1,2 @@
+export * from './components/CardDetailBadges';
 export * from './components/SheetNavSidebar';

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
@@ -9,82 +9,18 @@ import { ticketCountByBoardAtom } from '@/ticket/states/ticketsTotalCountState';
 import { IconCalendarEventFilled } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import {
-  Badge,
   BoardCardProps,
   Button,
   Separator,
   TextOverflowTooltip,
-  Tooltip,
 } from 'erxes-ui';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { useGetTags } from 'ui-modules';
+import { TicketCardDetails } from '@/ticket/components/TicketCardProperties';
 
 export const ticketBoardItemAtom = atom(
   (get) => (id: string) => get(allTicketsMapState)[id],
 );
-
-const MAX_VISIBLE_TICKET_TAGS = 5;
-
-const TicketCardTags = ({ tagIds }: { tagIds: string[] }) => {
-  const { tags } = useGetTags({ variables: { type: 'frontline:ticket' } });
-
-  const selectedTags = tagIds
-    .map((tagId) => tags?.find((tag) => tag._id === tagId))
-    .filter((tag): tag is NonNullable<typeof tag> => Boolean(tag));
-
-  if (!selectedTags.length) {
-    return null;
-  }
-
-  const visibleTags = selectedTags.slice(0, MAX_VISIBLE_TICKET_TAGS);
-  const remainingCount = selectedTags.length - visibleTags.length;
-
-  return (
-    <Tooltip.Provider>
-      <div className="flex flex-wrap gap-1 px-3 pb-3">
-        {visibleTags.map((tag) => (
-          <Tooltip key={tag._id} delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="secondary"
-                className="h-5 max-w-full cursor-default px-1.5 font-normal"
-              >
-                <span
-                  className="size-1.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: tag.colorCode || '#FF6600' }}
-                />
-                <span className="truncate">{tag.name}</span>
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>{tag.name}</Tooltip.Content>
-          </Tooltip>
-        ))}
-        {remainingCount > 0 && (
-          <Tooltip delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="ghost"
-                className="h-5 cursor-default px-1.5 hover:bg-muted"
-              >
-                +{remainingCount}
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>
-              <div className="flex max-w-64 flex-col gap-1">
-                {selectedTags.slice(MAX_VISIBLE_TICKET_TAGS).map((tag) => (
-                  <span key={tag._id} className="wrap-break-word">
-                    {tag.name}
-                  </span>
-                ))}
-              </div>
-            </Tooltip.Content>
-          </Tooltip>
-        )}
-      </div>
-    </Tooltip.Provider>
-  );
-};
 
 export const TicketCard = ({ id, column }: BoardCardProps) => {
   const { t } = useTranslation('frontline');
@@ -107,6 +43,7 @@ export const TicketCard = ({ id, column }: BoardCardProps) => {
     pipelineId,
     assigneeId,
     tagIds,
+    propertiesData,
   } = ticket;
 
   return (
@@ -154,7 +91,10 @@ export const TicketCard = ({ id, column }: BoardCardProps) => {
           <SelectTagsTicket id={_id} value={tagIds || []} variant="card" />
         </div>
       </div>
-      <TicketCardTags tagIds={tagIds || []} />
+      <TicketCardDetails
+        tagIds={tagIds || []}
+        propertiesData={propertiesData}
+      />
       <Separator />
       <div className="h-9 flex items-center justify-between px-1.5">
         <Button

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCard.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Separator,
   TextOverflowTooltip,
+  useQueryState,
 } from 'erxes-ui';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
@@ -26,7 +27,13 @@ export const TicketCard = ({ id, column }: BoardCardProps) => {
   const { t } = useTranslation('frontline');
   const ticket = useAtomValue(ticketBoardItemAtom)(id);
   const [, setActiveTicket] = useTicketDetailSheet();
+  const [, setSelectedTab] = useQueryState<string>('tab');
   const setTicketCountByBoard = useSetAtom(ticketCountByBoardAtom);
+
+  const openTicketTab = (tab: 'overview' | 'properties') => {
+    setSelectedTab(tab);
+    setActiveTicket(id);
+  };
 
   if (!ticket) {
     return null;
@@ -94,6 +101,8 @@ export const TicketCard = ({ id, column }: BoardCardProps) => {
       <TicketCardDetails
         tagIds={tagIds || []}
         propertiesData={propertiesData}
+        onTagsOverflowClick={() => openTicketTab('overview')}
+        onPropertiesOverflowClick={() => openTicketTab('properties')}
       />
       <Separator />
       <div className="h-9 flex items-center justify-between px-1.5">

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
@@ -1,0 +1,158 @@
+import { Badge, Tooltip } from 'erxes-ui';
+import { useFields, useGetTags, type IField } from 'ui-modules';
+
+const MAX_VISIBLE_DETAILS = 5;
+
+const hasFieldValue = (value: unknown) => {
+  if (value === null || value === undefined || value === '') return false;
+  if (Array.isArray(value) && value.length === 0) return false;
+  return true;
+};
+
+const formatFieldValue = (field: IField, value: unknown): string => {
+  if (Array.isArray(value)) {
+    if (field.options?.length) {
+      return value
+        .map(
+          (item) =>
+            field.options?.find((option) => option.value === item)?.label ??
+            String(item),
+        )
+        .join(', ');
+    }
+    return value.join(', ');
+  }
+  if (field.options?.length) {
+    return (
+      field.options.find((option) => option.value === value)?.label ??
+      String(value)
+    );
+  }
+  if (field.type === 'boolean' || field.type === 'check') {
+    return value ? 'Yes' : 'No';
+  }
+  if (field.type === 'date') {
+    const date = new Date(value as string);
+    return Number.isNaN(date.getTime())
+      ? String(value)
+      : date.toLocaleDateString();
+  }
+  return String(value);
+};
+
+type CardDetailItem = {
+  _id: string;
+  name: string;
+  colorCode?: string;
+};
+
+const TooltipItemList = ({ items }: { items: string[] }) => (
+  <div className="flex max-w-64 flex-col gap-1">
+    {items.map((item, index) => (
+      <span key={`${item}-${index}`} className="wrap-break-word">
+        {item}
+      </span>
+    ))}
+  </div>
+);
+
+const CardDetails = ({
+  items,
+  color,
+}: {
+  items: CardDetailItem[];
+  color: string;
+}) => {
+  if (!items.length) {
+    return null;
+  }
+
+  const visibleItems = items.slice(0, MAX_VISIBLE_DETAILS);
+  const remainingCount = items.length - visibleItems.length;
+
+  return (
+    <Tooltip.Provider>
+      <div className="flex flex-wrap gap-1">
+        {visibleItems.map((item, index) => (
+          <Tooltip key={`${item._id}-${index}`} delayDuration={200}>
+            <Tooltip.Trigger asChild>
+              <Badge
+                variant="secondary"
+                className="h-5 max-w-full cursor-default px-1.5 font-normal"
+              >
+                <span
+                  className="size-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: item.colorCode || color }}
+                />
+                <span className="truncate">{item.name}</span>
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{item.name}</Tooltip.Content>
+          </Tooltip>
+        ))}
+        {remainingCount > 0 && (
+          <Tooltip delayDuration={200}>
+            <Tooltip.Trigger asChild>
+              <Badge
+                variant="ghost"
+                className="h-5 cursor-default px-1.5 hover:bg-muted"
+              >
+                +{remainingCount}
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <TooltipItemList
+                items={items
+                  .slice(MAX_VISIBLE_DETAILS)
+                  .map((item) => item.name)}
+              />
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+      </div>
+    </Tooltip.Provider>
+  );
+};
+
+type TicketCardDetailsProps = {
+  tagIds: string[];
+  propertiesData?: Record<string, unknown>;
+};
+
+export const TicketCardDetails = ({
+  tagIds,
+  propertiesData,
+}: TicketCardDetailsProps) => {
+  const { fields } = useFields({ contentType: 'frontline:ticket' });
+  const { tags } = useGetTags({ variables: { type: 'frontline:ticket' } });
+
+  const selectedTags = tagIds
+    .map((tagId) => tags?.find((tag) => tag._id === tagId))
+    .filter((tag): tag is NonNullable<typeof tag> => Boolean(tag));
+
+  const propertyItems = (fields || [])
+    .filter(
+      (field) =>
+        field.isVisibleInCard && hasFieldValue(propertiesData?.[field._id]),
+    )
+    .map((field) => ({
+      _id: field._id,
+      name: `${field.name}: ${formatFieldValue(
+        field,
+        propertiesData?.[field._id],
+      )}`,
+    }));
+
+  if (!selectedTags.length && !propertyItems.length) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-1 p-3 pt-0">
+      <div className="mt-1 flex flex-col gap-1">
+        <CardDetails items={selectedTags} color="#FF6600" />
+        <CardDetails items={propertyItems} color="#0EA5E9" />
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
@@ -1,9 +1,10 @@
-import { Badge, Tooltip } from 'erxes-ui';
 import {
+  CardDetailBadges,
   formatFieldValue,
   hasFieldValue,
   useFields,
   useGetTags,
+  type CardDetailBadgeItem,
   type IField,
 } from 'ui-modules';
 
@@ -12,19 +13,12 @@ const MAX_VISIBLE_PROPERTIES = 3;
 const TAG_COLOR = '#FF6600';
 const PROPERTY_COLOR = '#0EA5E9';
 
-type CardDetailItem = {
-  _id: string;
-  name: string;
-  colorCode?: string;
-};
-
 const getPropertyItems = (
   fields: IField[],
   propertiesData?: Record<string, unknown>,
-): CardDetailItem[] =>
+): CardDetailBadgeItem[] =>
   fields
     .filter((field) => hasFieldValue(propertiesData?.[field._id]))
-    .slice(0, MAX_VISIBLE_PROPERTIES)
     .map((field) => ({
       _id: field._id,
       name: `${field.name}: ${formatFieldValue(
@@ -33,79 +27,18 @@ const getPropertyItems = (
       )}`,
     }));
 
-const TooltipItemList = ({ items }: { items: string[] }) => (
-  <div className="flex max-w-64 flex-col gap-1">
-    {items.map((item, index) => (
-      <span key={`${item}-${index}`} className="wrap-break-word">
-        {item}
-      </span>
-    ))}
-  </div>
-);
-
-const DetailBadges = ({
-  items,
-  color,
-  maxVisibleItems,
-}: {
-  items: CardDetailItem[];
-  color: string;
-  maxVisibleItems: number;
-}) => {
-  if (!items.length) {
-    return null;
-  }
-
-  const visibleItems = items.slice(0, maxVisibleItems);
-  const remainingCount = items.length - visibleItems.length;
-  const remainingItems = items.slice(maxVisibleItems).map((item) => item.name);
-
-  return (
-    <div className="flex flex-wrap gap-1">
-      {visibleItems.map((item) => (
-        <Tooltip key={item._id} delayDuration={200}>
-          <Tooltip.Trigger asChild>
-            <Badge
-              variant="secondary"
-              className="h-5 max-w-full cursor-default px-1.5 font-normal"
-            >
-              <span
-                className="size-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: item.colorCode || color }}
-              />
-              <span className="truncate">{item.name}</span>
-            </Badge>
-          </Tooltip.Trigger>
-          <Tooltip.Content>{item.name}</Tooltip.Content>
-        </Tooltip>
-      ))}
-      {remainingCount > 0 && (
-        <Tooltip delayDuration={200}>
-          <Tooltip.Trigger asChild>
-            <Badge
-              variant="ghost"
-              className="h-5 cursor-default px-1.5 hover:bg-muted"
-            >
-              +{remainingCount}
-            </Badge>
-          </Tooltip.Trigger>
-          <Tooltip.Content>
-            <TooltipItemList items={remainingItems} />
-          </Tooltip.Content>
-        </Tooltip>
-      )}
-    </div>
-  );
-};
-
 type TicketCardDetailsProps = {
   tagIds: string[];
   propertiesData?: Record<string, unknown>;
+  onTagsOverflowClick: () => void;
+  onPropertiesOverflowClick: () => void;
 };
 
 export const TicketCardDetails = ({
   tagIds,
   propertiesData,
+  onTagsOverflowClick,
+  onPropertiesOverflowClick,
 }: TicketCardDetailsProps) => {
   const { fields } = useFields({ contentType: 'frontline:ticket' });
   const { tags } = useGetTags({ variables: { type: 'frontline:ticket' } });
@@ -121,19 +54,19 @@ export const TicketCardDetails = ({
   }
 
   return (
-    <Tooltip.Provider>
-      <div className="mt-1 flex flex-col gap-1 p-3 pt-0">
-        <DetailBadges
-          items={selectedTags}
-          color={TAG_COLOR}
-          maxVisibleItems={MAX_VISIBLE_TAGS}
-        />
-        <DetailBadges
-          items={propertyItems}
-          color={PROPERTY_COLOR}
-          maxVisibleItems={MAX_VISIBLE_PROPERTIES}
-        />
-      </div>
-    </Tooltip.Provider>
+    <div className="mt-1 flex flex-col gap-1 p-3 pt-0">
+      <CardDetailBadges
+        items={selectedTags}
+        color={TAG_COLOR}
+        maxVisibleItems={MAX_VISIBLE_TAGS}
+        onOverflowClick={onTagsOverflowClick}
+      />
+      <CardDetailBadges
+        items={propertyItems}
+        color={PROPERTY_COLOR}
+        maxVisibleItems={MAX_VISIBLE_PROPERTIES}
+        onOverflowClick={onPropertiesOverflowClick}
+      />
+    </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
@@ -1,50 +1,37 @@
 import { Badge, Tooltip } from 'erxes-ui';
-import { useFields, useGetTags, type IField } from 'ui-modules';
+import {
+  formatFieldValue,
+  hasFieldValue,
+  useFields,
+  useGetTags,
+  type IField,
+} from 'ui-modules';
 
-const MAX_VISIBLE_DETAILS = 5;
-
-const hasFieldValue = (value: unknown) => {
-  if (value === null || value === undefined || value === '') return false;
-  if (Array.isArray(value) && value.length === 0) return false;
-  return true;
-};
-
-const formatFieldValue = (field: IField, value: unknown): string => {
-  if (Array.isArray(value)) {
-    if (field.options?.length) {
-      return value
-        .map(
-          (item) =>
-            field.options?.find((option) => option.value === item)?.label ??
-            String(item),
-        )
-        .join(', ');
-    }
-    return value.join(', ');
-  }
-  if (field.options?.length) {
-    return (
-      field.options.find((option) => option.value === value)?.label ??
-      String(value)
-    );
-  }
-  if (field.type === 'boolean' || field.type === 'check') {
-    return value ? 'Yes' : 'No';
-  }
-  if (field.type === 'date') {
-    const date = new Date(value as string);
-    return Number.isNaN(date.getTime())
-      ? String(value)
-      : date.toLocaleDateString();
-  }
-  return String(value);
-};
+const MAX_VISIBLE_TAGS = 5;
+const MAX_VISIBLE_PROPERTIES = 3;
+const TAG_COLOR = '#FF6600';
+const PROPERTY_COLOR = '#0EA5E9';
 
 type CardDetailItem = {
   _id: string;
   name: string;
   colorCode?: string;
 };
+
+const getPropertyItems = (
+  fields: IField[],
+  propertiesData?: Record<string, unknown>,
+): CardDetailItem[] =>
+  fields
+    .filter((field) => hasFieldValue(propertiesData?.[field._id]))
+    .slice(0, MAX_VISIBLE_PROPERTIES)
+    .map((field) => ({
+      _id: field._id,
+      name: `${field.name}: ${formatFieldValue(
+        field,
+        propertiesData?.[field._id],
+      )}`,
+    }));
 
 const TooltipItemList = ({ items }: { items: string[] }) => (
   <div className="flex max-w-64 flex-col gap-1">
@@ -56,61 +43,58 @@ const TooltipItemList = ({ items }: { items: string[] }) => (
   </div>
 );
 
-const CardDetails = ({
+const DetailBadges = ({
   items,
   color,
+  maxVisibleItems,
 }: {
   items: CardDetailItem[];
   color: string;
+  maxVisibleItems: number;
 }) => {
   if (!items.length) {
     return null;
   }
 
-  const visibleItems = items.slice(0, MAX_VISIBLE_DETAILS);
+  const visibleItems = items.slice(0, maxVisibleItems);
   const remainingCount = items.length - visibleItems.length;
+  const remainingItems = items.slice(maxVisibleItems).map((item) => item.name);
 
   return (
-    <Tooltip.Provider>
-      <div className="flex flex-wrap gap-1">
-        {visibleItems.map((item, index) => (
-          <Tooltip key={`${item._id}-${index}`} delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="secondary"
-                className="h-5 max-w-full cursor-default px-1.5 font-normal"
-              >
-                <span
-                  className="size-1.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: item.colorCode || color }}
-                />
-                <span className="truncate">{item.name}</span>
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>{item.name}</Tooltip.Content>
-          </Tooltip>
-        ))}
-        {remainingCount > 0 && (
-          <Tooltip delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="ghost"
-                className="h-5 cursor-default px-1.5 hover:bg-muted"
-              >
-                +{remainingCount}
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>
-              <TooltipItemList
-                items={items
-                  .slice(MAX_VISIBLE_DETAILS)
-                  .map((item) => item.name)}
+    <div className="flex flex-wrap gap-1">
+      {visibleItems.map((item) => (
+        <Tooltip key={item._id} delayDuration={200}>
+          <Tooltip.Trigger asChild>
+            <Badge
+              variant="secondary"
+              className="h-5 max-w-full cursor-default px-1.5 font-normal"
+            >
+              <span
+                className="size-1.5 shrink-0 rounded-full"
+                style={{ backgroundColor: item.colorCode || color }}
               />
-            </Tooltip.Content>
-          </Tooltip>
-        )}
-      </div>
-    </Tooltip.Provider>
+              <span className="truncate">{item.name}</span>
+            </Badge>
+          </Tooltip.Trigger>
+          <Tooltip.Content>{item.name}</Tooltip.Content>
+        </Tooltip>
+      ))}
+      {remainingCount > 0 && (
+        <Tooltip delayDuration={200}>
+          <Tooltip.Trigger asChild>
+            <Badge
+              variant="ghost"
+              className="h-5 cursor-default px-1.5 hover:bg-muted"
+            >
+              +{remainingCount}
+            </Badge>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <TooltipItemList items={remainingItems} />
+          </Tooltip.Content>
+        </Tooltip>
+      )}
+    </div>
   );
 };
 
@@ -130,29 +114,26 @@ export const TicketCardDetails = ({
     .map((tagId) => tags?.find((tag) => tag._id === tagId))
     .filter((tag): tag is NonNullable<typeof tag> => Boolean(tag));
 
-  const propertyItems = (fields || [])
-    .filter(
-      (field) =>
-        field.isVisibleInCard && hasFieldValue(propertiesData?.[field._id]),
-    )
-    .map((field) => ({
-      _id: field._id,
-      name: `${field.name}: ${formatFieldValue(
-        field,
-        propertiesData?.[field._id],
-      )}`,
-    }));
+  const propertyItems = getPropertyItems(fields || [], propertiesData);
 
   if (!selectedTags.length && !propertyItems.length) {
     return null;
   }
 
   return (
-    <div className="flex flex-col gap-1 p-3 pt-0">
-      <div className="mt-1 flex flex-col gap-1">
-        <CardDetails items={selectedTags} color="#FF6600" />
-        <CardDetails items={propertyItems} color="#0EA5E9" />
+    <Tooltip.Provider>
+      <div className="mt-1 flex flex-col gap-1 p-3 pt-0">
+        <DetailBadges
+          items={selectedTags}
+          color={TAG_COLOR}
+          maxVisibleItems={MAX_VISIBLE_TAGS}
+        />
+        <DetailBadges
+          items={propertyItems}
+          color={PROPERTY_COLOR}
+          maxVisibleItems={MAX_VISIBLE_PROPERTIES}
+        />
       </div>
-    </div>
+    </Tooltip.Provider>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/ticket/graphql/queries/getTickets.ts
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/graphql/queries/getTickets.ts
@@ -27,6 +27,7 @@ export const GET_TICKETS = gql`
         number
         pipelineId
         state
+        propertiesData
       }
       ${GQL_PAGE_INFO}
       totalCount

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
@@ -16,14 +16,14 @@ import {
 } from 'ui-modules/modules/contacts';
 import { SelectTagsFilterBar } from 'ui-modules/modules/tags';
 import {
+  CardDetailBadges,
   formatFieldValue,
   hasFieldValue,
   useManageRelations,
   useFields,
+  type CardDetailBadgeItem,
 } from 'ui-modules';
 import {
-  type DealCardDetailItem,
-  DealCardDetails,
   DealCardProducts,
   DealCardRelationDetails,
 } from './DealsBoardCardDetails';
@@ -49,7 +49,7 @@ const normalizeSelectedIds = (value?: string | string[]) => {
 const normalizeCustomProperty = (
   property: unknown,
   index: number,
-): DealCardDetailItem | null => {
+): CardDetailBadgeItem | null => {
   if (typeof property !== 'object' || property === null) {
     return null;
   }
@@ -161,7 +161,7 @@ const CardDetails = ({ deal }: { deal: IDeal }) => {
   const customPropertyItems = Array.isArray(customProperties)
     ? customProperties
         .map((property, index) => normalizeCustomProperty(property, index))
-        .filter((item): item is DealCardDetailItem => Boolean(item))
+        .filter((item): item is CardDetailBadgeItem => Boolean(item))
     : [];
 
   if (
@@ -198,9 +198,21 @@ const CardDetails = ({ deal }: { deal: IDeal }) => {
         tags?.length || customPropertyItems.length || cardPropertyItems.length,
       ) && (
         <div className="mt-1 flex flex-col gap-1">
-          <DealCardDetails items={tags || []} color="#FF6600" />
-          <DealCardDetails items={customPropertyItems} color="#FF9900" />
-          <DealCardDetails items={cardPropertyItems} color="#0EA5E9" />
+          <CardDetailBadges
+            items={tags || []}
+            color="#FF6600"
+            maxVisibleItems={5}
+          />
+          <CardDetailBadges
+            items={customPropertyItems}
+            color="#FF9900"
+            maxVisibleItems={5}
+          />
+          <CardDetailBadges
+            items={cardPropertyItems}
+            color="#0EA5E9"
+            maxVisibleItems={5}
+          />
         </div>
       )}
     </div>

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCard.tsx
@@ -15,7 +15,12 @@ import {
   SelectCustomerFilterBar,
 } from 'ui-modules/modules/contacts';
 import { SelectTagsFilterBar } from 'ui-modules/modules/tags';
-import { useManageRelations, useFields, type IField } from 'ui-modules';
+import {
+  formatFieldValue,
+  hasFieldValue,
+  useManageRelations,
+  useFields,
+} from 'ui-modules';
 import {
   type DealCardDetailItem,
   DealCardDetails,
@@ -39,43 +44,6 @@ const normalizeSelectedIds = (value?: string | string[]) => {
   }
 
   return Array.isArray(value) ? value : [value];
-};
-
-const hasFieldValue = (value: unknown) => {
-  if (value === null || value === undefined || value === '') return false;
-  if (Array.isArray(value) && value.length === 0) return false;
-  return true;
-};
-
-const formatFieldValue = (field: IField, value: unknown): string => {
-  if (Array.isArray(value)) {
-    if (field.options?.length) {
-      return value
-        .map(
-          (v) =>
-            field.options?.find((option) => option.value === v)?.label ??
-            String(v),
-        )
-        .join(', ');
-    }
-    return value.join(', ');
-  }
-  if (field.options?.length) {
-    return (
-      field.options.find((option) => option.value === value)?.label ??
-      String(value)
-    );
-  }
-  if (field.type === 'boolean' || field.type === 'check') {
-    return value ? 'Yes' : 'No';
-  }
-  if (field.type === 'date') {
-    const date = new Date(value as string);
-    return Number.isNaN(date.getTime())
-      ? String(value)
-      : date.toLocaleDateString();
-  }
-  return String(value);
 };
 
 const normalizeCustomProperty = (

--- a/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCardDetails.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/boards/components/DealsBoardCardDetails.tsx
@@ -5,7 +5,7 @@ import {
   IconPackage,
   IconUsers,
 } from '@tabler/icons-react';
-import { Avatar, Badge, Tooltip, cn } from 'erxes-ui';
+import { Avatar, Tooltip, cn } from 'erxes-ui';
 
 export interface DealCardProductItem {
   _id: string;
@@ -22,12 +22,6 @@ export interface DealCardRelationItem {
   avatar?: string;
 }
 
-export interface DealCardDetailItem {
-  _id?: string;
-  name: string;
-  colorCode?: string;
-}
-
 type DealCardProductsProps = {
   items: DealCardProductItem[];
   label: string;
@@ -40,14 +34,8 @@ type DealCardRelationDetailsProps = {
   type: 'customer' | 'company' | 'department' | 'branch';
 };
 
-type DealCardDetailsProps = {
-  items: DealCardDetailItem[];
-  color: string;
-};
-
 const MAX_VISIBLE_PRODUCTS = 3;
 const MAX_VISIBLE_AVATARS = 3;
-const MAX_VISIBLE_DETAILS = 5;
 
 const RELATION_ICONS = {
   customer: IconUsers,
@@ -223,61 +211,6 @@ export const DealCardRelationDetails = ({
           <TooltipItemList items={items.map((item) => item.name)} />
         </Tooltip.Content>
       </Tooltip>
-    </Tooltip.Provider>
-  );
-};
-
-export const DealCardDetails = ({ items, color }: DealCardDetailsProps) => {
-  if (!items.length) {
-    return null;
-  }
-
-  const visibleItems = items.slice(0, MAX_VISIBLE_DETAILS);
-  const remainingCount = items.length - visibleItems.length;
-
-  return (
-    <Tooltip.Provider>
-      <div className="flex flex-wrap gap-1">
-        {visibleItems.map((item, index) => (
-          <Tooltip
-            key={`${item._id ?? item.name}-${index}`}
-            delayDuration={200}
-          >
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="secondary"
-                className="h-5 max-w-full cursor-default px-1.5 font-normal"
-              >
-                <span
-                  className="size-1.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: item.colorCode || color }}
-                />
-                <span className="truncate">{item.name}</span>
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>{item.name}</Tooltip.Content>
-          </Tooltip>
-        ))}
-        {remainingCount > 0 && (
-          <Tooltip delayDuration={200}>
-            <Tooltip.Trigger asChild>
-              <Badge
-                variant="ghost"
-                className="h-5 cursor-default px-1.5 hover:bg-muted"
-              >
-                +{remainingCount}
-              </Badge>
-            </Tooltip.Trigger>
-            <Tooltip.Content>
-              <TooltipItemList
-                items={items
-                  .slice(MAX_VISIBLE_DETAILS)
-                  .map((item) => item.name)}
-              />
-            </Tooltip.Content>
-          </Tooltip>
-        )}
-      </div>
     </Tooltip.Provider>
   );
 };


### PR DESCRIPTION
## Summary

- show ticket custom properties marked as visible on cards
- preserve ticket tag badges alongside property details
- include `propertiesData` in the ticket board query
- collapse overflow details behind a tooltip

## Validation

- `pnpm nx build frontline_ui --skip-nx-cache`
- `git diff --check`

## Summary by Sourcery

Show ticket properties on frontline board cards while preserving tag visibility and consolidating card detail presentation.

New Features:
- Display visible ticket custom properties alongside tags on frontline ticket cards.
- Open the ticket overview or properties tab from card detail overflow controls.

Enhancements:
- Centralize card detail badges and field-value formatting for reuse across frontline and sales cards.
- Add tooltip-based overflow handling for card tags and property details.

Chores:
- Include ticket property data in the board query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ticket cards now display relevant tags and custom-field details.
  * Property values are formatted for easier reading, including dates, options, arrays, and boolean fields.
  * Details appear as color-coded badges with tooltips, with overflow indicators for additional items.
  * Selecting an overflow indicator opens the relevant details view.
  * Ticket cards remain uncluttered when no details are available.
  * Deal cards use consistent formatting for custom-field values and detail badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->