### PR TITLE
chore(nav): note that the promoted rail is remote-gated

### DIFF
--- a/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.ts
+++ b/frontend/core-ui/src/modules/navigation/utils/promotedNavigationActivities.ts
@@ -1,6 +1,6 @@
 import { INavigationActivity } from '@/navigation/types/NavigationActivity';
 
-/** Rail order under Search: Command, then AI Agent. Matched on plugin defaultPath. */
+/** Rail order under Search: Command, then AI Agent. Matched on plugin defaultPath. If neither remote loaded, keep the old rail. */
 const PROMOTED_NAVIGATION_RANK: Record<string, number> = {
   'cf-os': 0,
   'erxes-agent': 1,


### PR DESCRIPTION
## Summary
- #9168 already landed the sidebar, but it came from a fork so `core-ui-ci` never ran as a `push` to `main` and `erxes-next-ui` was not published.
- Same-repo branch, one comment under `frontend/core-ui`, so the existing path filter fires. No workflow edits.

## Test plan
- [ ] PR run of `core-ui-ci` starts (build only, no Docker Hub login).
- [ ] After merge, `core-ui-ci` runs as `push` on `main` and pushes `erxes/erxes-next-ui`.

## Summary by Sourcery

Enhancements:
- Clarify that the promoted navigation rail falls back to its existing behavior until the required remote plugins are loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation guidance to clarify that the existing navigation rail is retained when no remote plugins are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->