### PR TITLE
fix(core): empty tag filter dropdown on Products page

### DIFF
--- a/frontend/core-ui/src/modules/products/components/ProductsFilter.tsx
+++ b/frontend/core-ui/src/modules/products/components/ProductsFilter.tsx
@@ -14,7 +14,7 @@ import {
   SelectCategory,
   SelectCompany,
   PropertiesFilter,
-  SelectTags,
+  TagsFilter,
 } from 'ui-modules';
 import { IconBriefcase, IconCheck, IconCircleDot } from '@tabler/icons-react';
 import { ComponentType } from 'react';
@@ -154,23 +154,6 @@ function BrandsFilterBar() {
   );
 }
 
-function TagsFilterBar() {
-  const [tags] = useQueryState<string[]>('tags');
-
-  if (!tags?.length) {
-    return null;
-  }
-
-  return (
-    <SelectTags.FilterBar
-      mode="multiple"
-      filterKey="tags"
-      label="Tags"
-      tagType="core:product"
-    />
-  );
-}
-
 export const ProductsFilter = () => {
   return (
     <Filter id="products-filter" sessionKey={PRODUCTS_CURSOR_SESSION_KEY}>
@@ -190,7 +173,7 @@ export const ProductsFilter = () => {
         <OptionFilterBar config={PRODUCT_TYPE_FILTER} />
         <VendorFilterBar />
         <BrandsFilterBar />
-        <TagsFilterBar />
+        <TagsFilter.Bar tagType="core:product" />
         <PropertiesFilter.Bar contentType="core:product" />
         <OptionFilterBar config={PRODUCT_STATUS_FILTER} />
         <ProductsTotalCount />
@@ -218,7 +201,7 @@ export const ProductsFilterPopover = () => {
                 <OptionFilterItem config={PRODUCT_TYPE_FILTER} />
                 <SelectCompany.FilterItem value="vendorId" label="Vendor" />
                 <SelectBrands.FilterItem value="brandIds" label="Brands" />
-                <SelectTags.FilterItem value="tags" label="Tags" />
+                <TagsFilter />
                 <PropertiesFilter />
                 <OptionFilterItem config={PRODUCT_STATUS_FILTER} />
               </Command.List>
@@ -228,7 +211,7 @@ export const ProductsFilterPopover = () => {
           <OptionFilterView config={PRODUCT_TYPE_FILTER} />
           <SelectCompany.FilterView mode="single" filterKey="vendorId" />
           <SelectBrands.FilterView mode="multiple" filterKey="brandIds" />
-          <SelectTags.FilterView mode="multiple" filterKey="tags" />
+          <TagsFilter.View tagType="core:product" />
           <PropertiesFilter.View contentType="core:product" />
           <OptionFilterView config={PRODUCT_STATUS_FILTER} />
         </Combobox.Content>


### PR DESCRIPTION
## Summary by Sourcery

Fix tag filtering on the Products page by using the shared tag filter components consistently.

Bug Fixes:
- Fix the Products page tag filter so tag options and active filters render correctly across the filter bar and popover.

Enhancements:
- Consolidate product tag filtering on the shared TagsFilter components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the product filter interface with refreshed tag-based filtering controls.
  - Product filtering continues to support filtering by core product tags through the standardized filter view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->