### PR TITLE
fix(frontline): ticket property validation, card limit and board layout

### DIFF
--- a/backend/plugins/frontline_api/src/modules/ticket/utils/pipelineProperties.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/utils/pipelineProperties.ts
@@ -29,11 +29,6 @@ export const validatePipelinePropertyIds = async (
   });
 
   const validIds = new Set(fields.map(({ _id }) => String(_id)));
-  const invalidId = uniquePropertyIds.find((id) => !validIds.has(id));
 
-  if (invalidId) {
-    throw new Error(`Ticket property field not found: ${invalidId}`);
-  }
-
-  return uniquePropertyIds;
+  return uniquePropertyIds.filter((id) => validIds.has(id));
 };

--- a/backend/plugins/frontline_api/src/modules/ticket/utils/ticketConfig.ts
+++ b/backend/plugins/frontline_api/src/modules/ticket/utils/ticketConfig.ts
@@ -56,20 +56,16 @@ export const validateTicketPropertyFields = async (
 
   const fieldById = new Map(fields.map((field) => [String(field._id), field]));
 
-  const missingField = uniqueFields.find(
-    (propertyField) => !fieldById.has(propertyField.fieldId),
+  const existingFields = uniqueFields.filter((propertyField) =>
+    fieldById.has(propertyField.fieldId),
   );
-
-  if (missingField) {
-    throw new Error(`Ticket property field not found: ${missingField.fieldId}`);
-  }
 
   // Both orders come from the submitted array, never from the submitted values:
   // a property's position is its `order`, and the position of the block its
   // group forms is that group's `groupOrder`.
   const groupPositions = new Map<string, number>();
 
-  return uniqueFields.map((propertyField, index) => {
+  return existingFields.map((propertyField, index) => {
     const field = fieldById.get(propertyField.fieldId);
     const groupId = propertyField.groupId || field?.groupId || undefined;
     const groupKey = groupId || '';

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/configs/components/TicketPropertyFields.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/configs/components/TicketPropertyFields.tsx
@@ -235,19 +235,26 @@ export const TicketPropertyFields = ({ form }: Props) => {
     insert(Math.min(insertAt, selectedFields.length), toPropertyValue(field));
   };
 
+  const groupRank = (groupId?: string | null) => {
+    const position = groupIds.indexOf(groupId ?? '');
+
+    return position === -1 ? groupIds.length : position;
+  };
+
   const toggleGroup = (group: PropertyGroup, checked: boolean) => {
     const values = form.getValues('propertyFields') ?? [];
     const groupFieldIds = new Set(group.groupFields.map((field) => field._id));
 
     replace(
-      checked
+      (checked
         ? [
             ...values,
             ...group.groupFields
               .filter((field) => indexOfSelected(field._id) === -1)
               .map(toPropertyValue),
           ]
-        : values.filter((value) => !groupFieldIds.has(value.fieldId)),
+        : values.filter((value) => !groupFieldIds.has(value.fieldId))
+      ).sort((a, b) => groupRank(a.groupId) - groupRank(b.groupId)),
     );
   };
 

--- a/frontend/plugins/frontline_ui/src/modules/pipelines/components/configs/components/TicketPropertyFields.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/pipelines/components/configs/components/TicketPropertyFields.tsx
@@ -26,7 +26,7 @@ import {
   cn,
 } from 'erxes-ui';
 import { useEffect, useRef, useState } from 'react';
-import { UseFormReturn, useFieldArray } from 'react-hook-form';
+import { UseFormReturn, useFieldArray, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { IField, useFieldGroups, useFields } from 'ui-modules';
 import { TICKET_PROPERTY_CONTENT_TYPE } from '../constant';
@@ -40,6 +40,18 @@ type PropertyGroup = {
   name: string;
   groupFields: IField[];
 };
+
+const toPropertyValue = (
+  field: IField,
+): TPipelineConfig['propertyFields'][number] => ({
+  fieldId: field._id,
+  groupId: field.groupId ?? null,
+  label: field.name,
+  placeholder: '',
+  isRequired: !!field.isRequired,
+  type: field.type ?? null,
+  options: (field.options ?? []).map(({ label, value }) => ({ label, value })),
+});
 
 // The properties list is a picker, the platform cursor pagination caps at 100.
 const PROPERTY_FIELDS_LIMIT = 100;
@@ -70,6 +82,8 @@ export const TicketPropertyFields = ({ form }: Props) => {
     control,
     name: 'propertyFields',
   });
+
+  const propertyValues = useWatch({ control, name: 'propertyFields' }) ?? [];
 
   const [groupIds, setGroupIds] = useState<string[]>([]);
   const [openGroupIds, setOpenGroupIds] = useState<string[]>([]);
@@ -218,18 +232,45 @@ export const TicketPropertyFields = ({ form }: Props) => {
       if (groupId === field.groupId) break;
     }
 
-    insert(Math.min(insertAt, selectedFields.length), {
-      fieldId: field._id,
-      groupId: field.groupId ?? null,
-      label: field.name,
-      placeholder: '',
-      isRequired: !!field.isRequired,
-      type: field.type ?? null,
-      options: (field.options ?? []).map(({ label, value }) => ({
-        label,
-        value,
-      })),
+    insert(Math.min(insertAt, selectedFields.length), toPropertyValue(field));
+  };
+
+  const toggleGroup = (group: PropertyGroup, checked: boolean) => {
+    const values = form.getValues('propertyFields') ?? [];
+    const groupFieldIds = new Set(group.groupFields.map((field) => field._id));
+
+    replace(
+      checked
+        ? [
+            ...values,
+            ...group.groupFields
+              .filter((field) => indexOfSelected(field._id) === -1)
+              .map(toPropertyValue),
+          ]
+        : values.filter((value) => !groupFieldIds.has(value.fieldId)),
+    );
+  };
+
+  const toggleGroupRequired = (group: PropertyGroup, checked: boolean) => {
+    group.groupFields.forEach((field) => {
+      const index = indexOfSelected(field._id);
+
+      if (index > -1) {
+        form.setValue(`propertyFields.${index}.isRequired`, checked);
+      }
     });
+  };
+
+  const isGroupRequired = (group: PropertyGroup) => {
+    const selectedIds = selectedIdsOf(group);
+
+    return (
+      selectedIds.length > 0 &&
+      selectedIds.every(
+        (fieldId) =>
+          propertyValues.find((value) => value.fieldId === fieldId)?.isRequired,
+      )
+    );
   };
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
@@ -311,6 +352,9 @@ export const TicketPropertyFields = ({ form }: Props) => {
                   group={group}
                   indexOfSelected={indexOfSelected}
                   onToggleField={toggleField}
+                  onToggleGroup={toggleGroup}
+                  onToggleGroupRequired={toggleGroupRequired}
+                  required={isGroupRequired(group)}
                   selectedIds={selectedIdsOf(group)}
                 />
               ))}
@@ -327,12 +371,18 @@ const SortablePropertyGroup = ({
   group,
   indexOfSelected,
   onToggleField,
+  onToggleGroup,
+  onToggleGroupRequired,
+  required,
   selectedIds,
 }: {
   form: UseFormReturn<TPipelineConfig>;
   group: PropertyGroup;
   indexOfSelected: (fieldId: string) => number;
   onToggleField: (field: IField, checked: boolean) => void;
+  onToggleGroup: (group: PropertyGroup, checked: boolean) => void;
+  onToggleGroupRequired: (group: PropertyGroup, checked: boolean) => void;
+  required: boolean;
   selectedIds: string[];
 }) => {
   const { t } = useTranslation('frontline');
@@ -372,8 +422,28 @@ const SortablePropertyGroup = ({
         <Accordion.Trigger className="py-2.5 flex-1 text-sm hover:no-underline">
           {group.name}
         </Accordion.Trigger>
+        {!!selectedFields.length && (
+          <div className="flex flex-none items-center gap-2">
+            <span className="text-sm text-muted-foreground">
+              {t('required-attribute')}
+            </span>
+            <Switch
+              aria-label={t('required-attribute')}
+              checked={required}
+              onCheckedChange={(checked) =>
+                onToggleGroupRequired(group, checked)
+              }
+            />
+          </div>
+        )}
+        <Switch
+          aria-label={group.name}
+          checked={!unselectedFields.length}
+          className="flex-none"
+          onCheckedChange={(checked) => onToggleGroup(group, checked)}
+        />
       </div>
-      <Accordion.Content className="flex flex-col divide-y pb-2.5 pl-6 pt-0">
+      <Accordion.Content className="flex flex-col divide-y pb-2.5 pl-6 pt-2">
         <SortableContext
           items={selectedIds.map((fieldId) => `${FIELD_DRAG_PREFIX}${fieldId}`)}
           strategy={verticalListSortingStrategy}

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketCardProperties.tsx
@@ -10,6 +10,7 @@ import {
 
 const MAX_VISIBLE_TAGS = 5;
 const MAX_VISIBLE_PROPERTIES = 3;
+const PROPERTY_FIELDS_LIMIT = 100;
 const TAG_COLOR = '#FF6600';
 const PROPERTY_COLOR = '#0EA5E9';
 
@@ -40,7 +41,10 @@ export const TicketCardDetails = ({
   onTagsOverflowClick,
   onPropertiesOverflowClick,
 }: TicketCardDetailsProps) => {
-  const { fields } = useFields({ contentType: 'frontline:ticket' });
+  const { fields } = useFields({
+    contentType: 'frontline:ticket',
+    limit: PROPERTY_FIELDS_LIMIT,
+  });
   const { tags } = useGetTags({ variables: { type: 'frontline:ticket' } });
 
   const selectedTags = tagIds

--- a/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsBoard.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/ticket/components/TicketsBoard.tsx
@@ -273,7 +273,11 @@ export const TicketsBoardCards = ({
           />
         )}
       </Board.Header>
-      <Board.Cards id={column.id} items={boardCards.map((ticket) => ticket.id)}>
+      <Board.Cards
+        className="max-w-80"
+        id={column.id}
+        items={boardCards.map((ticket) => ticket.id)}
+      >
         {loading ? (
           <SkeletonArray
             className="p-24 w-full rounded shadow-xs opacity-80"


### PR DESCRIPTION
## Summary by Sourcery

Improve frontline ticket property handling and board presentation by tolerating removed fields, adding group-level configuration controls, limiting property loading, and constraining card widths.

New Features:
- Add group-level controls for selecting ticket property fields and marking selected fields as required.

Bug Fixes:
- Ignore missing ticket property fields during pipeline configuration validation instead of rejecting the entire configuration.
- Limit ticket card property loading to the supported field range.

Enhancements:
- Constrain ticket board card columns to a narrower layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group-level controls for selecting ticket property fields and marking groups as required.
  * Preserved configured group order when adding or removing selected fields.

* **Bug Fixes**
  * Invalid or unavailable ticket property fields are now ignored instead of causing configuration errors.
  * Ticket property displays now load up to 100 fields for more consistent results.

* **Style**
  * Improved ticket board card sizing and spacing in property field configuration panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->