### PR TITLE
fix(frontline): support Facebook page access tokens

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/constants.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/constants.ts
@@ -19,12 +19,11 @@ export const INTEGRATION_KINDS = {
   ALL: ['facebook-post', 'facebook-messenger'],
 };
 
-export const SUBSCRIBED_FIELDS = [
-  'conversations',
-  'feed',
-  'messages',
-  'standby',
-  'messaging_handovers',
-  'messaging_postbacks',
-  'messaging_referrals',
-];
+export const SUBSCRIBED_FIELDS_BY_KIND: Record<string, string[]> = {
+  [INTEGRATION_KINDS.MESSENGER]: [
+    'messages',
+    'messaging_postbacks',
+    'messaging_referrals',
+  ],
+  [INTEGRATION_KINDS.POST]: ['feed'],
+};

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/db/models/Bots.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/db/models/Bots.ts
@@ -1,4 +1,7 @@
-import { SUBSCRIBED_FIELDS } from '@/integrations/facebook/constants';
+import {
+  INTEGRATION_KINDS,
+  SUBSCRIBED_FIELDS_BY_KIND,
+} from '@/integrations/facebook/constants';
 import {
   getPageAccessToken,
   graphRequest,
@@ -614,8 +617,8 @@ export const loadFacebookBotClass = (models: IModels, subdomain: string) => {
         (item) => item?.subscribed_fields || [],
       );
 
-      return SUBSCRIBED_FIELDS.every((field) =>
-        subscribedFields.includes(field),
+      return SUBSCRIBED_FIELDS_BY_KIND[INTEGRATION_KINDS.MESSENGER].every(
+        (field) => subscribedFields.includes(field),
       );
     }
 
@@ -891,7 +894,10 @@ export const loadFacebookBotClass = (models: IModels, subdomain: string) => {
       let pageTokenResponse;
 
       try {
-        pageTokenResponse = await getPageAccessToken(pageId, account.token);
+        pageTokenResponse =
+          account.scope === 'page_access_token'
+            ? account.token
+            : await getPageAccessToken(pageId, account.token);
       } catch (e) {
         console.error(
           `Error ocurred while trying to get page access token with ${e.message}`,
@@ -959,10 +965,10 @@ export const loadFacebookBotClass = (models: IModels, subdomain: string) => {
           throw new Error('Not found account');
         }
 
-        const pageAccessToken = await getPageAccessToken(
-          bot.pageId,
-          relatedAccount.token,
-        );
+        const pageAccessToken =
+          relatedAccount.scope === 'page_access_token'
+            ? relatedAccount.token
+            : await getPageAccessToken(bot.pageId, relatedAccount.token);
 
         if (bot.token !== pageAccessToken) {
           bot.token = pageAccessToken;

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/mutations.ts
@@ -4,7 +4,11 @@ import {
   updateConfigs,
 } from '@/integrations/facebook/helpers';
 import { IReplyParams } from '@/integrations/facebook/@types/utils';
-import { sendReply } from '@/integrations/facebook/utils';
+import { graphRequest, sendReply } from '@/integrations/facebook/utils';
+import {
+  facebookAccountSelector,
+  resolveFacebookApp,
+} from '@/integrations/facebook/commonUtils';
 import {
   ICreatePostArgs,
   publishPagePost,
@@ -12,6 +16,76 @@ import {
 import { sendNotifications } from '@/inbox/graphql/resolvers/mutations/conversations';
 import { TCreateBotInputDoc } from '../../db/models/Bots';
 export const facebookMutations = {
+  async facebookConnectPageToken(
+    _root,
+    {
+      pageAccessToken,
+      integrationKind,
+    }: { pageAccessToken: string; integrationKind: string },
+    { models, checkPermission }: IContext,
+  ) {
+    await checkPermission('integrationsEdit');
+
+    const token = pageAccessToken.trim();
+
+    if (!token) {
+      throw new Error('Page access token is required');
+    }
+
+    const app = await resolveFacebookApp(models, integrationKind);
+    const debugResponse = (await graphRequest.get(
+      `/debug_token?input_token=${encodeURIComponent(token)}`,
+      `${app.appId}|${app.appSecret}`,
+    )) as {
+      data?: {
+        app_id?: string;
+        data_id?: string;
+        is_valid?: boolean;
+        profile_id?: string;
+        granular_scopes?: Array<{ target_ids?: string[] }>;
+      };
+    };
+    const tokenData = debugResponse.data;
+    const granularTargetId = tokenData?.granular_scopes
+      ?.flatMap(({ target_ids = [] }) => target_ids)
+      .find(Boolean);
+    const pageId =
+      tokenData?.profile_id || tokenData?.data_id || granularTargetId;
+
+    if (!tokenData?.is_valid || tokenData.app_id !== app.appId || !pageId) {
+      throw new Error(
+        'The token must be a valid Facebook Page token for the configured app',
+      );
+    }
+
+    const pageName = `Facebook Page ${pageId}`;
+    const selector = facebookAccountSelector(pageId, app);
+    const accountData = {
+      kind: 'facebook',
+      token,
+      scope: 'page_access_token',
+      name: pageName,
+      uid: pageId,
+      appId: app.appId,
+    };
+    const existingAccount = await models.FacebookAccounts.findOne(selector);
+    const account = existingAccount
+      ? await models.FacebookAccounts.findByIdAndUpdate(
+          existingAccount._id,
+          { $set: accountData },
+          { new: true },
+        )
+      : await models.FacebookAccounts.create(accountData);
+
+    if (!account) {
+      throw new Error('Failed to save the Facebook Page account');
+    }
+
+    return {
+      account: { _id: account._id, name: account.name },
+      page: { id: pageId, name: pageName },
+    };
+  },
   async facebookUpdateConfigs(
     _root,
     { configsMap },

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/queries.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/resolvers/queries.ts
@@ -279,7 +279,22 @@ export const facebookQueries = {
     let pages: any[] = [];
 
     try {
-      pages = await getPageList(models, accessToken, kind);
+      if (account.scope === 'page_access_token') {
+        const integration = await models.FacebookIntegrations.findOne({
+          facebookPageIds: account.uid,
+          kind,
+        });
+
+        pages = [
+          {
+            id: account.uid,
+            name: account.name,
+            isUsed: Boolean(integration),
+          },
+        ];
+      } else {
+        pages = await getPageList(models, accessToken, kind);
+      }
     } catch (e) {
       if (!e.message.includes('Application request limit reached')) {
         await models.Integrations.updateOne(

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/schema/facebook.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/graphql/schema/facebook.ts
@@ -173,6 +173,7 @@ export const queries = `
 
 export const mutations = `
   facebookUpdateConfigs(configsMap: JSON!): JSON
+  facebookConnectPageToken(pageAccessToken: String!, integrationKind: String!): JSON
   facebookRepair(_id: String!): JSON
   facebookReplyToComment(conversationId: String, commentId: String, content: String): FacebookComment
   facebookCreatePost(erxesApiId: String!, pageId: String!, message: String!, link: String, imageKeys: [String]): JSON

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/helpers.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/helpers.ts
@@ -52,7 +52,10 @@ export const removeIntegration = async (
       let pageTokenResponse;
 
       try {
-        pageTokenResponse = await getPageAccessToken(pageId, account.token);
+        pageTokenResponse =
+          account.scope === 'page_access_token'
+            ? account.token
+            : await getPageAccessToken(pageId, account.token);
       } catch (e) {
         debugError(
           `Error occurred while trying to get page access token with ${e.message}`,
@@ -176,7 +179,7 @@ export const repairIntegrations = async (
       integration,
     );
 
-    await subscribePage(models, pageId, pageTokens[pageId]);
+    await subscribePage(models, pageId, pageTokens[pageId], integration.kind);
 
     models.FacebookBots.reviveByPageId({
       pageId,
@@ -294,12 +297,15 @@ export const facebookCreateIntegration = async (
     for (const pageId of facebookPageIds) {
       try {
         // Get the access token for the page
-        const pageAccessToken = await getPageAccessToken(pageId, account.token);
+        const pageAccessToken =
+          account.scope === 'page_access_token'
+            ? account.token
+            : await getPageAccessToken(pageId, account.token);
         facebookPageTokensMap[pageId] = pageAccessToken;
 
         try {
           // Subscribe the page using the access token
-          await subscribePage(models, pageId, pageAccessToken);
+          await subscribePage(models, pageId, pageAccessToken, kind);
           debugFacebook(`Successfully subscribed page ${pageId}`);
         } catch (e) {
           // Log and throw error if subscription fails

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/utils.ts
@@ -9,14 +9,14 @@ import * as AWS from 'aws-sdk';
 import { randomAlphanumeric, sendTRPCMessage } from 'erxes-api-shared/utils';
 import * as graph from 'fbgraph';
 import { IModels } from '~/connectionResolvers';
-import { SUBSCRIBED_FIELDS } from './constants';
+import { SUBSCRIBED_FIELDS_BY_KIND } from './constants';
 import { validateMediaUrl } from './urlValidation';
 
 export const graphRequest = {
   base(method: string, path?: any, accessToken?: any, ...otherParams) {
     // set access token
     graph.setAccessToken(accessToken);
-    graph.setVersion('7.0');
+    graph.setVersion('26.0');
 
     return new Promise((resolve, reject) => {
       graph[method](path, ...otherParams, (error, response) => {
@@ -123,7 +123,7 @@ export const uploadUnpublishedPhotoFromKey = async (
 
   try {
     const response = await fetch(
-      `https://graph.facebook.com/v7.0/${pageId}/photos`,
+      `https://graph.facebook.com/v26.0/${pageId}/photos`,
       { method: 'POST', body: form },
     );
 
@@ -411,7 +411,10 @@ export const refreshPageAccessToken = async (
 
   const facebookPageTokensMap = integration.facebookPageTokensMap || {};
 
-  const pageAccessToken = await getPageAccessToken(pageId, account.token);
+  const pageAccessToken =
+    account.scope === 'page_access_token'
+      ? account.token
+      : await getPageAccessToken(pageId, account.token);
 
   facebookPageTokensMap[pageId] = pageAccessToken;
 
@@ -429,9 +432,10 @@ export const subscribePage = async (
   models: IModels,
   pageId,
   pageToken,
+  kind: string,
 ): Promise<{ success: true } | any> => {
   return graphRequest.post(`${pageId}/subscribed_apps`, pageToken, {
-    subscribed_fields: SUBSCRIBED_FIELDS,
+    subscribed_fields: SUBSCRIBED_FIELDS_BY_KIND[kind] || [],
   });
 };
 

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookGetAccounts.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookGetAccounts.tsx
@@ -3,11 +3,17 @@ import {
   Button,
   cn,
   Command,
+  Form,
   Input,
   REACT_APP_API_URL,
   RadioGroup,
   Spinner,
+  useToast,
 } from 'erxes-ui';
+import { useMutation } from '@apollo/client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 import { useFacebookAccounts } from '../hooks/useFacebookAccounts';
 import { IconBrandFacebook } from '@tabler/icons-react';
 import { useAtom, useSetAtom } from 'jotai';
@@ -23,6 +29,14 @@ import {
 import { useFacebookPages } from '../hooks/useFacebookPages';
 import { useFbAuthPopup } from '../hooks/useFbAuthPopup';
 import { useFbIntegrationContext } from '../contexts/FbIntegrationContext';
+import { SecretInput } from '@/integrations/components/SecretInput';
+import { FACEBOOK_CONNECT_PAGE_TOKEN } from '../graphql/mutations/fbConfig';
+
+const PAGE_TOKEN_SCHEMA = z.object({
+  pageAccessToken: z.string().trim().min(1, 'Page access token is required'),
+});
+
+type TPageTokenForm = z.infer<typeof PAGE_TOKEN_SCHEMA>;
 
 const FacebookAccountRow = ({
   account,
@@ -76,6 +90,17 @@ export const FacebookGetAccounts = () => {
   const setActiveStep = useSetAtom(activeFacebookFormStepAtom);
   const [searchTerm, setSearchTerm] = useState('');
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const { toast } = useToast();
+  const pageTokenForm = useForm<TPageTokenForm>({
+    resolver: zodResolver(PAGE_TOKEN_SCHEMA),
+    defaultValues: { pageAccessToken: '' },
+  });
+  const [connectPageToken, { loading: connectingPageToken }] = useMutation<{
+    facebookConnectPageToken: {
+      account: { _id: string; name: string };
+      page: { id: string; name: string };
+    };
+  }>(FACEBOOK_CONNECT_PAGE_TOKEN);
 
   const { popupWindow } = useFbAuthPopup(() => {
     refetch();
@@ -90,6 +115,33 @@ export const FacebookGetAccounts = () => {
       660,
       750,
     );
+  };
+
+  const handlePageTokenConnect = async ({
+    pageAccessToken,
+  }: TPageTokenForm) => {
+    await connectPageToken({
+      variables: { pageAccessToken, integrationKind },
+      onCompleted: ({ facebookConnectPageToken }) => {
+        setSelectedAccount(facebookConnectPageToken.account._id);
+        pageTokenForm.reset();
+        refetch();
+        toast({
+          title: t('success'),
+          description: t('facebook-page-token-connected', {
+            defaultValue: 'Facebook Page connected',
+          }),
+          variant: 'success',
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+      },
+    });
   };
 
   const onNext = () => setActiveStep(2);
@@ -160,6 +212,49 @@ export const FacebookGetAccounts = () => {
               )}
             </Button>
           </div>
+
+          <Form {...pageTokenForm}>
+            <form
+              className="flex items-start gap-2 px-1 pb-2"
+              onSubmit={pageTokenForm.handleSubmit(handlePageTokenConnect)}
+            >
+              <Form.Field
+                control={pageTokenForm.control}
+                name="pageAccessToken"
+                render={({ field }) => (
+                  <Form.Item className="flex-1">
+                    <Form.Label>
+                      {t('facebook-page-access-token', {
+                        defaultValue: 'Page access token',
+                      })}
+                    </Form.Label>
+                    <Form.Control>
+                      <SecretInput
+                        {...field}
+                        autoComplete="off"
+                        placeholder={t('paste-facebook-page-access-token', {
+                          defaultValue: 'Paste a Page access token',
+                        })}
+                      />
+                    </Form.Control>
+                    <Form.Message />
+                  </Form.Item>
+                )}
+              />
+              <Button
+                type="submit"
+                variant="outline"
+                className="mt-6"
+                disabled={connectingPageToken}
+              >
+                {connectingPageToken ? (
+                  <Spinner className="size-4" />
+                ) : (
+                  t('connect-page-token', { defaultValue: 'Connect token' })
+                )}
+              </Button>
+            </form>
+          </Form>
 
           <RadioGroup
             value={selectedAccount}

--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/graphql/mutations/fbConfig.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/graphql/mutations/fbConfig.ts
@@ -6,6 +6,18 @@ export const FACEBOOK_UPDATE_CONFIGS = gql`
   }
 `;
 
+export const FACEBOOK_CONNECT_PAGE_TOKEN = gql`
+  mutation FacebookConnectPageToken(
+    $pageAccessToken: String!
+    $integrationKind: String!
+  ) {
+    facebookConnectPageToken(
+      pageAccessToken: $pageAccessToken
+      integrationKind: $integrationKind
+    )
+  }
+`;
+
 export const FACEBOOK_REPAIR = gql`
   mutation FacebookRepair($_id: String!, $kind: String!) {
     integrationsRepair(_id: $_id, kind: $kind)


### PR DESCRIPTION
## Summary

- add a permission-gated flow for connecting Facebook pages with a Page access token
- reuse stored Page tokens across page listing, integration creation, repair, refresh, and bot health checks
- subscribe to webhook fields by integration kind and update Facebook Graph API calls to v26.0

## Validation

- `pnpm nx run-many -t build -p frontline_api frontline_ui --parallel=2`
- focused ESLint completed with one pre-existing `@typescript-eslint/no-wrapper-object-types` error at `backend/plugins/frontline_api/src/modules/integrations/facebook/db/models/Bots.ts:31`

## Summary by Sourcery

Support connecting and managing Facebook Page integrations with Page access tokens.

New Features:
- Add a permission-gated UI and API flow for connecting Facebook Pages with a Page access token.

Bug Fixes:
- Reuse stored Page access tokens across Facebook page discovery, integration lifecycle operations, token refresh, and bot health checks.

Enhancements:
- Subscribe to webhook fields according to the Facebook integration kind.
- Upgrade Facebook Graph API requests to version 26.0.