### PR TITLE
fix(core): normalize custom field value keys

### DIFF
--- a/backend/core-api/src/modules/properties/db/models/Field.ts
+++ b/backend/core-api/src/modules/properties/db/models/Field.ts
@@ -232,7 +232,7 @@ export const loadFieldClass = (models: IModels) => {
         }
 
         try {
-          result[fieldName] = await this.validateFieldValue(
+          result[fieldId] = await this.validateFieldValue(
             fieldId,
             fieldValue,
           );


### PR DESCRIPTION
## What changed

Custom field values provided by code are now stored under the resolved field ID, matching how the UI reads them.

## Validation

- ESLint passed for the changed file
- Core API TypeScript check passed

Fixes #8856