### PR TITLE
Revert "fix(sales): bound and strictly validate agent-facing deal reads"

### DIFF
--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -49,17 +49,17 @@
 
 ## Architecture
 
-| Area                | Path                                                                      | Responsibility                                                        |
-| ------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Bootstrap           | `src/main.ts`                                                             | Starts and registers the sales plugin                                 |
-| Runtime             | `src/main.ts`, `src/connectionResolvers.ts`, `src/trpc`                   | Start the plugin, load tenant-scoped models, and expose tRPC          |
-| Agent tool metadata | `src/trpc/agentMeta.ts`                                                   | Local `agentMeta` helper for agent-callable tRPC annotations          |
-| Models              | `src/modules/sales/db`                                                    | Sales Mongoose schemas and models                                     |
-| GraphQL             | `src/modules/sales/graphql`, `src/apollo`                                 | Sales schemas, resolvers, mutations, queries, and subscriptions       |
-| Pipeline validation | `src/modules/sales/utils/pipelineProperties.ts`                           | Validates pipeline property ids through Core tRPC                     |
-| References          | `src/modules/sales/meta`                                                  | Sales reference values, automation constants, and after-process logic |
-| Documents           | `src/modules/sales/documents`                                             | Generate sales document content and amount mappings                   |
-| POS and ecommerce   | `src/modules/pos`, `src/modules/ecommerce`                                | Provide sales-owned POS and ecommerce behavior                        |
+| Area                | Path                                                    | Responsibility                                                        |
+| ------------------- | ------------------------------------------------------- | --------------------------------------------------------------------- |
+| Bootstrap           | `src/main.ts`                                           | Starts and registers the sales plugin                                 |
+| Runtime             | `src/main.ts`, `src/connectionResolvers.ts`, `src/trpc` | Start the plugin, load tenant-scoped models, and expose tRPC          |
+| Agent tool metadata | `src/trpc/agentMeta.ts`                                 | Local `agentMeta` helper for agent-callable tRPC annotations          |
+| Models              | `src/modules/sales/db`                                  | Sales Mongoose schemas and models                                     |
+| GraphQL             | `src/modules/sales/graphql`, `src/apollo`               | Sales schemas, resolvers, mutations, queries, and subscriptions       |
+| Pipeline validation | `src/modules/sales/utils/pipelineProperties.ts`         | Validates pipeline property ids through Core tRPC                     |
+| References          | `src/modules/sales/meta`                                | Sales reference values, automation constants, and after-process logic |
+| Documents           | `src/modules/sales/documents`                           | Generate sales document content and amount mappings                   |
+| POS and ecommerce   | `src/modules/pos`, `src/modules/ecommerce`              | Provide sales-owned POS and ecommerce behavior                        |
 
 ## Contracts
 

--- a/backend/plugins/sales_api/AGENTS.md
+++ b/backend/plugins/sales_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `sales_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/sales_api`
-- **Last synchronized:** `2026-08-21`
+- **Last synchronized:** `2026-08-19`
 
 ## Scope
 
@@ -69,11 +69,7 @@
   `salesPipelinesAdd`, and `salesPipelinesEdit`.
 - Agent-callable tRPC tools (admit-only via `.meta({ agent })`), each gated by
   the listed sales permission action:
-  - `deal.findOne`, `deal.getLink` — `showDeals`
-  - `deal.find` — `showDeals`; strict input `{ query?, skip?, limit?, sort?, fields? }`
-    (unknown keys rejected by name), always bounded (`limit` defaults to 20,
-    hard max 100), `fields` drives a real projection
-  - `deal.count` — `showDeals`; strict input `{ filter? }` (`{}` counts all)
+  - `deal.findOne`, `deal.find`, `deal.count`, `deal.getLink` — `showDeals`
   - `stage.findOne`, `stage.find` — `showDeals`
   - `pipeline.findOne` — `pipelinesWatch`
   - `pos.findOne`, `pos.find` — `posRead`
@@ -120,11 +116,6 @@
   the full total amount.
 - Deal amount fallbacks should preserve the existing `tickUsed` semantics used
   by sales totals.
-- Agent-facing deal reads are always bounded and strictly shaped: `deal.find`
-  clamps `limit` to 1–100 (default 20) on every path and rejects unknown input
-  keys by name, `deal.count` takes `{ filter? }` — an agent's unbounded
-  `deal.find {}` over 1.27M deals crash-looped this service (exit 139) on
-  2026-08-20, and wrapper-shaped input silently matched nothing.
 - Do not introduce new `schemaWrapper` usage in backend schemas.
 - Agent tool annotations are admit-only: never annotate raw-mongo helpers
   (`deal.aggregate`, `deal.updateOne`, `orders.updateOne`), system-user
@@ -155,25 +146,6 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
-
-### `2026-08-21` — Bounded, strict agent-facing deal reads
-
-- **Summary:** `deal.find` can no longer execute unbounded or mis-shaped
-  queries: input is now a strict zod object (`{ query?, skip?, limit?, sort?, fields? }`
-  — unknown keys such as an invented `arg` wrapper are rejected by name
-  instead of silently matching nothing), results are always bounded (`limit`
-  defaults to 20 and is hard-capped at 100, including the no-query path — an
-  agent's `deal.find {}` over 1.27M deals crash-looped this service with
-  exit 139 on 2026-08-20), and `fields` now drives a real projection so
-  agents stay under the 64KB agent-tools response budget. `deal.count` takes
-  an explicit `{ filter? }` object for the same reason (a `{ query: ... }`
-  wrapper previously counted 0 silently). No cross-plugin tRPC callers of
-  either procedure exist, so the tightened contracts break no consumers.
-- **Affected areas:** `src/modules/sales/trpc/deal.ts`.
-- **Contracts changed:** `deal.find` input is now strict
-  `{ query?, skip?, limit?, sort?, fields? }` (the bare top-level filter form
-  is rejected) with `limit` clamped to 1–100 (default 20); `deal.count` input
-  is now strict `{ filter? }` instead of a bare filter object.
 
 ### `2026-08-19` — Agent-callable tRPC tools
 

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -379,7 +379,7 @@ export const dealTrpcRouter = t.router({
     find: t.procedure
       .meta(
         agentMeta(
-          'List stages ordered by position: { pipelineId? } or any MongoDB-style query. Pass pipelineId from pipeline.findOne to see a pipeline\'s stages in order.',
+          "List stages ordered by position: { pipelineId? } or any MongoDB-style query. Pass pipelineId from pipeline.findOne to see a pipeline's stages in order.",
           { module: 'deal', action: 'showDeals' },
         ),
       )

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -1,6 +1,5 @@
 import { initTRPC } from '@trpc/server';
 import { ITRPCContext, sendTRPCMessage } from 'erxes-api-shared/utils';
-import type { SortOrder } from 'mongoose';
 import { z } from 'zod';
 import { IModels } from '~/connectionResolvers';
 import { agentMeta } from '~/trpc/agentMeta';
@@ -66,33 +65,6 @@ const updateDealProcedure = t.procedure
     });
   });
 
-// Agent-facing reads are ALWAYS bounded. An unbounded find serializes the
-// whole deals collection (observed 2026-08-20: an agent's `deal.find {}` call
-// over 1.27M deals crash-looped the service — exit 139 — taking every
-// subsequent agent call down with it). Defaults also keep a full-document
-// page inside the 64KB agent-tools response budget.
-const AGENT_FIND_DEFAULT_LIMIT = 20;
-const AGENT_FIND_MAX_LIMIT = 100;
-
-// Strict input objects: unknown top-level keys are rejected by name instead
-// of being silently treated as document filters (an invented "arg"/"query"
-// wrapper used to match 0 records and the agent reported "no data" as fact).
-const dealFindInput = z
-  .object({
-    query: z.record(z.unknown()).optional(),
-    skip: z.number().int().min(0).optional(),
-    limit: z.number().int().min(1).optional(),
-    sort: z.record(z.unknown()).optional(),
-    fields: z.array(z.string()).optional(),
-  })
-  .strict();
-
-const dealCountInput = z
-  .object({
-    filter: z.record(z.unknown()).optional(),
-  })
-  .strict();
-
 export const dealTrpcRouter = t.router({
   deal: {
     findOne: t.procedure
@@ -111,29 +83,24 @@ export const dealTrpcRouter = t.router({
     find: t.procedure
       .meta(
         agentMeta(
-          'Search deals: { query: {...}, skip?, limit?, sort?, fields? }, e.g. { query: { stageId: "..." } } or { query: { assignedUserIds: { $in: ["userId"] } } }. Only the listed fields are accepted. Results are always bounded: limit defaults to 20 and is capped at 100 — paginate with skip, and pass fields to project only the attributes you need. Resolve stage names to stageId with stage.find and pipeline names with pipeline.findOne first.',
+          'Search deals with a MongoDB-style filter: { query: {...}, skip?, limit?, sort? }, e.g. { query: { stageId: "..." } } or { query: { assignedUserIds: { $in: ["userId"] } } }. Pass a plain filter object without query to match directly. Resolve stage names to stageId with stage.find and pipeline names with pipeline.findOne first.',
           { module: 'deal', action: 'showDeals' },
         ),
       )
-      .input(dealFindInput)
+      .input(z.any())
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
-        const { query = {}, skip = 0, limit, sort = {}, fields } = input;
 
-        const boundedLimit = Math.min(
-          limit ?? AGENT_FIND_DEFAULT_LIMIT,
-          AGENT_FIND_MAX_LIMIT,
-        );
-        const projection = fields?.length
-          ? Object.fromEntries(fields.map((field) => [field, 1]))
-          : undefined;
+        const { query, skip, limit, sort = {} } = input;
 
-        return await models.Deals.find(query, projection)
-          .skip(skip)
-          .limit(boundedLimit)
-          // Sort directions arrive as plain JSON; mongoose validates the
-          // values at query time (external-library boundary cast).
-          .sort(sort as Record<string, SortOrder>)
+        if (!query) {
+          return await models.Deals.find(input).lean();
+        }
+
+        return await models.Deals.find(query)
+          .skip(skip || 0)
+          .limit(limit || 0)
+          .sort(sort)
           .lean();
       }),
 
@@ -146,15 +113,15 @@ export const dealTrpcRouter = t.router({
     count: t.procedure
       .meta(
         agentMeta(
-          'Count deals matching a MongoDB-style filter: { filter: {...} }, e.g. { filter: { stageId: "..." } }; {} counts every deal. Use for "how many deals ..." questions instead of deal.find.',
+          'Count deals matching a filter, e.g. { stageId: "..." }. Use for "how many deals ..." questions instead of deal.find.',
           { module: 'deal', action: 'showDeals' },
         ),
       )
-      .input(dealCountInput)
+      .input(z.any())
       .query(async ({ ctx, input }) => {
         const { models } = ctx;
 
-        return await models.Deals.find(input.filter ?? {}).countDocuments();
+        return await models.Deals.find(input).countDocuments();
       }),
 
     getLink: t.procedure


### PR DESCRIPTION
Reverts erxes/erxes#9102

## Summary by Sourcery

Revert the bounded and strict validation changes for agent-facing sales deal reads.

Enhancements:
- Restore the previous flexible agent-facing deal read contracts, allowing unvalidated filters and unbounded result queries for deal search and counting.

Documentation:
- Revert the sales API agent documentation describing bounded and strictly validated deal reads.

Chores:
- Revert the strict validation and bounding changes for sales deal tRPC reads, including support for direct filter inputs and optional query wrappers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Deal searches now support broader filter inputs.
  * Optional skip, limit, and sort settings are applied when provided through a search query.
  * Automatic pagination enforcement and field projection have been removed from deal searches.
  * Deal counts now evaluate the complete filter provided, improving consistency with search filtering.
  * Updated deal stage-listing descriptions and related synchronization documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->