### PR TITLE
feat(frontline): expose scoped tRPC queries for agents

### DIFF
--- a/backend/plugins/frontline_api/AGENTS.md
+++ b/backend/plugins/frontline_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `frontline_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/frontline_api`
-- **Last synchronized:** `2026-09-02`
+- **Last synchronized:** `2026-09-05`
 
 ## Scope
 
@@ -111,10 +111,10 @@
   SES or SendGrid path: mail enters and leaves through Cloudflare only.
 - Ticket boards/pipelines, response templates, forms, knowledgebase articles,
   and report aggregations.
-- Read-only inbox, integration, and form-submission tRPC procedures are
-  exposed to AI agents through `/agent-tools/manifest` and `/agent-tools/call`
-  via `.meta(agentMeta(...))` annotations; every other procedure remains
-  invisible to agents.
+- Typed `agent.*` tRPC queries expose membership-scoped conversations, messages,
+  integrations, channels, tickets, form submissions, and published public article
+  summaries. Lists default to 20 rows and cap at 50. Raw legacy inbox/form
+  annotations are excluded from discovery and execution in `src/main.ts`.
 - Contributes permissions, notifications, segments, references, and
   import/export handlers to the platform through `meta/`.
 
@@ -212,16 +212,13 @@ accountId, brandId, data)` — `channelId` is **nullable** for every kind;
 - tRPC `appRouter` consumed by other services, including
   `inbox.updateUserChannels({ channelIds, userId })` — replaces a user's team
   channel memberships; never touches their personal channel.
-- Agent-callable tRPC tools (admit-only via `.meta({ agent })`), each gated by
-  the listed frontline permission action:
-  - `inbox.conversations.findOne`, `inbox.conversations.count`,
-    `inbox.getConversationsList`, `inbox.conversationMessages.findOne`,
-    `inbox.conversationMessages.find` — `showConversations`
-  - `inbox.conversations.changeStatus` — `conversationsChangeStatus`
-  - `inbox.integrations.findOne`, `inbox.integrations.find`,
-    `inbox.integrations.count`, `inbox.getIntegrationKinds` —
-    `showIntegrations`
-  - `form.submissionsByConversation` — `showFormSubmissions`
+- Agent-callable tRPC: `agent.conversations`, `agent.conversationCount`,
+  `agent.conversation`, `agent.messages` (`showConversations`);
+  `agent.integrations` (`showIntegrations`); `agent.channels` (`showChannels`);
+  `agent.tickets` (`showTickets`); `agent.formSubmissions` (`showFormSubmissions`);
+  `agent.articles` (`showKnowledgeBase`). These return projected data directly.
+- Agent clients must migrate old `inbox.*` and `form.submissionsByConversation`
+  tool IDs to `agent.*`; service-to-service paths remain unchanged.
 - HTTP routes in `src/routes.ts` and provider webhooks under
   `src/modules/integrations/*`: Express webhook routes `/facebook/*` and
   `/instagram/*`, including the OAuth entry points `/facebook/fblogin`,
@@ -1289,6 +1286,7 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 
 ## Validation
 
+- `pnpm exec jest --config backend/plugins/frontline_api/jest.agent.cjs --runInBand`
 - `pnpm nx lint frontline_api` (repository-wide pre-existing errors exist in
   `src/public/widget/messengerWidget.bundle.js` and some ticket/report files;
   lint the files you touched)
@@ -1326,10 +1324,10 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   range covering `calls_cdrs` documents whose `actionType` contains
   `QUEUE[<queue>]`. Every tab must show numbers; an empty `calls_cdrs` renders
   every tab blank, which is expected, not a bug.
-- Smoke: `GET /agent-tools/manifest` on the frontline service lists only the
-  annotated procedures above; `ticket.create`, `inbox.removeConversation`,
-  `inbox.conversationMessages.updateOne`, and `inbox.channels.find` never
-  appear.
+- Smoke: authenticated `GET /agent-tools/manifest` lists only `agent.*` tools;
+  legacy `inbox.*`, `form.submissionsByConversation`, and `ticket.create` cannot
+  execute through the agent endpoint. A user cannot read another channel’s
+  conversations, messages, submissions, or tickets.
 - Smoke: with `CALLPRO_ENABLED` unset, `POST /callpro/receive` must 404. With it
   set to `true`, create a Call Pro line and post
   `{ numberTo, numberFrom, disp, callID, owner }` — a conversation appears in
@@ -1341,7 +1339,41 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 
 <!-- Newest first. Keep at most 10 entries. -->
 
-<<<<<<< HEAD
+### `2026-09-05` — Scoped agent queries
+
+- **Summary:** Replaced unrestricted legacy agent entries with typed, paginated queries that enforce acting-user permissions and record visibility.
+- **Affected areas:** `src/trpc/agentRouter.ts`, `src/trpc/__tests__/agentRouter.spec.ts`, `jest.agent.cjs`, `src/init-trpc.ts`, `src/main.ts`.
+- **Contracts changed:** Agent discovery uses `agent.*` tool IDs; old inbox/form agent IDs are excluded, while ordinary tRPC contracts remain intact. New mutations remain private because the shared call endpoint does not enforce an approval token.
+
+### `2026-09-02` — Ticket visibility rules apply outside pipeline-scoped lists
+
+- **Summary:** All four pipeline visibility rules were dead on the channel
+  ticket list: `generateFilter` only consulted the pipeline when the query
+  carried a `filter.pipelineId`, and the channel page never sends one, so every
+  ticket in the channel was returned. `isCheckDate` was additionally never
+  referenced by any query, and `isCheckBranch`/`isCheckDepartment` only acted as
+  pipeline access gates rather than the per-ticket filters their labels promise.
+  Rules now live in `buildVisibilityCondition` and are applied per pipeline on
+  unscoped lists, which also stops private-pipeline tickets leaking there.
+- **Affected areas:** `src/modules/ticket/utils/generateFilter.ts`.
+- **Contracts changed:** None (`getTickets` arguments are unchanged).
+
+### `2026-09-02` — IMAP integration removed
+
+- **Summary:** The IMAP channel runtime was deleted in full — poller, client,
+  message processing/saving, models, message broker, and GraphQL layer — along
+  with every registration that referenced it.
+- **Affected areas:** `src/modules/integrations/imap/` (deleted), `src/main.ts`,
+  `src/connectionResolvers.ts`, `src/apollo/{resolvers,schema}`,
+  `src/modules/inbox/graphql/resolvers/{customResolvers/integration.ts,mutations/integrations.ts}`,
+  `src/modules/inbox/utils.ts`, `src/modules/inbox/trpc/inbox.ts`,
+  `src/shared/types.ts`, `package.json`.
+- **Contracts changed:** Removed GraphQL `imapConversationDetail`,
+  `imapGetIntegrations`, `imapLogs`, `imapSendMail`, types `IMap` and
+  `IMapIntegration`; `imap` is no longer an accepted integration kind for
+  create/update/remove or `getIntegrationsKinds`; the `imap_customers`,
+  `imap_integrations`, `imap_messages` and `imap_logs` models are no longer
+  registered.
 
 ### `2026-09-01` — `checkTargetMatch` producer removed
 
@@ -1397,40 +1429,6 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
 - **Contracts changed:** Ticket content type now declares
   `contentType: 'frontline:tickets.tickets'`; new relations
   `customer.tickets`, `company.tickets`, `user.assignedTickets`.
-  =======
-  <<<<<<< HEAD
-
-### `2026-09-02` — Ticket visibility rules apply outside pipeline-scoped lists
-
-- **Summary:** All four pipeline visibility rules were dead on the channel
-  ticket list: `generateFilter` only consulted the pipeline when the query
-  carried a `filter.pipelineId`, and the channel page never sends one, so every
-  ticket in the channel was returned. `isCheckDate` was additionally never
-  referenced by any query, and `isCheckBranch`/`isCheckDepartment` only acted as
-  pipeline access gates rather than the per-ticket filters their labels promise.
-  Rules now live in `buildVisibilityCondition` and are applied per pipeline on
-  unscoped lists, which also stops private-pipeline tickets leaking there.
-- **Affected areas:** `src/modules/ticket/utils/generateFilter.ts`.
-- # **Contracts changed:** None (`getTickets` arguments are unchanged).
-  > > > > > > > cba2acc12f171a512ce661d11ce7c9a5481eb89c
-
-### `2026-09-02` — IMAP integration removed
-
-- **Summary:** The IMAP channel runtime was deleted in full — poller, client,
-  message processing/saving, models, message broker, and GraphQL layer — along
-  with every registration that referenced it.
-- **Affected areas:** `src/modules/integrations/imap/` (deleted), `src/main.ts`,
-  `src/connectionResolvers.ts`, `src/apollo/{resolvers,schema}`,
-  `src/modules/inbox/graphql/resolvers/{customResolvers/integration.ts,mutations/integrations.ts}`,
-  `src/modules/inbox/utils.ts`, `src/modules/inbox/trpc/inbox.ts`,
-  `src/shared/types.ts`, `package.json`.
-- **Contracts changed:** Removed GraphQL `imapConversationDetail`,
-  `imapGetIntegrations`, `imapLogs`, `imapSendMail`, types `IMap` and
-  `IMapIntegration`; `imap` is no longer an accepted integration kind for
-  create/update/remove or `getIntegrationsKinds`; the `imap_customers`,
-  `imap_integrations`, `imap_messages` and `imap_logs` models are no longer
-  registered.
-  > > > > > > > 8b1bde58e0fa2b2698872aef1fc19189dc98bd8d
 
 ### `2026-08-28` — Every zone is listed, and the picker says which are usable
 
@@ -1477,219 +1475,3 @@ customerIds, tagIds, propertiesData: JSON)` — the public messenger ticket
   (two guard messages no longer claim one account serves one workspace).
 - **Contracts changed:** None. `provision.ts` already read every name from the
   connection document, and `buildScriptMetadata` already took them as arguments.
-
-### `2026-08-28` — Header threading works again on sent replies
-
-- **Summary:** `createCloudflareTransport` discarded the `message_id` Cloudflare
-  returns, so every sent reply was stored with no `providerMessageId`. The
-  machinery around it was already complete — `toWireReferences` swaps the internal
-  id for the wire one, and inbound matching checks `providerMessageId` — but with
-  the field empty the sent message was filtered out of outgoing `References`
-  entirely and a customer reply quoting it could not be matched. Replies still
-  threaded through the tagged `Reply-To` and the original inbound id, which is why
-  this stayed hidden. The stored `from` on a sent message now also carries the
-  display name that actually went out instead of repeating the address.
-- **Affected areas:**
-  `src/modules/integrations/mail/@types/cloudflare.ts`,
-  `src/modules/integrations/mail/utils/transports/cloudflare.ts`,
-  `src/modules/integrations/mail/db/models/Messages.ts`.
-- **Contracts changed:** None — `providerMessageId` was already stored and
-  returned; it was simply never populated for Cloudflare sends.
-
-### `2026-08-28` — A forwarded message is no longer flagged as an unverified sender
-
-- **Summary:** Mail arriving through a forwarding rule was always banded
-  "Unverified sender". `isForwardedBy` compared the SMTP envelope sender against
-  the inbox's `forwardFrom`, but a forwarder hands the message over under its own
-  relay — Gmail's is a rotating `postmaster@mail-….google.com` — so no value of
-  `forwardFrom` could ever match and the guard could not be satisfied at all. The
-  worker now carries `Delivered-To` (every hop, joined, since the forwarding
-  mailbox is only one of them) and `isForwardedBy` accepts a match on either that
-  or the envelope sender. A genuine sender mismatch is still flagged.
-- **Affected areas:**
-  `src/modules/integrations/mail/controller/receiveMessage.ts`,
-  `src/modules/integrations/mail/worker/bundle.generated.ts`,
-  `cloudflare/mail-worker/src/parse.ts`,
-  `cloudflare/mail-worker/fixtures/delivered-to.json`.
-- **Contracts changed:** The inbound webhook payload's `headers` may now carry
-  `delivered-to`. The worker bundle version changed, so a workspace running the
-  worker on its own Cloudflare account has to press _Update worker_.
-
-### `2026-08-27` — An inbox can choose the name recipients see
-
-- **Summary:** Replies carried the inbox integration's `name` as their display
-  name with no way to change it, so a mailbox called "support" appeared to
-  recipients as `support`. A mail integration now owns an optional `senderName`,
-  used for the `From` display name and falling back to the inbox name when empty.
-  It is validated on create and edit: line breaks are rejected so the value cannot
-  smuggle a second header, and length is capped at `MAIL_SENDER_NAME_MAX_LENGTH`.
-  The `From` address itself is unchanged.
-- **Affected areas:** `src/modules/integrations/mail/db/definitions/integrations.ts`,
-  `src/modules/integrations/mail/@types/integration.ts`,
-  `src/modules/integrations/mail/db/models/Messages.ts`,
-  `src/modules/integrations/mail/{messageBroker,constants}.ts`.
-- **Contracts changed:** `mailCreateIntegration` and `mailUpdateIntegration` accept
-  `data.senderName`; `mailIntegrationDetails` returns it.
-
-### `2026-08-27` — Mail sends through Cloudflare only; SES and SendGrid are gone
-
-- **Summary:** Outbound mail now leaves through Cloudflare Email Sending on every
-  path, matching the inbound side. A workspace that has connected its own
-  Cloudflare account replies from its own zone; every other workspace replies from
-  its generated address on `MAIL_DOMAIN` through the deployment's Cloudflare
-  account, configured with `MAIL_SENDING_ACCOUNT_ID` and `MAIL_SENDING_API_TOKEN`.
-  The workspace-owned SES/SendGrid sending domains — the model, its DNS-proof
-  verification, the provider transport and the whole Settings → Integrations config
-  → Sending domains panel — are removed, along with the per-inbox sender choice:
-  an inbox always answers from its own address. `checkPlatformSendRate` still caps
-  the shared lane, because a Cloudflare account shares its daily quota and its
-  suppression list across every workspace on it.
-- **Affected areas:** `src/modules/integrations/mail/utils/`
-  (`platformConfig.ts` rewritten, `transports/{index,readiness,types}.ts`;
-  `dnsProof.ts`, `sendingSerialize.ts`, `transports/provider.ts` deleted),
-  `src/modules/integrations/mail/db/{definitions,models}/` (`sending.ts`,
-  `SendingAccounts.ts` deleted; `integrations.ts` loses `sendingAccountId` /
-  `sendingAddress`), `src/modules/integrations/mail/@types/{sending,integration}.ts`,
-  `src/modules/integrations/mail/{messageBroker,constants}.ts`,
-  `src/modules/integrations/mail/controller/receiveMessage.ts`,
-  `src/modules/integrations/mail/graphql/`, `src/connectionResolvers.ts`.
-- **Contracts changed:** removes the `mailSendingAccounts` query, the
-  `mailSendingAccountAdd` / `mailSendingAccountVerify` / `mailSendingAccountRemove`
-  mutations, the `MailSendingAccount` and `MailSendingDnsRecord` types and
-  `MailSendingReadiness.accounts`; `mailCreateIntegration` and
-  `mailUpdateIntegration` ignore `data.sendingAccountId` / `data.sendingAddress`.
-  Env `MAIL_SENDING_DEFAULT_EMAIL_SERVICE`, `MAIL_SENDING_AWS_SES_*`,
-  `MAIL_SENDING_AWS_REGION` and `MAIL_SENDING_SENDGRID_API_KEY` are replaced by
-  `MAIL_SENDING_ACCOUNT_ID` and `MAIL_SENDING_API_TOKEN`. The
-  `mail_sending_accounts` collection is orphaned and can be dropped.
-
-### `2026-08-27` — Deprecated Messenger tags normalized to HUMAN_AGENT
-
-- **Summary:** `sendReply` coerces the Meta-retired CONFIRMED_EVENT_UPDATE / POST_PURCHASE_UPDATE / ACCOUNT_UPDATE tags to `HUMAN_AGENT` before every Send API call, restoring replies to conversations older than 24 hours (retired tags fail with error 100 "Invalid parameter" since 2026-04-27).
-- **Affected areas:** `src/modules/integrations/facebook/utils.ts` (`normalizeMessengerTag`, `HUMAN_AGENT_MESSENGER_TAG`, `sendReply`)
-- **Contracts changed:** None
-
-### `2026-08-26` — Mail automation and reply drafts removed
-
-- **Summary:** An inbound call that Follow Me forwarded to an agent's mobile
-  produced two inbox conversations — the queue leg as `NO ANSWER · Inbound` and
-  the `FOLLOWME` leg, filed by the PBX under a second `uniqueid`, as
-  `ANSWERED · Outbound`. The CTI path created the second one because it looked
-  a session up by `uniqueid` alone, and the CDR path's existing FOLLOWME merge
-  could never run once that session carried a `conversationId`. Both paths now
-  adopt the call a leg belongs to before creating one — the CTI path by the
-  child leg's `linkedid`, then by a recent sibling session for the same
-  customer, and it takes a forwarded leg's customer from the parent leg or from
-  `callerName` instead of filing the agent's mobile as the caller. The CDR path
-  also merges any time-overlapping leg (not only `FOLLOWME`-tagged ones) and
-  writes a resolved `conversationId` back onto a session that had none, and a
-  customer-scoped Redis lock keeps sibling legs from racing each other into two
-  conversations. Conversation content is now derived from every leg of the
-  conversation and reports a `FOLLOWME` leg as `Inbound`, so a merged call
-  reads `ANSWERED · Inbound` regardless of which leg's CDR lands last. Fixed
-  the CTI `startedAt`/`endedAt` parsing that stored PBX local time eight hours
-  ahead.
-  The call history and agent stats fold a `FOLLOWME` leg into its parent call
-  instead of listing it as a second, outgoing call placed to the agent's own
-  mobile.
-- **Affected areas:**
-  `src/modules/reports/callReportService.ts` (`withForwardedCallKeys`),
-  `src/modules/integrations/call/services/callEventService.ts`,
-  `src/modules/integrations/call/services/cdrServices.ts`,
-  `src/modules/integrations/call/services/cdrUtils.ts`
-  (`getConversationContent`),
-  `src/modules/integrations/call/db/models/CallSessions.ts`
-  (`findSibling`), `src/modules/integrations/call/redlock.ts`
-  (`acquireCustomerLock`).
-- **Contracts changed:** None. `POST /call/event`, `/call/receiveCall`, and
-  `/call/cdrReceive` keep their payloads; only how legs are grouped into a
-  conversation changed.
-
-### `2026-08-20` — The agent who answered a call is assigned to it
-
-- **Summary:** A call conversation stayed unassigned because the CDR path
-  looked the operator up with `extractOperatorId`, which returns the queue/DID
-  number on the inbound Queue legs an agent actually answers, and then carried
-  the match to the inbox as `owner` — the user's optional
-  `details.operatorPhone`. Both the CDR and the CTI path now resolve the
-  answering operator from the leg's answering extension
-  (`resolveCdrOperator`) and pass that operator's `userId` straight to
-  `create-or-update-conversation`, so assignment no longer depends on a
-  profile field being filled in.
-- **Affected areas:**
-  `src/modules/integrations/call/services/cdrUtils.ts`,
-  `src/modules/integrations/call/services/cdrServices.ts`,
-  `src/modules/integrations/call/services/callEventService.ts`,
-  `src/modules/inbox/receiveMessage.ts`.
-- **Contracts changed:** None — `create-or-update-conversation` already
-  accepted `userId`; the call paths now send it, and the create branch no
-  longer leaks `owner`/`userId` onto the new conversation document.
-
-### `2026-08-19` — Call Pro webhook integration
-
-- **Summary:** Ported the Call Pro PBX integration from the legacy
-  `plugin-integrations-api`: a `CALLPRO_ENABLED`-gated `/callpro/receive`
-  webhook turns each call event into an inbox conversation with the caller
-  attached and the recording URL resolved, and defers attribution to the agent
-  when one number matches several customers.
-- **Affected areas:** `src/modules/integrations/callpro/` (new),
-  `src/connectionResolvers.ts`, `src/routes.ts`,
-  `src/apollo/{schema/schema.ts,resolvers/queries.ts,resolvers/mutations.ts}`,
-  `src/modules/inbox/{@types,db/definitions}/conversations.ts`,
-  `src/modules/inbox/graphql/schemas/conversation.ts`,
-  `src/modules/inbox/graphql/resolvers/customResolvers/conversation.ts`,
-  `src/modules/inbox/graphql/resolvers/mutations/integrations.ts`
-- **Contracts changed:** Added `POST /callpro/receive`; queries `callProConfig`,
-  `callProIntegrationDetail`, `callProCustomersByPhone`; mutation
-  `callProCustomerSelect`; `Conversation.callProPotentialCustomerIds` and
-  `Conversation.callProPhone`; a resolver for the previously dangling
-  `Conversation.callProAudio`; `callpro` cases in `sendCreateIntegration`,
-  `sendUpdateIntegration`, and `sendRemoveIntegration`.
-
-### `2026-08-19` — Call history reports the ring on unanswered calls
-
-- **Summary:** `CallHistoryEntry.waitTime` was `null` for every call nobody
-  answered, so the Waited column showed a dash on exactly the rows a supervisor
-  wants to read — a No answer row said nothing about whether it rang for three
-  seconds or three minutes. Unanswered calls now report `callRingSeconds`,
-  taken from `duration - billsec` on the legs that held the caller, since an
-  unanswered leg has no `answer` stamp for the existing helper to subtract. It
-  falls back to the call's own span when the PBX filed no `Queue`/`Dial` ring,
-  which is how an IVR-only call arrives — its menu time lands in `billsec`, so
-  subtracting it would report zero.
-- **Affected areas:**
-  `src/modules/integrations/call/services/cdrUtils.ts` (`callRingSeconds`,
-  `ICdrLegTiming.duration`), `src/modules/reports/callHistoryService.ts`,
-  `src/modules/reports/graphql/schema/call.ts`.
-- **Contracts changed:** None. `CallHistoryEntry.waitTime` keeps its type and
-  unit; it is now populated for unanswered calls instead of always `null`.
-
-### `2026-08-19` — Bot typing status survives conversation creation
-
-- **Summary:** `generateAiContext` re-publishes
-  `conversationBotTypingStatus:<conversationId>` with `typing: true` when the AI
-  agent starts, so a widget that only learns its `conversationId` from the
-  `widgetsInsertMessage` response still sees the indicator for the first message
-  of a conversation and for the whole agent run. Also removed the debug
-  `console.log` calls left in `widgetsInsertMessage`.
-- **Affected areas:** `src/modules/inbox/meta/automation/workers.ts`,
-  `src/modules/inbox/graphql/resolvers/mutations/widget.ts`.
-- **Contracts changed:** None — same subscription and payload shape, published
-  once more per agent run.
-- **Summary:** The mail channel no longer registers automation. The
-  `frontline:mail.messages` trigger, the `Send Email` and `Draft Email Reply`
-  actions, their workers and the AI-context builder are gone, and so is the reply
-  draft they were the only producer of — nothing else could create one, so the
-  draft model, its GraphQL surface and its inbox card would have been unreachable
-  code.
-- **Affected areas:** `src/modules/integrations/mail/meta/` (deleted),
-  `src/modules/integrations/mail/db/{models/Drafts.ts,definitions/drafts.ts}`,
-  `@types/draft.ts`, `utils/draftEvents.ts` (deleted),
-  `src/meta/automations.ts`, `src/connectionResolvers.ts`,
-  `src/apollo/subscription.ts`,
-  `src/modules/integrations/mail/{constants,messageBroker}.ts`,
-  `.../mail/controller/receiveMessage.ts`, `.../mail/graphql/`.
-- **Contracts changed:** Removed the `frontline:mail.messages` automation
-  trigger, both mail automation actions, `MailDraft`, `mailConversationDraft`,
-  `mailDraftSave`, `mailDraftApprove`, `mailDraftRemove`, and the
-  `mailDraftChanged` subscription.

--- a/backend/plugins/frontline_api/jest.agent.cjs
+++ b/backend/plugins/frontline_api/jest.agent.cjs
@@ -4,9 +4,12 @@ module.exports = {
   testMatch: ['<rootDir>/src/trpc/__tests__/*.spec.ts'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: { isolatedModules: true, esModuleInterop: true },
-    }],
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: { isolatedModules: true, esModuleInterop: true },
+      },
+    ],
   },
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',

--- a/backend/plugins/frontline_api/jest.agent.cjs
+++ b/backend/plugins/frontline_api/jest.agent.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'frontline-agent-tools',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/trpc/__tests__/*.spec.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: { isolatedModules: true, esModuleInterop: true },
+    }],
+  },
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+    '^@/(.*)$': '<rootDir>/src/modules/$1',
+  },
+};

--- a/backend/plugins/frontline_api/src/init-trpc.ts
+++ b/backend/plugins/frontline_api/src/init-trpc.ts
@@ -12,12 +12,14 @@ import { inboxTrpcRouter } from './modules/inbox/trpc/inbox';
 import { integrationTrpcRouter } from './modules/integrations/trpc/integration';
 import { ticketTrpcRouter } from './modules/ticket/trpc/ticket';
 import { generateTicketFields } from './modules/ticket/meta/fields/fieldUtils';
+import { frontlineAgentRouter } from './trpc/agentRouter';
 
 export type FrontlineTRPCContext = ITRPCContext<{ models: IModels }>;
 
 const t = initTRPC.context<FrontlineTRPCContext>().create();
 
 export const appRouter = t.mergeRouters(
+  frontlineAgentRouter,
   integrationTrpcRouter,
   inboxTrpcRouter,
   conversationTrpcRouter,

--- a/backend/plugins/frontline_api/src/main.ts
+++ b/backend/plugins/frontline_api/src/main.ts
@@ -52,6 +52,7 @@ const formSubmissionExportTypes = [
 
 startPlugin({
   name: 'frontline',
+  agentToolsExclude: ['inbox.', 'form.submissionsByConversation'],
   port: 3304,
   graphql: async () => ({
     typeDefs: await typeDefs(),

--- a/backend/plugins/frontline_api/src/trpc/__tests__/agentRouter.spec.ts
+++ b/backend/plugins/frontline_api/src/trpc/__tests__/agentRouter.spec.ts
@@ -1,0 +1,165 @@
+import { frontlineAgentRouter } from '../agentRouter';
+import { permissions } from '../../meta/permissions';
+import type { FrontlineTRPCContext } from '../../init-trpc';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
+import { generateFilter } from '@/ticket/utils/generateFilter';
+
+jest.mock('erxes-api-shared/utils', () => ({ sendTRPCMessage: jest.fn() }));
+jest.mock('erxes-api-shared/core-modules', () => ({
+  checkPermissionGroup: jest.fn(),
+}));
+jest.mock('@/ticket/utils/generateFilter', () => ({
+  generateFilter: jest.fn(),
+}));
+
+const query = (value: unknown = []) => {
+  const result = {
+    select: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(value),
+    distinct: jest.fn().mockResolvedValue(value),
+  };
+  return result;
+};
+
+const setup = () => {
+  const rows = query([{ _id: 'conversation' }]);
+  const models = {
+    ChannelMembers: { find: jest.fn(() => query(['my-channel'])) },
+    Integrations: { find: jest.fn(() => query(['my-integration'])) },
+    Conversations: {
+      find: jest.fn(() => rows),
+      findOne: jest.fn(() => query({ _id: 'conversation' })),
+      countDocuments: jest.fn().mockResolvedValue(3),
+    },
+    ConversationMessages: { find: jest.fn(() => rows) },
+    FormSubmissions: { find: jest.fn(() => rows) },
+    Ticket: { find: jest.fn(() => rows) },
+  };
+  // A mock model container is the external boundary for these router tests.
+  const ctx = {
+    models,
+    userId: 'reader',
+    subdomain: 'tenant-a',
+  } as unknown as Awaited<ReturnType<FrontlineTRPCContext>>;
+  return {
+    models,
+    rows,
+    ctx,
+    caller: frontlineAgentRouter.createCaller(ctx).agent,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(sendTRPCMessage).mockResolvedValue({ _id: 'reader' });
+  jest
+    .mocked(checkPermissionGroup)
+    .mockReturnValue(jest.fn().mockResolvedValue(undefined));
+  jest
+    .mocked(generateFilter)
+    .mockResolvedValue({ statusId: { $nin: ['private-status'] } });
+});
+
+test('every exposed tool is a query with a registered module/action and object input', () => {
+  for (const procedure of Object.values(frontlineAgentRouter._def.procedures)) {
+    const definition = (
+      procedure as unknown as {
+        _def: { meta: unknown; type: string; inputs: unknown[] };
+      }
+    )._def;
+    const meta = definition.meta as {
+      agent: { permission: { module: string; action: string } };
+    };
+    const module = permissions.modules.find(
+      (entry) => entry.name === meta.agent.permission.module,
+    );
+    expect(
+      module?.actions.some(
+        (action) => action.name === meta.agent.permission.action,
+      ),
+    ).toBe(true);
+    expect(definition.type).toBe('query');
+    expect(definition.inputs).toHaveLength(1);
+  }
+});
+
+test('rejects missing identity before touching models', async () => {
+  const { ctx, models } = setup();
+  await expect(
+    frontlineAgentRouter
+      .createCaller({ ...ctx, userId: undefined })
+      .agent.conversations({}),
+  ).rejects.toThrow();
+  expect(models.ChannelMembers.find).not.toHaveBeenCalled();
+});
+
+test('denied permissions prevent model access', async () => {
+  jest
+    .mocked(checkPermissionGroup)
+    .mockReturnValue(jest.fn().mockRejectedValue(new Error('denied')));
+  const { caller, models } = setup();
+  await expect(caller.conversations({})).rejects.toThrow('denied');
+  expect(models.ChannelMembers.find).not.toHaveBeenCalled();
+});
+
+test.each([
+  { limit: 0 },
+  { limit: 51 },
+  { offset: -1 },
+  { offset: 10001 },
+  { query: { $where: 'true' } },
+  { userId: 'other' },
+])('rejects unsafe inputs %j', async (input) => {
+  const { caller, models } = setup();
+  await expect(caller.conversations(input)).rejects.toThrow();
+  expect(models.Conversations.find).not.toHaveBeenCalled();
+});
+
+test('caller filters cannot replace membership scope and pagination is bounded by default', async () => {
+  const { caller, models, rows } = setup();
+  await caller.conversations({ integrationId: 'other-integration' });
+  expect(models.Conversations.find).toHaveBeenCalledWith({
+    $and: [
+      { integrationId: { $in: ['my-integration'] } },
+      { integrationId: 'other-integration' },
+    ],
+  });
+  expect(rows.limit).toHaveBeenCalledWith(20);
+  expect(rows.select).toHaveBeenCalledWith(
+    expect.not.stringContaining('content'),
+  );
+  expect(sendTRPCMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      subdomain: 'tenant-a',
+      input: { query: { _id: 'reader' } },
+    }),
+  );
+});
+
+test('inaccessible conversations prevent reading messages and submissions', async () => {
+  const { caller, models } = setup();
+  models.Conversations.findOne.mockReturnValue(query(null));
+  await expect(
+    caller.messages({ conversationId: 'private' }),
+  ).rejects.toThrow();
+  await expect(
+    caller.formSubmissions({ conversationId: 'private' }),
+  ).rejects.toThrow();
+  expect(models.ConversationMessages.find).not.toHaveBeenCalled();
+  expect(models.FormSubmissions.find).not.toHaveBeenCalled();
+});
+
+test('ticket visibility includes the existing pipeline/status filter and channel membership', async () => {
+  const { caller, models } = setup();
+  await caller.tickets({});
+  expect(models.Ticket.find).toHaveBeenCalledWith({
+    $and: [
+      { statusId: { $nin: ['private-status'] } },
+      { channelId: { $in: ['my-channel'] } },
+    ],
+  });
+});

--- a/backend/plugins/frontline_api/src/trpc/agentRouter.ts
+++ b/backend/plugins/frontline_api/src/trpc/agentRouter.ts
@@ -1,0 +1,240 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import type { IUserDocument } from 'erxes-api-shared/core-types';
+import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import type { FrontlineTRPCContext } from '~/init-trpc';
+import { generateFilter } from '@/ticket/utils/generateFilter';
+import { agentMeta } from './agentMeta';
+
+const t = initTRPC.context<FrontlineTRPCContext>().create();
+type AgentContext = Awaited<ReturnType<FrontlineTRPCContext>>;
+const id = z.string().trim().min(1).max(100);
+const page = {
+  limit: z.number().int().min(1).max(50).default(20),
+  offset: z.number().int().min(0).max(10000).default(0),
+};
+const conversationFilter = {
+  integrationId: id.optional(),
+  customerId: id.optional(),
+  assignedUserId: id.optional(),
+  status: z.enum(['new', 'open', 'closed', 'resolved']).optional(),
+};
+const conversationFields =
+  '_id integrationId customerId assignedUserId status number messageCount createdAt updatedAt';
+
+const procedure = (module: string, action: string, description: string) =>
+  t.procedure
+    .meta(agentMeta(description, { module, action }))
+    .use(async ({ ctx, next }) => {
+      if (!ctx.userId || !ctx.subdomain) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+      const user: IUserDocument | null = await sendTRPCMessage({
+        subdomain: ctx.subdomain,
+        pluginName: 'core',
+        module: 'users',
+        action: 'findOne',
+        method: 'query',
+        input: { query: { _id: ctx.userId } },
+        defaultValue: null,
+      });
+      if (!user || user._id !== ctx.userId) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+      await checkPermissionGroup(ctx.subdomain, user)(action);
+      return next({ ctx: { ...ctx, user } });
+    });
+
+// Inbox visibility is membership-based, including for workspace owners.
+const integrationScope = async (ctx: AgentContext) => {
+  const channelIds = await ctx.models.ChannelMembers.find({
+    memberId: ctx.userId,
+  }).distinct('channelId');
+  const integrations = await ctx.models.Integrations.find({
+    channelId: { $in: channelIds },
+    isActive: { $ne: false },
+  }).distinct('_id');
+  return { integrationId: { $in: integrations } };
+};
+
+const requireConversation = async (
+  ctx: AgentContext,
+  conversationId: string,
+) => {
+  const scope = await integrationScope(ctx);
+  const conversation = await ctx.models.Conversations.findOne({
+    _id: conversationId,
+    ...scope,
+  })
+    .select(conversationFields)
+    .lean();
+  if (!conversation) throw new TRPCError({ code: 'NOT_FOUND' });
+  return conversation;
+};
+
+export const frontlineAgentRouter = t.router({
+  agent: t.router({
+    conversations: procedure(
+      'inbox',
+      'showConversations',
+      'List visible inbox conversations. Use offset and limit to page; use conversation for one record and messages for its text.',
+    )
+      .input(z.object({ ...conversationFilter, ...page }).strict())
+      .query(async ({ ctx, input: { limit, offset, ...filter } }) => {
+        const scope = await integrationScope(ctx);
+        return ctx.models.Conversations.find({ $and: [scope, filter] })
+          .select(conversationFields)
+          .sort({ updatedAt: -1, _id: -1 })
+          .skip(offset)
+          .limit(limit)
+          .lean();
+      }),
+    conversationCount: procedure(
+      'inbox',
+      'showConversations',
+      'Count inbox conversations visible to the acting user with optional status, customer, integration or assignee filters.',
+    )
+      .input(z.object(conversationFilter).strict())
+      .query(async ({ ctx, input }) =>
+        ctx.models.Conversations.countDocuments({
+          $and: [await integrationScope(ctx), input],
+        }),
+      ),
+    conversation: procedure(
+      'inbox',
+      'showConversations',
+      'Get one visible inbox conversation by its ID. Read its messages separately.',
+    )
+      .input(z.object({ conversationId: id }).strict())
+      .query(({ ctx, input }) =>
+        requireConversation(ctx, input.conversationId),
+      ),
+    messages: procedure(
+      'inbox',
+      'showConversations',
+      'Read a page of inbox messages for a visible conversation, newest first. Provider-specific mail and call records are not included.',
+    )
+      .input(z.object({ conversationId: id, ...page }).strict())
+      .query(async ({ ctx, input }) => {
+        await requireConversation(ctx, input.conversationId);
+        return ctx.models.ConversationMessages.find({
+          conversationId: input.conversationId,
+        })
+          .select('_id conversationId content createdAt userId customerId')
+          .sort({ createdAt: -1, _id: -1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+    integrations: procedure(
+      'integration',
+      'showIntegrations',
+      'List active integrations in channels the acting user belongs to. Returns identifiers and labels without integration credentials.',
+    )
+      .input(z.object({ kind: id.optional(), ...page }).strict())
+      .query(async ({ ctx, input }) => {
+        const scope = await integrationScope(ctx);
+        return ctx.models.Integrations.find({
+          _id: scope.integrationId,
+          ...(input.kind ? { kind: input.kind } : {}),
+        })
+          .select('_id name kind channelId brandId isActive')
+          .sort({ _id: 1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+    channels: procedure(
+      'channel',
+      'showChannels',
+      'List channels the acting user belongs to, including their own personal inbox.',
+    )
+      .input(z.object(page).strict())
+      .query(async ({ ctx, input }) => {
+        const channelIds = await ctx.models.ChannelMembers.find({
+          memberId: ctx.userId,
+        }).distinct('channelId');
+        return ctx.models.Channels.find({ _id: { $in: channelIds } })
+          .select('_id name scope')
+          .sort({ _id: 1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+    tickets: procedure(
+      'ticket',
+      'showTickets',
+      'List tickets with the same pipeline and status visibility rules as the ticket list. Optionally filter by pipeline, status, or literal search text.',
+    )
+      .input(
+        z
+          .object({
+            pipelineId: id.optional(),
+            statusId: id.optional(),
+            searchValue: z.string().max(100).optional(),
+            ...page,
+          })
+          .strict(),
+      )
+      .query(async ({ ctx, input }) => {
+        const filter = await generateFilter(input, ctx.user, ctx.models);
+        const channels = await ctx.models.ChannelMembers.find({
+          memberId: ctx.userId,
+        }).distinct('channelId');
+        return ctx.models.Ticket.find({
+          $and: [filter, { channelId: { $in: channels } }],
+        })
+          .select(
+            '_id name number channelId pipelineId statusId assigneeId priority state createdAt updatedAt',
+          )
+          .sort({ updatedAt: -1, _id: -1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+    formSubmissions: procedure(
+      'form',
+      'showFormSubmissions',
+      'Read a page of form submission fields attached to a conversation visible to the acting user.',
+    )
+      .input(z.object({ conversationId: id, ...page }).strict())
+      .query(async ({ ctx, input }) => {
+        await requireConversation(ctx, input.conversationId);
+        return ctx.models.FormSubmissions.find({
+          conversationId: input.conversationId,
+        })
+          .select('_id formId formFieldId value submittedAt')
+          .sort({ _id: 1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+    articles: procedure(
+      'knowledgeBase',
+      'showKnowledgeBase',
+      'List published, non-private knowledge base article summaries. Filter by topic or category and page with offset.',
+    )
+      .input(
+        z
+          .object({
+            topicId: id.optional(),
+            categoryId: id.optional(),
+            ...page,
+          })
+          .strict(),
+      )
+      .query(({ ctx, input: { limit, offset, ...filter } }) =>
+        ctx.models.Article.find({
+          ...filter,
+          status: 'publish',
+          isPrivate: { $ne: true },
+        })
+          .select('_id title summary code topicId categoryId')
+          .sort({ _id: 1 })
+          .skip(offset)
+          .limit(limit)
+          .lean(),
+      ),
+  }),
+});


### PR DESCRIPTION
Frontline's existing agent entries accepted raw Mongo filters and exposed a status write as a query. Add nine typed, paginated `agent.*` queries for conversations/count/detail, messages, integrations, channels, tickets, form submissions and published public article summaries. Resolve the acting user, enforce registered permissions and channel membership, preserve ticket pipeline/status visibility, and project integration fields without credentials.

Exclude the legacy `inbox.*` and `form.submissionsByConversation` agent entries through the existing platform exclusion hook. Their service-to-service contracts remain unchanged; agent clients must migrate to the documented `agent.*` IDs. Update the plugin guide, reconcile committed conflict markers in its recent history, and retain its newest ten entries.

Validation: focused router tests (12) and ESLint on touched TypeScript pass. `NODE_OPTIONS=--max-old-space-size=3072 NX_DAEMON=false pnpm nx build frontline_api --parallel=1` passes. Full-project lint was run and fails on existing unrelated errors, including `src/meta/import-export/export/getTicketExportData.ts` and the generated messenger widget bundle.

Scope: backend Frontline only; Sales is untouched. Mutations, provider ingestion, credentials, device/internal utilities and bulk writes remain outside this agent catalog. The shared call endpoint checks permissions but has no approval-token enforcement; this PR does not change that platform contract or activate tenant tools. List responses cap at 50 records; the platform's response byte limit still applies to long message/submission content.

Run focused tests with `pnpm exec jest --config backend/plugins/frontline_api/jest.agent.cjs --runInBand`. Live HMAC endpoint/tenant activation smoke tests require a running configured environment and were not performed.

## Summary by Sourcery

Expose a permission-aware, membership-scoped `agent.*` query catalog for Frontline clients and retire the legacy agent tool IDs.

New Features:
- Expose typed, paginated `agent.*` queries for scoped conversations, messages, integrations, channels, tickets, form submissions, and published article summaries.

Bug Fixes:
- Prevent agent access from bypassing channel membership, conversation visibility, ticket pipeline/status rules, or integration credential redaction.

Enhancements:
- Replace legacy inbox and form agent discovery with permission-aware acting-user-scoped queries while preserving service-to-service contracts.
- Add focused router tests covering permissions, identity, input validation, membership scoping, pagination, and ticket visibility.

Documentation:
- Update the Frontline agent-tool guide with the new catalog, migration requirements, validation guidance, and reconciled recent history.

Tests:
- Add a dedicated Jest configuration and focused tests for the Frontline agent router.

Chores:
- Exclude legacy `inbox.*` and `form.submissionsByConversation` entries from agent discovery and execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-facing queries for conversations, messages, integrations, channels, tickets, form submissions, and published articles.
  * Results are scoped to the agent’s permitted memberships and support filtering, sorting, field selection, and pagination.
  * Lists default to 20 results and are capped at 50.

* **Security**
  * Added permission checks and access controls to prevent unauthorized or unsafe data queries.

* **Documentation**
  * Updated Frontline API documentation with the new agent query capabilities and migration guidance for legacy tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->