### PR TITLE
feat(frontline): ticket comments as a client-portal thread

### DIFF
--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -1355,7 +1355,6 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 
 <!-- Newest first. Keep at most 10 entries. -->
 
-
 ### `2026-09-02` — Ticket visibility rules apply outside pipeline-scoped lists
 
 - **Summary:** All four pipeline visibility rules were dead on the channel

--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -51,6 +51,12 @@
 
 ## Current Capabilities
 
+- A ticket note carries a `type`: `note` is internal to the team, `comment` is
+  the thread the requester reads and answers in the client portal. Notes stored
+  before comments existed have no `type`, so every internal-note read matches
+  `type: { $ne: 'comment' }` rather than `type: 'note'`.
+- `cpTicketGetNotes` returns comments only. Internal notes were previously
+  handed to the portal alongside them.
 - Ticket pipelines persist an ordered unique `propertyIds` selection. Create
   and update validate every id against Core `frontline:ticket` fields before
   writing it. `isPropertySelectionConfigured` distinguishes untouched legacy
@@ -392,6 +398,24 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   to the `propertyFields` of the pipeline's ticket config, checked for the
   required ones, validated through core `fields.validateFieldValues`, and stored
   on `Ticket.propertiesData`.
+- GraphQL: `ticketGetNotes(contentId: String!, type: String): [Note]` — a
+  ticket's notes oldest-first; `type: "comment"` returns the requester thread
+  and anything else returns internal notes.
+- GraphQL: `ticketCreateNote(content, contentId, mentions, type)` — `type`
+  accepts `note` (default) or `comment`.
+- GraphQL: `Note.type: String` and `Note.clientPortalAuthor` — the latter is a
+  `TicketNoteClientPortalAuthor { _id, fullName, email, avatar }` resolved from
+  Core `cpUsers`, and is null for notes written by an erxes user.
+- GraphQL: `Note.createdAt` / `Note.updatedAt` use the `Date` scalar, like
+  `Ticket` and `Activity`. They were `String`, which serialized a Mongoose
+  `Date` to epoch milliseconds as text — a value `new Date()` cannot parse.
+- GraphQL (client portal): `cpTicketCreateNote` always writes `type: "comment"`
+  and `cpTicketGetNotes(ticketId)` only reads comments back.
+- GraphQL subscription: `cpTicketCommentInserted(ticketId: String!): Note` —
+  every comment on that ticket, from either side, pushed to the client portal.
+  It aliases the internal `ticketCommentInserted:<ticketId>` pubsub topic that
+  `Note.createNote` publishes. The team does not need it; the ticket detail
+  already learns about comments through `ticketActivityChanged`.
 
 ### Consumes
 
@@ -521,9 +545,24 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - Facebook upload configuration is cached in a module-level variable in
   `src/modules/integrations/facebook/utils.ts` and is **not** keyed by
   subdomain — treat it as a known cross-tenant hazard when touching that file.
+- `Note.type` (`'note' | 'comment'`, default `'note'`, indexed) partitions the
+  single `notes` collection into internal notes and the portal comment thread.
+- A comment written in the portal is stored with `createdBy: "cp:<id>"`, where
+  the id is the author's `erxesCustomerId` when it exists and their cp user
+  `_id` otherwise.
 
 ## Local Invariants
 
+- Any timestamp a client renders must be exposed through the `Date` scalar.
+  `String` turns a Mongoose `Date` into epoch milliseconds as text, which
+  `new Date()` rejects.
+- `Ticket.subscribedUserIds` only ever holds erxes user ids. `createNote` skips
+  the `$addToSet` when the author is a `cp:` portal user, so a requester's
+  comment can never make them a subscriber.
+- Every client-portal-facing note resolver filters on `type: 'comment'`.
+  Internal notes must never reach the portal.
+- Comments raise a `COMMENT` activity, not a `NOTE` one, so the ticket timeline
+  and the comment thread stay separate surfaces over one subscription.
 - Call Pro stays invisible unless `CALLPRO_ENABLED=true`. That single env var
   gates the webhook route, the create/update handlers, `callProAudio`, and —
   through `callProConfig` — every UI surface. It is independent of the
@@ -1317,6 +1356,27 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   `imap_integrations`, `imap_messages` and `imap_logs` models are no longer
   registered.
 
+### `2026-09-01` — Ticket comments split from internal notes
+
+- **Summary:** Ticket notes gained a `type`, so the team's internal notes and
+  the two-way comment thread with the client-portal requester are separate
+  surfaces; the portal now reads and writes comments only, where it previously
+  received every internal note on the ticket.
+- **Affected areas:** `src/apollo/subscription.ts`,
+  `src/modules/ticket/@types/note.ts`,
+  `src/modules/ticket/db/definitions/note.ts`,
+  `src/modules/ticket/db/models/Note.ts`,
+  `src/modules/ticket/graphql/schemas/note.ts`,
+  `src/modules/ticket/graphql/resolvers/{queries,mutations}/{note,clientPortal}.ts`,
+  `src/modules/ticket/graphql/resolvers/customResolvers/note.ts`,
+  `src/apollo/resolvers/resolvers.ts`, `src/utils/notifications.ts`.
+- **Contracts changed:** `Note` gained `type` and `clientPortalAuthor`; new
+  `TicketNoteClientPortalAuthor` type and `ticketGetNotes` query;
+  `ticketCreateNote` gained `type`; `cpTicketGetNotes` narrowed to comments;
+  new `cpTicketCommentInserted(ticketId)` subscription; `Note.createdAt` /
+  `Note.updatedAt` moved from `String` to the `Date` scalar, so they now
+  serialize as ISO strings instead of epoch milliseconds.
+
 ### `2026-08-28` — Every zone is listed, and the picker says which are usable
 
 - **Summary:** `listZones` asked for a single page of 50, so an account with more
@@ -1453,23 +1513,3 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - **Summary:** `sendReply` coerces the Meta-retired CONFIRMED_EVENT_UPDATE / POST_PURCHASE_UPDATE / ACCOUNT_UPDATE tags to `HUMAN_AGENT` before every Send API call, restoring replies to conversations older than 24 hours (retired tags fail with error 100 "Invalid parameter" since 2026-04-27).
 - **Affected areas:** `src/modules/integrations/facebook/utils.ts` (`normalizeMessengerTag`, `HUMAN_AGENT_MESSENGER_TAG`, `sendReply`)
 - **Contracts changed:** None
-
-### `2026-08-26` — Mail automation and reply drafts removed
-
-- **Summary:** The mail channel no longer registers automation. The
-  `frontline:mail.messages` trigger, the `Send Email` and `Draft Email Reply`
-  actions, their workers and the AI-context builder are gone, and so is the reply
-  draft they were the only producer of — nothing else could create one, so the
-  draft model, its GraphQL surface and its inbox card would have been unreachable
-  code.
-- **Affected areas:** `src/modules/integrations/mail/meta/` (deleted),
-  `src/modules/integrations/mail/db/{models/Drafts.ts,definitions/drafts.ts}`,
-  `@types/draft.ts`, `utils/draftEvents.ts` (deleted),
-  `src/meta/automations.ts`, `src/connectionResolvers.ts`,
-  `src/apollo/subscription.ts`,
-  `src/modules/integrations/mail/{constants,messageBroker}.ts`,
-  `.../mail/controller/receiveMessage.ts`, `.../mail/graphql/`.
-- **Contracts changed:** Removed the `frontline:mail.messages` automation
-  trigger, both mail automation actions, `MailDraft`, `mailConversationDraft`,
-  `mailDraftSave`, `mailDraftApprove`, `mailDraftRemove`, and the
-  `mailDraftChanged` subscription.

--- a/backend/plugins/frontline_api/src/apollo/resolvers/resolvers.ts
+++ b/backend/plugins/frontline_api/src/apollo/resolvers/resolvers.ts
@@ -5,6 +5,7 @@ import { Channel } from '@/channel/graphql/resolvers/customResolvers/channel';
 import { ChannelMember } from '@/channel/graphql/resolvers/customResolvers/member';
 import { Pipeline } from '@/ticket/graphql/resolvers/customResolvers/pipeline';
 import { Ticket } from '@/ticket/graphql/resolvers/customResolvers/status';
+import { Note } from '@/ticket/graphql/resolvers/customResolvers/note';
 import {
   Form,
   Submission,
@@ -23,6 +24,7 @@ export const customResolvers = {
   ChannelMember,
   Pipeline,
   Ticket,
+  Note,
   Form,
   Submission,
   KnowledgeBaseArticle,

--- a/backend/plugins/frontline_api/src/apollo/subscription.ts
+++ b/backend/plugins/frontline_api/src/apollo/subscription.ts
@@ -24,6 +24,7 @@ export default {
       cpConversationChanged(_id: String!): ConversationChangedResponse
       cpConversationMessageInserted(_id: String!): ConversationMessage
       cpConversationClientMessageInserted(userId: String!): ConversationMessage
+      cpTicketCommentInserted(ticketId: String!): Note
 
 		`,
   generateResolvers: (graphqlPubsub) => {
@@ -415,6 +416,12 @@ export default {
           graphqlPubsub.asyncIterator(
             `conversationClientMessageInserted:${subdomain}:${userId}`,
           ),
+      },
+
+      cpTicketCommentInserted: {
+        resolve: (payload) => payload.ticketCommentInserted,
+        subscribe: (_, { ticketId }) =>
+          graphqlPubsub.asyncIterator(`ticketCommentInserted:${ticketId}`),
       },
     };
   },

--- a/backend/plugins/frontline_api/src/modules/ticket/@types/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/@types/note.ts
@@ -1,15 +1,25 @@
 import { Model, Document } from 'mongoose';
 
+export const NOTE_TYPES = ['note', 'comment'] as const;
+
+/**
+ * `note` is an internal, team-only note. `comment` is a message in the thread
+ * the ticket requester sees and answers in the client portal.
+ */
+export type TNoteType = (typeof NOTE_TYPES)[number];
+
 export interface INote {
   content: string;
   contentId: string;
   createdBy: string;
   mentions?: string[];
   statusId?: string;
+  type?: TNoteType;
 }
 
 export interface INoteDocument extends INote, Document {
   _id: string;
+  type: TNoteType;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/backend/plugins/frontline_api/src/modules/ticket/db/definitions/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/definitions/note.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'mongoose';
+import { NOTE_TYPES } from '@/ticket/@types/note';
 
 export const noteSchema = new Schema(
   {
@@ -7,6 +8,7 @@ export const noteSchema = new Schema(
     createdBy: { type: String, required: true },
     mentions: { type: [String], default: [] },
     statusId: { type: String },
+    type: { type: String, enum: NOTE_TYPES, default: 'note', index: true },
   },
   {
     timestamps: true,

--- a/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
@@ -1,8 +1,16 @@
 import { noteSchema } from '@/ticket/db/definitions/note';
-import { INote, INoteDocument } from '@/ticket/@types/note';
+import { INote, INoteDocument, TNoteType } from '@/ticket/@types/note';
 import { FilterQuery, Model } from 'mongoose';
+import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 import { createNotifications } from '~/utils/notifications';
+
+/**
+ * Client portal authors are stored as `cp:<id>`, so they can never be mixed
+ * into fields that hold erxes user ids.
+ */
+export const isClientPortalAuthor = (createdBy?: string) =>
+  !!createdBy?.startsWith('cp:');
 
 export interface INoteModel extends Model<INoteDocument> {
   getNote(_id: string): Promise<INoteDocument>;
@@ -53,6 +61,8 @@ export const loadNoteClass = (models: IModels) => {
       subdomain: string;
       userId: string;
     }): Promise<INoteDocument> {
+      const type: TNoteType = doc.type === 'comment' ? 'comment' : 'note';
+
       if (doc.contentId && !doc.statusId) {
         const ticket = await models.Ticket.findOne(
           { _id: doc.contentId },
@@ -63,12 +73,12 @@ export const loadNoteClass = (models: IModels) => {
         }
       }
 
-      const note = await models.Note.create(doc);
+      const note = await models.Note.create({ ...doc, type });
 
       await models.Activity.createActivity({
         action: 'CREATED',
         contentId: doc.contentId,
-        module: 'NOTE',
+        module: type === 'comment' ? 'COMMENT' : 'NOTE',
         metadata: {
           previousValue: undefined,
           newValue: note._id,
@@ -85,7 +95,9 @@ export const loadNoteClass = (models: IModels) => {
           .forEach((id) => mentionUserIds.add(id));
       }
 
-      if (note.contentId) {
+      // `subscribedUserIds` only ever holds erxes user ids, so a comment left
+      // by the requester in the client portal must not land in it.
+      if (note.contentId && !isClientPortalAuthor(userId)) {
         await models.Ticket.updateOne(
           { _id: note.contentId },
           { $addToSet: { subscribedUserIds: userId } },
@@ -119,7 +131,65 @@ export const loadNoteClass = (models: IModels) => {
         });
       }
 
+      if (type === 'comment') {
+        // The team reads comments off `ticketActivityChanged`; the client
+        // portal has no activity feed, so it gets its own topic.
+        await graphqlPubsub.publish(
+          `ticketCommentInserted:${note.contentId}`,
+          { ticketCommentInserted: note },
+        );
+
+        if (isClientPortalAuthor(doc.createdBy)) {
+          await Note.notifyTeamOfPortalComment({ note, subdomain, userId });
+        }
+      }
+
       return note;
+    }
+
+    /**
+     * A comment written in the client portal has no erxes author to notify
+     * from, so the whole team following the ticket is told instead.
+     */
+    private static async notifyTeamOfPortalComment({
+      note,
+      subdomain,
+      userId,
+    }: {
+      note: INoteDocument;
+      subdomain: string;
+      userId: string;
+    }) {
+      const ticket = await models.Ticket.findOne(
+        { _id: note.contentId },
+        { assigneeId: 1, assignedMembers: 1, subscribedUserIds: 1 },
+      ).lean();
+
+      if (!ticket) {
+        return;
+      }
+
+      const recipientIds = new Set<string>(
+        [
+          ticket.assigneeId,
+          ...(ticket.assignedMembers || []),
+          ...(ticket.subscribedUserIds || []),
+        ].filter((id): id is string => !!id && !isClientPortalAuthor(id)),
+      );
+
+      if (recipientIds.size === 0) {
+        return;
+      }
+
+      await createNotifications({
+        contentType: 'ticket',
+        contentTypeId: note.contentId,
+        fromUserId: userId,
+        subdomain,
+        notificationType: 'ticketComment',
+        userIds: Array.from(recipientIds),
+        action: 'create',
+      });
     }
 
     public static async updateNote(doc: INoteDocument) {

--- a/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/db/models/Note.ts
@@ -134,10 +134,9 @@ export const loadNoteClass = (models: IModels) => {
       if (type === 'comment') {
         // The team reads comments off `ticketActivityChanged`; the client
         // portal has no activity feed, so it gets its own topic.
-        await graphqlPubsub.publish(
-          `ticketCommentInserted:${note.contentId}`,
-          { ticketCommentInserted: note },
-        );
+        await graphqlPubsub.publish(`ticketCommentInserted:${note.contentId}`, {
+          ticketCommentInserted: note,
+        });
 
         if (isClientPortalAuthor(doc.createdBy)) {
           await Note.notifyTeamOfPortalComment({ note, subdomain, userId });

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/customResolvers/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/customResolvers/note.ts
@@ -1,0 +1,71 @@
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { isClientPortalAuthor } from '@/ticket/db/models/Note';
+import { IContext } from '~/connectionResolvers';
+
+type TCpUser = {
+  _id: string;
+  firstName?: string;
+  lastName?: string;
+  username?: string;
+  email?: string;
+  avatar?: string;
+};
+
+const buildFullName = (cpUser: TCpUser) =>
+  [cpUser.firstName, cpUser.lastName].filter(Boolean).join(' ') ||
+  cpUser.username ||
+  cpUser.email ||
+  '';
+
+export const Note = {
+  /**
+   * `createdBy` holds `cp:<erxesCustomerId | cpUserId>` for portal authors and
+   * a plain erxes user id for team members, which the UI resolves itself.
+   */
+  async clientPortalAuthor(
+    { createdBy }: { createdBy?: string },
+    _params: undefined,
+    { subdomain }: IContext,
+  ) {
+    if (!isClientPortalAuthor(createdBy)) {
+      return null;
+    }
+
+    const authorId = (createdBy as string).slice('cp:'.length);
+
+    if (!authorId) {
+      return null;
+    }
+
+    const cpUser: TCpUser | null =
+      (await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        module: 'cpUsers',
+        method: 'query',
+        action: 'get',
+        input: { erxesCustomerId: authorId },
+        defaultValue: null,
+      })) ||
+      (await sendTRPCMessage({
+        subdomain,
+        pluginName: 'core',
+        module: 'cpUsers',
+        method: 'query',
+        action: 'get',
+        input: { id: authorId },
+        defaultValue: null,
+      }));
+
+    if (!cpUser) {
+      return { _id: authorId, fullName: '', email: '', avatar: '' };
+    }
+
+    return {
+      _id: cpUser._id,
+      fullName: buildFullName(cpUser),
+      email: cpUser.email || '',
+      avatar: cpUser.avatar || '',
+    };
+  },
+};

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/clientPortal.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/clientPortal.ts
@@ -81,6 +81,7 @@ export const cpTicketMutations: Record<string, Resolver> = {
       doc: {
         content,
         contentId,
+        type: 'comment',
         createdBy: `cp:${userId}`,
       },
       subdomain,

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/mutations/note.ts
@@ -1,10 +1,20 @@
-import { INoteDocument } from '@/ticket/@types/note';
+import { INoteDocument, TNoteType } from '@/ticket/@types/note';
 import { IContext } from '~/connectionResolvers';
 
 export const noteMutations = {
   ticketCreateNote: async (
     _parent: undefined,
-    { content, contentId, mentions },
+    {
+      content,
+      contentId,
+      mentions,
+      type,
+    }: {
+      content: string;
+      contentId: string;
+      mentions?: string[];
+      type?: TNoteType;
+    },
     { models, user, subdomain }: IContext,
   ) => {
     const userId = user._id || '';
@@ -13,6 +23,7 @@ export const noteMutations = {
         content,
         contentId,
         mentions,
+        type: type === 'comment' ? 'comment' : 'note',
         createdBy: user._id,
       },
       subdomain,

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/clientPortal.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/clientPortal.ts
@@ -51,13 +51,16 @@ export const cpTicketQueries = {
     return models.Status.getStatus(_id);
   },
 
+  // The portal only ever sees the comment thread; internal notes stay inside
+  // the team's ticket detail.
   cpTicketGetNotes: async (
     _parent: undefined,
     { ticketId }: { ticketId: string },
     { models }: IContext,
   ) => {
-     return models.Note.find({ contentId: ticketId }).sort({ createdAt: -1 }).lean();
-
+    return models.Note.find({ contentId: ticketId, type: 'comment' })
+      .sort({ createdAt: -1 })
+      .lean();
   },
 };
 

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/resolvers/queries/note.ts
@@ -1,4 +1,15 @@
+import { FilterQuery } from 'mongoose';
+import { INoteDocument, TNoteType } from '@/ticket/@types/note';
 import { IContext } from '~/connectionResolvers';
+
+/**
+ * Notes written before comments existed have no `type`, so anything that is
+ * not explicitly a comment is an internal note.
+ */
+export const buildNoteTypeFilter = (
+  type?: string,
+): FilterQuery<INoteDocument> =>
+  type === 'comment' ? { type: 'comment' } : { type: { $ne: 'comment' } };
 
 export const noteQueries = {
   ticketGetNote: async (
@@ -7,5 +18,18 @@ export const noteQueries = {
     { models }: IContext,
   ) => {
     return models.Note.findOne({ _id });
+  },
+
+  ticketGetNotes: async (
+    _parent: undefined,
+    { contentId, type }: { contentId: string; type?: TNoteType },
+    { models }: IContext,
+  ) => {
+    return models.Note.find({
+      contentId,
+      ...buildNoteTypeFilter(type),
+    })
+      .sort({ createdAt: 1 })
+      .lean();
   },
 };

--- a/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/note.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/graphql/schemas/note.ts
@@ -1,4 +1,11 @@
 export const types = `
+    type TicketNoteClientPortalAuthor {
+        _id: String
+        fullName: String
+        email: String
+        avatar: String
+    }
+
     type Note {
         _id: String
         content: String
@@ -6,9 +13,18 @@ export const types = `
         createdBy: String
         mentions: [String]
         statusId: String
+        """
+        "note" for internal team notes, "comment" for the thread the ticket
+        requester reads and answers in the client portal.
+        """
+        type: String
+        """
+        Set only when the note was written by a client portal user.
+        """
+        clientPortalAuthor: TicketNoteClientPortalAuthor
 
-        createdAt: String
-        updatedAt: String
+        createdAt: Date
+        updatedAt: Date
     }
 `;
 
@@ -16,6 +32,7 @@ const createNoteParams = `
     content: String
     contentId: String
     mentions: [String]
+    type: String
 `;
 
 const updateNoteParams = `
@@ -27,6 +44,7 @@ const updateNoteParams = `
 
 export const queries = `
     ticketGetNote(_id: String!): Note
+    ticketGetNotes(contentId: String!, type: String): [Note]
     cpTicketGetNotes(ticketId: String!): [Note]
 `;
 

--- a/backend/plugins/frontline_api/src/utils/notifications.ts
+++ b/backend/plugins/frontline_api/src/utils/notifications.ts
@@ -32,6 +32,8 @@ const getMessage = (contentType: string, notificationType: string) => {
       return `Ticket updated`;
     case 'note':
       return `You have been mentioned in ${contentType}'s note`;
+    case 'ticketComment':
+      return 'The requester left a comment on ticket';
     case 'channel':
       return 'You have been invited to channel';
     case 'status':

--- a/frontend/plugins/frontline_ui/AGENTS.md
+++ b/frontend/plugins/frontline_ui/AGENTS.md
@@ -62,6 +62,24 @@
 
 ## Current Capabilities
 
+- The ticket detail's writing area is a two-tab surface under the activity
+  timeline: **Note** keeps the existing internal editor with `@` mentions, and
+  **Comments** is the thread shared with the person who submitted the request
+  from the client portal. The Comments trigger carries the thread's count.
+- Comments render inside the activity timeline next to notes, so the ticket's
+  history reads in one chronological stream. `CommentActivityItem` draws the row:
+  a message icon on the timeline rail, the author — `MembersInline` for a
+  teammate, the portal name plus a "Requester" label for the requester — a
+  relative timestamp, and the read-only block content with no bounding box.
+- The two tabs under the timeline are composers only; neither lists anything.
+- Both composers sit under `EditorToolbar`, an always-visible row for bold,
+  italic, underline, strikethrough, bulleted and numbered lists, and image
+  insert. Its buttons `preventDefault` on mousedown so the caret and selection
+  survive the click, and the image button reuses the slash menu's flow: insert
+  an `image` block, then open `editor.filePanel` on it.
+- Comment editors carry no mention menu, because the requester reads them.
+- A comment row is skipped until `TicketGetComments` has its body, so a portal
+  comment appears complete rather than as an empty bubble.
 - Ticket pipeline settings include a Properties route that lists only Core
   `frontline:ticket` properties, grouped by their Core field group. Checked
   fields are stored on the pipeline, and ticket detail renders only that
@@ -243,6 +261,9 @@
   card shares: `id`, `filterConfig` (what gets saved), `queryFilters` (what gets
   queried, with the relative `date` resolved to a range), and `filtersRestored`.
   A new ticket card uses this rather than reading the filter atoms itself.
+- `ActivityList` renders the ticket timeline — notes and comments interleaved —
+  plus the Note/Comments composer tabs, and is the only consumer of
+  `useTicketComments`; `TicketFields` mounts it.
 
 ### Consumes
 
@@ -388,9 +409,25 @@ awaitingResponse?)` — a JSON map. `only: "byChannels"` keys by channel id,
   window is in flight, so the thread never blanks. Whether the quoted part of a
   message and whether its remote images are shown are per-message component
   state and deliberately not persisted.
+- `TicketGetComments` (`ticketGetNotes(contentId, type: "comment")`) supplies the
+  body and client-portal author that a COMMENT activity record does not carry;
+  `ActivityList` indexes the result by `_id` and joins it to the activity through
+  `metadata.newValue`. `useTicketComments` takes a `syncToken` — the newest
+  COMMENT activity id from the existing `ticketActivityChanged` subscription —
+  and refetches whenever it changes, so no second subscription is opened.
+- `useCreateTicketComment` posts through `TicketCreateNote` with
+  `type: 'comment'` and refetches `TicketGetComments` before resolving.
 
 ## Local Invariants
 
+- The comment editor must never mount `AssignMemberInEditor`. Comments are
+  visible to the requester, so mentioning teammates there would leak the team's
+  membership.
+- A COMMENT activity must render through `CommentActivityItem`, never through
+  `ActivityItemWrapper`: the wrapper resolves its author with `MembersInline`
+  from `createdBy`, which cannot resolve a client-portal requester.
+- Editor content is trimmed through `trimEmptyBlocks` from `@/activity/utils`
+  before it is sent; do not re-implement the empty-paragraph trimming inline.
 - The inbox navigation is a single-selection tree over three query params that
   intersect on the server: `channelId`, `integrationId`, and `integrationType`.
   Every selector writes all three through `INBOX_TARGET_KEYS`, clearing the ones
@@ -788,6 +825,26 @@ status })` returns the leaving side as `canMoveTicket` (what disables the
 
 <!-- Newest first. Keep at most 10 entries. -->
 
+### `2026-09-02` — Note and comment editors gained a visible toolbar
+
+- **Summary:** Formatting and image insert were only reachable through the `/`
+  menu or by selecting text, so neither looked available. Both composers now
+  carry a persistent toolbar with bold, italic, underline, strikethrough, the two
+  list types, and an image button that opens the upload panel.
+- **Affected areas:**
+  `src/modules/activity/components/{EditorToolbar,CommentInput,NoteInput}.tsx`.
+- **Contracts changed:** None.
+
+### `2026-09-02` — Comments moved into the ticket timeline
+
+- **Summary:** Comments no longer sit in their own thread under the tabs. They
+  render as timeline rows beside notes, so the ticket reads as one chronological
+  stream, and the Note/Comments tabs are now composers only. The comment body
+  lost its bounding box and its author avatar matches the timeline's.
+- **Affected areas:**
+  `src/modules/activity/components/{ActivityList,CommentThread}.tsx`.
+- **Contracts changed:** None.
+
 ### `2026-09-02` — IMAP integration UI removed
 
 - **Summary:** Every IMAP surface was deleted — the connect form and sheet, the
@@ -806,6 +863,23 @@ status })` returns the leaving side as `canMoveTicket` (what disables the
 - **Contracts changed:** `IntegrationType.IMAP` removed; the UI no longer sends
   `imapConversationDetail`, `imapGetIntegrations` or `imapSendMail`. The
   conversation detail no longer suppresses `MessageInput` for the `imap` kind.
+
+### `2026-09-01` — Ticket detail gained a Comments tab
+
+- **Summary:** The ticket detail's "Leave a note" box became a Note/Comments
+  tab strip. Comments are the two-way thread with the client-portal requester —
+  the thread lists both sides with author and time, posts without mentions, and
+  refreshes live off the ticket activity subscription.
+- **Affected areas:**
+  `src/modules/activity/components/{ActivityList,CommentInput,CommentThread,NoteInput}.tsx`,
+  `src/modules/activity/hooks/{useTicketComments,useCreateTicketComment}.tsx`,
+  `src/modules/activity/graphql/queries/getTicketComments.ts`,
+  `src/modules/activity/graphql/mutations/createTicketNote.ts`,
+  `src/modules/activity/{constants.ts,types.ts,utils/editorContent.ts}`,
+  `src/modules/ticket/types/ticketHotkeyScope.ts`.
+- **Contracts changed:** New `TicketGetComments` query; `TicketCreateNote`
+  sends `type` and selects `type`; both rely on the matching `frontline_api`
+  additions.
 
 ### `2026-08-28` — The domain picker is searchable and says which domains are usable
 
@@ -893,54 +967,3 @@ status })` returns the leaving side as `canMoveTicket` (what disables the
 - **Summary:** The stale-conversation gate offers a single "Reply as human agent" action instead of the three Meta-retired tags, measures both windows from the customer's last message, blocks replies after 7 days, and resets the chosen tag when switching conversations.
 - **Affected areas:** `src/modules/integrations/facebook/components/FacebookMessageInputWrapper.tsx`, `constants/FbMessageWindow.ts`, `types/FacebookTypes.ts` (`EnumFacebookTag` now HUMAN_AGENT only), removed `constants/FbTagSchema.ts`
 - **Contracts changed:** None
-
-### `2026-08-26` — Sidebar selections no longer strand each other
-
-- **Summary:** Selecting a Discord channel and then a team or personal channel
-  left `integrationId` set alongside `channelId`, and the two intersect to
-  nothing, so the list emptied with no chip explaining why. Every inbox
-  navigation selector now writes the whole target through `INBOX_TARGET_KEYS`
-  and clears the params it does not own, and a Discord selection finally shows as
-  its own removable chip in the filter bar.
-- **Affected areas:**
-  `src/modules/inbox/conversations/constants/inboxTarget.ts` (new),
-  `src/modules/integrations/discord/components/DiscordChannelFilterBar.tsx` (new),
-  `src/modules/inbox/channel/components/{PersonalInboxNav,TeamChannelsNav}.tsx`,
-  `src/modules/integrations/components/ChooseIntegrationType.tsx`,
-  `src/modules/integrations/discord/components/DiscordChannelsNav.tsx`,
-  `src/modules/inbox/conversations/components/ConversationsFilter.tsx`.
-- **Contracts changed:** None.
-
-### `2026-08-26` — Mail automation surface and the draft card removed
-
-- **Summary:** The mail channel's automation widgets (trigger form and both
-  action forms) are gone along with their `AutomationRemoteEntry` registration,
-  and so is the reply-draft card in the thread — the backend action that was the
-  only thing able to create a draft was removed with them.
-- **Affected areas:** `src/widgets/automations/modules/mail/` (deleted),
-  `src/widgets/automations/components/AutomationRemoteEntry.tsx`,
-  `src/modules/integrations/mail/components/{MailDraftCard.tsx (deleted),MailConversationDetail.tsx}`,
-  `src/modules/integrations/mail/hooks/useMailDraft.tsx` (deleted),
-  `src/modules/integrations/mail/graphql/{queries/mailQueries,mutations/mailMutations}.ts`,
-  `backend/gateway/src/locales/{en,mn}/frontline.json`.
-- **Contracts changed:** Stops consuming `mailConversationDraft`,
-  `mailDraftSave`, `mailDraftApprove`, `mailDraftRemove` and the
-  `mailDraftChanged` subscription; drops the `mail` automation remote entry.
-  Removed the five now-unused `draft` translation keys.
-
-### `2026-08-25` — Integration rows show their unread count again
-
-- **Summary:** The inbox navigation now reads `unreadConversationCount` from the
-  `integrationsGetUsedTypesByChannel` query it already makes, instead of
-  recomputing the figure through a second `conversationCounts` request per
-  expanded channel that was rendering blank; a row and its channel row now count
-  the same thing.
-- **Affected areas:**
-  `src/modules/integrations/graphql/queries/getIntegrations.ts`,
-  `src/modules/integrations/types/Integration.ts`,
-  `src/modules/inbox/conversations/hooks/useConversationCounts.tsx`
-  (`useConversationCountsByIntegrationType` narrowed to
-  `useAwaitingCountsByIntegrationType`),
-  `src/modules/inbox/channel/components/{PersonalInboxNav,TeamChannelsNav}.tsx`.
-- **Contracts changed:** None on the API; the by-channel used-types document now
-  selects `unreadConversationCount`.

--- a/frontend/plugins/frontline_ui/src/modules/activity/components/ActivityList.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/components/ActivityList.tsx
@@ -1,12 +1,25 @@
+import { useMemo, useState } from 'react';
 import { ITicket } from '@/ticket/types';
 import { ActivityListProvider } from '@/activity/context/ActivityListContext';
 import { ACTIVITY_MODULES } from '@/activity/constants';
 import { NoteInputReadOnly } from '@/activity/components/NoteInputReadOnly';
 import { NoteInput } from '@/activity/components/NoteInput';
+import { CommentInput } from '@/activity/components/CommentInput';
+import { CommentActivityItem } from '@/activity/components/CommentThread';
 import { CreatorInfo } from '@/activity/components/CreatorInfo';
 import { ActivityItemWrapper } from '@/activity/components/ActivityItemWrapper';
 import { useActivities } from '@/activity/hooks/useActivities';
-import { Spinner } from 'erxes-ui';
+import { useTicketComments } from '@/activity/hooks/useTicketComments';
+import { IActivity } from '@/activity/types';
+import { Badge, Spinner, Tabs } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+const ACTIVITY_TABS = {
+  NOTE: 'note',
+  COMMENTS: 'comments',
+} as const;
+
+type TActivityTab = (typeof ACTIVITY_TABS)[keyof typeof ACTIVITY_TABS];
 
 export const ActivityList = ({
   contentId,
@@ -15,7 +28,40 @@ export const ActivityList = ({
   contentId: string;
   contentDetail: ITicket;
 }) => {
+  const { t } = useTranslation('frontline');
+  const [tab, setTab] = useState<TActivityTab>(ACTIVITY_TABS.NOTE);
   const { activities, loading } = useActivities(contentId);
+
+  // Comments live in the timeline next to notes so the ticket reads as one
+  // chronological stream. Their body and client-portal author come from the
+  // thread query, because the activity record carries only the note's id.
+  const timelineActivities: IActivity[] = activities ?? [];
+
+  // The newest COMMENT activity is the signal that the thread moved; passing it
+  // as the sync token reuses the existing activity subscription instead of
+  // opening a second one. The count drives the Comments tab badge.
+  const { latestCommentActivityId, commentCount } = useMemo(() => {
+    const commentActivities = (activities ?? []).filter(
+      (activity) => activity.module === ACTIVITY_MODULES.COMMENT,
+    );
+
+    return {
+      latestCommentActivityId:
+        commentActivities[commentActivities.length - 1]?._id,
+      commentCount: commentActivities.length,
+    };
+  }, [activities]);
+
+  const { comments } = useTicketComments({
+    contentId,
+    syncToken: latestCommentActivityId,
+  });
+
+  const commentsById = useMemo(
+    () => new Map(comments.map((comment) => [comment._id, comment])),
+    [comments],
+  );
+
   if (loading) {
     return <Spinner />;
   }
@@ -25,22 +71,56 @@ export const ActivityList = ({
       <ActivityListProvider contentDetail={contentDetail}>
         <div className="ml-2.5 relative before:absolute before:left-0 before:top-1 before:bottom-1 before:w-px before:bg-muted before:-translate-x-1/2  flex flex-col gap-6">
           <CreatorInfo contentDetail={contentDetail} />
-          {activities?.map((activity) => (
-            <div className="flex flex-col gap-2" key={activity._id}>
-              <ActivityItemWrapper activity={activity} />
-              {activity.module === ACTIVITY_MODULES.NOTE && (
-                <NoteInputReadOnly
+          {timelineActivities.map((activity) => {
+            if (activity.module === ACTIVITY_MODULES.COMMENT) {
+              const comment = commentsById.get(activity.metadata?.newValue);
+
+              return comment ? (
+                <CommentActivityItem
                   key={activity._id}
-                  newValueId={activity.metadata?.newValue}
+                  activity={activity}
+                  comment={comment}
                 />
-              )}
-            </div>
-          ))}
+              ) : null;
+            }
+
+            return (
+              <div className="flex flex-col gap-2" key={activity._id}>
+                <ActivityItemWrapper activity={activity} />
+                {activity.module === ACTIVITY_MODULES.NOTE && (
+                  <NoteInputReadOnly newValueId={activity.metadata?.newValue} />
+                )}
+              </div>
+            );
+          })}
         </div>
       </ActivityListProvider>
-      <span className="ml-2.5 mb-6">
-        <NoteInput contentId={contentId} />
-      </span>
+
+      <Tabs
+        value={tab}
+        onValueChange={(value) => setTab(value as TActivityTab)}
+        className="ml-2.5 mb-6 flex flex-col gap-4"
+      >
+        <Tabs.List>
+          <Tabs.Trigger value={ACTIVITY_TABS.NOTE}>
+            {t('note', 'Note')}
+          </Tabs.Trigger>
+          <Tabs.Trigger value={ACTIVITY_TABS.COMMENTS} className="gap-2">
+            {t('comments', 'Comments')}
+            {commentCount > 0 && (
+              <Badge variant="secondary">{commentCount}</Badge>
+            )}
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value={ACTIVITY_TABS.NOTE}>
+          <NoteInput contentId={contentId} />
+        </Tabs.Content>
+
+        <Tabs.Content value={ACTIVITY_TABS.COMMENTS}>
+          <CommentInput contentId={contentId} />
+        </Tabs.Content>
+      </Tabs>
     </div>
   );
 };

--- a/frontend/plugins/frontline_ui/src/modules/activity/components/CommentInput.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/components/CommentInput.tsx
@@ -1,62 +1,70 @@
 import { EditorToolbar } from '@/activity/components/EditorToolbar';
-import { useCreateTicketNote } from '@/activity/hooks/useCreateTicketNote';
-import { toMentionScanBlocks, trimEmptyBlocks } from '@/activity/utils';
+import { useCreateTicketComment } from '@/activity/hooks/useCreateTicketComment';
+import { trimEmptyBlocks } from '@/activity/utils';
 import { TicketHotKeyScope } from '@/ticket/types/ticketHotkeyScope';
 import type { Block } from '@blocknote/core';
 import { IconCommand, IconCornerDownLeft } from '@tabler/icons-react';
 import {
   BlockEditor,
   Button,
-  getMentionedUserIds,
   Kbd,
   useBlockEditor,
   usePreviousHotkeyScope,
   useScopedHotkeys,
+  useToast,
 } from 'erxes-ui';
-import { AssignMemberInEditor } from 'ui-modules';
 import { useTranslation } from 'react-i18next';
 
-export const NoteInput = ({ contentId }: { contentId: string }) => {
+/**
+ * Comments are read by the requester in the client portal, so this editor
+ * deliberately has no team mentions.
+ */
+export const CommentInput = ({ contentId }: { contentId: string }) => {
   const { t } = useTranslation('frontline');
-  const editor = useBlockEditor({ placeholder: t('leave-a-note') });
-  const { createTicketNote, loading } = useCreateTicketNote();
+  const { toast } = useToast();
+  const editor = useBlockEditor({
+    placeholder: t('write-a-comment', 'Write a comment...'),
+  });
+  const { createTicketComment, loading } = useCreateTicketComment(contentId);
   const {
     setHotkeyScopeAndMemorizePreviousScope,
     goBackToPreviousHotkeyScope,
   } = usePreviousHotkeyScope();
 
-  const onSend = async () => {
+  const onSend = () => {
     const trimmedContent = trimEmptyBlocks((editor?.document || []) as Block[]);
 
-    if (trimmedContent.length === 0) {
+    if (trimmedContent.length === 0 || loading) {
       return;
     }
 
-    createTicketNote({
-      variables: {
-        content: JSON.stringify(trimmedContent),
-        contentId: contentId,
-        mentions: getMentionedUserIds(toMentionScanBlocks(trimmedContent)),
-      },
+    createTicketComment(JSON.stringify(trimmedContent), {
       onCompleted: () => {
         editor.replaceBlocks(editor.topLevelBlocks, []);
       },
+      onError: (error) => {
+        toast({
+          title: t('error'),
+          description: error.message,
+          variant: 'destructive',
+        });
+      },
     });
   };
-  useScopedHotkeys('mod+enter', onSend, TicketHotKeyScope.NoteInput);
+
+  useScopedHotkeys('mod+enter', onSend, TicketHotKeyScope.CommentInput);
+
   return (
-    <div className="flex flex-col border rounded-lg min-h-14 px-4 py-3  ">
+    <div className="flex flex-col border rounded-lg min-h-14 px-4 py-3">
       <EditorToolbar editor={editor} />
       <BlockEditor
         editor={editor}
         onFocus={() =>
-          setHotkeyScopeAndMemorizePreviousScope(TicketHotKeyScope.NoteInput)
+          setHotkeyScopeAndMemorizePreviousScope(TicketHotKeyScope.CommentInput)
         }
         onBlur={() => goBackToPreviousHotkeyScope()}
         className="read-only"
-      >
-        <AssignMemberInEditor editor={editor} />
-      </BlockEditor>
+      />
       <div className="flex justify-end">
         <Button
           size="lg"

--- a/frontend/plugins/frontline_ui/src/modules/activity/components/CommentThread.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/components/CommentThread.tsx
@@ -1,0 +1,59 @@
+import { IActivity, INote } from '@/activity/types';
+import { ActivityTimelineItem } from '@/activity/components/ActivityTimelineItem';
+import { IconMessage2 } from '@tabler/icons-react';
+import { BlockEditorReadOnly } from 'erxes-ui';
+import { MembersInline } from 'ui-modules';
+import { useTranslation } from 'react-i18next';
+
+const CommentAuthorName = ({ comment }: { comment: INote }) => {
+  const { t } = useTranslation('frontline');
+  const { clientPortalAuthor, createdBy } = comment;
+
+  if (clientPortalAuthor) {
+    const fullName =
+      clientPortalAuthor.fullName ||
+      clientPortalAuthor.email ||
+      t('unknown', 'Unknown');
+
+    return (
+      <>
+        <span className="font-semibold">{fullName}</span>
+        <span className="text-xs text-muted-foreground leading-6">
+          {t('requester', 'Requester')}
+        </span>
+      </>
+    );
+  }
+
+  return (
+    <MembersInline.Provider memberIds={createdBy ? [createdBy] : []}>
+      <MembersInline.Title className="font-semibold" />
+    </MembersInline.Provider>
+  );
+};
+
+export const CommentActivityItem = ({
+  activity,
+  comment,
+}: {
+  activity: IActivity;
+  comment: INote;
+}) => {
+  const { t } = useTranslation('frontline');
+
+  return (
+    <div className="flex flex-col gap-1">
+      <ActivityTimelineItem
+        avatar={<IconMessage2 className="size-4 text-accent-foreground" />}
+        createdAt={activity.createdAt?.toLocaleString()}
+        id={activity._id}
+      >
+        <CommentAuthorName comment={comment} />
+        <div className="lowercase">{t('activity-comment', 'commented')}</div>
+      </ActivityTimelineItem>
+      <div className="ml-4">
+        <BlockEditorReadOnly content={comment.content} className="read-only" />
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/activity/components/EditorToolbar.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/components/EditorToolbar.tsx
@@ -1,0 +1,123 @@
+import {
+  IconBold,
+  IconItalic,
+  IconList,
+  IconListNumbers,
+  IconPhoto,
+  IconStrikethrough,
+  IconUnderline,
+} from '@tabler/icons-react';
+import { Button, Separator, Tooltip, useBlockEditor } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+type BlockEditorInstance = ReturnType<typeof useBlockEditor>;
+
+const ToolbarButton = ({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) => (
+  <Tooltip>
+    <Tooltip.Trigger asChild>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        aria-label={label}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={onClick}
+      >
+        {children}
+      </Button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>{label}</Tooltip.Content>
+  </Tooltip>
+);
+
+export const EditorToolbar = ({ editor }: { editor: BlockEditorInstance }) => {
+  const { t } = useTranslation('frontline');
+
+  // Clicking the list type that is already applied returns the block to a
+  // paragraph, matching how BlockNote's own toolbar behaves.
+  const toggleBlockType = (type: 'bulletListItem' | 'numberedListItem') => {
+    const block = editor.getTextCursorPosition()?.block;
+    if (!block) return;
+
+    editor.updateBlock(block, {
+      type: block.type === type ? 'paragraph' : type,
+    });
+  };
+
+  const insertImage = () => {
+    const currentBlock = editor.getTextCursorPosition()?.block;
+    if (!currentBlock) return;
+
+    const insertedBlock = editor.insertBlocks(
+      [{ type: 'image' }],
+      currentBlock,
+      'after',
+    )[0];
+
+    const filePanel = editor.filePanel;
+    if (filePanel) {
+      editor.transact((tr) =>
+        tr.setMeta(filePanel.plugins[0], { block: insertedBlock }),
+      );
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-0.5 pb-1">
+      <ToolbarButton
+        label={t('bold', 'Bold')}
+        onClick={() => editor.toggleStyles({ bold: true })}
+      >
+        <IconBold className="size-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        label={t('italic', 'Italic')}
+        onClick={() => editor.toggleStyles({ italic: true })}
+      >
+        <IconItalic className="size-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        label={t('underline', 'Underline')}
+        onClick={() => editor.toggleStyles({ underline: true })}
+      >
+        <IconUnderline className="size-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        label={t('strikethrough', 'Strikethrough')}
+        onClick={() => editor.toggleStyles({ strike: true })}
+      >
+        <IconStrikethrough className="size-4" />
+      </ToolbarButton>
+
+      <Separator.Inline className="mx-1 h-4" />
+
+      <ToolbarButton
+        label={t('bulleted-list', 'Bulleted list')}
+        onClick={() => toggleBlockType('bulletListItem')}
+      >
+        <IconList className="size-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        label={t('numbered-list', 'Numbered list')}
+        onClick={() => toggleBlockType('numberedListItem')}
+      >
+        <IconListNumbers className="size-4" />
+      </ToolbarButton>
+
+      <Separator.Inline className="mx-1 h-4" />
+
+      <ToolbarButton label={t('image', 'Image')} onClick={insertImage}>
+        <IconPhoto className="size-4" />
+      </ToolbarButton>
+    </div>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/activity/constants.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/constants.ts
@@ -6,6 +6,7 @@ export const ACTIVITY_MODULES = {
   END_DATE: 'END_DATE',
   ASSIGNEE: 'ASSIGNEE',
   NOTE: 'NOTE',
+  COMMENT: 'COMMENT',
   DESCRIPTION: 'DESCRIPTION',
   FORM_SUBMISSION: 'FORM_SUBMISSION',
 };
@@ -14,4 +15,9 @@ export const ACTIVITY_ACTIONS = {
   CREATED: 'CREATED',
   CHANGED: 'CHANGED',
   REMOVED: 'REMOVED',
+} as const;
+
+export const NOTE_TYPES = {
+  NOTE: 'note',
+  COMMENT: 'comment',
 } as const;

--- a/frontend/plugins/frontline_ui/src/modules/activity/graphql/mutations/createTicketNote.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/graphql/mutations/createTicketNote.ts
@@ -4,17 +4,20 @@ export const CREATE_TICKET_NOTE = gql`
     $content: String
     $contentId: String
     $mentions: [String]
+    $type: String
   ) {
     ticketCreateNote(
       content: $content
       contentId: $contentId
       mentions: $mentions
+      type: $type
     ) {
       _id
       content
       contentId
       createdBy
       mentions
+      type
       createdAt
       updatedAt
     }

--- a/frontend/plugins/frontline_ui/src/modules/activity/graphql/queries/getTicketComments.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/graphql/queries/getTicketComments.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const GET_TICKET_COMMENTS = gql`
+  query TicketGetComments($contentId: String!) {
+    ticketGetNotes(contentId: $contentId, type: "comment") {
+      _id
+      content
+      contentId
+      createdBy
+      type
+      createdAt
+      updatedAt
+      clientPortalAuthor {
+        _id
+        fullName
+        email
+        avatar
+      }
+    }
+  }
+`;

--- a/frontend/plugins/frontline_ui/src/modules/activity/hooks/useCreateTicketComment.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/hooks/useCreateTicketComment.tsx
@@ -1,0 +1,26 @@
+import { MutationHookOptions, useMutation } from '@apollo/client';
+import { CREATE_TICKET_NOTE } from '@/activity/graphql/mutations/createTicketNote';
+import { GET_TICKET_COMMENTS } from '@/activity/graphql/queries/getTicketComments';
+import { NOTE_TYPES } from '@/activity/constants';
+
+export const useCreateTicketComment = (contentId: string) => {
+  const [mutate, { loading, error }] = useMutation(CREATE_TICKET_NOTE, {
+    refetchQueries: [{ query: GET_TICKET_COMMENTS, variables: { contentId } }],
+    awaitRefetchQueries: true,
+  });
+
+  const createTicketComment = (
+    content: string,
+    options?: Pick<MutationHookOptions, 'onCompleted' | 'onError'>,
+  ) =>
+    mutate({
+      variables: {
+        content,
+        contentId,
+        type: NOTE_TYPES.COMMENT,
+      },
+      ...options,
+    });
+
+  return { createTicketComment, loading, error };
+};

--- a/frontend/plugins/frontline_ui/src/modules/activity/hooks/useTicketComments.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/activity/hooks/useTicketComments.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@apollo/client';
+import { GET_TICKET_COMMENTS } from '@/activity/graphql/queries/getTicketComments';
+import { INote } from '@/activity/types';
+
+interface UseTicketCommentsArgs {
+  contentId: string;
+  /**
+   * Id of the newest COMMENT activity on the ticket. It changes when either
+   * side posts, which is the signal to pull the thread again.
+   */
+  syncToken?: string;
+}
+
+export const useTicketComments = ({
+  contentId,
+  syncToken,
+}: UseTicketCommentsArgs) => {
+  const { data, loading, error, refetch } = useQuery<{
+    ticketGetNotes: INote[];
+  }>(GET_TICKET_COMMENTS, {
+    variables: { contentId },
+    skip: !contentId,
+  });
+
+  const lastSyncToken = useRef(syncToken);
+
+  useEffect(() => {
+    if (!contentId || lastSyncToken.current === syncToken) {
+      return;
+    }
+
+    lastSyncToken.current = syncToken;
+    refetch();
+  }, [contentId, syncToken, refetch]);
+
+  return {
+    comments: data?.ticketGetNotes ?? [],
+    loading,
+    error,
+    refetch,
+  };
+};

--- a/frontend/plugins/frontline_ui/src/modules/activity/types.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/types.ts
@@ -21,6 +21,15 @@ export interface IActivity {
   createdAt: string;
   updatedAt: string;
 }
+export type TNoteType = 'note' | 'comment';
+
+export interface INoteClientPortalAuthor {
+  _id: string;
+  fullName: string;
+  email: string;
+  avatar: string;
+}
+
 export interface INote {
   _id: string;
   content: string;
@@ -29,4 +38,7 @@ export interface INote {
   contentId: string;
   mentions: string[];
   updatedAt: string;
+  type?: TNoteType;
+  /** Set only when the author wrote from the client portal. */
+  clientPortalAuthor?: INoteClientPortalAuthor | null;
 }

--- a/frontend/plugins/frontline_ui/src/modules/activity/utils/editorContent.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/utils/editorContent.ts
@@ -1,0 +1,40 @@
+import type { Block } from '@blocknote/core';
+
+const isEmptyParagraph = (block: Block) =>
+  block.type === 'paragraph' &&
+  (!block.content || block.content.length === 0) &&
+  (!block.children || block.children.length === 0);
+
+/**
+ * BlockNote keeps a trailing empty paragraph and happily collects leading ones,
+ * so strip them before deciding whether the author actually typed something.
+ */
+export const trimEmptyBlocks = (content: Block[]): Block[] => {
+  let start = 0;
+  while (start < content.length && isEmptyParagraph(content[start])) {
+    start++;
+  }
+
+  let end = content.length - 1;
+  while (end >= start && isEmptyParagraph(content[end])) {
+    end--;
+  }
+
+  return content.slice(start, end + 1);
+};
+
+/**
+ * The shape `getMentionedUserIds` (erxes-ui) describes its input with. BlockNote's
+ * `Block` matches it at runtime but not structurally, because `content` there is
+ * a union of styled text and links rather than a plain `{ type, props }` list.
+ */
+type MentionScanBlock = {
+  content?: { type: string; props: Record<string, string> }[];
+};
+
+/**
+ * Narrows editor blocks to what `getMentionedUserIds` accepts. The cast lives
+ * here alone so call sites stay free of it.
+ */
+export const toMentionScanBlocks = (blocks: Block[]): MentionScanBlock[] =>
+  blocks as unknown as MentionScanBlock[];

--- a/frontend/plugins/frontline_ui/src/modules/activity/utils/index.ts
+++ b/frontend/plugins/frontline_ui/src/modules/activity/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './editorContent';

--- a/frontend/plugins/frontline_ui/src/modules/ticket/types/ticketHotkeyScope.ts
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/types/ticketHotkeyScope.ts
@@ -3,4 +3,5 @@ export enum TicketHotKeyScope {
   TicketAddSheet = 'TicketAddSheet',
   TicketTableCell = 'TicketTableCell',
   NoteInput = 'NoteInput',
+  CommentInput = 'CommentInput',
 }


### PR DESCRIPTION
Splits comments from internal notes on the ticket detail. A note stays team-only; a comment is the two-way thread the requester reads and answers in the client portal.

- Notes and comments render interleaved in the activity timeline, so the ticket reads as one chronological stream. A comment row is drawn by CommentActivityItem rather than ActivityItemWrapper, because the wrapper resolves its author from `createdBy` through MembersInline, which cannot resolve a client-portal requester.
- The Note/Comments tabs under the timeline are composers only.
- Both composers carry a visible EditorToolbar (bold, italic, underline, strikethrough, the two list types, image insert). BlockNote already ships these through the `/` menu and the selection toolbar, but neither is discoverable; the image button reuses the slash menu's insert-then-open- file-panel flow.
- `toMentionScanBlocks` narrows editor blocks to the shape erxes-ui's `getMentionedUserIds` describes, which BlockNote's `Block` matches at runtime but not structurally.

## Summary by Sourcery

Separate internal ticket notes from client-portal comments and present both as a unified ticket activity experience.

New Features:
- Add a separate client-portal comment thread alongside internal ticket notes, with comments visible and replyable by requesters.
- Display comments as chronological activity timeline entries with requester-aware authorship and live synchronization.
- Provide dedicated Note and Comments composers with visible formatting and image-insertion controls.

Bug Fixes:
- Prevent internal ticket notes from being exposed through client-portal APIs.
- Correct note timestamp fields to use the GraphQL Date scalar for valid client-side serialization.
- Prevent portal commenters from being added to internal ticket subscribers and notify relevant team members of requester comments.

Enhancements:
- Support legacy notes without a type by treating all non-comment records as internal notes.
- Resolve client-portal authors from Core customer portal users and distinguish comment activities from note activities.
- Centralize editor content trimming and mention-input shaping for ticket note submission.

Documentation:
- Document the note/comment data model, GraphQL contracts, portal filtering, subscriptions, and ticket activity behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate Notes and Comments tabs to ticket activity.
  * Comments appear in the ticket timeline alongside notes.
  * Added formatted comment creation with image support and keyboard submission.
  * Client portal comment authors are identified in the timeline.
  * Added real-time updates and notifications for new comments.
  * Internal notes are excluded from client portal comment views.
* **Bug Fixes**
  * Empty editor content is removed before submission.
* **Removed**
  * Removed IMAP and mail automation/draft functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->