### PR TITLE
fix(document): print height calculation bug

### DIFF
--- a/frontend/core-ui/src/modules/documents/components/Documents.tsx
+++ b/frontend/core-ui/src/modules/documents/components/Documents.tsx
@@ -25,18 +25,18 @@ export const Documents = ({ viewType }: Props) => {
     <div className="h-full overflow-y-auto">
       <Component documents={documents} />
 
-        {!loading && documents?.length === 0 && (
-          <div className="flex h-full min-h-[400px] w-full flex-col items-center justify-center px-8 text-center">
-            <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
-              <IconFilePlus size={28} className="text-muted-foreground" />
-            </div>
-            <h3 className="mb-1 text-lg font-semibold">
-              {t('no-document-title')}
-            </h3>
-            <p className="max-w-sm text-sm text-muted-foreground">
-              {t('no-document-description')}
-            </p>
+      {!loading && documents?.length === 0 && (
+        <div className="flex h-[80%] min-h-[400px] w-full flex-col items-center justify-center px-8 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <IconFilePlus size={28} className="text-muted-foreground" />
           </div>
+          <h3 className="mb-1 text-lg font-semibold">
+            {t('no-document-title')}
+          </h3>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {t('no-document-description')}
+          </p>
+        </div>
       )}
     </div>
   );

--- a/frontend/libs/ui-modules/src/modules/documents/utils/index.ts
+++ b/frontend/libs/ui-modules/src/modules/documents/utils/index.ts
@@ -6,6 +6,8 @@ import {
 
 export const PAGE_STYLE_ID = 'erxes-page-size';
 
+const CONTINUOUS_PAGE_HEIGHT_SAFETY_MM = 1;
+
 export const paper = (size: string, orientation: 'portrait' | 'landscape') => {
   const BASE_SIZE = PAPER_SIZES[size] || PAPER_SIZES.A4;
 
@@ -227,7 +229,8 @@ export const syncPageHeight = (iframe: HTMLIFrameElement, config: any) => {
 
   const paperHeight = Math.max(
     1,
-    Math.ceil(content.getBoundingClientRect().height / PX_PER_MM),
+    Math.ceil(content.getBoundingClientRect().height / PX_PER_MM) +
+      CONTINUOUS_PAGE_HEIGHT_SAFETY_MM,
   );
 
   style.textContent = `@page { size: ${width}mm ${paperHeight}mm; margin: 0; }`;


### PR DESCRIPTION
## Summary by Sourcery

Fix document printing height calculation and improve the empty-state layout.

Bug Fixes:
- Fix continuous document print height calculation by adding a small safety allowance to the computed page height.

Enhancements:
- Adjust the empty documents state to occupy 80% of the available container height for improved layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the documents empty state layout so it no longer fills the entire container.
  * Added a small safety margin when calculating continuous-roll document page height to help prevent sizing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->