### PR TITLE
fix(core): Products tag filter matches all selected tags, excludes workspace tags

### DIFF
--- a/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
@@ -354,9 +354,8 @@ const generateFilter = async (
   }
 
   if (categoryIds) {
-    const categories = await models.ProductCategories.getChildCategories(
-      categoryIds,
-    );
+    const categories =
+      await models.ProductCategories.getChildCategories(categoryIds);
 
     const catIds = categories.map((c) => c._id);
     andFilters.push({ categoryId: { $in: catIds } });
@@ -781,9 +780,8 @@ export const productQueries: Record<string, Resolver<any, any, IContext>> = {
         );
       };
 
-      const similarityGroups = await models.ProductsConfigs.getConfig(
-        'similarityGroup',
-      );
+      const similarityGroups =
+        await models.ProductsConfigs.getConfig('similarityGroup');
 
       const codeMasks = Object.keys(similarityGroups);
       const customFieldIds = (product.customFieldsData || []).map(

--- a/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
@@ -375,17 +375,17 @@ const generateFilter = async (
   }
 
   if (tagIds) {
-    const baseTagIds: Set<string> = new Set(tagIds);
-
     if (tagWithRelated) {
       const tagObjs = await models.Tags.find({ _id: { $in: tagIds } }).lean();
 
-      for (const tag of tagObjs) {
-        (tag.relatedIds || []).forEach((id) => baseTagIds.add(id));
-      }
+      andFilters.push(
+        ...tagObjs.map((tag) => ({
+          tagIds: { $in: [tag._id, ...(tag.relatedIds || [])] },
+        })),
+      );
+    } else {
+      andFilters.push({ tagIds: { $all: tagIds } });
     }
-
-    andFilters.push({ tagIds: { $in: Array.from(baseTagIds) } });
   }
 
   if (excludeTagIds?.length) {

--- a/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/queries/product.ts
@@ -376,10 +376,13 @@ const generateFilter = async (
   if (tagIds) {
     if (tagWithRelated) {
       const tagObjs = await models.Tags.find({ _id: { $in: tagIds } }).lean();
+      const tagsById = new Map(tagObjs.map((tag) => [tag._id, tag]));
 
       andFilters.push(
-        ...tagObjs.map((tag) => ({
-          tagIds: { $in: [tag._id, ...(tag.relatedIds || [])] },
+        ...tagIds.map((tagId) => ({
+          tagIds: {
+            $in: [tagId, ...(tagsById.get(tagId)?.relatedIds || [])],
+          },
         })),
       );
     } else {

--- a/backend/core-api/src/modules/tags/graphql/queries.ts
+++ b/backend/core-api/src/modules/tags/graphql/queries.ts
@@ -155,10 +155,7 @@ export const tagQueries: Record<string, Resolver<any, any, IContext>> = {
 
   async tagsMain(
     _parent: undefined,
-    {
-      type,
-      excludeWorkspaceTags,
-    }: { type: string; excludeWorkspaceTags?: boolean },
+    { type }: { type: string },
     { models }: IContext,
   ) {
     const filter: FilterQuery<ITagDocument> = {
@@ -166,11 +163,7 @@ export const tagQueries: Record<string, Resolver<any, any, IContext>> = {
     };
 
     if (type) {
-      filter.type = { $in: [null, '', type] };
-    }
-
-    if (type && excludeWorkspaceTags) {
-      filter.type = { $eq: type };
+      filter.type = type;
     }
 
     return await models.Tags.find(filter).sort({ name: 1 });


### PR DESCRIPTION
## Summary by Sourcery

Correct product tag filtering to enforce all selected tags and return only tags from the requested type.

Bug Fixes:
- Require products to match all selected tags and ensure related-tag matching is applied independently for each selected tag.
- Restrict tag queries to the requested tag type so workspace tags are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Related-tag product filtering now evaluates every requested tag, including tags that are no longer available, along with any related tags.
  - Tag listings now filter strictly by the selected tag type.
- **Changes**
  - Workspace-tag exclusion options are no longer available when retrieving tag listings.
  - Product searches using multiple tags continue to return products containing every requested tag, while related-tag searches provide more consistent results when tag data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->