### PR TITLE
fix(team-members): show name and status for deactivated/deleted assig…

### DIFF
--- a/frontend/core-ui/src/modules/settings/team-member/components/record/TeamMemberColumns.tsx
+++ b/frontend/core-ui/src/modules/settings/team-member/components/record/TeamMemberColumns.tsx
@@ -73,7 +73,7 @@ export const teamMemberColumns: (t: TFunction) => ColumnDef<IUser>[] = (t) => {
         const setRenderingTeamMemberDetail = useSetAtom(
           renderingTeamMemberDetailAtom,
         );
-        const { details, _id } = cell.row.original;
+        const { details, _id, isActive } = cell.row.original;
         const { firstName, lastName, ...rest } = details || {};
 
         const { usersEdit } = useUserEdit();
@@ -117,6 +117,12 @@ export const teamMemberColumns: (t: TFunction) => ColumnDef<IUser>[] = (t) => {
                 }}
               >
                 <FullNameValue />
+                {isActive === false && (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    ({t('deactivated', { defaultValue: 'deactivated' })})
+                  </span>
+                )}
               </Badge>
             </RecordTableInlineCell.Trigger>
           </FullNameField>

--- a/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
@@ -244,7 +244,9 @@ export const MembersInlineAvatar = ({
             size={size || 'lg'}
             {...props}
           >
-            {!isDeleted && <Avatar.Image src={readImage(avatar as string, 200)} />}
+            {!isDeleted && (
+              <Avatar.Image src={readImage(avatar as string, 200)} />
+            )}
             <Avatar.Fallback>
               {isDeleted ? (
                 <IconUserCancel className="size-3.5" />

--- a/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
+++ b/frontend/libs/ui-modules/src/modules/team-members/components/MembersInline.tsx
@@ -10,8 +10,9 @@ import {
   readImage,
 } from 'erxes-ui';
 import { useAtomValue } from 'jotai';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
 import { currentUserState } from 'ui-modules/states';
 
 import {
@@ -72,33 +73,12 @@ export const MembersInlineProvider = ({
   allowUnassigned?: boolean;
 }) => {
   const [_members, _setMembers] = useState<IUser[]>(members || []);
-  const [inactiveMemberIds, setInactiveMemberIds] = useState<string[]>([]);
   const currentMembers = members || _members;
-  const activeMembers = currentMembers.filter(
-    ({ _id, isActive }) =>
-      isActive !== false && !inactiveMemberIds.includes(_id),
-  );
-  const handleMemberActiveChange = useCallback(
-    (memberId: string, isActive: boolean) => {
-      setInactiveMemberIds((currentIds) => {
-        if (isActive) {
-          return currentIds.includes(memberId)
-            ? currentIds.filter((id) => id !== memberId)
-            : currentIds;
-        }
-
-        return currentIds.includes(memberId)
-          ? currentIds
-          : [...currentIds, memberId];
-      });
-    },
-    [],
-  );
 
   return (
     <MembersInlineContext.Provider
       value={{
-        members: activeMembers,
+        members: currentMembers,
         loading: false,
         memberIds: memberIds,
         placeholder: isUndefinedOrNull(placeholder)
@@ -111,27 +91,17 @@ export const MembersInlineProvider = ({
     >
       <Tooltip.Provider>{children}</Tooltip.Provider>
       {memberIds?.map((memberId) => (
-        <MemberInlineEffectComponent
-          key={memberId}
-          memberId={memberId}
-          onActiveChange={handleMemberActiveChange}
-        />
+        <MemberInlineEffectComponent key={memberId} memberId={memberId} />
       ))}
     </MembersInlineContext.Provider>
   );
 };
 
-const MemberInlineEffectComponent = ({
-  memberId,
-  onActiveChange,
-}: {
-  memberId: string;
-  onActiveChange: (memberId: string, isActive: boolean) => void;
-}) => {
+const MemberInlineEffectComponent = ({ memberId }: { memberId: string }) => {
   const currentUser = useAtomValue(currentUserState) as IUser;
   const { updateMembers } = useMembersInlineContext();
   const skip = !memberId || memberId === currentUser?._id;
-  const { userDetail } = useMemberInline({
+  const { userDetail, loading: memberLoading } = useMemberInline({
     variables: {
       _id: memberId,
     },
@@ -149,26 +119,40 @@ const MemberInlineEffectComponent = ({
     statusChangedUser?._id === memberId ? statusChangedUser : userDetail;
 
   useEffect(() => {
-    if (!updateMembers) return;
+    if (!updateMembers || skip) return;
 
-    if (resolvedUser?.isActive === false) {
-      onActiveChange(memberId, false);
-      updateMembers((prev) => prev.filter(({ _id }) => _id !== memberId));
-    } else if (resolvedUser) {
-      onActiveChange(memberId, true);
+    const upsert = (member: IUser) =>
       updateMembers((prev) => {
-        if (prev.some((m) => m._id === memberId)) return prev;
-        return [...prev, { ...resolvedUser, _id: memberId }];
+        const existingIndex = prev.findIndex((m) => m._id === memberId);
+        if (existingIndex === -1) return [...prev, member];
+        if (
+          prev[existingIndex].isActive === member.isActive &&
+          prev[existingIndex].isDeleted === member.isDeleted &&
+          prev[existingIndex].details?.fullName === member.details?.fullName
+        ) {
+          return prev;
+        }
+        const next = [...prev];
+        next[existingIndex] = member;
+        return next;
       });
+
+    if (resolvedUser) {
+      upsert({ ...resolvedUser, _id: memberId });
+    } else if (!memberLoading) {
+      // Query resolved with no matching user: the member was deleted.
+      upsert({ _id: memberId, isActive: false, isDeleted: true } as IUser);
     }
-    if (currentUser?._id === memberId) {
-      onActiveChange(memberId, true);
-      updateMembers((prev) => {
-        if (prev.some((m) => m._id === memberId)) return prev;
-        return [currentUser, ...prev];
-      });
-    }
-  }, [resolvedUser, currentUser, memberId, onActiveChange, updateMembers]);
+  }, [resolvedUser, memberLoading, memberId, updateMembers, skip]);
+
+  useEffect(() => {
+    if (!updateMembers || currentUser?._id !== memberId) return;
+
+    updateMembers((prev) => {
+      if (prev.some((m) => m._id === memberId)) return prev;
+      return [currentUser, ...prev];
+    });
+  }, [currentUser, memberId, updateMembers]);
 
   return null;
 };
@@ -184,11 +168,13 @@ export const MembersInlineAvatar = ({
     useMembersInlineContext();
   const currentUser = useAtomValue(currentUserState) as IUser;
 
-  const activeMembers = memberIds
+  const { t } = useTranslation('team-member');
+
+  const valueMembers = memberIds
     ? members.filter((m) => memberIds.includes(m._id))
     : members;
 
-  const sortedMembers = [...activeMembers].sort((a, b) => {
+  const sortedMembers = [...valueMembers].sort((a, b) => {
     if (a._id === currentUser?._id) return -1;
     if (b._id === currentUser?._id) return 1;
     return 0;
@@ -205,9 +191,45 @@ export const MembersInlineAvatar = ({
       </div>
     );
 
+  const getMemberLabel = (member: IUser) => {
+    if (member.isDeleted) {
+      return t('deleted-user', { defaultValue: 'Deleted user' });
+    }
+    if (member.isActive === false) {
+      const name =
+        member.details?.fullName || member.email || member.username || '';
+      return `${name} (${t('deactivated', { defaultValue: 'deactivated' })})`;
+    }
+    return member.details?.fullName;
+  };
+
+  const renderMemberLabel = (member: IUser) => {
+    if (member.isDeleted) {
+      return (
+        <span className="text-muted-foreground">
+          {t('deleted-user', { defaultValue: 'Deleted user' })}
+        </span>
+      );
+    }
+    if (member.isActive === false) {
+      const name =
+        member.details?.fullName || member.email || member.username || '';
+      return (
+        <>
+          {name}{' '}
+          <span className="text-muted-foreground">
+            ({t('deactivated', { defaultValue: 'deactivated' })})
+          </span>
+        </>
+      );
+    }
+    return member.details?.fullName;
+  };
+
   const renderAvatar = (member: IUser) => {
-    const { details } = member;
+    const { details, isDeleted, isActive } = member;
     const { avatar, fullName } = details || {};
+    const isInactiveOrDeleted = isDeleted || isActive === false;
 
     return (
       <Tooltip delayDuration={100} key={member._id}>
@@ -215,24 +237,31 @@ export const MembersInlineAvatar = ({
           <Avatar
             className={cn(
               'bg-background',
-              activeMembers.length > 1 && 'ring-2 ring-background',
+              valueMembers.length > 1 && 'ring-2 ring-background',
+              isInactiveOrDeleted && 'opacity-60 grayscale',
               className,
             )}
             size={size || 'lg'}
             {...props}
           >
-            <Avatar.Image src={readImage(avatar as string, 200)} />
-            <Avatar.Fallback>{fullName?.charAt(0) || ''}</Avatar.Fallback>
+            {!isDeleted && <Avatar.Image src={readImage(avatar as string, 200)} />}
+            <Avatar.Fallback>
+              {isDeleted ? (
+                <IconUserCancel className="size-3.5" />
+              ) : (
+                fullName?.charAt(0) || ''
+              )}
+            </Avatar.Fallback>
           </Avatar>
         </Tooltip.Trigger>
         <Tooltip.Content>
-          <p>{fullName}</p>
+          <p>{renderMemberLabel(member)}</p>
         </Tooltip.Content>
       </Tooltip>
     );
   };
 
-  if (activeMembers.length === 0) {
+  if (valueMembers.length === 0) {
     if (allowUnassigned) {
       return (
         <IconUserCancel className="text-muted-foreground flex-none size-4" />
@@ -241,7 +270,7 @@ export const MembersInlineAvatar = ({
     return null;
   }
 
-  if (activeMembers.length === 1) return renderAvatar(activeMembers[0]);
+  if (valueMembers.length === 1) return renderAvatar(valueMembers[0]);
 
   const withAvatar = sortedMembers.slice(0, sortedMembers.length > 3 ? 2 : 3);
   const restMembers = sortedMembers.slice(withAvatar.length);
@@ -263,7 +292,7 @@ export const MembersInlineAvatar = ({
             </Avatar>
           </Tooltip.Trigger>
           <Tooltip.Content>
-            <p>{restMembers.map((m) => m.details?.fullName).join(', ')}</p>
+            <p>{restMembers.map((m) => getMemberLabel(m)).join(', ')}</p>
           </Tooltip.Content>
         </Tooltip>
       )}
@@ -280,14 +309,38 @@ export const MembersInlineTitle = ({ className }: { className?: string }) => {
     memberIds,
   } = useMembersInlineContext();
   const currentUser = useAtomValue(currentUserState) as IUser;
+  const { t } = useTranslation('team-member');
 
-  const activeMembers = memberIds?.length
+  const valueMembers = memberIds?.length
     ? allMembers.filter((m) => memberIds.includes(m._id))
     : allMembers;
-  const isCurrentUser = activeMembers.some((m) => m._id === currentUser._id);
+  const isCurrentUser = valueMembers.some((m) => m._id === currentUser._id);
+
+  const renderMemberLabel = (member: IUser) => {
+    if (member.isDeleted) {
+      return (
+        <span className="text-muted-foreground">
+          {t('deleted-user', { defaultValue: 'Deleted user' })}
+        </span>
+      );
+    }
+    if (member.isActive === false) {
+      const name =
+        member.details?.fullName || member.email || member.username || '';
+      return (
+        <>
+          {name}{' '}
+          <span className="text-muted-foreground">
+            ({t('deactivated', { defaultValue: 'deactivated' })})
+          </span>
+        </>
+      );
+    }
+    return member.details?.fullName;
+  };
 
   const getDisplayValue = () => {
-    if (!activeMembers || activeMembers.length === 0) {
+    if (!valueMembers || valueMembers.length === 0) {
       if (allowUnassigned) {
         return (
           <span className="capitalize text-muted-foreground/80">
@@ -298,21 +351,25 @@ export const MembersInlineTitle = ({ className }: { className?: string }) => {
       return undefined;
     }
 
-    if (activeMembers.length === 1) {
-      return activeMembers?.[0].details?.fullName;
+    if (valueMembers.length === 1) {
+      return renderMemberLabel(valueMembers[0]);
     }
 
     if (isCurrentUser) {
-      const otherMembersCount = activeMembers.length - 1;
+      const otherMembersCount = valueMembers.length - 1;
       if (otherMembersCount > 1) {
         return `You and ${otherMembersCount} others`;
       }
 
-      const otherMember = activeMembers.find((m) => m._id !== currentUser._id);
-      return `You and ${otherMember?.details?.fullName}`;
+      const otherMember = valueMembers.find((m) => m._id !== currentUser._id);
+      return otherMember ? (
+        <>You and {renderMemberLabel(otherMember)}</>
+      ) : (
+        'You and '
+      );
     }
 
-    return `${activeMembers.length} members`;
+    return `${valueMembers.length} members`;
   };
 
   return (

--- a/frontend/libs/ui-modules/src/modules/team-members/types/TeamMembers.ts
+++ b/frontend/libs/ui-modules/src/modules/team-members/types/TeamMembers.ts
@@ -6,6 +6,7 @@ export interface IUser {
   username?: string;
   isOwner?: boolean;
   isActive?: boolean;
+  isDeleted?: boolean;
   configs?: any;
   isOnboarded: boolean;
   details?: {

--- a/frontend/plugins/frontline_ui/src/modules/channels/components/settings/members/MemberForm.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/channels/components/settings/members/MemberForm.tsx
@@ -111,6 +111,9 @@ export const MemberFormContent = ({
           !excludeIds?.find((excludeId) => excludeId === user._id),
       )
     : users;
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -122,7 +125,7 @@ export const MemberFormContent = ({
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.map((member) => (
+        {selectableMembers.map((member) => (
           <SelectMember.CommandItem key={member._id} user={member} />
         ))}
         <Command.Separator className="my-1" />

--- a/frontend/plugins/frontline_ui/src/modules/report/components/frontline-card/MemberFormContent.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/report/components/frontline-card/MemberFormContent.tsx
@@ -48,6 +48,10 @@ export const MemberFormContent = ({
     );
   }, [users, memberIds, excludedMemberIds, exclude, currentUser]);
 
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
+
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -60,7 +64,7 @@ export const MemberFormContent = ({
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
 
-        {members.map((member) => (
+        {selectableMembers.map((member) => (
           <SelectMember.CommandItem key={member._id} user={member} />
         ))}
 

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-selects/SelectAssignedMembersTicket.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-selects/SelectAssignedMembersTicket.tsx
@@ -36,6 +36,9 @@ const SelectAssignedMembersContent = () => {
   const membersList = users.filter(
     (user) => !members.find((member) => member._id === user._id),
   );
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
 
   return (
     <Command shouldFilter={false}>
@@ -48,9 +51,9 @@ const SelectAssignedMembersContent = () => {
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             {!loading && membersList.length > 0 && (

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-selects/SelectAssigneeTicket.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/ticket-selects/SelectAssigneeTicket.tsx
@@ -66,6 +66,9 @@ const SelectTeamMemberContent = () => {
   const membersList = [currentUser, ...filteredUsers].filter(
     (user) => !members.find((member) => member._id === user._id),
   );
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
 
   return (
     <Command shouldFilter={false}>
@@ -78,9 +81,9 @@ const SelectTeamMemberContent = () => {
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             {!loading && membersList.length > 0 && (

--- a/frontend/plugins/operation_ui/src/modules/project/components/select/SelectLead.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/components/select/SelectLead.tsx
@@ -65,6 +65,9 @@ export const SelectTeamMemberContent = ({
     : [currentUser, ...users].filter(
         (user) => !members.find((member) => member._id === user._id),
       );
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -77,13 +80,13 @@ export const SelectTeamMemberContent = ({
 
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.map((member) => (
+        {selectableMembers.map((member) => (
           <SelectMember.CommandItem key={member._id} user={member} />
         ))}
-        {members.length > 0 &&
-          members.some((member) => !memberIds?.includes(member._id)) && (
-            <Command.Separator className="my-1" />
-          )}
+        {selectableMembers.length > 0 &&
+          selectableMembers.some(
+            (member) => !memberIds?.includes(member._id),
+          ) && <Command.Separator className="my-1" />}
         {!loading &&
           membersList.map((user) => (
             <SelectMember.CommandItem key={user._id} user={user} />

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectAssigneeTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectAssigneeTask.tsx
@@ -294,6 +294,10 @@ const SelectTeamMemberContent = ({
           (user) => !members.find((member) => member._id === user._id),
         );
 
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
+
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -305,9 +309,9 @@ const SelectTeamMemberContent = ({
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             {!loading && membersList.length > 0 && (

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectAssigneeTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectAssigneeTask.tsx
@@ -110,7 +110,9 @@ const ExpandableSection = <T,>({
                   setExpanded(!expanded);
                 }}
               >
-                {expanded ? t('show-less') : t('show-more', { count: remainingCount })}
+                {expanded
+                  ? t('show-less')
+                  : t('show-more', { count: remainingCount })}
               </Button>
             )}
           </>
@@ -258,7 +260,9 @@ const SelectAssigneeValue = ({
       </MembersInline.Provider>
     );
   }
-  return <SelectMember.Value placeholder={placeholder || t('select-assignee')} />;
+  return (
+    <SelectMember.Value placeholder={placeholder || t('select-assignee')} />
+  );
 };
 
 const SelectTeamMemberContent = ({

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCreatorTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCreatorTask.tsx
@@ -39,6 +39,10 @@ const SelectCreatorContent = () => {
     (user) => !members.find((member) => member._id === user._id),
   );
 
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
+
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -50,9 +54,9 @@ const SelectCreatorContent = () => {
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             {!loading && usersList.length > 0 && (

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCreatorTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCreatorTask.tsx
@@ -28,7 +28,7 @@ const SelectCreatorContent = () => {
   const [debouncedSearch] = useDebounce(search, 500);
   const currentUser = useAtomValue(currentUserState) as IUser;
   const { members } = useSelectMemberContext();
-  
+
   const { users, loading, handleFetchMore, totalCount, error } = useUsers({
     variables: {
       searchValue: debouncedSearch,
@@ -82,7 +82,7 @@ const SelectCreatorContent = () => {
 const SelectCreatorFilterView = () => {
   const [createdBy, setCreatedBy] = useQueryState<string>('createdBy');
   const { resetFilterState } = useFilterContext();
-  
+
   return (
     <Filter.View filterKey="createdBy">
       <SelectCreatorProvider
@@ -102,7 +102,7 @@ const SelectCreatorFilterView = () => {
 export const SelectCreatorFilterBar = () => {
   const [createdBy, setCreatedBy] = useQueryState<string>('createdBy');
   const [open, setOpen] = useState(false);
-  
+
   return (
     <SelectCreatorProvider
       mode="single"

--- a/frontend/plugins/operation_ui/src/modules/team/components/members/MemberForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/members/MemberForm.tsx
@@ -109,6 +109,9 @@ export const MemberFormContent = ({
           !excludeIds?.find((excludeId) => excludeId === user._id),
       )
     : users;
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
   return (
     <Command shouldFilter={false}>
       <Command.Input
@@ -120,9 +123,9 @@ export const MemberFormContent = ({
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             <Command.Separator className="my-1" />

--- a/frontend/plugins/operation_ui/src/modules/team/components/members/MemberForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/members/MemberForm.tsx
@@ -30,7 +30,9 @@ export const MemberForm = ({
         render={({ field }) => (
           <Form.Item>
             <Form.Label>{t('choose-members')}</Form.Label>
-            <Form.Description className="sr-only">{t('members')}</Form.Description>
+            <Form.Description className="sr-only">
+              {t('members')}
+            </Form.Description>
             <SelectTeamMember
               teamId={teamId}
               mode="multiple"

--- a/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/deal-selects/SelectAssigneeDeal.tsx
@@ -89,6 +89,9 @@ const SelectTeamMemberContent = ({
     : [currentUser, ...users].filter(
         (user) => !members.find((member) => member._id === user._id),
       );
+  const selectableMembers = members.filter(
+    (member) => member.isActive !== false && !member.isDeleted,
+  );
 
   return (
     <Command shouldFilter={false}>
@@ -101,9 +104,9 @@ const SelectTeamMemberContent = ({
       />
       <Command.List className="max-h-[300px] overflow-y-auto">
         <Combobox.Empty loading={loading} error={error} />
-        {members.length > 0 && (
+        {selectableMembers.length > 0 && (
           <>
-            {members.map((member) => (
+            {selectableMembers.map((member) => (
               <SelectMember.CommandItem key={member._id} user={member} />
             ))}
             {!loading && membersList.length > 0 && (


### PR DESCRIPTION
…nees

Selectors previously fell back to the placeholder ("Select member") when the assigned/created user was deactivated or deleted, since the shared MembersInline fetch effect discarded inactive members instead of keeping them for display. Now inactive members render "Name (deactivated)" and deleted ones render "Deleted user", with the avatar kept (dimmed for inactive). They remain excluded from the selectable dropdown list in every consumer that duplicates that dropdown-content pattern.

## Summary by Sourcery

Show clear deactivated and deleted user states for existing assignments while keeping them unavailable for new selections.

Bug Fixes:
- Preserve deactivated and deleted assignees in member displays instead of replacing them with the default placeholder.
- Show deactivated users with their name and status, and deleted users as “Deleted user,” while retaining appropriately styled avatars.

Enhancements:
- Keep inactive members available as display values while excluding deactivated and deleted users from member-selection dropdowns across supported consumers.
- Extend team-member data with deleted-user state and update team-member records to identify deactivated users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inactive and deleted team members are now clearly identified with localized labels and muted styling.
  * Member lists preserve inactive and deleted users for historical context, including tooltips and selection displays.
* **Bug Fixes**
  * Member selectors across channels, tickets, projects, tasks, teams, and deals now show only active, non-deleted members as selectable options.
  * Deleted users no longer display profile images where inappropriate.
  * Deactivated users are clearly labeled in team member records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->