### PR TITLE
fix(sales): restore internal deal read contract as deal.findMany

### DIFF
--- a/backend/plugins/accounting_api/AGENTS.md
+++ b/backend/plugins/accounting_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `accounting_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/accounting_api`
-- **Last synchronized:** `2026-08-17`
+- **Last synchronized:** `2026-09-02`
 
 ## Scope
 
@@ -68,6 +68,9 @@
 ### Consumes
 
 - Core branch, department, customer, company, product, and organization data through `sendTRPCMessage`, GraphQL, HTTP, or shared platform contracts.
+- Sales deals through the sales plugin's internal `deal.findMany` tRPC
+  contract (legacy dual-shape, not agent-facing) in
+  `src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts`.
 - Shared backend utilities, cursor pagination helpers, pubsub, and service startup APIs from `erxes-api-shared`.
 
 ## Data and State
@@ -111,6 +114,16 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Deal read moved to `deal.findMany`
+
+- **Summary:** The deal lookup in `checkSynced` now calls the sales
+  plugin's internal `deal.findMany` tRPC procedure instead of
+  `deal.find`, which was tightened into a strict agent-facing contract
+  by erxes #9102 and no longer accepts this plugin's bare
+  `{ _id: { $in } }` filter shape.
+- **Affected areas:** `src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts`.
+- **Contracts changed:** Internal tRPC call site only; no accounting GraphQL contract changed.
 
 ### `2026-08-17` — `Related Account Storage Shape`
 

--- a/backend/plugins/accounting_api/AGENTS.md
+++ b/backend/plugins/accounting_api/AGENTS.md
@@ -71,6 +71,9 @@
 - Sales deals through the sales plugin's internal `deal.findMany` tRPC
   contract (legacy dual-shape, not agent-facing) in
   `src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts`.
+  The call fails closed: `defaultValue: null` distinguishes an
+  unavailable/failed sales service from a valid empty match, and every
+  requested deal id is reported in `error` when sales is unreachable.
 - Shared backend utilities, cursor pagination helpers, pubsub, and service startup APIs from `erxes-api-shared`.
 
 ## Data and State
@@ -114,6 +117,16 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Deal sync fails closed on unreachable sales service
+
+- **Summary:** `accountingSyncDeals`'s `deal.findMany` call now uses
+  `defaultValue: null` so a disabled or failed sales plugin surfaces
+  every requested deal id in the `error` result list instead of being
+  silently skipped as an empty match (PR #9207 review finding).
+- **Affected areas:** `src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts`.
+- **Contracts changed:** `accountingSyncDeals` result semantics on
+  sales-service failure: ids move to `error` instead of vanishing.
 
 ### `2026-09-02` — Deal read moved to `deal.findMany`
 

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts
@@ -110,7 +110,7 @@ const checkSyncedMutations = {
       subdomain,
       pluginName: 'sales',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: { _id: { $in: ids } },
       defaultValue: [],
     })) as SalesDeal[];

--- a/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts
+++ b/backend/plugins/accounting_api/src/modules/accounting/graphql/resolvers/mutations/checkSynced.ts
@@ -106,14 +106,23 @@ const checkSyncedMutations = {
       return result;
     }
 
+    // Distinguish an unavailable sales service from a valid empty match:
+    // defaultValue is null here so a disabled/failed sales plugin surfaces
+    // as an error for every requested deal instead of being silently
+    // skipped as "nothing to sync".
     const deals = (await sendTRPCMessage({
       subdomain,
       pluginName: 'sales',
       module: 'deal',
       action: 'findMany',
       input: { _id: { $in: ids } },
-      defaultValue: [],
-    })) as SalesDeal[];
+      defaultValue: null,
+    })) as SalesDeal[] | null;
+
+    if (deals === null) {
+      result.error.push(...ids);
+      return result;
+    }
 
     for (const deal of deals || []) {
       const config = rule.value;

--- a/backend/plugins/mongolian_api/AGENTS.md
+++ b/backend/plugins/mongolian_api/AGENTS.md
@@ -47,19 +47,19 @@
 
 ## Architecture
 
-| Area                  | Path                                       | Responsibility                                            |
-| --------------------- | ------------------------------------------ | --------------------------------------------------------- |
-| Bootstrap             | `src/main.ts`                              | Starts and registers the mongolian plugin                 |
-| Runtime               | `src/connectionResolvers.ts`, `src/trpc`   | Tenant-scoped models and tRPC app router                   |
-| Models                | `src/modules/*/db`                         | Mongolian Mongoose schemas and models                     |
-| GraphQL               | `src/modules/*/graphql`, `src/apollo`      | Mongolian schemas, resolvers, subscriptions               |
-| eBarimt               | `src/modules/ebarimt`                      | Receipt issuing, put responses, product groups/rules      |
-| Erkhet                | `src/modules/erkhet`                       | Deal/order sync to the Erkhet accounting system           |
-| MS Dynamic            | `src/modules/msdynamic`                    | Deal/order sync to MS Dynamics                             |
-| Product places        | `src/modules/productPlaces`                | Deal product pricing, split, place, and print handling     |
-| Exchange rates        | `src/modules/exchangeRates`                | Exchange rate storage and queries                         |
-| Configs               | `src/modules/configs`                      | Mongolian integration configuration                       |
-| After-process         | `src/meta/afterProcess.ts`                 | Post-mutation integration handlers                        |
+| Area           | Path                                     | Responsibility                                         |
+| -------------- | ---------------------------------------- | ------------------------------------------------------ |
+| Bootstrap      | `src/main.ts`                            | Starts and registers the mongolian plugin              |
+| Runtime        | `src/connectionResolvers.ts`, `src/trpc` | Tenant-scoped models and tRPC app router               |
+| Models         | `src/modules/*/db`                       | Mongolian Mongoose schemas and models                  |
+| GraphQL        | `src/modules/*/graphql`, `src/apollo`    | Mongolian schemas, resolvers, subscriptions            |
+| eBarimt        | `src/modules/ebarimt`                    | Receipt issuing, put responses, product groups/rules   |
+| Erkhet         | `src/modules/erkhet`                     | Deal/order sync to the Erkhet accounting system        |
+| MS Dynamic     | `src/modules/msdynamic`                  | Deal/order sync to MS Dynamics                         |
+| Product places | `src/modules/productPlaces`              | Deal product pricing, split, place, and print handling |
+| Exchange rates | `src/modules/exchangeRates`              | Exchange rate storage and queries                      |
+| Configs        | `src/modules/configs`                    | Mongolian integration configuration                    |
+| After-process  | `src/meta/afterProcess.ts`               | Post-mutation integration handlers                     |
 
 ## Contracts
 

--- a/backend/plugins/mongolian_api/AGENTS.md
+++ b/backend/plugins/mongolian_api/AGENTS.md
@@ -1,0 +1,126 @@
+# `mongolian_api` Plugin Guide
+
+## Identity
+
+- **Plugin:** `mongolian`
+- **Project:** `mongolian_api`
+- **Layer:** `Backend API`
+- **Path:** `backend/plugins/mongolian_api`
+- **Last synchronized:** `2026-09-02`
+
+## Scope
+
+### Owns
+
+- Mongolian-market integrations: eBarimt receipt issuing and put-response
+  storage, product groups, product rules, Erkhet accounting sync,
+  MS Dynamic sync, product place handling (pricing, split, place,
+  print), exchange rates, and Mongolian integration configs.
+- Mongolian-owned GraphQL schemas, resolvers, tRPC procedures, Mongoose
+  models, after-mutation handlers, and after-process logic.
+
+### Does not own
+
+- Sales deals, pipelines, stages, POS orders, or their storage; those are
+  consumed through the sales plugin's published tRPC contracts only.
+- Core products, customers, users, branches, or shared platform packages.
+- Frontend UI; any mongolian UI lives outside this project.
+- Direct source imports from another plugin; cross-service access must use
+  published GraphQL, tRPC, HTTP, event, or federation contracts.
+
+## Current Capabilities
+
+- Runs as the `mongolian` federated GraphQL and tRPC plugin service on
+  port 3313 with tenant-scoped models and GraphQL subscriptions.
+- Issues eBarimt receipts for POS orders and deals, stores put responses,
+  and exposes them through GraphQL and tRPC (`putResponses` procedures
+  consumed by the sales POS module).
+- Reads sales deals for receipt detail, sync filtering, and deal links
+  through the sales plugin's tRPC contracts.
+- Syncs deals and orders to Erkhet and MS Dynamics, writing sync results
+  back onto deals via the sales `deal.updateOne` tRPC contract.
+- Applies product place rules (pricing, split, place, print) that rewrite
+  deal `productsData` via the sales plugin's tRPC contracts.
+- Manages eBarimt product groups and product rules, including the
+  `productRules` tRPC contract consumed by accounting tax rules and the
+  sales POS module.
+
+## Architecture
+
+| Area                  | Path                                       | Responsibility                                            |
+| --------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| Bootstrap             | `src/main.ts`                              | Starts and registers the mongolian plugin                 |
+| Runtime               | `src/connectionResolvers.ts`, `src/trpc`   | Tenant-scoped models and tRPC app router                   |
+| Models                | `src/modules/*/db`                         | Mongolian Mongoose schemas and models                     |
+| GraphQL               | `src/modules/*/graphql`, `src/apollo`      | Mongolian schemas, resolvers, subscriptions               |
+| eBarimt               | `src/modules/ebarimt`                      | Receipt issuing, put responses, product groups/rules      |
+| Erkhet                | `src/modules/erkhet`                       | Deal/order sync to the Erkhet accounting system           |
+| MS Dynamic            | `src/modules/msdynamic`                    | Deal/order sync to MS Dynamics                             |
+| Product places        | `src/modules/productPlaces`                | Deal product pricing, split, place, and print handling     |
+| Exchange rates        | `src/modules/exchangeRates`                | Exchange rate storage and queries                         |
+| Configs               | `src/modules/configs`                      | Mongolian integration configuration                       |
+| After-process         | `src/meta/afterProcess.ts`                 | Post-mutation integration handlers                        |
+
+## Contracts
+
+### Provides
+
+- Mongolian GraphQL schema and resolvers for eBarimt put responses,
+  product groups, product rules, exchange rates, and sync queries.
+- tRPC procedures under `src/trpc` and module trpc directories,
+  including `putResponses.*` (consumed by the sales POS module) and
+  `productRules.find` (consumed by accounting tax rules and sales POS).
+
+### Consumes
+
+- Sales deals and links through the sales plugin's tRPC contracts:
+  `deal.findMany` (internal legacy dual-shape deal reads, not
+  agent-facing), `deal.findOne`, `deal.getLink`, and `deal.updateOne`.
+- Core products, customers, and configuration through public platform
+  contracts.
+- `erxes-api-shared` utilities and plugin startup APIs.
+
+## Data and State
+
+- Tenant-scoped Mongoose models are generated per request `subdomain`.
+- eBarimt put responses, product groups, product rules, sync logs, and
+  exchange rates are stored in mongolian-owned tenant-scoped collections.
+- No sales, POS, or core documents are stored here; deal and order data
+  are always fetched or written through sales plugin tRPC contracts.
+
+## Local Invariants
+
+- Preserve tenant isolation by using the request `subdomain` for every
+  model, service, resolver, worker, and route access.
+- All sales data access goes through the sales plugin's published tRPC
+  contracts; never read or mutate another plugin's collections directly.
+- `deal.findMany` is the service-only deal read: it restores the legacy
+  `deal.find` dual-shape input and must not be replaced by the strict
+  agent-facing `deal.find` contract.
+- `sendTRPCMessage` returns `defaultValue` on any error, including input
+  schema rejections; validate integration results defensively instead of
+  assuming an empty array means "no data".
+
+## Validation
+
+- `pnpm nx build mongolian_api`
+- Smoke scenario: issue an eBarimt receipt for a POS order and verify the
+  put response is stored and queryable.
+- Smoke scenario: trigger Erkhet deal sync and verify sync logs are
+  created for the resolved deals.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Deal reads moved to `deal.findMany`
+
+- **Summary:** eBarimt deal filtering and Erkhet deal sync now call the
+  sales plugin's internal `deal.findMany` tRPC procedure instead of
+  `deal.find`, which was tightened into a strict agent-facing contract
+  by erxes #9102 and no longer accepts this plugin's bare
+  Mongo-filter input shape.
+- **Affected areas:** `src/modules/ebarimt/graphql/resolvers/queries/ebarimt.ts`,
+  `src/modules/erkhet/graphql/resolvers/mutations/checkSynced.ts`.
+- **Contracts changed:** Internal tRPC call sites only; no mongolian
+  GraphQL or tRPC contract changed.

--- a/backend/plugins/mongolian_api/src/modules/ebarimt/graphql/resolvers/queries/ebarimt.ts
+++ b/backend/plugins/mongolian_api/src/modules/ebarimt/graphql/resolvers/queries/ebarimt.ts
@@ -87,7 +87,7 @@ const generateFilter = async (subdomain, params) => {
           pluginName: 'sales',
           method: 'query',
           module: 'deal',
-          action: 'find',
+          action: 'findMany',
           input: { ...dealsFilter },
           defaultValue: [],
         });

--- a/backend/plugins/mongolian_api/src/modules/erkhet/graphql/resolvers/mutations/checkSynced.ts
+++ b/backend/plugins/mongolian_api/src/modules/erkhet/graphql/resolvers/mutations/checkSynced.ts
@@ -109,7 +109,7 @@ const checkSyncedMutations = {
       subdomain,
       pluginName: 'sales',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: { _id: { $in: dealIds } },
       defaultValue: [],
     });

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -49,17 +49,17 @@
 
 ## Architecture
 
-| Area                | Path                                                                      | Responsibility                                                        |
-| ------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Bootstrap           | `src/main.ts`                                                             | Starts and registers the sales plugin                                 |
-| Runtime             | `src/main.ts`, `src/connectionResolvers.ts`, `src/trpc`                   | Start the plugin, load tenant-scoped models, and expose tRPC          |
-| Agent tool metadata | `src/trpc/agentMeta.ts`                                                   | Local `agentMeta` helper for agent-callable tRPC annotations          |
-| Models              | `src/modules/sales/db`                                                    | Sales Mongoose schemas and models                                     |
-| GraphQL             | `src/modules/sales/graphql`, `src/apollo`                                 | Sales schemas, resolvers, mutations, queries, and subscriptions       |
-| Pipeline validation | `src/modules/sales/utils/pipelineProperties.ts`                           | Validates pipeline property ids through Core tRPC                     |
-| References          | `src/modules/sales/meta`                                                  | Sales reference values, automation constants, and after-process logic |
-| Documents           | `src/modules/sales/documents`                                             | Generate sales document content and amount mappings                   |
-| POS and ecommerce   | `src/modules/pos`, `src/modules/ecommerce`                                | Provide sales-owned POS and ecommerce behavior                        |
+| Area                | Path                                                    | Responsibility                                                        |
+| ------------------- | ------------------------------------------------------- | --------------------------------------------------------------------- |
+| Bootstrap           | `src/main.ts`                                           | Starts and registers the sales plugin                                 |
+| Runtime             | `src/main.ts`, `src/connectionResolvers.ts`, `src/trpc` | Start the plugin, load tenant-scoped models, and expose tRPC          |
+| Agent tool metadata | `src/trpc/agentMeta.ts`                                 | Local `agentMeta` helper for agent-callable tRPC annotations          |
+| Models              | `src/modules/sales/db`                                  | Sales Mongoose schemas and models                                     |
+| GraphQL             | `src/modules/sales/graphql`, `src/apollo`               | Sales schemas, resolvers, mutations, queries, and subscriptions       |
+| Pipeline validation | `src/modules/sales/utils/pipelineProperties.ts`         | Validates pipeline property ids through Core tRPC                     |
+| References          | `src/modules/sales/meta`                                | Sales reference values, automation constants, and after-process logic |
+| Documents           | `src/modules/sales/documents`                           | Generate sales document content and amount mappings                   |
+| POS and ecommerce   | `src/modules/pos`, `src/modules/ecommerce`              | Provide sales-owned POS and ecommerce behavior                        |
 
 ## Contracts
 
@@ -174,7 +174,7 @@
 - **Summary:** Restored the cross-plugin deal read path that #9102
   unintentionally severed: `deal.find` was a shared service contract
   (legacy dual-shape — bare Mongo filter or `{ query, search?, skip?,
-  limit?, sort? }`) before #9058 also exposed it to agents and #9102
+limit?, sort? }`) before #9058 also exposed it to agents and #9102
   tightened it for agents only. The #9102 claim that no cross-plugin
   callers existed was wrong: accounting, mongolian (ebarimt, erkhet),
   and tourism (4 PMS sites) called `deal.find`, and their zod-rejected

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -84,8 +84,12 @@
   annotation): accepts the legacy dual-shape input of the pre-#9102
   `deal.find` — a bare Mongo filter (input itself is the query) or the
   wrapped `{ query, search?, skip?, limit?, sort? }` form with unbounded
-  results. Consumed by accounting (`checkSynced`), mongolian
-  (`ebarimt`, `erkhet checkSynced`), and tourism (`pms configs`, 4 sites).
+  results (`limit` 0 = unbounded, kept for tourism availability scans).
+  `search` expands to the sales name/number/description/date predicate
+  composed with `query` under `$and`. Input is a zod union validating
+  `skip`/`limit` as non-negative integers while preserving Mongo
+  operators. Consumed by accounting (`checkSynced`), mongolian
+  (`ebarimt`, `erkhet checkSynced`), and tourism (`pms configs`).
 - Record reference resolvers under `src/modules/sales/meta/references`.
 - Sales metadata and automation contracts under `src/modules/sales/meta`.
 
@@ -168,6 +172,20 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Review hardening of `deal.findMany`
+
+- **Summary:** Addressed PR #9207 review findings: `deal.findMany` input
+  is now a zod union (bare record or wrapped
+  `{ query, search?, skip?, limit?, sort? }` with non-negative integer
+  `skip`/`limit`) instead of `z.any()`, and the previously dropped
+  `search` key now expands to the sales name/number/description/date
+  predicate composed with `query` under `$and`, so tourism PMS room
+  searches filter correctly.
+- **Affected areas:** `src/modules/sales/trpc/deal.ts`.
+- **Contracts changed:** `deal.findMany` wrapped input now honors
+  `search`; malformed inputs (non-object, negative skip/limit) are
+  rejected instead of reaching Mongo.
 
 ### `2026-09-02` — Internal `deal.findMany` service contract
 

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `sales_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/sales_api`
-- **Last synchronized:** `2026-08-21`
+- **Last synchronized:** `2026-09-02`
 
 ## Scope
 
@@ -80,6 +80,12 @@
   - `pos.ordersDeliveryInfo`, `orders.findOne`, `orders.find` — `posOrderRead`
 - tRPC service contracts under `src/trpc` and module-specific `trpc`
   directories for platform and cross-plugin callers (not agent-visible).
+- Internal cross-plugin deal read contract `deal.findMany` (no agent
+  annotation): accepts the legacy dual-shape input of the pre-#9102
+  `deal.find` — a bare Mongo filter (input itself is the query) or the
+  wrapped `{ query, search?, skip?, limit?, sort? }` form with unbounded
+  results. Consumed by accounting (`checkSynced`), mongolian
+  (`ebarimt`, `erkhet checkSynced`), and tourism (`pms configs`, 4 sites).
 - Record reference resolvers under `src/modules/sales/meta/references`.
 - Sales metadata and automation contracts under `src/modules/sales/meta`.
 
@@ -127,17 +133,24 @@
   2026-08-20, and wrapper-shaped input silently matched nothing.
 - Do not introduce new `schemaWrapper` usage in backend schemas.
 - Agent tool annotations are admit-only: never annotate raw-mongo helpers
-  (`deal.aggregate`, `deal.updateOne`, `orders.updateOne`), system-user
-  procedures (`deal.create`, `deal.updateOne`), procedures that trust a caller
-  supplied `user` object (`deal.createItem`, `deal.editItem`), POS device-sync
-  endpoints (`pos.createOrUpdateOrders*`, `pos.confirmCover`), token-scoped
-  lookups (`pos.ecommerceGetBranches`), destructive bulk operations
-  (`deal.removeItem`), or internal plumbing (`deal.subscriptionWrapper`,
+  (`deal.aggregate`, `deal.updateOne`, `deal.findMany`, `orders.updateOne`),
+  system-user procedures (`deal.create`, `deal.updateOne`), procedures that
+  trust a caller supplied `user` object (`deal.createItem`, `deal.editItem`),
+  POS device-sync endpoints (`pos.createOrUpdateOrders*`, `pos.confirmCover`),
+  token-scoped lookups (`pos.ecommerceGetBranches`), destructive bulk
+  operations (`deal.removeItem`), or internal plumbing (`deal.subscriptionWrapper`,
   `deal.tag`, `deal.getFilterParams`, `deal.replaceContent`,
   `deal.contentIds`, `deal.generateInternalNoteNotif`, `deal.notifiedUserIds`,
   `deal.createCommentActivityLog`, `documents.editorAttributes`,
   `fields.getFieldList`). New procedures are agent-invisible unless explicitly
   annotated.
+- Cross-plugin service callers and agents must not share one input schema:
+  `deal.find` is the strict, bounded, agent-facing contract; `deal.findMany`
+  is the lax, unbounded, service-only contract. Before tightening any
+  tRPC procedure input, sweep every plugin and `erxes-api-shared` for
+  `sendTRPCMessage` callers of that procedure — `sendTRPCMessage` swallows
+  zod rejections into `defaultValue`, so a broken caller fails silently
+  with empty results instead of erroring.
 
 ## Validation
 
@@ -156,6 +169,26 @@
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-09-02` — Internal `deal.findMany` service contract
+
+- **Summary:** Restored the cross-plugin deal read path that #9102
+  unintentionally severed: `deal.find` was a shared service contract
+  (legacy dual-shape — bare Mongo filter or `{ query, search?, skip?,
+  limit?, sort? }`) before #9058 also exposed it to agents and #9102
+  tightened it for agents only. The #9102 claim that no cross-plugin
+  callers existed was wrong: accounting, mongolian (ebarimt, erkhet),
+  and tourism (4 PMS sites) called `deal.find`, and their zod-rejected
+  inputs were silently swallowed into `defaultValue: []` by
+  `sendTRPCMessage`, producing silent sync failures and empty results.
+  Added unannotated `deal.findMany` (invisible to agents) restoring the
+  exact legacy semantics and migrated all 7 call sites to it.
+- **Affected areas:** `src/modules/sales/trpc/deal.ts` (`deal.findMany`
+  added); cross-plugin callers in accounting, mongolian, and tourism
+  updated to call `deal.findMany`.
+- **Contracts changed:** `deal.find` (agent-facing, strict, bounded) is
+  unchanged; new internal `deal.findMany` (service-only, legacy dual-shape,
+  unbounded) carries the cross-plugin contract.
+
 ### `2026-08-21` — Bounded, strict agent-facing deal reads
 
 - **Summary:** `deal.find` can no longer execute unbounded or mis-shaped
@@ -167,8 +200,10 @@
   exit 139 on 2026-08-20), and `fields` now drives a real projection so
   agents stay under the 64KB agent-tools response budget. `deal.count` takes
   an explicit `{ filter? }` object for the same reason (a `{ query: ... }`
-  wrapper previously counted 0 silently). No cross-plugin tRPC callers of
-  either procedure exist, so the tightened contracts break no consumers.
+  wrapper previously counted 0 silently). The 2026-08-21 claim that no
+  cross-plugin callers existed was disproven on 2026-09-02 — see the
+  `deal.findMany` entry above; agent-facing `deal.find` behavior itself
+  is unchanged.
 - **Affected areas:** `src/modules/sales/trpc/deal.ts`.
 - **Contracts changed:** `deal.find` input is now strict
   `{ query?, skip?, limit?, sort?, fields? }` (the bare top-level filter form

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -200,8 +200,18 @@ export const dealTrpcRouter = t.router({
                 filter,
                 {
                   $or: [
-                    { name: { $regex: escapeRegExp(wrapped.search), $options: 'i' } },
-                    { number: { $regex: escapeRegExp(wrapped.search), $options: 'i' } },
+                    {
+                      name: {
+                        $regex: escapeRegExp(wrapped.search),
+                        $options: 'i',
+                      },
+                    },
+                    {
+                      number: {
+                        $regex: escapeRegExp(wrapped.search),
+                        $options: 'i',
+                      },
+                    },
                     {
                       description: {
                         $regex: escapeRegExp(wrapped.search),

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -1,5 +1,9 @@
 import { initTRPC } from '@trpc/server';
-import { ITRPCContext, sendTRPCMessage } from 'erxes-api-shared/utils';
+import {
+  escapeRegExp,
+  ITRPCContext,
+  sendTRPCMessage,
+} from 'erxes-api-shared/utils';
 import type { SortOrder } from 'mongoose';
 import { z } from 'zod';
 import { IModels } from '~/connectionResolvers';
@@ -10,6 +14,7 @@ import {
 } from '~/modules/sales/graphql/resolvers/mutations/utils';
 import { generateFilter } from '~/modules/sales/graphql/resolvers/queries/deals';
 import { subscriptionWrapper } from '~/modules/sales/graphql/resolvers/utils';
+import { getCreatedAtSearchFilter } from '~/modules/sales/utils';
 import {
   convertNestedDate,
   generateAmounts,
@@ -93,6 +98,25 @@ const dealCountInput = z
   })
   .strict();
 
+// Internal deal.findMany contract: the exact legacy dual-shape input of the
+// pre-#9102 `deal.find` — either a bare Mongo filter (the input itself is the
+// query) or the wrapped `{ query, search?, skip?, limit?, sort? }` form.
+// `search` must keep flowing through: tourism PMS callers pass it, and the
+// old handler silently dropped it. `skip`/`limit` stay non-negative so
+// `limit(0)` keeps meaning "unbounded" for availability scans.
+const dealFindManyWrappedInput = z.object({
+  query: z.record(z.unknown()),
+  search: z.string().optional(),
+  skip: z.number().int().min(0).optional(),
+  limit: z.number().int().min(0).optional(),
+  sort: z.record(z.unknown()).optional(),
+});
+
+const dealFindManyInput = z.union([
+  dealFindManyWrappedInput,
+  z.record(z.unknown()),
+]);
+
 export const dealTrpcRouter = t.router({
   deal: {
     findOne: t.procedure
@@ -147,21 +171,60 @@ export const dealTrpcRouter = t.router({
     // on `_id: { $in: ... }` lists; bounding here broke tourism
     // availability scans and turned zod rejections into silent
     // `defaultValue` empty arrays through sendTRPCMessage's catch.
-    findMany: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
-      const { models } = ctx;
+    findMany: t.procedure
+      .input(dealFindManyInput)
+      .query(async ({ ctx, input }) => {
+        const { models, subdomain } = ctx;
 
-      const { query, skip, limit, sort = {} } = input || {};
+        // Bare-record form: input is the Mongo filter itself. Wrapped form:
+        // `search` expands into the same name/number/description/createdAt
+        // predicate the sales board uses, composed with the caller's query.
+        let filter: Record<string, unknown>;
+        let skip: number | undefined;
+        let limit: number | undefined;
+        let sort: Record<string, unknown>;
 
-      if (!query) {
-        return await models.Deals.find(input).lean();
-      }
+        if ('query' in input) {
+          const wrapped = input as z.infer<typeof dealFindManyWrappedInput>;
 
-      return await models.Deals.find(query)
-        .skip(skip || 0)
-        .limit(limit || 0)
-        .sort(sort)
-        .lean();
-    }),
+          filter = wrapped.query;
+          skip = wrapped.skip;
+          limit = wrapped.limit;
+          sort = wrapped.sort ?? {};
+
+          if (wrapped.search?.trim()) {
+            const createdAtFilter = getCreatedAtSearchFilter(wrapped.search);
+
+            filter = {
+              $and: [
+                filter,
+                {
+                  $or: [
+                    { name: { $regex: escapeRegExp(wrapped.search), $options: 'i' } },
+                    { number: { $regex: escapeRegExp(wrapped.search), $options: 'i' } },
+                    {
+                      description: {
+                        $regex: escapeRegExp(wrapped.search),
+                        $options: 'i',
+                      },
+                    },
+                    ...(createdAtFilter ? [createdAtFilter] : []),
+                  ],
+                },
+              ],
+            };
+          }
+        } else {
+          filter = input;
+          sort = {};
+        }
+
+        return await models.Deals.find(filter)
+          .skip(skip || 0)
+          .limit(limit || 0)
+          .sort(sort as Record<string, SortOrder>)
+          .lean();
+      }),
 
     aggregate: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
       const { models } = ctx;

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -438,7 +438,7 @@ export const dealTrpcRouter = t.router({
     find: t.procedure
       .meta(
         agentMeta(
-          'List stages ordered by position: { pipelineId? } or any MongoDB-style query. Pass pipelineId from pipeline.findOne to see a pipeline\'s stages in order.',
+          "List stages ordered by position: { pipelineId? } or any MongoDB-style query. Pass pipelineId from pipeline.findOne to see a pipeline's stages in order.",
           { module: 'deal', action: 'showDeals' },
         ),
       )

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -137,6 +137,32 @@ export const dealTrpcRouter = t.router({
           .lean();
       }),
 
+    // Internal cross-plugin read contract (accounting, mongolian, tourism).
+    // NOT agent-callable: no `.meta({ agent })`, so it never appears in the
+    // agent-tools manifest. Restores the legacy dual-shape input of the old
+    // `deal.find` that #9102 tightened for agents: callers may pass either a
+    // bare Mongo filter (input itself is the query) or the wrapped
+    // `{ query, search?, skip?, limit?, sort? }` form. Results stay
+    // unbounded on purpose — internal callers paginate themselves or rely
+    // on `_id: { $in: ... }` lists; bounding here broke tourism
+    // availability scans and turned zod rejections into silent
+    // `defaultValue` empty arrays through sendTRPCMessage's catch.
+    findMany: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+      const { models } = ctx;
+
+      const { query, skip, limit, sort = {} } = input || {};
+
+      if (!query) {
+        return await models.Deals.find(input).lean();
+      }
+
+      return await models.Deals.find(query)
+        .skip(skip || 0)
+        .limit(limit || 0)
+        .sort(sort)
+        .lean();
+    }),
+
     aggregate: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
       const { models } = ctx;
 

--- a/backend/plugins/tourism_api/AGENTS.md
+++ b/backend/plugins/tourism_api/AGENTS.md
@@ -1,0 +1,105 @@
+# `tourism_api` Plugin Guide
+
+## Identity
+
+- **Plugin:** `tourism`
+- **Project:** `tourism_api`
+- **Layer:** `Backend API`
+- **Path:** `backend/plugins/tourism_api`
+- **Last synchronized:** `2026-09-02`
+
+## Scope
+
+### Owns
+
+- Tourism PMS room/deal availability queries, OTA data storage, BMS
+  GraphQL and tRPC APIs, and tourism-owned db collections and constants.
+- Tourism plugin GraphQL and tRPC contracts under `src/modules`.
+
+### Does not own
+
+- Sales deals, pipelines, and stages; consumed through the sales
+  plugin's tRPC contracts only.
+- Core products, customers, users, or shared platform packages.
+- Frontend UI; any tourism UI lives outside this project.
+- Direct source imports from another plugin; cross-service access must use
+  published GraphQL, tRPC, HTTP, event, or federation contracts.
+
+## Current Capabilities
+
+- Runs as the `tourism` federated GraphQL and tRPC plugin service on
+  port 3311 with tenant-scoped models.
+- PMS resolvers resolve pipeline stages and scan deals to report room
+  availability, busy rooms, and paginated deal lists by date range and
+  product/stage filters.
+- OTA module owns its tenant-scoped db collections and types.
+- BMS module owns its db, GraphQL, and tRPC APIs.
+
+## Architecture
+
+| Area       | Path                          | Responsibility                                  |
+| ---------- | ----------------------------- | ----------------------------------------------- |
+| Bootstrap  | `src/main.ts`                 | Starts and registers the tourism plugin          |
+| Runtime    | `src/connectionResolvers.ts`, `src/trpc` | Tenant-scoped models and tRPC app router |
+| PMS        | `src/modules/pms`             | Room availability and deal-scan GraphQL queries  |
+| OTA        | `src/modules/ota`              | OTA data storage and types                       |
+| BMS        | `src/modules/bms`              | BMS GraphQL and tRPC APIs                        |
+
+## Contracts
+
+### Provides
+
+- PMS GraphQL queries for room availability and deal listing
+  (`src/modules/pms/graphql`).
+- BMS GraphQL and tRPC contracts (`src/modules/bms`).
+
+### Consumes
+
+- Sales stages and deals through the sales plugin's tRPC contracts:
+  `stage.find` and `deal.findMany` (internal legacy dual-shape deal
+  reads, not agent-facing).
+- `erxes-api-shared` utilities and plugin startup APIs.
+
+## Data and State
+
+- Tenant-scoped Mongoose models are generated per request `subdomain`.
+- OTA and BMS data are stored in tourism-owned tenant-scoped collections.
+- No sales documents are stored here; deals and stages are always fetched
+  through sales plugin tRPC contracts.
+
+## Local Invariants
+
+- Preserve tenant isolation by using the request `subdomain` for every
+  model, service, resolver, worker, and route access.
+- All sales data access goes through the sales plugin's published tRPC
+  contracts; never read or mutate another plugin's collections directly.
+- `deal.findMany` is the service-only deal read: it restores the legacy
+  `deal.find` dual-shape input (including the extra `search` key) and
+  must not be replaced by the strict agent-facing `deal.find` contract.
+- Availability scans intentionally request unbounded results; keep them
+  on `deal.findMany`, never on the capped agent-facing `deal.find`.
+- `sendTRPCMessage` returns `defaultValue` on any error, including input
+  schema rejections; validate integration results defensively instead of
+  assuming an empty array means "no data".
+
+## Validation
+
+- `pnpm nx build tourism_api`
+- Smoke scenario: query PMS room availability for a date range with deals
+  spanning the boundary and verify busy rooms and availability match.
+
+## Recent Changes
+
+<!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Deal reads moved to `deal.findMany`
+
+- **Summary:** All four PMS deal-scan call sites in
+  `src/modules/pms/graphql/resolvers/queries/configs.ts` now call the
+  sales plugin's internal `deal.findMany` tRPC procedure instead of
+  `deal.find`, which was tightened into a strict agent-facing contract
+  by erxes #9102 and rejected this plugin's `{ query, search, ... }`
+  input shape.
+- **Affected areas:** `src/modules/pms/graphql/resolvers/queries/configs.ts`.
+- **Contracts changed:** Internal tRPC call sites only; no tourism
+  GraphQL or tRPC contract changed.

--- a/backend/plugins/tourism_api/AGENTS.md
+++ b/backend/plugins/tourism_api/AGENTS.md
@@ -78,6 +78,10 @@
   must not be replaced by the strict agent-facing `deal.find` contract.
 - Availability scans intentionally request unbounded results; keep them
   on `deal.findMany`, never on the capped agent-facing `deal.find`.
+- All four PMS deal-scan resolvers share the `fetchPmsDeals` helper
+  (stage resolution + `deal.findMany`); add new scans there instead of
+  duplicating the stage-filter block (SonarCloud new-code duplication
+  gate is ≤ 3%).
 - `sendTRPCMessage` returns `defaultValue` on any error, including input
   schema rejections; validate integration results defensively instead of
   assuming an empty array means "no data".
@@ -91,6 +95,18 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-02` — Shared `fetchPmsDeals` helper and working `search`
+
+- **Summary:** Extracted the four duplicated stage-resolution +
+  `deal.findMany` blocks into one `fetchPmsDeals` helper (resolves the
+  SonarCloud new-code duplication gate), and the `search` argument now
+  flows through to sales `deal.findMany` — it was silently dropped by
+  the old handler, so room-list searches returned non-matching deals
+  (PR #9207 review findings).
+- **Affected areas:** `src/modules/pms/graphql/resolvers/queries/configs.ts`.
+- **Contracts changed:** None in tourism GraphQL; behavior change is
+  that `pmsRooms`/`cpPmsRooms` now actually filter by `search`.
 
 ### `2026-09-02` — Deal reads moved to `deal.findMany`
 

--- a/backend/plugins/tourism_api/AGENTS.md
+++ b/backend/plugins/tourism_api/AGENTS.md
@@ -37,13 +37,13 @@
 
 ## Architecture
 
-| Area       | Path                          | Responsibility                                  |
-| ---------- | ----------------------------- | ----------------------------------------------- |
-| Bootstrap  | `src/main.ts`                 | Starts and registers the tourism plugin          |
-| Runtime    | `src/connectionResolvers.ts`, `src/trpc` | Tenant-scoped models and tRPC app router |
-| PMS        | `src/modules/pms`             | Room availability and deal-scan GraphQL queries  |
-| OTA        | `src/modules/ota`              | OTA data storage and types                       |
-| BMS        | `src/modules/bms`              | BMS GraphQL and tRPC APIs                        |
+| Area      | Path                                     | Responsibility                                  |
+| --------- | ---------------------------------------- | ----------------------------------------------- |
+| Bootstrap | `src/main.ts`                            | Starts and registers the tourism plugin         |
+| Runtime   | `src/connectionResolvers.ts`, `src/trpc` | Tenant-scoped models and tRPC app router        |
+| PMS       | `src/modules/pms`                        | Room availability and deal-scan GraphQL queries |
+| OTA       | `src/modules/ota`                        | OTA data storage and types                      |
+| BMS       | `src/modules/bms`                        | BMS GraphQL and tRPC APIs                       |
 
 ## Contracts
 

--- a/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
@@ -165,7 +165,7 @@ const configQueries: Record<string, Resolver> = {
       method: 'query',
       pluginName: 'sales',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: {
         query: {
           status: { $ne: ARCHIVED_DEAL_STATUS },
@@ -224,7 +224,7 @@ const configQueries: Record<string, Resolver> = {
       method: 'query',
       pluginName: 'sales',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: {
         query: {
           status: { $ne: ARCHIVED_DEAL_STATUS },
@@ -281,7 +281,7 @@ const configQueries: Record<string, Resolver> = {
       pluginName: 'sales',
       method: 'query',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: {
         query: {
           status: { $ne: ARCHIVED_DEAL_STATUS },
@@ -356,7 +356,7 @@ const configQueries: Record<string, Resolver> = {
       pluginName: 'sales',
       method: 'query',
       module: 'deal',
-      action: 'find',
+      action: 'findMany',
       input: {
         query: {
           status: { $ne: ARCHIVED_DEAL_STATUS },

--- a/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
+++ b/backend/plugins/tourism_api/src/modules/pms/graphql/resolvers/queries/configs.ts
@@ -6,6 +6,73 @@ import { IContext } from '~/connectionResolvers';
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+type PmsDeal = {
+  _id: string;
+  productsData?: Array<{
+    productId: string;
+    startDate?: Date;
+    endDate?: Date;
+  }>;
+  startDate: Date;
+  closeDate: Date;
+};
+
+// Shared PMS deal scan: resolve the pipeline's non-skipped stages, then read
+// deals through the sales plugin's internal `deal.findMany` tRPC contract.
+// `query` carries the caller-specific date/product conditions; `search`,
+// `skip`, and `limit` flow through to the paginated room-list queries.
+const fetchPmsDeals = async ({
+  subdomain,
+  pipelineId,
+  skipStageIds,
+  query,
+  search,
+  skip,
+  limit,
+}: {
+  subdomain: string;
+  pipelineId: string;
+  skipStageIds?: string[];
+  query: Record<string, unknown>;
+  search?: string;
+  skip?: number;
+  limit?: number;
+}): Promise<PmsDeal[]> => {
+  const stages = await sendTRPCMessage({
+    subdomain,
+    method: 'query',
+    pluginName: 'sales',
+    module: 'stage',
+    action: 'find',
+    input: { pipelineId },
+  });
+
+  const stageIds = stages?.map((x) => x._id) || [];
+  const stageIdFilter = stageIds.filter(
+    (item) => !skipStageIds?.includes(item),
+  );
+
+  const deals = await sendTRPCMessage({
+    subdomain,
+    method: 'query',
+    pluginName: 'sales',
+    module: 'deal',
+    action: 'findMany',
+    input: {
+      query: {
+        status: { $ne: ARCHIVED_DEAL_STATUS },
+        stageId: { $in: stageIdFilter },
+        ...query,
+      },
+      ...(search ? { search } : {}),
+      ...(skip !== undefined ? { skip } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+    },
+  });
+
+  return (deals as PmsDeal[]) || [];
+};
+
 const getFilteredProducts = async ({
   subdomain,
   categoryIds,
@@ -148,42 +215,22 @@ const configQueries: Record<string, Resolver> = {
     },
     { subdomain }: IContext,
   ) {
-    const stages = await sendTRPCMessage({
+    return fetchPmsDeals({
       subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'stage',
-      action: 'find',
-      input: { pipelineId: pipelineId },
-    });
-
-    const stageIds = stages?.map((x) => x._id) || [];
-    const newArray = stageIds.filter((item) => !skipStageIds?.includes(item));
-
-    const deals = await sendTRPCMessage({
-      subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'deal',
-      action: 'findMany',
-      input: {
-        query: {
-          status: { $ne: ARCHIVED_DEAL_STATUS },
-          stageId: { $in: newArray },
-          productsData: {
-            $elemMatch: {
-              startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
-              endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
-            },
+      pipelineId,
+      skipStageIds,
+      query: {
+        productsData: {
+          $elemMatch: {
+            startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
+            endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
           },
         },
-        search,
-        skip: (page - 1) * perPage,
-        limit: perPage,
       },
+      search,
+      skip: (page - 1) * perPage,
+      limit: perPage,
     });
-
-    return deals || [];
   },
 
   async cpPmsRooms(
@@ -207,41 +254,23 @@ const configQueries: Record<string, Resolver> = {
     },
     { models, subdomain }: IContext,
   ) {
-    const stages = await sendTRPCMessage({
+    const deals = await fetchPmsDeals({
       subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'stage',
-      action: 'find',
-      input: { pipelineId: pipelineId },
-    });
-
-    const stageIds = stages?.map((x) => x._id) || [];
-    const newArray = stageIds.filter((item) => !skipStageIds?.includes(item));
-
-    const deals = await sendTRPCMessage({
-      subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'deal',
-      action: 'findMany',
-      input: {
-        query: {
-          status: { $ne: ARCHIVED_DEAL_STATUS },
-          stageId: { $in: newArray },
-          productsData: {
-            $elemMatch: {
-              startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
-              endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
-            },
+      pipelineId,
+      skipStageIds,
+      query: {
+        productsData: {
+          $elemMatch: {
+            startDate: { $lte: new Date(endDate) }, // Document starts before your range ends
+            endDate: { $gte: new Date(startDate) }, // Document ends after your range starts
           },
         },
-        search,
-        skip: (page - 1) * perPage,
-        limit: perPage,
       },
+      search,
+      skip: (page - 1) * perPage,
+      limit: perPage,
     });
-    return deals || [];
+    return deals;
   },
 
   async pmsCheckRooms(
@@ -261,38 +290,20 @@ const configQueries: Record<string, Resolver> = {
     },
     { models, subdomain }: IContext,
   ) {
-    const stages = await sendTRPCMessage({
-      subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'stage',
-      action: 'find',
-      input: { pipelineId: pipelineId },
-    });
-
-    const stageIds = stages?.map((x) => x._id) || [];
-    const newArray = stageIds.filter((item) => !skipStageIds?.includes(item));
-
     const searchStart = new Date(startDate);
     const searchEnd = new Date(endDate);
 
-    const deals = await sendTRPCMessage({
+    const deals = await fetchPmsDeals({
       subdomain,
-      pluginName: 'sales',
-      method: 'query',
-      module: 'deal',
-      action: 'findMany',
-      input: {
-        query: {
-          status: { $ne: ARCHIVED_DEAL_STATUS },
-          stageId: { $in: newArray },
-          // 1. Broad filter: Find any deal that touches our range and has our rooms
-          productsData: {
-            $elemMatch: { productId: { $in: ids } },
-          },
-          startDate: { $lt: searchEnd },
-          closeDate: { $gt: searchStart },
+      pipelineId,
+      skipStageIds,
+      query: {
+        // 1. Broad filter: Find any deal that touches our range and has our rooms
+        productsData: {
+          $elemMatch: { productId: { $in: ids } },
         },
+        startDate: { $lt: searchEnd },
+        closeDate: { $gt: searchStart },
       },
     });
 
@@ -339,37 +350,19 @@ const configQueries: Record<string, Resolver> = {
     },
     { models, subdomain }: IContext,
   ) {
-    const stages = await sendTRPCMessage({
+    const deals = await fetchPmsDeals({
       subdomain,
-      method: 'query',
-      pluginName: 'sales',
-      module: 'stage',
-      action: 'find',
-      input: { pipelineId: pipelineId },
-    });
-
-    const stageIds = stages?.map((x) => x._id) || [];
-    const newArray = stageIds.filter((item) => !skipStageIds?.includes(item));
-
-    const deals = await sendTRPCMessage({
-      subdomain,
-      pluginName: 'sales',
-      method: 'query',
-      module: 'deal',
-      action: 'findMany',
-      input: {
-        query: {
-          status: { $ne: ARCHIVED_DEAL_STATUS },
-          stageId: { $in: newArray },
-          productsData: {
-            $elemMatch: {
-              productId: { $in: ids },
-              startDate: {
-                $lte: new Date(endDate), // 🔥 important
-              },
-              endDate: {
-                $gte: new Date(startDate), // 🔥 important
-              },
+      pipelineId,
+      skipStageIds,
+      query: {
+        productsData: {
+          $elemMatch: {
+            productId: { $in: ids },
+            startDate: {
+              $lte: new Date(endDate), // 🔥 important
+            },
+            endDate: {
+              $gte: new Date(startDate), // 🔥 important
             },
           },
         },


### PR DESCRIPTION
## Summary

#9102 tightened `deal.find` into a strict, bounded, agent-facing contract and stated *"Verified no cross-plugin `sendTRPCMessage` callers of `deal.find`/`deal.count` exist."* **That compatibility claim was wrong.** `deal.find` was a shared service contract long before #9058 exposed it to agents — the legacy `if (!query)` dual-shape branch (bare Mongo filter, or `{ query, skip, limit, sort }` with `limit || 0` = unbounded) existed precisely to serve internal plugin callers.

Cross-plugin callers that #9102 silently broke:

| Caller | Form | Silent failure |
|---|---|---|
| `accounting_api` `checkSynced.ts` | `{ _id: { $in: ids } }` | deals stop syncing to transactions — no error, no log |
| `mongolian_api` `ebarimt.ts` | `{ ...dealsFilter }` | `contentId: { $in: [] }` → empty results as fact |
| `mongolian_api` `erkhet/checkSynced.ts` | `{ _id: { $in: dealIds } }` | sync logs never created |
| `tourism_api` `configs.ts` ×4 | `{ query, search, skip, limit }` | `search` key rejected by zod → empty deal lists |

Because `sendTRPCMessage` (`erxes-api-shared/src/utils/trpc/index.ts`) catches **every** error and returns `defaultValue`, each zod `BAD_REQUEST` was swallowed into a silent empty array — the same "silent wrong answer" bug class #9102 set out to kill, reintroduced against internal services.

## Changes

- **`sales_api`** — new `deal.findMany` tRPC procedure, **unannotated** (admit-only rule ⇒ invisible to agents, never in `/agent-tools/manifest`). Restores the exact legacy dual-shape input of pre-#9102 `deal.find`: bare Mongo filter or wrapped `{ query, search?, skip?, limit?, sort? }`, unbounded results on purpose (tourism availability scans rely on unbounded reads; `_id: { $in }` calls are inherently bounded).
- **Migrated all 7 call sites** (action name only, no other change): accounting ×1, mongolian ×2, tourism ×4.
- **`AGENTS.md`**: updated sales (incl. correcting the disproven "no cross-plugin callers" claim) and accounting; **created** the missing mongolian and tourism guides. All record a new invariant: *sweep every plugin and `erxes-api-shared` for `sendTRPCMessage` callers before tightening any tRPC procedure input — its catch swallows schema rejections into `defaultValue`, so broken callers fail silently with empty results.*

`deal.find` (agent-facing, strict, bounded) and `deal.count` are unchanged. `deal.findMany` is the service-only contract; agents and services no longer share one input schema.

## Compatibility

Verified by exhaustive repo-wide sweep (`module: 'deal'` in both quote styles, all backend/frontend/apps dirs, plus dynamic-module maps in tags/template — none reach deal):
- **0** remaining cross-plugin callers of `deal.find`/`deal.count` after migration
- **0** cross-plugin callers of `deal.count` ever existed
- All 7 former `deal.find` sites now call `deal.findMany`

## Test plan

- `pnpm nx build sales_api` ✅ `pnpm nx build accounting_api` ✅ `pnpm nx build mongolian_api` ✅ `pnpm nx build tourism_api` ✅ (all exit 0, `findMany` verified present in dist artifacts)
- `pnpm nx test accounting_api` ✅ (39/39 pass)
- Smoke: `GET /agent-tools/manifest` on sales service must **not** list `deal.findMany` (unannotated ⇒ agent-invisible)
- Smoke: accounting deal sync / erkhet sync / tourism PMS availability return populated results again instead of silent empty arrays

## Summary by Sourcery

Restore reliable internal deal reads by introducing an agent-invisible `deal.findMany` contract and migrating all cross-plugin callers to it.

New Features:
- Add an internal, agent-invisible `deal.findMany` service contract that preserves legacy deal query shapes and supports unbounded reads and search filtering.

Bug Fixes:
- Restore deal synchronization, receipt filtering, accounting sync logging, and tourism PMS availability results by migrating seven cross-plugin callers from the tightened `deal.find` contract.
- Ensure accounting reports all requested deal IDs as errors when the sales service is unavailable instead of silently treating the failure as an empty match.

Enhancements:
- Separate strict bounded agent-facing deal reads from the legacy service-only deal read contract.
- Consolidate tourism PMS deal retrieval and preserve search, pagination, stage, and date filtering across its queries.

Documentation:
- Document the internal deal contract, cross-plugin dependency checks, failure-handling invariant, and ownership guidance for accounting, mongolian, sales, and tourism plugins.

Tests:
- Validate sales, accounting, mongolian, and tourism builds and accounting tests, with smoke checks for agent manifest visibility and restored integration results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deal synchronization reliability across accounting, tourism, and Mongolian integrations.
  - Deal lookup failures now surface all affected deal IDs instead of appearing as empty results.
  - Improved deal filtering for name, pipeline, and room searches to return matching sales records more consistently.

- **Documentation**
  - Updated integration guides with current synchronization behavior, service contracts, validation steps, architecture, and operational workflows.
  - Added documentation for the tourism integration’s deal retrieval and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->