### PR TITLE
feat(operation): expose scoped task and project agent queries

### DIFF
--- a/backend/plugins/operation_api/AGENTS.md
+++ b/backend/plugins/operation_api/AGENTS.md
@@ -6,7 +6,7 @@
 - **Project:** `operation_api`
 - **Layer:** `Backend API`
 - **Path:** `backend/plugins/operation_api`
-- **Last synchronized:** `2026-09-01`
+- **Last synchronized:** `2026-09-05`
 
 ## Scope
 
@@ -33,6 +33,8 @@
 
 ## Current Capabilities
 
+- Agent queries list/count/read tasks and list projects, teams, statuses, cycles,
+  and milestones through typed, permission-gated, team-membership-scoped inputs.
 - Tasks are a segment content type: 19 filterable fields, member listing and
   counting, materialised membership on the record, and two relations from a
   team member (`user.assignedTasks`, `user.createdTasks`).
@@ -56,6 +58,9 @@
 
 ### Provides
 
+- tRPC `agent.tasks`, `agent.taskCount`, `agent.task`, `agent.projects`,
+  `agent.teams`, `agent.statuses`, `agent.cycles`, `agent.milestones`.
+  Lists default to 20 rows, cap at 50, and accept offset up to 10000.
 - GraphQL queries, mutations and subscriptions for tasks, teams, statuses,
   cycles, milestones, projects, notes and templates.
 - Segment content type `operation:task.tasks`, with `segmentFields`,
@@ -83,6 +88,10 @@
 
 ## Local Invariants
 
+- Agent filters accept typed identifiers, never raw Mongo queries or a caller
+  userId. All agent reads require acting-user permissions and team membership.
+- Bulk tagging, field discovery, GitHub configuration and mutations remain
+  agent-invisible. The shared agent endpoint does not enforce approval tokens.
 - A task's `_id` stays an `ObjectId`. `schemaWrapper` must never be applied to
   `taskSchema`: it would make `_id` a generated string and orphan every
   existing task and reference. `segmentIds` is therefore declared by hand.
@@ -105,12 +114,10 @@
 
 ## Validation
 
-- `npx tsc --noEmit -p backend/plugins/operation_api/tsconfig.json` - expect
-  exactly two errors, both `TS2307: Cannot find module '@octokit/app'` from
-  `src/utils/githubClient.ts`. The dependency is declared in `package.json` but
-  is not installed, and it blocks `pnpm nx build operation_api` as well. Any
-  third error is new.
-- `pnpm nx build operation_api` (currently blocked by the above)
+- `pnpm exec jest --config backend/plugins/operation_api/jest.agent.cjs --runInBand`
+- `pnpm exec tsc --noEmit -p backend/plugins/operation_api/tsconfig.json`
+- `pnpm nx build operation_api`
+- `pnpm nx lint operation_api`
 - Build a task segment on an assignee, confirm the preview count matches the
   task list filtered the same way, then confirm `segmentIds` lands on those
   tasks after the rebuild.
@@ -118,6 +125,12 @@
 ## Recent Changes
 
 <!-- Newest first. Keep at most 10 entries. -->
+
+### `2026-09-05` — Scoped agent queries
+
+- **Summary:** Added eight typed, paginated queries for task and project discovery within the acting user’s teams.
+- **Affected areas:** `src/trpc/agentRouter.ts`, `src/trpc/init-trpc.ts`, `src/trpc/__tests__/agentRouter.spec.ts`, `jest.agent.cjs`.
+- **Contracts changed:** Added `agent.*` tRPC queries; internal procedures retain their contracts and remain private.
 
 ### `2026-09-01` — `checkTargetMatch` producer removed
 

--- a/backend/plugins/operation_api/jest.agent.cjs
+++ b/backend/plugins/operation_api/jest.agent.cjs
@@ -4,9 +4,12 @@ module.exports = {
   testMatch: ['<rootDir>/src/trpc/__tests__/*.spec.ts'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: { isolatedModules: true, esModuleInterop: true },
-    }],
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: { isolatedModules: true, esModuleInterop: true },
+      },
+    ],
   },
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',

--- a/backend/plugins/operation_api/jest.agent.cjs
+++ b/backend/plugins/operation_api/jest.agent.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'operation-agent-tools',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/trpc/__tests__/*.spec.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: { isolatedModules: true, esModuleInterop: true },
+    }],
+  },
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+    '^@/(.*)$': '<rootDir>/src/modules/$1',
+  },
+};

--- a/backend/plugins/operation_api/src/trpc/__tests__/agentRouter.spec.ts
+++ b/backend/plugins/operation_api/src/trpc/__tests__/agentRouter.spec.ts
@@ -1,0 +1,134 @@
+import { operationAgentRouter } from '../agentRouter';
+import { permissions } from '../../meta/permissions';
+import type { OperationTRPCContext } from '../init-trpc';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
+
+jest.mock('erxes-api-shared/utils', () => ({ sendTRPCMessage: jest.fn() }));
+jest.mock('erxes-api-shared/core-modules', () => ({
+  checkPermissionGroup: jest.fn(),
+}));
+const query = (value: unknown = []) => ({
+  select: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockResolvedValue(value),
+  distinct: jest.fn().mockResolvedValue(value),
+});
+const setup = () => {
+  const rows = query([]);
+  const models = {
+    TeamMember: { find: jest.fn(() => query(['0123456789abcdef01234567'])) },
+    Task: {
+      find: jest.fn(() => rows),
+      findOne: jest.fn(() => query(null)),
+      countDocuments: jest.fn().mockResolvedValue(0),
+    },
+    Project: { exists: jest.fn().mockResolvedValue(null) },
+    Milestone: { find: jest.fn(() => rows) },
+  };
+  const ctx = {
+    subdomain: 'tenant-a',
+    userId: 'reader',
+    models,
+  } as unknown as Awaited<ReturnType<OperationTRPCContext>>;
+  return {
+    models,
+    rows,
+    ctx,
+    caller: operationAgentRouter.createCaller(ctx).agent,
+  };
+};
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(sendTRPCMessage).mockResolvedValue({ _id: 'reader' });
+  jest
+    .mocked(checkPermissionGroup)
+    .mockReturnValue(jest.fn().mockResolvedValue(undefined));
+});
+test('all eight tools declare a registered permission and remain queries', () => {
+  const procedures = Object.values(operationAgentRouter._def.procedures);
+  expect(procedures).toHaveLength(8);
+  for (const raw of procedures) {
+    const def = (
+      raw as unknown as {
+        _def: {
+          type: string;
+          meta: { agent: { permission: { module: string; action: string } } };
+        };
+      }
+    )._def;
+    const { module, action } = def.meta.agent.permission;
+    expect(
+      permissions.modules
+        .find((entry) => entry.name === module)
+        ?.actions.some((entry) => entry.name === action),
+    ).toBe(true);
+    expect(def.type).toBe('query');
+  }
+});
+test.each([
+  { limit: 0 },
+  { limit: 51 },
+  { offset: -1 },
+  { offset: 10001 },
+  { teamId: 'bad-id' },
+  { query: { $where: 'true' } },
+  { userId: 'other' },
+])('rejects unsafe input %j', async (input) => {
+  const { caller, models } = setup();
+  await expect(caller.tasks(input)).rejects.toThrow();
+  expect(models.Task.find).not.toHaveBeenCalled();
+});
+test('rejects missing acting user before data access', async () => {
+  const { ctx, models } = setup();
+  await expect(
+    operationAgentRouter
+      .createCaller({ ...ctx, userId: undefined })
+      .agent.tasks({}),
+  ).rejects.toThrow();
+  expect(models.TeamMember.find).not.toHaveBeenCalled();
+});
+test('rejects denied permissions before data access', async () => {
+  jest
+    .mocked(checkPermissionGroup)
+    .mockReturnValue(jest.fn().mockRejectedValue(new Error('denied')));
+  const { caller, models } = setup();
+  await expect(caller.tasks({})).rejects.toThrow('denied');
+  expect(models.TeamMember.find).not.toHaveBeenCalled();
+});
+test('intersects requested team with membership and applies safe pagination', async () => {
+  const { caller, models, rows } = setup();
+  await caller.tasks({ teamId: 'ffffffffffffffffffffffff' });
+  expect(models.Task.find).toHaveBeenCalledWith({
+    $and: [
+      { teamId: { $in: ['0123456789abcdef01234567'] } },
+      { teamId: 'ffffffffffffffffffffffff' },
+    ],
+  });
+  expect(rows.limit).toHaveBeenCalledWith(20);
+  expect(sendTRPCMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      subdomain: 'tenant-a',
+      input: { query: { _id: 'reader' } },
+    }),
+  );
+});
+test('task lookup includes membership and hides inaccessible records', async () => {
+  const { caller, models } = setup();
+  await expect(
+    caller.task({ _id: 'ffffffffffffffffffffffff' }),
+  ).rejects.toThrow();
+  expect(models.Task.findOne).toHaveBeenCalledWith({
+    _id: 'ffffffffffffffffffffffff',
+    teamId: { $in: ['0123456789abcdef01234567'] },
+  });
+});
+test('milestones cannot be read through a project outside the acting user’s teams', async () => {
+  const { caller, models } = setup();
+  await expect(
+    caller.milestones({ projectId: 'ffffffffffffffffffffffff' }),
+  ).rejects.toThrow();
+  expect(models.Milestone.find).not.toHaveBeenCalled();
+});

--- a/backend/plugins/operation_api/src/trpc/agentRouter.ts
+++ b/backend/plugins/operation_api/src/trpc/agentRouter.ts
@@ -1,0 +1,182 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import type { IUserDocument } from 'erxes-api-shared/core-types';
+import { checkPermissionGroup } from 'erxes-api-shared/core-modules';
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import type { OperationTRPCContext } from './init-trpc';
+
+const t = initTRPC.context<OperationTRPCContext>().create();
+type AgentContext = Awaited<ReturnType<OperationTRPCContext>>;
+const objectId = z.string().regex(/^[a-fA-F0-9]{24}$/);
+const id = z.string().trim().min(1).max(100);
+const page = {
+  limit: z.number().int().min(1).max(50).default(20),
+  offset: z.number().int().min(0).max(10000).default(0),
+};
+const taskFilter = {
+  teamId: objectId.optional(),
+  projectId: objectId.optional(),
+  status: objectId.optional(),
+  assigneeId: id.optional(),
+  priority: z.number().int().min(0).max(4).optional(),
+};
+const taskFields =
+  '_id name number status statusType priority teamId projectId assigneeId createdBy targetDate createdAt updatedAt';
+
+export const agentMeta = (
+  description: string,
+  permission: { module: string; action: string },
+) => ({ agent: { description, permission } });
+const procedure = (module: string, action: string, description: string) =>
+  t.procedure
+    .meta(agentMeta(description, { module, action }))
+    .use(async ({ ctx, next }) => {
+      if (!ctx.userId || !ctx.subdomain)
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      const user: IUserDocument | null = await sendTRPCMessage({
+        subdomain: ctx.subdomain,
+        pluginName: 'core',
+        module: 'users',
+        action: 'findOne',
+        method: 'query',
+        input: { query: { _id: ctx.userId } },
+        defaultValue: null,
+      });
+      if (!user || user._id !== ctx.userId)
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      await checkPermissionGroup(ctx.subdomain, user)(action);
+      return next({ ctx: { ...ctx, user } });
+    });
+const teamIds = (ctx: AgentContext) =>
+  ctx.models.TeamMember.find({ memberId: ctx.userId }).distinct('teamId');
+
+export const operationAgentRouter = t.router({
+  agent: t.router({
+    tasks: procedure(
+      'task',
+      'taskRead',
+      'List tasks in teams the acting user belongs to. Filter by team, project, status, assignee or priority; page with offset and limit.',
+    )
+      .input(z.object({ ...taskFilter, ...page }).strict())
+      .query(async ({ ctx, input: { limit, offset, ...filter } }) =>
+        ctx.models.Task.find({
+          $and: [{ teamId: { $in: await teamIds(ctx) } }, filter],
+        })
+          .select(taskFields)
+          .sort({ _id: -1 })
+          .skip(offset)
+          .limit(limit)
+          .lean(),
+      ),
+    taskCount: procedure(
+      'task',
+      'taskRead',
+      'Count matching tasks in the acting user’s teams without downloading task records.',
+    )
+      .input(z.object(taskFilter).strict())
+      .query(async ({ ctx, input }) =>
+        ctx.models.Task.countDocuments({
+          $and: [{ teamId: { $in: await teamIds(ctx) } }, input],
+        }),
+      ),
+    task: procedure(
+      'task',
+      'taskRead',
+      'Get one task, including its description, by its 24-character ObjectId. Requires membership of its team.',
+    )
+      .input(z.object({ _id: objectId }).strict())
+      .query(async ({ ctx, input }) => {
+        const task = await ctx.models.Task.findOne({
+          _id: input._id,
+          teamId: { $in: await teamIds(ctx) },
+        })
+          .select(taskFields + ' description cycleId milestoneId estimatePoint')
+          .lean();
+        if (!task) throw new TRPCError({ code: 'NOT_FOUND' });
+        return task;
+      }),
+    projects: procedure(
+      'project',
+      'projectRead',
+      'List project summaries associated with the acting user’s teams. Page with offset and limit.',
+    )
+      .input(z.object({ ...page }).strict())
+      .query(async ({ ctx, input }) =>
+        ctx.models.Project.find({ teamIds: { $in: await teamIds(ctx) } })
+          .select(
+            '_id name status priority teamIds leadId targetDate startDate',
+          )
+          .sort({ _id: -1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean(),
+      ),
+    teams: procedure(
+      'team',
+      'teamRead',
+      'List the acting user’s teams to discover IDs for task, status and cycle queries.',
+    )
+      .input(z.object(page).strict())
+      .query(async ({ ctx, input }) =>
+        ctx.models.Team.find({ _id: { $in: await teamIds(ctx) } })
+          .select('_id name description cycleEnabled triageEnabled')
+          .sort({ _id: 1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean(),
+      ),
+    statuses: procedure(
+      'status',
+      'statusRead',
+      'List statuses for the acting user’s teams, optionally narrowed to a team ID.',
+    )
+      .input(z.object({ teamId: objectId.optional(), ...page }).strict())
+      .query(async ({ ctx, input: { limit, offset, ...filter } }) =>
+        ctx.models.Status.find({
+          $and: [{ teamId: { $in: await teamIds(ctx) } }, filter],
+        })
+          .select('_id name type teamId order')
+          .sort({ _id: 1 })
+          .skip(offset)
+          .limit(limit)
+          .lean(),
+      ),
+    cycles: procedure(
+      'cycle',
+      'cycleRead',
+      'List cycle dates and progress flags in the acting user’s teams, optionally narrowed to a team ID.',
+    )
+      .input(z.object({ teamId: objectId.optional(), ...page }).strict())
+      .query(async ({ ctx, input: { limit, offset, ...filter } }) =>
+        ctx.models.Cycle.find({
+          $and: [{ teamId: { $in: await teamIds(ctx) } }, filter],
+        })
+          .select(
+            '_id name teamId startDate endDate isActive isCompleted donePercent',
+          )
+          .sort({ _id: -1 })
+          .skip(offset)
+          .limit(limit)
+          .lean(),
+      ),
+    milestones: procedure(
+      'milestone',
+      'milestoneRead',
+      'List milestones for one project associated with the acting user’s teams.',
+    )
+      .input(z.object({ projectId: objectId, ...page }).strict())
+      .query(async ({ ctx, input }) => {
+        const project = await ctx.models.Project.exists({
+          _id: input.projectId,
+          teamIds: { $in: await teamIds(ctx) },
+        });
+        if (!project) throw new TRPCError({ code: 'NOT_FOUND' });
+        return ctx.models.Milestone.find({ projectId: input.projectId })
+          .select('_id name targetDate projectId')
+          .sort({ _id: 1 })
+          .skip(input.offset)
+          .limit(input.limit)
+          .lean();
+      }),
+  }),
+});

--- a/backend/plugins/operation_api/src/trpc/init-trpc.ts
+++ b/backend/plugins/operation_api/src/trpc/init-trpc.ts
@@ -8,12 +8,14 @@ import {
   generateTaskFields,
 } from '~/modules/fields/fieldUtils';
 import { taskTrpcRouter } from '~/modules/task/trpc/task';
+import { operationAgentRouter } from './agentRouter';
 
 export type OperationTRPCContext = ITRPCContext<{ models: IModels }>;
 
 const t = initTRPC.context<OperationTRPCContext>().create();
 
 export const appRouter = t.mergeRouters(
+  operationAgentRouter,
   t.router({
     operation: {
       hello: t.procedure.query(() => {


### PR DESCRIPTION
Operation previously exposed only internal task tagging and field plumbing over tRPC. Add eight agent queries for tasks/list/count/detail, projects, teams, statuses, cycles and milestones, each gated by its registered permission and the acting user's team membership. Inputs use typed ObjectIds and allowlisted filters; lists default to 20 rows and cap at 50.

Reuse tenant-scoped models without changing their ObjectId schemas or existing tRPC contracts. Internal bulk tagging, GitHub integration configuration, field plumbing and writes remain unannotated. Update the plugin guide and add focused router tests.

Validation: `pnpm nx build operation_api --parallel=1`, `pnpm exec tsc --noEmit -p backend/plugins/operation_api/tsconfig.json`, and `pnpm nx lint operation_api` pass (lint has two existing warnings). Thirteen focused tests pass with `pnpm exec jest --config backend/plugins/operation_api/jest.agent.cjs --runInBand`; touched-file ESLint and diff checks pass. Build/typecheck used `NODE_OPTIONS=--max-old-space-size=3072`.

No tenant activation, deployment or Sales changes. Agent reads deliberately require membership even for owners. Live HMAC endpoint smoke testing requires a running environment and was not performed. Mutation exposure remains excluded pending verified approval enforcement in the shared agent execution path; this PR does not change shared code.

## Summary by Sourcery

Expose team-scoped, permission-checked agent queries for operation tasks and project management data.

New Features:
- Expose eight permission-gated agent queries for task discovery and project-related entities, scoped to the acting user’s team membership.
- Provide typed ObjectId filters and bounded pagination for agent list, count, and detail queries.

Enhancements:
- Keep existing internal tRPC procedures, tenant models, ObjectId schemas, and mutation exposure unchanged while adding the agent query surface.

Documentation:
- Update the operation plugin guide with the new agent query capabilities, access invariants, and validation commands.

Tests:
- Add focused router coverage for permission registration, query-only exposure, unsafe inputs, authorization ordering, team scoping, pagination, and inaccessible records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-gated, read-only agent queries for tasks, projects, teams, statuses, cycles, and milestones.
  * Added team-membership scoping and safe pagination for agent data access.
  * Added clear authorization and not-found handling for protected records.

* **Tests**
  * Added coverage for permissions, authentication, input validation, team scoping, pagination, and protected data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->