### PR TITLE
fix(core): sort fields query by order instead of code

### DIFF
--- a/backend/core-api/src/modules/properties/graphql/resolvers/queries/field.ts
+++ b/backend/core-api/src/modules/properties/graphql/resolvers/queries/field.ts
@@ -38,7 +38,7 @@ export const fieldQueries: Record<string, Resolver<any, any, IContext>> = {
     const filter = await generateFilter(models, params);
 
     if (!params.orderBy) {
-      params.orderBy = { code: 1 };
+      params.orderBy = { order: 1 };
     }
 
     return await cursorPaginate<IFieldDocument>({


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Sort fields by their configured order by default instead of sorting by field code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the default field listing order to follow the configured field order when no specific sorting is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->