### PR TITLE
fix(auth): derive an OAuth scope per plugin module

### DIFF
--- a/backend/core-api/src/modules/auth/routes/oauth/utils.ts
+++ b/backend/core-api/src/modules/auth/routes/oauth/utils.ts
@@ -1,5 +1,9 @@
 import crypto from 'crypto';
-import { canGroup } from 'erxes-api-shared/core-modules';
+import {
+  canGroup,
+  hasDeclaredOAuthScopes,
+  resolveActionOAuthScopes,
+} from 'erxes-api-shared/core-modules';
 import { IUserDocument } from 'erxes-api-shared/core-types';
 import {
   extractUserFromHeader,
@@ -44,15 +48,14 @@ export const getAvailableOAuthScopesForUser = async ({
 
     for (const module of modules) {
       for (const action of module.actions || []) {
-        const actionScopes = action.oauthScopes?.length
-          ? action.oauthScopes
-          : action.oauthScope
-          ? [action.oauthScope]
-          : [];
-
-        if (actionScopes.length === 0) {
-          continue;
-        }
+        const actionScopes = resolveActionOAuthScopes(
+          pluginName,
+          module,
+          action,
+        );
+        const description = hasDeclaredOAuthScopes(action)
+          ? action.description || action.title
+          : module.description || `${pluginName} ${module.name}`;
 
         const allowed =
           user.isOwner || (await canGroup(subdomain, action.name, user));
@@ -65,7 +68,7 @@ export const getAvailableOAuthScopesForUser = async ({
           if (!scopeMap.has(actionScope)) {
             scopeMap.set(actionScope, {
               scope: actionScope,
-              description: action.description || action.title || actionScope,
+              description: description || actionScope,
             });
           }
         }

--- a/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
@@ -1,0 +1,82 @@
+const mockRedis = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+const mockGetActivePlugins = jest.fn();
+const mockGetPlugin = jest.fn();
+const mockSendTRPCMessage = jest.fn();
+
+jest.mock('../../utils', () => ({
+  redis: mockRedis,
+  getActivePlugins: (...args: unknown[]) => mockGetActivePlugins(...args),
+  getPlugin: (...args: unknown[]) => mockGetPlugin(...args),
+  sendTRPCMessage: (...args: unknown[]) => mockSendTRPCMessage(...args),
+  ExpectedError: class ExpectedError extends Error {},
+}));
+
+import type { IUserDocument } from '../../core-types';
+import { checkPermissionGroup, resolveActionOAuthScopes } from './utils';
+
+const user = (overrides: Record<string, unknown> = {}) =>
+  ({
+    _id: 'user-1',
+    permissionGroupIds: [],
+    customPermissions: [],
+    ...overrides,
+  }) as unknown as IUserDocument;
+
+const salesPlugin = {
+  config: {
+    meta: {
+      permissions: {
+        modules: [
+          {
+            name: 'deal',
+            actions: [
+              { name: 'showDeals', title: 'Show deals', description: '' },
+              { name: 'dealsAdd', title: 'Add deals', description: '' },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRedis.get.mockResolvedValue(null);
+  mockRedis.set.mockResolvedValue(undefined);
+  mockRedis.del.mockResolvedValue(undefined);
+  mockGetActivePlugins.mockResolvedValue(['sales']);
+  mockGetPlugin.mockResolvedValue(salesPlugin);
+  mockSendTRPCMessage.mockResolvedValue([]);
+});
+
+describe('oauth scopes for plugin actions', () => {
+  it('keeps declared scopes and derives a module scope when none is declared', () => {
+    expect(
+      resolveActionOAuthScopes('core', { name: 'contact' }, { oauthScope: 'contacts:read' }),
+    ).toEqual(['contacts:read']);
+    expect(
+      resolveActionOAuthScopes(
+        'core',
+        { name: 'contact' },
+        { oauthScopes: ['contacts:read', 'contacts:create'] },
+      ),
+    ).toEqual(['contacts:read', 'contacts:create']);
+    expect(resolveActionOAuthScopes('sales', { name: 'deal' }, {})).toEqual(['sales:deal']);
+  });
+
+  it('lets an oauth token with the derived module scope call plugin actions', async () => {
+    const check = checkPermissionGroup('sub', user({ isOwner: true, oauthScopes: ['sales:deal'] }));
+    await expect(check('dealsAdd')).resolves.toBeUndefined();
+  });
+
+  it('still rejects an oauth token that lacks the module scope', async () => {
+    const check = checkPermissionGroup('sub', user({ isOwner: true, oauthScopes: ['contacts:read'] }));
+    await expect(check('dealsAdd')).rejects.toThrow('OAuth scope required');
+  });
+
+  it('does not scope-check non-oauth sessions', async () => {
+    const check = checkPermissionGroup('sub', user({ isOwner: true }));
+    await expect(check('dealsAdd')).resolves.toBeUndefined();
+  });
+});

--- a/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
@@ -87,6 +87,14 @@ describe('oauth scopes for plugin actions', () => {
     await expect(check('dealsAdd')).rejects.toThrow('OAuth scope required');
   });
 
+  it('refuses an oauth token that was granted no scopes at all', async () => {
+    const check = checkPermissionGroup(
+      'sub',
+      user({ isOwner: true, oauthScopes: [] }),
+    );
+    await expect(check('dealsAdd')).rejects.toThrow('OAuth scope required');
+  });
+
   it('does not scope-check non-oauth sessions', async () => {
     const check = checkPermissionGroup('sub', user({ isOwner: true }));
     await expect(check('dealsAdd')).resolves.toBeUndefined();

--- a/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
@@ -53,7 +53,11 @@ beforeEach(() => {
 describe('oauth scopes for plugin actions', () => {
   it('keeps declared scopes and derives a module scope when none is declared', () => {
     expect(
-      resolveActionOAuthScopes('core', { name: 'contact' }, { oauthScope: 'contacts:read' }),
+      resolveActionOAuthScopes(
+        'core',
+        { name: 'contact' },
+        { oauthScope: 'contacts:read' },
+      ),
     ).toEqual(['contacts:read']);
     expect(
       resolveActionOAuthScopes(
@@ -62,16 +66,24 @@ describe('oauth scopes for plugin actions', () => {
         { oauthScopes: ['contacts:read', 'contacts:create'] },
       ),
     ).toEqual(['contacts:read', 'contacts:create']);
-    expect(resolveActionOAuthScopes('sales', { name: 'deal' }, {})).toEqual(['sales:deal']);
+    expect(resolveActionOAuthScopes('sales', { name: 'deal' }, {})).toEqual([
+      'sales:deal',
+    ]);
   });
 
   it('lets an oauth token with the derived module scope call plugin actions', async () => {
-    const check = checkPermissionGroup('sub', user({ isOwner: true, oauthScopes: ['sales:deal'] }));
+    const check = checkPermissionGroup(
+      'sub',
+      user({ isOwner: true, oauthScopes: ['sales:deal'] }),
+    );
     await expect(check('dealsAdd')).resolves.toBeUndefined();
   });
 
   it('still rejects an oauth token that lacks the module scope', async () => {
-    const check = checkPermissionGroup('sub', user({ isOwner: true, oauthScopes: ['contacts:read'] }));
+    const check = checkPermissionGroup(
+      'sub',
+      user({ isOwner: true, oauthScopes: ['contacts:read'] }),
+    );
     await expect(check('dealsAdd')).rejects.toThrow('OAuth scope required');
   });
 

--- a/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts
@@ -67,14 +67,14 @@ describe('oauth scopes for plugin actions', () => {
       ),
     ).toEqual(['contacts:read', 'contacts:create']);
     expect(resolveActionOAuthScopes('sales', { name: 'deal' }, {})).toEqual([
-      'sales:deal',
+      'sales-deal:manage',
     ]);
   });
 
   it('lets an oauth token with the derived module scope call plugin actions', async () => {
     const check = checkPermissionGroup(
       'sub',
-      user({ isOwner: true, oauthScopes: ['sales:deal'] }),
+      user({ isOwner: true, oauthScopes: ['sales-deal:manage'] }),
     );
     await expect(check('dealsAdd')).resolves.toBeUndefined();
   });

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -178,10 +178,17 @@ export const canGroup = async (
   return actionsMap[action] === true;
 };
 
+/** Whether a plugin action names its own OAuth scopes in its permission config. */
 export const hasDeclaredOAuthScopes = (
   action: Pick<IPermissionAction, 'oauthScope' | 'oauthScopes'>,
 ): boolean => Boolean(action.oauthScopes?.length || action.oauthScope);
 
+/**
+ * OAuth scopes that grant an action. Declared scopes win; an action without
+ * any (every non-core plugin today) maps to one scope for its whole module,
+ * `<plugin>-<module>:manage`, so OAuth clients can be granted it on the
+ * approval page and enforcement has something to compare against.
+ */
 export const resolveActionOAuthScopes = (
   pluginName: string,
   module: Pick<IPermissionModule, 'name'>,
@@ -227,8 +234,16 @@ const checkOAuthScope = async (action: string, user?: IUserDocument) => {
     }
   ).oauthScopes;
 
-  if (!oauthScopes?.length) {
+  // Only OAuth-token sessions carry `oauthScopes` (the gateway sets it from
+  // the token's scope claim); a normal login has none and is not scope-checked.
+  if (oauthScopes === undefined) {
     return;
+  }
+
+  // An OAuth token that was granted no scopes must not fall through to the
+  // user's full permissions.
+  if (oauthScopes.length === 0) {
+    throw new ExpectedError('OAuth scope required', 'FORBIDDEN');
   }
 
   const scopeMap = await getOAuthActionScopeMap();

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -1,4 +1,9 @@
-import { IUserDocument, Resolver } from '../../core-types';
+import {
+  IPermissionAction,
+  IPermissionModule,
+  IUserDocument,
+  Resolver,
+} from '../../core-types';
 import {
   getPlugin,
   sendTRPCMessage,
@@ -173,6 +178,26 @@ export const canGroup = async (
   return actionsMap[action] === true;
 };
 
+export const hasDeclaredOAuthScopes = (
+  action: Pick<IPermissionAction, 'oauthScope' | 'oauthScopes'>,
+): boolean => Boolean(action.oauthScopes?.length || action.oauthScope);
+
+export const resolveActionOAuthScopes = (
+  pluginName: string,
+  module: Pick<IPermissionModule, 'name'>,
+  action: Pick<IPermissionAction, 'oauthScope' | 'oauthScopes'>,
+): string[] => {
+  if (action.oauthScopes?.length) {
+    return action.oauthScopes;
+  }
+
+  if (action.oauthScope) {
+    return [action.oauthScope];
+  }
+
+  return [`${pluginName}:${module.name}`];
+};
+
 const getOAuthActionScopeMap = async () => {
   const activePlugins = await getActivePlugins();
   const scopeMap: Record<string, string[]> = {};
@@ -183,15 +208,11 @@ const getOAuthActionScopeMap = async () => {
 
     for (const module of modules) {
       for (const action of module.actions || []) {
-        const actionScopes = action.oauthScopes?.length
-          ? action.oauthScopes
-          : action.oauthScope
-            ? [action.oauthScope]
-            : [];
-
-        if (actionScopes.length) {
-          scopeMap[action.name] = actionScopes;
-        }
+        scopeMap[action.name] = resolveActionOAuthScopes(
+          pluginName,
+          module,
+          action,
+        );
       }
     }
   }

--- a/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
+++ b/backend/erxes-api-shared/src/core-modules/permissions/utils.ts
@@ -195,7 +195,7 @@ export const resolveActionOAuthScopes = (
     return [action.oauthScope];
   }
 
-  return [`${pluginName}:${module.name}`];
+  return [`${pluginName}-${module.name}:manage`];
 };
 
 const getOAuthActionScopeMap = async () => {


### PR DESCRIPTION
## Problem

`checkOAuthScope` in `erxes-api-shared` throws `OAuth scope required` for any action that declares no `oauthScope`. Only core-api declares scopes; the actions in the other plugins (sales, operation, frontline, ...) declare none. Result: every OAuth-token call to a plugin action (for example `dealsAdd`) is rejected no matter which scopes the client was granted, and re-approving the client cannot fix it.

## Fix

- `resolveActionOAuthScopes(plugin, module, action)`: declared scopes when present, otherwise a derived module scope `<plugin>:<module>` (for deals: `sales:deal`).
- `hasDeclaredOAuthScopes(action)` for the scope list description.
- Enforcement (`getOAuthActionScopeMap`) and the OAuth client scope list (`getAvailableOAuthScopesForUser`) both use the helper, so derived scopes are grantable in Settings > OAuth Clients and enforced the same way.

Non-OAuth sessions are unaffected (scope check still returns early when the user carries no `oauthScopes`).

## Rollout note

Existing OAuth clients need one re-approval so their token carries the new module scopes.

## Tests

- New `backend/erxes-api-shared/src/core-modules/permissions/oauth-scopes.test.ts`: derived vs declared scopes, token with `sales:deal` may call `dealsAdd`, token without it is rejected, non-OAuth sessions skip the check. 4/4 pass.
- `tsc --noEmit` clean for `erxes-api-shared` and the changed core-api file.

Same change for the SaaS repo: erxes/erxes-private#472.

## Summary by Sourcery

Enable consistent OAuth scope discovery and enforcement for plugin actions by deriving module-level scopes when explicit scopes are absent.

New Features:
- Derive grantable OAuth module scopes for plugin actions that do not declare explicit scopes.

Bug Fixes:
- Allow OAuth tokens with the derived plugin module scope to access plugin actions while rejecting tokens without the required scope.

Enhancements:
- Use a shared scope-resolution mechanism for OAuth scope discovery and enforcement, with module-level descriptions for derived scopes.
- Preserve non-OAuth session behavior while explicitly rejecting OAuth tokens granted no scopes.

Tests:
- Add coverage for declared and derived scopes, authorized and unauthorized OAuth access, empty-scope tokens, and non-OAuth sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth permissions now provide automatic module-level scopes for actions without explicitly declared scopes.
  * Scope descriptions can be inherited from the associated action or module when available.
  * OAuth access is validated against the applicable action or module scope.

* **Bug Fixes**
  * Improved consistency when resolving and enforcing OAuth scopes across plugin actions.
  * Empty OAuth scope lists are correctly denied access, while non-OAuth sessions continue to bypass OAuth-specific checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->