### PR TITLE
fix(core-ui): prevent global search loading flicker

### DIFF
--- a/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchDialog.tsx
@@ -42,6 +42,7 @@ const SearchCategoryLabel = ({
 }) => {
   const { t } = useTranslation(category.labelNamespace ?? 'common', {
     keyPrefix: category.labelNamespace ? undefined : 'global-search',
+    useSuspense: false,
   });
 
   return <>{t(category.labelKey ?? category.key, category.label)}</>;

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchGroup.tsx
@@ -113,6 +113,7 @@ export const GlobalSearchProviderGroup = ({
 }) => {
   const { t } = useTranslation(group.labelNamespace ?? 'common', {
     keyPrefix: group.labelNamespace ? undefined : 'global-search',
+    useSuspense: false,
   });
   const { t: tCommon } = useTranslation('common', {
     keyPrefix: 'global-search',

--- a/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
+++ b/frontend/core-ui/src/modules/search/components/GlobalSearchItem.tsx
@@ -38,7 +38,9 @@ export const GlobalSearchItem = ({
   actionLabel: string;
   onSelect: (path: string) => void;
 }) => {
-  const { t } = useTranslation(['common', 'mongolian']);
+  const { t } = useTranslation(['common', 'mongolian'], {
+    useSuspense: false,
+  });
   const visibleFieldsMatch =
     includesSearchValue(item.title, searchValue) ||
     includesSearchValue(item.description, searchValue);


### PR DESCRIPTION
Opening global search could briefly replace the entire page with a white `Loading...` screen while search items or category labels loaded a translation namespace. Those translation hooks suspended rendering and reached the page-level Suspense fallback.

Disable Suspense for translation hooks in search items, category labels, and provider headings. Search renders immediately using existing fallback labels, then updates labels when translations arrive.

Validation:
- `pnpm nx build core-ui` passed (bundle-size warning).
- `pnpm nx test core-ui` passed: 5 suites, 19 tests.
- ESLint passed for all three changed files; `git diff --check` passed.
- A focused delayed-translation rendering check reproduced the original page fallback and verified that the fix renders search content immediately and translated labels after loading.
- Full core-ui lint and TypeScript checks remain failing on errors outside the changed files; no diagnostics were reported for the changed files.

## Summary by Sourcery

Prevent translation loading in global search from triggering the page-level loading screen.

Bug Fixes:
- Prevent global search from replacing the page with a loading fallback while its translations load.

Enhancements:
- Allow search items, category labels, and provider headings to render with fallback text before translations are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global search stability by preventing translation loading from interrupting search categories, groups, and results.
  * Search content now remains available while translations load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->