### PR TITLE
fix(content): sync page detail header language

### DIFF
--- a/frontend/plugins/content_ui/src/modules/cms/shared/HeaderLanguageTabs.tsx
+++ b/frontend/plugins/content_ui/src/modules/cms/shared/HeaderLanguageTabs.tsx
@@ -27,10 +27,8 @@ export const HeaderLanguageTabs = ({
   const availableLanguages: string[] = cmsConfig?.languages || [];
   const defaultLanguage: string = cmsConfig?.language || 'en';
 
-  // In editor mode (onLanguageChange provided) the form owns the active
-  // language and mirrors it into this atom, so the tabs simply reflect it —
-  // exactly like the sidebar selector. We must not reset or write the atom
-  // here, or we'd fight the form and desync the highlight from the content.
+  // In editor mode (onLanguageChange provided) the form owns the content for
+  // the active language and mirrors it into this atom.
   const isEditorMode = Boolean(onLanguageChange);
 
   useEffect(() => {
@@ -56,12 +54,13 @@ export const HeaderLanguageTabs = ({
   const activeLanguage = selectedLanguage || defaultLanguage;
 
   const handleClick = (lang: string) => {
-    // Editor mode: drive the form, which mirrors the choice back into the atom.
-    // List mode: this atom is the source of truth for the list query.
+    // Commit the header selection immediately. This also re-synchronizes the
+    // atom when the editor already has the requested language and its handler
+    // therefore has no local state change to mirror back.
+    setSelectedLanguage(lang);
+
     if (onLanguageChange) {
       onLanguageChange(lang);
-    } else {
-      setSelectedLanguage(lang);
     }
   };
 


### PR DESCRIPTION
## Summary

- update the CMS header language state immediately when a language button is clicked
- keep the page editor callback synchronized with the selected header language
- fix the EN to MN switch when the editor already considers MN active

## Validation

- `pnpm nx test content_ui --runInBand`
- `pnpm nx build content_ui`

## Known validation issue

- `pnpm nx lint content_ui` remains blocked by six pre-existing errors in unrelated custom-fields, custom-types, and client-portal files.

## Summary by Sourcery

Bug Fixes:
- Synchronize the CMS header language selection immediately with the page editor and prevent language switches from becoming stale when the editor already has the requested language active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language tab selection so the chosen language is consistently updated across CMS views.
  - Ensured editor-specific language change actions are triggered reliably when selecting a language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->