### PR TITLE
docs: fix README environment template filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd erxes
 pnpm install
 
 # Set up environment variables
-cp .env.example .env
+cp .env.sample .env
 # Edit .env and configure MONGO_URL, REDIS_HOST, etc.
 
 # Start core services (Gateway + Core API)


### PR DESCRIPTION
## What
Updated the README Quick Start command from `.env.example` to `.env.sample`.

## Why
`.env.example` does not exist in the repository, while `.env.sample` is the available environment template. The old command prevented a fresh setup from working.

## How
Changed one line in `README.md`. No application code or dependencies were modified.

## Testing
Confirmed that `.env.sample` exists.
Confirmed that `.env.example` does not exist.
Ran `git diff --check`.
Confirmed that only `README.md` was changed.

Closes #9175

## Summary by Sourcery

Correct the Quick Start environment setup instructions to reference the available template file.

Bug Fixes:
- Fix the README Quick Start environment setup command to use the repository’s available `.env.sample` template.

Documentation:
- Correct the README environment template filename so fresh setup instructions work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the environment setup instructions to use `.env.sample` when creating the local `.env` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->