### PR TITLE
feat(nav): pin Command and AI Agent only when those plugins load

### DIFF
--- a/frontend/core-ui/src/modules/navigation/components/NavigationActivityRail.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/NavigationActivityRail.tsx
@@ -1,10 +1,13 @@
+import { NavigationActivityButton } from '@/navigation/components/navigation-activity-rail/NavigationActivityButton';
 import { NavigationActivityGroups } from '@/navigation/components/navigation-activity-rail/NavigationActivityGroups';
 import { NavigationActivitySearchButton } from '@/navigation/components/navigation-activity-rail/NavigationActivitySearchButton';
 import { NavigationFavoritesSection } from '@/navigation/components/navigation-activity-rail/NavigationFavoritesSection';
+import { NavigationInboxButton } from '@/navigation/components/navigation-activity-rail/NavigationInboxButton';
 import { NavigationActivityMore } from '@/navigation/components/NavigationActivityMore';
 import { NavigationRailLogo } from '@/navigation/components/NavigationRailLogo';
 import { NavigationSidebarFooter } from '@/navigation/components/NavigationSidebarFooter';
 import { INavigationActivity } from '@/navigation/types/NavigationActivity';
+import { splitPromotedNavigationActivities } from '@/navigation/utils/promotedNavigationActivities';
 import { cn, Sidebar } from 'erxes-ui';
 
 export const NavigationActivityRail = ({
@@ -35,6 +38,9 @@ export const NavigationActivityRail = ({
   const { isMobile, state } = Sidebar.useSidebar();
   const expanded = isMobile ? mobileExpanded : state === 'expanded';
   const hoverEnabled = !expanded && !isMobile;
+  const { promoted, rest } = splitPromotedNavigationActivities(activities);
+  const visibleRest = splitPromotedNavigationActivities(visibleActivities).rest;
+  const usePromotedRail = promoted.length > 0;
 
   return (
     <aside
@@ -45,7 +51,33 @@ export const NavigationActivityRail = ({
       )}
     >
       <NavigationRailLogo expanded={expanded} />
-      <NavigationActivitySearchButton expanded={expanded} onSearch={onSearch} />
+      {usePromotedRail ? (
+        <div className="mb-1 flex shrink-0 flex-col gap-1">
+          <NavigationInboxButton
+            expanded={expanded}
+            isInboxActive={isInboxActive}
+            onSelectInbox={onSelectInbox}
+          />
+          <NavigationActivitySearchButton
+            expanded={expanded}
+            onSearch={onSearch}
+          />
+          {promoted.map((activity) => (
+            <NavigationActivityButton
+              key={activity.id}
+              activity={activity}
+              active={!isSettings && activity.id === activeActivityId}
+              expanded={expanded}
+              onSelect={() => onSelectActivity(activity)}
+            />
+          ))}
+        </div>
+      ) : (
+        <NavigationActivitySearchButton
+          expanded={expanded}
+          onSearch={onSearch}
+        />
+      )}
       <div
         className={cn(
           'flex min-h-0 flex-1 flex-col items-stretch gap-1 overflow-x-hidden overflow-y-auto',
@@ -56,10 +88,11 @@ export const NavigationActivityRail = ({
           expanded={expanded}
           isInboxActive={isInboxActive}
           onSelectInbox={onSelectInbox}
+          showInbox={!usePromotedRail}
         />
         <NavigationActivityGroups
           activeActivityId={activeActivityId}
-          activities={visibleActivities}
+          activities={usePromotedRail ? visibleRest : visibleActivities}
           expanded={expanded}
           hoverEnabled={hoverEnabled}
           isActivityPinned={isActivityPinned}
@@ -68,7 +101,7 @@ export const NavigationActivityRail = ({
           onSelectActivity={onSelectActivity}
         />
         <NavigationActivityMore
-          activities={activities}
+          activities={usePromotedRail ? rest : activities}
           expanded={expanded}
           isActivityPinned={isActivityPinned}
           onPinnedChange={onActivityPinnedChange}

--- a/frontend/core-ui/src/modules/navigation/components/navigation-activity-rail/NavigationFavoritesSection.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/navigation-activity-rail/NavigationFavoritesSection.tsx
@@ -1,39 +1,36 @@
-import { NavigationActivityButton } from '@/navigation/components/navigation-activity-rail/NavigationActivityButton';
+import { NavigationInboxButton } from '@/navigation/components/navigation-activity-rail/NavigationInboxButton';
 import { NavigationActivitySection } from '@/navigation/components/navigation-activity-rail/NavigationActivitySection';
 import { SidebarNavigationFavorites } from '@/navigation/components/SidebarNavigationFavorites';
-import { INavigationActivity } from '@/navigation/types/NavigationActivity';
-import { NotificationCount } from '@/notification/components/MyInboxNavigationItem';
-import { IconInbox } from '@tabler/icons-react';
+import { useFavorites } from '@/navigation/hooks/useFavorites';
 import { useTranslation } from 'react-i18next';
 
 export const NavigationFavoritesSection = ({
   expanded,
   isInboxActive,
   onSelectInbox,
+  showInbox = true,
 }: Readonly<{
   expanded: boolean;
   isInboxActive: boolean;
   onSelectInbox: () => void;
+  showInbox?: boolean;
 }>) => {
   const { t } = useTranslation('common', { keyPrefix: 'sidebar' });
-  const inboxActivity: INavigationActivity = {
-    id: 'navigation:inbox',
-    label: t('my-inbox'),
-    icon: IconInbox,
-    kind: 'core',
-    modules: [],
-    defaultPath: 'my-inbox',
-  };
+  const favorites = useFavorites();
+
+  if (!showInbox && favorites.length === 0) {
+    return null;
+  }
 
   return (
     <NavigationActivitySection expanded={expanded} label={t('favorites')}>
-      <NavigationActivityButton
-        activity={inboxActivity}
-        active={isInboxActive}
-        expanded={expanded}
-        indicator={<NotificationCount />}
-        onSelect={onSelectInbox}
-      />
+      {showInbox ? (
+        <NavigationInboxButton
+          expanded={expanded}
+          isInboxActive={isInboxActive}
+          onSelectInbox={onSelectInbox}
+        />
+      ) : null}
       <SidebarNavigationFavorites expanded={expanded} />
     </NavigationActivitySection>
   );

--- a/frontend/core-ui/src/modules/navigation/components/navigation-activity-rail/NavigationInboxButton.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/navigation-activity-rail/NavigationInboxButton.tsx
@@ -1,0 +1,35 @@
+import { NavigationActivityButton } from '@/navigation/components/navigation-activity-rail/NavigationActivityButton';
+import { INavigationActivity } from '@/navigation/types/NavigationActivity';
+import { NotificationCount } from '@/notification/components/MyInboxNavigationItem';
+import { IconInbox } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+
+export const NavigationInboxButton = ({
+  expanded,
+  isInboxActive,
+  onSelectInbox,
+}: Readonly<{
+  expanded: boolean;
+  isInboxActive: boolean;
+  onSelectInbox: () => void;
+}>) => {
+  const { t } = useTranslation('common', { keyPrefix: 'sidebar' });
+  const inboxActivity: INavigationActivity = {
+    id: 'navigation:inbox',
+    label: t('my-inbox'),
+    icon: IconInbox,
+    kind: 'core',
+    modules: [],
+    defaultPath: 'my-inbox',
+  };
+
+  return (
+    <NavigationActivityButton
+      activity={inboxActivity}
+      active={isInboxActive}
+      expanded={expanded}
+      indicator={<NotificationCount />}
+      onSelect={onSelectInbox}
+    />
+  );
+};

--- a/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.spec.ts
+++ b/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.spec.ts
@@ -1,0 +1,56 @@
+import { INavigationActivity } from '@/navigation/types/NavigationActivity';
+import {
+  getPromotedNavigationRank,
+  isPromotedNavigationActivity,
+  splitPromotedNavigationActivities,
+} from '@/navigation/utils/promotedNavigationActivities';
+
+const activity = (
+  defaultPath: string,
+  id = defaultPath,
+): INavigationActivity => ({
+  id,
+  label: id,
+  kind: 'plugin',
+  modules: [],
+  defaultPath,
+});
+
+describe('promoted navigation activities', () => {
+  it('ranks Command before AI Agent', () => {
+    expect(getPromotedNavigationRank(activity('cf-os'))).toBe(0);
+    expect(getPromotedNavigationRank(activity('erxes-agent'))).toBe(1);
+    expect(getPromotedNavigationRank(activity('/cf-os/'))).toBe(0);
+  });
+
+  it('leaves other plugins unpromoted', () => {
+    expect(isPromotedNavigationActivity(activity('sales'))).toBe(false);
+    expect(isPromotedNavigationActivity(activity('erxes-agent/agents'))).toBe(
+      false,
+    );
+  });
+
+  it('pulls Command and AI Agent out of the plugin list and sorts them', () => {
+    const sales = activity('sales');
+    const agent = activity('erxes-agent', 'AI Agent');
+    const command = activity('cf-os', 'command');
+    const operation = activity('operation');
+
+    expect(
+      splitPromotedNavigationActivities([sales, agent, command, operation]),
+    ).toEqual({
+      promoted: [command, agent],
+      rest: [sales, operation],
+    });
+  });
+
+  it('keeps the full plugin list when neither product is loaded', () => {
+    const sales = activity('sales');
+    const operation = activity('operation');
+
+    expect(splitPromotedNavigationActivities([sales, operation])).toEqual({
+      promoted: [],
+      rest: [sales, operation],
+    });
+  });
+});

--- a/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.ts
+++ b/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.ts
@@ -1,0 +1,41 @@
+import { INavigationActivity } from '@/navigation/types/NavigationActivity';
+
+/** Rail order under Search: Command, then AI Agent. Matched on plugin defaultPath. */
+const PROMOTED_NAVIGATION_RANK: Record<string, number> = {
+  'cf-os': 0,
+  'erxes-agent': 1,
+};
+
+const trimPath = (path: string) => path.replace(/^\/+|\/+$/g, '');
+
+export const getPromotedNavigationRank = (activity: INavigationActivity) => {
+  const rank = PROMOTED_NAVIGATION_RANK[trimPath(activity.defaultPath)];
+
+  return rank === undefined ? null : rank;
+};
+
+export const isPromotedNavigationActivity = (activity: INavigationActivity) =>
+  getPromotedNavigationRank(activity) !== null;
+
+export const splitPromotedNavigationActivities = (
+  activities: INavigationActivity[],
+) => {
+  const promoted: INavigationActivity[] = [];
+  const rest: INavigationActivity[] = [];
+
+  for (const activity of activities) {
+    if (isPromotedNavigationActivity(activity)) {
+      promoted.push(activity);
+    } else {
+      rest.push(activity);
+    }
+  }
+
+  promoted.sort(
+    (left, right) =>
+      (getPromotedNavigationRank(left) ?? 0) -
+      (getPromotedNavigationRank(right) ?? 0),
+  );
+
+  return { promoted, rest };
+};


### PR DESCRIPTION
## Summary
- Tenants without Command or AI Agent would have gotten a surprise sidebar if we shipped the inbox/search stack to every `erxes-next-ui` image.
- The new rail (My inbox, Search, then Command / AI Agent) only turns on when a `cf-os` or `erxes-agent` plugin actually loaded. Everyone else keeps Search on top and My inbox under Favorites.

## Test plan
- [ ] Tenant with neither plugin: rail matches current production (Search, then Favorites with My inbox).
- [ ] Tenant with Command and/or AI Agent: order is My inbox, Search, Command, AI Agent. Those two stay out of Plugins / More.
- [ ] Favorites with the new rail is stars only, and the section hides when empty.
- [ ] Inbox badge still shows in both layouts.

## Summary by Sourcery

Show a plugin-aware navigation rail that promotes Command and AI Agent only when available while preserving the existing layout for other tenants.

New Features:
- Promote Command and AI Agent into a dedicated navigation rail when their plugins are loaded.
- Keep My Inbox visible with its notification badge in the promoted rail layout.

Bug Fixes:
- Prevent tenants without Command or AI Agent plugins from receiving the new promoted navigation rail.
- Keep Favorites focused on user-starred items and hide the section when it is empty.

Enhancements:
- Centralize promoted navigation detection and ordering so Command precedes AI Agent while other plugins remain in their existing locations.

Tests:
- Add coverage for promoted navigation ranking, filtering, ordering, and fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promoted activities now appear prominently in the navigation rail.
  * Inbox, search, and promoted activities are grouped at the top for quicker access.
  * Inbox notifications remain visible through a dedicated inbox entry.
* **Improvements**
  * Favorites, groups, and additional activities are organized more clearly when promoted activities are available.
  * Navigation activities are consistently prioritized and ordered.
* **Tests**
  * Added coverage for activity promotion, ranking, ordering, and preservation of other activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->