### PR TITLE
fix(sales): combine deal search filters

### DIFF
--- a/frontend/plugins/sales_ui/src/modules/deals/components/commonSearch.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/commonSearch.tsx
@@ -1,207 +1,23 @@
-import { IconCalendar, IconLoader2, IconSearch } from '@tabler/icons-react';
-import {
-  Badge,
-  Button,
-  DateRangeDialogContent,
-  Dialog,
-  highlightMatch,
-  Input,
-  parseDateRangeFromString,
-  SearchOrderSelect,
-  Skeleton,
-  Tabs,
-} from 'erxes-ui';
-
-import { IDeal } from '@/deals/types/deals';
-import { dealDetailSheetState } from '@/deals/states/dealDetailSheetState';
-import {
-  TDealSearchSortOrder,
-  useDealSearch,
-} from '@/deals/hooks/useDealSearch';
-import { useDebounce } from 'use-debounce';
-import { useInView } from 'react-intersection-observer';
-import { useNavigate } from 'react-router-dom';
-import { useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { DealSearchInput } from '@/deals/components/search/DealSearchInput';
+import { DealSearchResults } from '@/deals/components/search/DealSearchResults';
+import { DealSearchToolbar } from '@/deals/components/search/DealSearchToolbar';
+import { useCommonDealSearch } from '@/deals/hooks/useCommonDealSearch';
+import { TDealSearchCategory } from '@/deals/types/dealSearch';
+import { IconSearch } from '@tabler/icons-react';
+import { Button, Dialog } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
-import type { DateRange } from 'react-day-picker';
-
-const dealDateFormatter = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-});
-
-type TDealSearchCategory = 'date' | 'number' | 'name';
-
-const isSearchReady = (search: string, category: TDealSearchCategory) => {
-  if (category === 'date') {
-    return /^\d{4}-\d{2}-\d{2}$/.test(search);
-  }
-
-  return search.length >= 2;
-};
-
-const getDateLabel = (
-  dateRange: DateRange | undefined,
-  fallback: string,
-): string => {
-  if (!dateRange?.from) return fallback;
-  if (!dateRange.to) return dealDateFormatter.format(dateRange.from);
-
-  return `${dealDateFormatter.format(
-    dateRange.from,
-  )} – ${dealDateFormatter.format(dateRange.to)}`;
-};
-
-const getSearchPromptKey = (
-  category: TDealSearchCategory,
-): readonly [string, string] => {
-  if (category === 'date') {
-    return ['select-date-to-search-deals', 'Select a date to search deals'];
-  }
-  if (category === 'number') {
-    return [
-      'enter-number-to-search-deals',
-      'Enter at least 2 characters of the deal number',
-    ];
-  }
-  return [
-    'enter-name-to-search-deals',
-    'Enter at least 2 characters of the name',
-  ];
-};
-
-const DealSearchResult = ({
-  deal,
-  category,
-  nameSearch,
-  numberSearch,
-  onSelect,
-}: {
-  deal: IDeal;
-  category: TDealSearchCategory;
-  nameSearch: string;
-  numberSearch: string;
-  onSelect: (deal: IDeal) => void;
-}) => {
-  const { t } = useTranslation('sales');
-  const hasPipeline = Boolean(
-    deal.pipeline?._id && (deal.boardId || deal.pipeline.boardId),
-  );
-
-  return (
-    <button
-      type="button"
-      disabled={!hasPipeline}
-      className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-4 py-3 text-left text-sm hover:bg-muted focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-      onClick={() => onSelect(deal)}
-    >
-      <span className="min-w-0 truncate font-medium">
-        {highlightMatch(
-          deal.name || t('unnamed-deal', 'Unnamed deal'),
-          category === 'name' ? nameSearch : '',
-        )}
-      </span>
-      <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-        {deal.number ? (
-          <>
-            #
-            {highlightMatch(
-              deal.number,
-              category === 'number' ? numberSearch : '',
-            )}
-          </>
-        ) : (
-          '—'
-        )}
-      </span>
-      <span className="flex min-w-0 items-center gap-2 truncate text-xs text-muted-foreground">
-        {deal.pipeline?.name || t('no-pipeline')}
-        {deal.status === 'archived' && (
-          <Badge
-            variant="secondary"
-            className="h-4 border-yellow-200 bg-yellow-100 py-0 text-[11px] text-yellow-800"
-          >
-            {t('archived')}
-          </Badge>
-        )}
-      </span>
-      <time
-        className="whitespace-nowrap text-xs text-muted-foreground"
-        dateTime={deal.createdAt?.toString()}
-      >
-        {deal.createdAt
-          ? dealDateFormatter.format(new Date(deal.createdAt))
-          : '—'}
-      </time>
-    </button>
-  );
-};
 
 export const CommonDealSearch = () => {
   const { t } = useTranslation('sales');
-  const navigate = useNavigate();
-  const setActiveDealId = useSetAtom(dealDetailSheetState);
-
-  const [search, setSearch] = useState('');
-  const [open, setOpen] = useState(false);
-  const [dateDialogOpen, setDateDialogOpen] = useState(false);
-  const [dateRange, setDateRange] = useState<DateRange>();
-  const [category, setCategory] = useState<TDealSearchCategory>('name');
-  const [sortOrder, setSortOrder] = useState<TDealSearchSortOrder>('newest');
-  const trimmedSearch = search.trim();
-  const [debouncedSearch] = useDebounce(trimmedSearch, 350);
-  const dealNumber = debouncedSearch.replace(/^#\s*/, '');
-  const searchSettled =
-    category === 'date' || debouncedSearch === trimmedSearch;
-  const searchReady =
-    (category === 'date' && Boolean(dateRange?.from)) ||
-    (category !== 'date' && isSearchReady(debouncedSearch, category));
-  const resultsReady = searchReady && searchSettled;
-
-  const { deals, loading, loadingMore, totalCount, pageInfo, loadMore } =
-    useDealSearch(
-      category === 'name' && searchReady ? debouncedSearch : '',
-      sortOrder,
-      category === 'date' ? dateRange : undefined,
-      category === 'number' && searchReady ? dealNumber : undefined,
-    );
-  const { ref: loadMoreRef, inView: loadMoreInView } = useInView();
-
-  useEffect(() => {
-    if (loadMoreInView) {
-      loadMore();
-    }
-  }, [loadMore, loadMoreInView]);
-
-  const hasDeals = resultsReady && deals.length > 0;
-
+  const search = useCommonDealSearch();
   const placeholders: Record<TDealSearchCategory, string> = {
     date: t('search-deals-by-date', 'Search by date'),
     number: t('search-deals-by-number', 'Search by deal number, e.g. #0000'),
     name: t('search-deals-by-name', 'Search by name'),
   };
 
-  const selectedDateLabel = getDateLabel(dateRange, placeholders.date);
-  const [searchPromptKey, searchPromptFallback] = getSearchPromptKey(category);
-
-  const handleSelect = (deal: IDeal) => {
-    const pipelineId = deal.pipeline?._id;
-    const boardId = deal.boardId || deal.pipeline?.boardId;
-
-    if (!pipelineId || !boardId) {
-      return;
-    }
-
-    setActiveDealId(deal._id);
-    setSearch('');
-    setOpen(false);
-    navigate(
-      `/sales/deals?boardId=${boardId}&pipelineId=${pipelineId}&salesItemId=${deal._id}`,
-    );
-  };
-
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={search.open} onOpenChange={search.setOpen}>
       <Dialog.Trigger asChild>
         <Button
           variant="ghost"
@@ -221,140 +37,37 @@ export const CommonDealSearch = () => {
           )}
         </Dialog.Description>
 
-        <div className="border-b">
-          {category === 'date' ? (
-            <Dialog open={dateDialogOpen} onOpenChange={setDateDialogOpen}>
-              <Dialog.Trigger asChild>
-                <Button
-                  variant="ghost"
-                  className="h-10 w-full justify-start rounded-none px-3 font-normal text-muted-foreground hover:bg-transparent focus-visible:ring-0 focus-visible:outline-none"
-                >
-                  <IconCalendar className="size-4" />
-                  {selectedDateLabel}
-                </Button>
-              </Dialog.Trigger>
-              <DateRangeDialogContent
-                label={t('date-created', 'Date created')}
-                value={
-                  dateRange?.from
-                    ? `${dateRange.from.toISOString()},${(
-                        dateRange.to ?? dateRange.from
-                      ).toISOString()}`
-                    : null
-                }
-                onApply={(value) => {
-                  setDateRange(parseDateRangeFromString(value));
-                  setDateDialogOpen(false);
-                }}
-              />
-            </Dialog>
-          ) : (
-            <div className="relative">
-              <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                autoFocus
-                className="h-10 rounded-none border-0 pl-9 shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:outline-none"
-                type="search"
-                placeholder={placeholders[category]}
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-              />
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-center border-b">
-          <Tabs
-            className="min-w-0 flex-1"
-            value={category}
-            onValueChange={(value) => {
-              setCategory(value as TDealSearchCategory);
-              setSearch('');
-            }}
-          >
-            <Tabs.List
-              variant="underline"
-              className="flex w-full justify-start gap-1 border-b-0 px-2 py-0"
-            >
-              <Tabs.Trigger
-                className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
-                value="date"
-              >
-                {t('by-date', 'By date')}
-              </Tabs.Trigger>
-              <Tabs.Trigger
-                className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
-                value="number"
-              >
-                {t('by-deal-number', 'By deal number')}
-              </Tabs.Trigger>
-              <Tabs.Trigger
-                className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
-                value="name"
-              >
-                {t('by-name', 'By name')}
-              </Tabs.Trigger>
-            </Tabs.List>
-          </Tabs>
-
-          <SearchOrderSelect
-            value={sortOrder}
-            newestLabel={t('newest-to-oldest', 'Newest to oldest')}
-            oldestLabel={t('oldest-to-newest', 'Oldest to newest')}
-            triggerClassName="mr-2 h-7 w-44 shrink-0 text-xs focus:shadow-none focus:ring-0 focus-visible:ring-0 focus-visible:outline-none"
-            onValueChange={setSortOrder}
-          />
-        </div>
-
-        <div className="max-h-[50vh] min-h-24 overflow-y-auto">
-          {searchSettled && !searchReady && (
-            <div className="px-3 py-3 text-sm text-muted-foreground">
-              {t(searchPromptKey, searchPromptFallback)}
-            </div>
-          )}
-
-          {(!searchSettled || (resultsReady && loading && !hasDeals)) && (
-            <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
-              <IconLoader2 className="size-4 animate-spin" />
-              {t('searching')}
-            </div>
-          )}
-
-          {resultsReady && !loading && !hasDeals && (
-            <div className="px-3 py-2 text-sm text-muted-foreground">
-              {t('no-deals-found')}
-            </div>
-          )}
-
-          {resultsReady &&
-            deals.map((deal) => (
-              <DealSearchResult
-                key={deal._id}
-                category={category}
-                deal={deal}
-                nameSearch={debouncedSearch}
-                numberSearch={dealNumber}
-                onSelect={handleSelect}
-              />
-            ))}
-
-          {resultsReady &&
-            pageInfo?.hasNextPage &&
-            deals.length < totalCount && (
-              <div ref={loadMoreRef} className="px-3 py-2">
-                {loadingMore && <Skeleton className="h-8 w-full" />}
-              </div>
-            )}
-        </div>
-
-        {resultsReady && hasDeals && (
-          <div className="border-t px-3 py-2 text-xs text-muted-foreground">
-            {t('count-out-of', {
-              current: deals.length,
-              total: totalCount,
-            })}
-          </div>
-        )}
+        <DealSearchInput
+          category={search.category}
+          dateRange={search.dateRange}
+          placeholders={placeholders}
+          searches={search.searches}
+          onDateRangeChange={search.setDateRange}
+          onSearchChange={search.setActiveSearch}
+        />
+        <DealSearchToolbar
+          category={search.category}
+          hasDateFilter={Boolean(search.dateRange?.from)}
+          hasNameFilter={search.nameSearchReady}
+          hasNumberFilter={search.numberSearchReady}
+          sortOrder={search.sortOrder}
+          onCategoryChange={search.setCategory}
+          onSortOrderChange={search.setSortOrder}
+        />
+        <DealSearchResults
+          category={search.category}
+          deals={search.deals}
+          loading={search.loading}
+          loadingMore={search.loadingMore}
+          nameSearch={search.nameSearch}
+          numberSearch={search.numberSearch}
+          resultsReady={search.resultsReady}
+          searchSettled={search.searchSettled}
+          totalCount={search.totalCount}
+          hasNextPage={search.pageInfo?.hasNextPage}
+          loadMoreRef={search.loadMoreRef}
+          onSelect={search.selectDeal}
+        />
       </Dialog.Content>
     </Dialog>
   );

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchInput.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchInput.tsx
@@ -40,7 +40,6 @@ export const DealSearchInput = ({
       <div className="relative border-b">
         <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
-          autoFocus
           className="h-10 rounded-none border-0 pl-9 shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:outline-none"
           type="search"
           placeholder={placeholders[category]}

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchInput.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchInput.tsx
@@ -1,0 +1,83 @@
+import {
+  TDealSearchCategory,
+  TDealTextSearches,
+} from '@/deals/types/dealSearch';
+import { getDealSearchDateLabel } from '@/deals/utils/dealSearch';
+import { IconCalendar, IconSearch } from '@tabler/icons-react';
+import {
+  Button,
+  DateRangeDialogContent,
+  Dialog,
+  Input,
+  parseDateRangeFromString,
+} from 'erxes-ui';
+import { useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+import { useTranslation } from 'react-i18next';
+
+type TDealSearchInputProps = {
+  category: TDealSearchCategory;
+  dateRange?: DateRange;
+  placeholders: Record<TDealSearchCategory, string>;
+  searches: TDealTextSearches;
+  onDateRangeChange: (dateRange?: DateRange) => void;
+  onSearchChange: (value: string) => void;
+};
+
+export const DealSearchInput = ({
+  category,
+  dateRange,
+  placeholders,
+  searches,
+  onDateRangeChange,
+  onSearchChange,
+}: TDealSearchInputProps) => {
+  const { t } = useTranslation('sales');
+  const [dateDialogOpen, setDateDialogOpen] = useState(false);
+
+  if (category !== 'date') {
+    return (
+      <div className="relative border-b">
+        <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          autoFocus
+          className="h-10 rounded-none border-0 pl-9 shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:outline-none"
+          type="search"
+          placeholder={placeholders[category]}
+          value={searches[category]}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-b">
+      <Dialog open={dateDialogOpen} onOpenChange={setDateDialogOpen}>
+        <Dialog.Trigger asChild>
+          <Button
+            variant="ghost"
+            className="h-10 w-full justify-start rounded-none px-3 font-normal text-muted-foreground hover:bg-transparent focus-visible:ring-0 focus-visible:outline-none"
+          >
+            <IconCalendar className="size-4" />
+            {getDealSearchDateLabel(dateRange, placeholders.date)}
+          </Button>
+        </Dialog.Trigger>
+        <DateRangeDialogContent
+          label={t('date-created', 'Date created')}
+          value={
+            dateRange?.from
+              ? `${dateRange.from.toISOString()},${(
+                  dateRange.to ?? dateRange.from
+                ).toISOString()}`
+              : null
+          }
+          onApply={(value) => {
+            onDateRangeChange(parseDateRangeFromString(value));
+            setDateDialogOpen(false);
+          }}
+        />
+      </Dialog>
+    </div>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResult.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResult.tsx
@@ -1,0 +1,59 @@
+import { IDeal } from '@/deals/types/deals';
+import { formatDealSearchResultDate } from '@/deals/utils/dealSearch';
+import { Badge, highlightMatch } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+type TDealSearchResultProps = {
+  deal: IDeal;
+  nameSearch: string;
+  numberSearch: string;
+  onSelect: (deal: IDeal) => void;
+};
+
+export const DealSearchResult = ({
+  deal,
+  nameSearch,
+  numberSearch,
+  onSelect,
+}: TDealSearchResultProps) => {
+  const { t } = useTranslation('sales');
+  const hasPipeline = Boolean(
+    deal.pipeline?._id && (deal.boardId || deal.pipeline.boardId),
+  );
+
+  return (
+    <button
+      type="button"
+      disabled={!hasPipeline}
+      className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-4 py-3 text-left text-sm hover:bg-muted focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+      onClick={() => onSelect(deal)}
+    >
+      <span className="min-w-0 truncate font-medium">
+        {highlightMatch(
+          deal.name || t('unnamed-deal', 'Unnamed deal'),
+          nameSearch,
+        )}
+      </span>
+      <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+        {deal.number ? <>#{highlightMatch(deal.number, numberSearch)}</> : '—'}
+      </span>
+      <span className="flex min-w-0 items-center gap-2 truncate text-xs text-muted-foreground">
+        {deal.pipeline?.name || t('no-pipeline')}
+        {deal.status === 'archived' && (
+          <Badge
+            variant="secondary"
+            className="h-4 border-yellow-200 bg-yellow-100 py-0 text-[11px] text-yellow-800"
+          >
+            {t('archived')}
+          </Badge>
+        )}
+      </span>
+      <time
+        className="whitespace-nowrap text-xs text-muted-foreground"
+        dateTime={deal.createdAt?.toString()}
+      >
+        {deal.createdAt ? formatDealSearchResultDate(deal.createdAt) : '—'}
+      </time>
+    </button>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResult.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResult.tsx
@@ -1,6 +1,6 @@
 import { IDeal } from '@/deals/types/deals';
 import { formatDealSearchResultDate } from '@/deals/utils/dealSearch';
-import { Badge, highlightMatch } from 'erxes-ui';
+import { Badge, Button, highlightMatch } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 
 type TDealSearchResultProps = {
@@ -22,10 +22,11 @@ export const DealSearchResult = ({
   );
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       disabled={!hasPipeline}
-      className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-4 py-3 text-left text-sm hover:bg-muted focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+      className="grid h-auto w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 rounded-none px-4 py-3 text-left text-sm whitespace-normal disabled:cursor-not-allowed disabled:opacity-60"
       onClick={() => onSelect(deal)}
     >
       <span className="min-w-0 truncate font-medium">
@@ -54,6 +55,6 @@ export const DealSearchResult = ({
       >
         {deal.createdAt ? formatDealSearchResultDate(deal.createdAt) : '—'}
       </time>
-    </button>
+    </Button>
   );
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResults.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchResults.tsx
@@ -1,0 +1,90 @@
+import { DealSearchResult } from '@/deals/components/search/DealSearchResult';
+import { TDealSearchCategory } from '@/deals/types/dealSearch';
+import { IDeal } from '@/deals/types/deals';
+import { getDealSearchPrompt } from '@/deals/utils/dealSearch';
+import { IconLoader2 } from '@tabler/icons-react';
+import { Skeleton } from 'erxes-ui';
+import { Ref } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type TDealSearchResultsProps = {
+  category: TDealSearchCategory;
+  deals: IDeal[];
+  loading: boolean;
+  loadingMore: boolean;
+  nameSearch: string;
+  numberSearch: string;
+  resultsReady: boolean;
+  searchSettled: boolean;
+  totalCount: number;
+  hasNextPage?: boolean;
+  loadMoreRef: Ref<HTMLDivElement>;
+  onSelect: (deal: IDeal) => void;
+};
+
+export const DealSearchResults = ({
+  category,
+  deals,
+  loading,
+  loadingMore,
+  nameSearch,
+  numberSearch,
+  resultsReady,
+  searchSettled,
+  totalCount,
+  hasNextPage,
+  loadMoreRef,
+  onSelect,
+}: TDealSearchResultsProps) => {
+  const { t } = useTranslation('sales');
+  const [promptKey, promptFallback] = getDealSearchPrompt(category);
+  const hasDeals = resultsReady && deals.length > 0;
+
+  return (
+    <>
+      <div className="max-h-[50vh] min-h-24 overflow-y-auto">
+        {searchSettled && !resultsReady && (
+          <div className="px-3 py-3 text-sm text-muted-foreground">
+            {t(promptKey, promptFallback)}
+          </div>
+        )}
+
+        {(!searchSettled || (resultsReady && loading && !hasDeals)) && (
+          <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+            <IconLoader2 className="size-4 animate-spin" />
+            {t('searching')}
+          </div>
+        )}
+
+        {resultsReady && !loading && !hasDeals && (
+          <div className="px-3 py-2 text-sm text-muted-foreground">
+            {t('no-deals-found')}
+          </div>
+        )}
+
+        {resultsReady &&
+          deals.map((deal) => (
+            <DealSearchResult
+              key={deal._id}
+              deal={deal}
+              nameSearch={nameSearch}
+              numberSearch={numberSearch}
+              onSelect={onSelect}
+            />
+          ))}
+
+        {resultsReady && hasNextPage && deals.length < totalCount && (
+          <div ref={loadMoreRef} className="px-3 py-2">
+            {loadingMore && <Skeleton className="h-8 w-full" />}
+          </div>
+        )}
+      </div>
+
+      {resultsReady && hasDeals && (
+        <div className="border-t px-3 py-2 text-xs text-muted-foreground">
+          {t('count-out-of', { current: deals.length, total: totalCount })}
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchToolbar.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchToolbar.tsx
@@ -1,5 +1,5 @@
 import { TDealSearchCategory } from '@/deals/types/dealSearch';
-import { Badge, SearchOrderSelect, Tabs, TSearchSortOrder } from 'erxes-ui';
+import { SearchOrderSelect, Tabs, TSearchSortOrder } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 
 type TDealSearchToolbarProps = {
@@ -41,25 +41,31 @@ export const DealSearchToolbar = ({
           className="flex w-full justify-start gap-1 border-b-0 px-2 py-0"
         >
           <Tabs.Trigger
-            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            className="h-8 gap-1.5 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
             value="date"
           >
             {t('by-date', 'By date')}
-            {hasDateFilter && <Badge variant="secondary">1</Badge>}
+            {hasDateFilter && (
+              <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+            )}
           </Tabs.Trigger>
           <Tabs.Trigger
-            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            className="h-8 gap-1.5 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
             value="number"
           >
             {t('by-deal-number', 'By deal number')}
-            {hasNumberFilter && <Badge variant="secondary">1</Badge>}
+            {hasNumberFilter && (
+              <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+            )}
           </Tabs.Trigger>
           <Tabs.Trigger
-            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            className="h-8 gap-1.5 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
             value="name"
           >
             {t('by-name', 'By name')}
-            {hasNameFilter && <Badge variant="secondary">1</Badge>}
+            {hasNameFilter && (
+              <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+            )}
           </Tabs.Trigger>
         </Tabs.List>
       </Tabs>

--- a/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchToolbar.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/components/search/DealSearchToolbar.tsx
@@ -1,0 +1,76 @@
+import { TDealSearchCategory } from '@/deals/types/dealSearch';
+import { Badge, SearchOrderSelect, Tabs, TSearchSortOrder } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+type TDealSearchToolbarProps = {
+  category: TDealSearchCategory;
+  hasDateFilter: boolean;
+  hasNameFilter: boolean;
+  hasNumberFilter: boolean;
+  sortOrder: TSearchSortOrder;
+  onCategoryChange: (category: TDealSearchCategory) => void;
+  onSortOrderChange: (sortOrder: TSearchSortOrder) => void;
+};
+
+const isDealSearchCategory = (value: string): value is TDealSearchCategory =>
+  value === 'date' || value === 'number' || value === 'name';
+
+export const DealSearchToolbar = ({
+  category,
+  hasDateFilter,
+  hasNameFilter,
+  hasNumberFilter,
+  sortOrder,
+  onCategoryChange,
+  onSortOrderChange,
+}: TDealSearchToolbarProps) => {
+  const { t } = useTranslation('sales');
+  const handleCategoryChange = (value: string) => {
+    if (isDealSearchCategory(value)) onCategoryChange(value);
+  };
+
+  return (
+    <div className="flex items-center border-b">
+      <Tabs
+        className="min-w-0 flex-1"
+        value={category}
+        onValueChange={handleCategoryChange}
+      >
+        <Tabs.List
+          variant="underline"
+          className="flex w-full justify-start gap-1 border-b-0 px-2 py-0"
+        >
+          <Tabs.Trigger
+            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            value="date"
+          >
+            {t('by-date', 'By date')}
+            {hasDateFilter && <Badge variant="secondary">1</Badge>}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            value="number"
+          >
+            {t('by-deal-number', 'By deal number')}
+            {hasNumberFilter && <Badge variant="secondary">1</Badge>}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            className="h-8 px-2 text-xs transition-none hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none data-[state=active]:hover:bg-transparent"
+            value="name"
+          >
+            {t('by-name', 'By name')}
+            {hasNameFilter && <Badge variant="secondary">1</Badge>}
+          </Tabs.Trigger>
+        </Tabs.List>
+      </Tabs>
+
+      <SearchOrderSelect
+        value={sortOrder}
+        newestLabel={t('newest-to-oldest', 'Newest to oldest')}
+        oldestLabel={t('oldest-to-newest', 'Oldest to newest')}
+        triggerClassName="mr-2 h-7 w-44 shrink-0 text-xs focus:shadow-none focus:ring-0 focus-visible:ring-0 focus-visible:outline-none"
+        onValueChange={onSortOrderChange}
+      />
+    </div>
+  );
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/hooks/useCommonDealSearch.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/hooks/useCommonDealSearch.ts
@@ -1,0 +1,107 @@
+import { useDealSearch } from '@/deals/hooks/useDealSearch';
+import { dealDetailSheetState } from '@/deals/states/dealDetailSheetState';
+import {
+  TDealSearchCategory,
+  TDealTextSearches,
+} from '@/deals/types/dealSearch';
+import { IDeal } from '@/deals/types/deals';
+import { isDealSearchReady } from '@/deals/utils/dealSearch';
+import { TSearchSortOrder } from 'erxes-ui';
+import { useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+import { useInView } from 'react-intersection-observer';
+import { useNavigate } from 'react-router-dom';
+import { useDebounce } from 'use-debounce';
+
+const INITIAL_TEXT_SEARCHES: TDealTextSearches = { name: '', number: '' };
+
+export const useCommonDealSearch = () => {
+  const navigate = useNavigate();
+  const setActiveDealId = useSetAtom(dealDetailSheetState);
+  const [searches, setSearches] = useState(INITIAL_TEXT_SEARCHES);
+  const [open, setOpen] = useState(false);
+  const [dateRange, setDateRange] = useState<DateRange>();
+  const [category, setCategory] = useState<TDealSearchCategory>('name');
+  const [sortOrder, setSortOrder] = useState<TSearchSortOrder>('newest');
+  const trimmedNameSearch = searches.name.trim();
+  const trimmedNumberSearch = searches.number.trim();
+  const [debouncedNameSearch] = useDebounce(trimmedNameSearch, 350);
+  const [debouncedNumberSearch] = useDebounce(trimmedNumberSearch, 350);
+  const dealNumber = debouncedNumberSearch.replace(/^#\s*/, '');
+  const nameSearchReady = isDealSearchReady(debouncedNameSearch, 'name');
+  const numberSearchReady = isDealSearchReady(dealNumber, 'number');
+  const activeSearch = category === 'date' ? '' : searches[category].trim();
+  const normalizedActiveSearch =
+    category === 'number' ? activeSearch.replace(/^#\s*/, '') : activeSearch;
+  const searchSettled =
+    category === 'date' ||
+    (category === 'name'
+      ? debouncedNameSearch === trimmedNameSearch
+      : debouncedNumberSearch === trimmedNumberSearch);
+  const hasSearchFilter =
+    Boolean(dateRange?.from) || nameSearchReady || numberSearchReady;
+  const hasIncompleteActiveSearch =
+    category !== 'date' &&
+    Boolean(activeSearch) &&
+    !isDealSearchReady(normalizedActiveSearch, category);
+  const resultsReady =
+    hasSearchFilter && searchSettled && !hasIncompleteActiveSearch;
+
+  const searchResult = useDealSearch(
+    nameSearchReady ? debouncedNameSearch : '',
+    sortOrder,
+    dateRange?.from ? dateRange : undefined,
+    numberSearchReady ? dealNumber : undefined,
+  );
+  const { ref: loadMoreRef, inView: loadMoreInView } = useInView();
+
+  useEffect(() => {
+    if (loadMoreInView) {
+      searchResult.loadMore();
+    }
+  }, [loadMoreInView, searchResult.loadMore]);
+
+  const setActiveSearch = (value: string) => {
+    if (category === 'date') return;
+
+    setSearches((current) => ({ ...current, [category]: value }));
+  };
+
+  const selectDeal = (deal: IDeal) => {
+    const pipelineId = deal.pipeline?._id;
+    const boardId = deal.boardId || deal.pipeline?.boardId;
+
+    if (!pipelineId || !boardId) return;
+
+    setActiveDealId(deal._id);
+    setSearches(INITIAL_TEXT_SEARCHES);
+    setDateRange(undefined);
+    setOpen(false);
+    navigate(
+      `/sales/deals?boardId=${boardId}&pipelineId=${pipelineId}&salesItemId=${deal._id}`,
+    );
+  };
+
+  return {
+    ...searchResult,
+    category,
+    dateRange,
+    loadMoreRef,
+    nameSearch: nameSearchReady ? debouncedNameSearch : '',
+    nameSearchReady,
+    numberSearch: numberSearchReady ? dealNumber : '',
+    numberSearchReady,
+    open,
+    resultsReady,
+    searchSettled,
+    searches,
+    selectDeal,
+    setActiveSearch,
+    setCategory,
+    setDateRange,
+    setOpen,
+    setSortOrder,
+    sortOrder,
+  };
+};

--- a/frontend/plugins/sales_ui/src/modules/deals/hooks/useCommonDealSearch.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/hooks/useCommonDealSearch.ts
@@ -21,7 +21,7 @@ export const useCommonDealSearch = () => {
   const setActiveDealId = useSetAtom(dealDetailSheetState);
   const [searches, setSearches] = useState(INITIAL_TEXT_SEARCHES);
   const [open, setOpen] = useState(false);
-  const [dateRange, setDateRange] = useState<DateRange>();
+  const [dateRange, setDateRange] = useState<DateRange | null>(null);
   const [category, setCategory] = useState<TDealSearchCategory>('name');
   const [sortOrder, setSortOrder] = useState<TSearchSortOrder>('newest');
   const trimmedNameSearch = searches.name.trim();
@@ -35,10 +35,8 @@ export const useCommonDealSearch = () => {
   const normalizedActiveSearch =
     category === 'number' ? activeSearch.replace(/^#\s*/, '') : activeSearch;
   const searchSettled =
-    category === 'date' ||
-    (category === 'name'
-      ? debouncedNameSearch === trimmedNameSearch
-      : debouncedNumberSearch === trimmedNumberSearch);
+    debouncedNameSearch === trimmedNameSearch &&
+    debouncedNumberSearch === trimmedNumberSearch;
   const hasSearchFilter =
     Boolean(dateRange?.from) || nameSearchReady || numberSearchReady;
   const hasIncompleteActiveSearch =
@@ -68,6 +66,10 @@ export const useCommonDealSearch = () => {
     setSearches((current) => ({ ...current, [category]: value }));
   };
 
+  const setSearchDateRange = (value?: DateRange) => {
+    setDateRange(value ?? null);
+  };
+
   const selectDeal = (deal: IDeal) => {
     const pipelineId = deal.pipeline?._id;
     const boardId = deal.boardId || deal.pipeline?.boardId;
@@ -76,7 +78,7 @@ export const useCommonDealSearch = () => {
 
     setActiveDealId(deal._id);
     setSearches(INITIAL_TEXT_SEARCHES);
-    setDateRange(undefined);
+    setDateRange(null);
     setOpen(false);
     navigate(
       `/sales/deals?boardId=${boardId}&pipelineId=${pipelineId}&salesItemId=${deal._id}`,
@@ -86,7 +88,7 @@ export const useCommonDealSearch = () => {
   return {
     ...searchResult,
     category,
-    dateRange,
+    dateRange: dateRange ?? undefined,
     loadMoreRef,
     nameSearch: nameSearchReady ? debouncedNameSearch : '',
     nameSearchReady,
@@ -99,7 +101,7 @@ export const useCommonDealSearch = () => {
     selectDeal,
     setActiveSearch,
     setCategory,
-    setDateRange,
+    setDateRange: setSearchDateRange,
     setOpen,
     setSortOrder,
     sortOrder,

--- a/frontend/plugins/sales_ui/src/modules/deals/types/dealSearch.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/types/dealSearch.ts
@@ -1,0 +1,6 @@
+export type TDealSearchCategory = 'date' | 'number' | 'name';
+
+export type TDealTextSearches = Record<
+  Exclude<TDealSearchCategory, 'date'>,
+  string
+>;

--- a/frontend/plugins/sales_ui/src/modules/deals/utils/dealSearch.ts
+++ b/frontend/plugins/sales_ui/src/modules/deals/utils/dealSearch.ts
@@ -1,0 +1,52 @@
+import { TDealSearchCategory } from '@/deals/types/dealSearch';
+import type { DateRange } from 'react-day-picker';
+
+const dealDateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+});
+
+export const isDealSearchReady = (
+  search: string,
+  category: TDealSearchCategory,
+) => {
+  if (category === 'date') {
+    return /^\d{4}-\d{2}-\d{2}$/.test(search);
+  }
+
+  return search.length >= 2;
+};
+
+export const getDealSearchDateLabel = (
+  dateRange: DateRange | undefined,
+  fallback: string,
+): string => {
+  if (!dateRange?.from) return fallback;
+  if (!dateRange.to) return dealDateFormatter.format(dateRange.from);
+
+  return `${dealDateFormatter.format(
+    dateRange.from,
+  )} – ${dealDateFormatter.format(dateRange.to)}`;
+};
+
+export const formatDealSearchResultDate = (date: Date | string) =>
+  dealDateFormatter.format(new Date(date));
+
+export const getDealSearchPrompt = (
+  category: TDealSearchCategory,
+): readonly [string, string] => {
+  if (category === 'date') {
+    return ['select-date-to-search-deals', 'Select a date to search deals'];
+  }
+
+  if (category === 'number') {
+    return [
+      'enter-number-to-search-deals',
+      'Enter at least 2 characters of the deal number',
+    ];
+  }
+
+  return [
+    'enter-name-to-search-deals',
+    'Enter at least 2 characters of the name',
+  ];
+};


### PR DESCRIPTION
## Summary

- preserve date, deal number, and name filters when switching search tabs
- combine all active deal search filters in the same query
- show active-filter indicators and highlight both name and number matches
- split the deal search UI into focused components, a controller hook, types, and utilities

## Validation

- `pnpm nx build sales_ui`
- ESLint on all changed TypeScript files
- Prettier check
- `git diff --check`

## Summary by Sourcery

Combine deal search filters and retain them across tabs while reorganizing the search experience into focused components and shared state management.

New Features:
- Combine date, deal number, and name filters in a single deal search query while preserving each filter across search-tab changes.
- Display active-filter indicators and highlight simultaneous name and deal-number matches in results.

Bug Fixes:
- Prevent switching search tabs from clearing previously entered deal search criteria.

Enhancements:
- Split deal search state management, input, toolbar, results, types, and shared utilities into focused modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search deals by name, number, or date.
  * Select date ranges, sort results, and view active filter indicators.
  * Browse paginated results with loading states, result counts, and “no deals found” messaging.
  * Receive category-specific prompts to guide searches.
  * Select a result to open its deal view.
* **Refactor**
  * Improved the organization and consistency of the deal search experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->