### PR TITLE
feat(documents): improve editor controls and error states

### DIFF
--- a/backend/core-api/src/modules/documents/barcode.ts
+++ b/backend/core-api/src/modules/documents/barcode.ts
@@ -18,7 +18,10 @@ export const generateBarcodeSvg = (
       paddingheight: 0,
     });
 
-    return svg.replace('<svg ', `<svg width="${width}" height="${height}" `);
+    return svg.replace(
+      '<svg ',
+      `<svg width="${width}" height="${height}" preserveAspectRatio="none" `,
+    );
   } catch {
     return '';
   }

--- a/backend/core-api/src/modules/documents/barcode.ts
+++ b/backend/core-api/src/modules/documents/barcode.ts
@@ -1,6 +1,9 @@
 import bwipjs from 'bwip-js';
 
-export const generateBarcodeSvg = (value: string): string => {
+export const generateBarcodeSvg = (
+  value: string,
+  { width = 150, height = 50 } = {},
+): string => {
   if (!value) {
     return '';
   }
@@ -15,7 +18,7 @@ export const generateBarcodeSvg = (value: string): string => {
       paddingheight: 0,
     });
 
-    return svg.replace('<svg ', '<svg width="150" height="50" ');
+    return svg.replace('<svg ', `<svg width="${width}" height="${height}" `);
   } catch {
     return '';
   }

--- a/backend/core-api/src/modules/documents/blocksToHtml.ts
+++ b/backend/core-api/src/modules/documents/blocksToHtml.ts
@@ -268,8 +268,8 @@ const renderBlock = (block: Block | PartialBlock, config?: Config): string => {
 
       let html = `<div style="margin: 16px 0;">
         <img src="${escapeHtml(src)}" alt="${escapeHtml(
-        name || '',
-      )}" width="${width}" style="${imgStyle}" />`;
+          name || '',
+        )}" width="${width}" style="${imgStyle}" />`;
 
       if (caption) {
         html += `<div style="margin-top: 8px; font-size: 14px; color: #666; font-style: italic;">${escapeHtml(

--- a/backend/core-api/src/modules/documents/blocksToHtml.ts
+++ b/backend/core-api/src/modules/documents/blocksToHtml.ts
@@ -54,7 +54,7 @@ const getColor = (
   return color;
 };
 
-const escapeHtml = (text: string): string => {
+export const escapeHtml = (text: string): string => {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -268,8 +268,8 @@ const renderBlock = (block: Block | PartialBlock, config?: Config): string => {
 
       let html = `<div style="margin: 16px 0;">
         <img src="${escapeHtml(src)}" alt="${escapeHtml(
-          name || '',
-        )}" width="${width}" style="${imgStyle}" />`;
+        name || '',
+      )}" width="${width}" style="${imgStyle}" />`;
 
       if (caption) {
         html += `<div style="margin-top: 8px; font-size: 14px; color: #666; font-style: italic;">${escapeHtml(

--- a/backend/core-api/src/modules/documents/blocksToHtml.ts
+++ b/backend/core-api/src/modules/documents/blocksToHtml.ts
@@ -268,8 +268,8 @@ const renderBlock = (block: Block | PartialBlock, config?: Config): string => {
 
       let html = `<div style="margin: 16px 0;">
         <img src="${escapeHtml(src)}" alt="${escapeHtml(
-          name || '',
-        )}" width="${width}" style="${imgStyle}" />`;
+        name || '',
+      )}" width="${width}" style="${imgStyle}" />`;
 
       if (caption) {
         html += `<div style="margin-top: 8px; font-size: 14px; color: #666; font-style: italic;">${escapeHtml(

--- a/backend/core-api/src/modules/products/meta/document/productReplacer.ts
+++ b/backend/core-api/src/modules/products/meta/document/productReplacer.ts
@@ -2,7 +2,7 @@ import { dateToShortStr, getEnv } from 'erxes-api-shared/utils';
 import dayjs from 'dayjs';
 import { IModels } from '~/connectionResolvers';
 import { generateBarcodeSvg } from '~/modules/documents/barcode';
-import { blocksToHtml } from '~/modules/documents/blocksToHtml';
+import { blocksToHtml, escapeHtml } from '~/modules/documents/blocksToHtml';
 
 const readFileUrl = (key: string, subdomain: string) => {
   if (key.startsWith('http://') || key.startsWith('https://')) {
@@ -137,9 +137,8 @@ export const buildProductReplacer = async ({
       );
       const barcodeImageUrl = product.variants?.[baseBarcode]?.image?.url;
       const barcode = barcodeImageUrl
-        ? `<img src="${readFileUrl(
-            barcodeImageUrl,
-            subdomain,
+        ? `<img src="${escapeHtml(
+            readFileUrl(barcodeImageUrl, subdomain),
           )}" width="${width}" height="${height}" alt="" />`
         : generateBarcodeSvg(barcodeValue, { width, height });
 

--- a/backend/core-api/src/modules/products/meta/document/productReplacer.ts
+++ b/backend/core-api/src/modules/products/meta/document/productReplacer.ts
@@ -127,14 +127,28 @@ export const buildProductReplacer = async ({
         return { ...block, type: 'rawHtml', props: { ...props, html: '' } };
       }
 
-      const svg = generateBarcodeSvg(barcodeValue);
+      const width = Math.min(
+        600,
+        Math.max(80, typeof props.width === 'number' ? props.width : 150),
+      );
+      const height = Math.min(
+        300,
+        Math.max(30, typeof props.height === 'number' ? props.height : 50),
+      );
+      const barcodeImageUrl = product.variants?.[baseBarcode]?.image?.url;
+      const barcode = barcodeImageUrl
+        ? `<img src="${readFileUrl(
+            barcodeImageUrl,
+            subdomain,
+          )}" width="${width}" height="${height}" alt="" />`
+        : generateBarcodeSvg(barcodeValue, { width, height });
 
       return {
         ...block,
         type: 'rawHtml',
         props: {
           ...props,
-          html: `<span style="display: inline-block;">${svg}</span>`,
+          html: `<span style="display: inline-block;">${barcode}</span>`,
         },
       };
     }

--- a/backend/core-api/src/modules/products/meta/document/productReplacer.ts
+++ b/backend/core-api/src/modules/products/meta/document/productReplacer.ts
@@ -2,7 +2,7 @@ import { dateToShortStr, getEnv } from 'erxes-api-shared/utils';
 import dayjs from 'dayjs';
 import { IModels } from '~/connectionResolvers';
 import { generateBarcodeSvg } from '~/modules/documents/barcode';
-import { blocksToHtml, escapeHtml } from '~/modules/documents/blocksToHtml';
+import { blocksToHtml } from '~/modules/documents/blocksToHtml';
 
 const readFileUrl = (key: string, subdomain: string) => {
   if (key.startsWith('http://') || key.startsWith('https://')) {
@@ -123,10 +123,6 @@ export const buildProductReplacer = async ({
     const path = props?.value;
 
     if (path === 'barcode') {
-      if (!barcodeValue) {
-        return { ...block, type: 'rawHtml', props: { ...props, html: '' } };
-      }
-
       const width = Math.min(
         600,
         Math.max(80, typeof props.width === 'number' ? props.width : 150),
@@ -135,12 +131,10 @@ export const buildProductReplacer = async ({
         300,
         Math.max(30, typeof props.height === 'number' ? props.height : 50),
       );
-      const barcodeImageUrl = product.variants?.[baseBarcode]?.image?.url;
-      const barcode = barcodeImageUrl
-        ? `<img src="${escapeHtml(
-            readFileUrl(barcodeImageUrl, subdomain),
-          )}" width="${width}" height="${height}" alt="" />`
-        : generateBarcodeSvg(barcodeValue, { width, height });
+      const barcode = generateBarcodeSvg(barcodeValue || '123456789012', {
+        width,
+        height,
+      });
 
       return {
         ...block,

--- a/backend/gateway/src/locales/en/documents.json
+++ b/backend/gateway/src/locales/en/documents.json
@@ -1,14 +1,17 @@
 {
-    "documents": "Documents",
-    "document-types" : "Document types",
-    "customer" : "Customer",
-    "company" : "Company",
-    "product" : "Product",
-    "team-member" : "Team member",
-    "add-document" : "Add document",
-    "no-document-title" : "No document yet",
-    "no-document-description" : "Get started by creating your first document.",
-    "filter" : {
+  "documents": "Documents",
+  "document-types": "Document types",
+  "customer": "Customer",
+  "company": "Company",
+  "product": "Product",
+  "team-member": "Team member",
+  "add-document": "Add document",
+  "no-document-title": "No document yet",
+  "no-document-description": "Get started by creating your first document.",
+  "filtered-empty-title": "No documents found",
+  "filtered-empty-description": "Try changing or clearing your filters.",
+  "clear-filters": "Clear filters",
+  "filter": {
     "search": "Search",
     "created-at": "Created At",
     "assigned-to": "Assigned To"

--- a/backend/gateway/src/locales/mn/documents.json
+++ b/backend/gateway/src/locales/mn/documents.json
@@ -8,6 +8,9 @@
   "add-document": "Баримт нэмэх",
   "no-document-title": "Одоогоор баримт алга",
   "no-document-description": "Эхний баримтаа үүсгэж эхлээрэй.",
+  "filtered-empty-title": "Баримт олдсонгүй",
+  "filtered-empty-description": "Шүүлтүүрээ өөрчлөх эсвэл арилгана уу.",
+  "clear-filters": "Шүүлтүүр арилгах",
   "filter": {
     "search": "Хайх",
     "created-at": "Үүсгэсэн огноо",

--- a/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
@@ -1,5 +1,6 @@
 import { DocumentAttributesSidebar } from '@/documents/components/DocumentAttributesSidebar';
 import { DocumentEditorSkeleton } from '@/documents/components/DocumentEditorSkeleton';
+import { DocumentsErrorState } from '@/documents/components/DocumentsErrorState';
 import { useDocument } from '@/documents/hooks/useDocument';
 import { useDocumentAttributes } from '@/documents/hooks/useDocumentAttributes';
 import {
@@ -214,7 +215,7 @@ const DocumentTitleEditor = ({
 };
 
 export const DocumentEditor = () => {
-  const { document, documentId, loading } = useDocument();
+  const { document, documentId, hasError, loading, refetch } = useDocument();
   const editor = useBlockEditor({});
   const { attributes, loading: attributesLoading } = useDocumentAttributes();
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -232,6 +233,16 @@ export const DocumentEditor = () => {
 
   if (loading) {
     return <DocumentEditorSkeleton />;
+  }
+
+  if (hasError) {
+    return (
+      <DocumentsErrorState
+        title="Couldn’t load document"
+        description="Check your connection and try again."
+        onRetry={() => void refetch()}
+      />
+    );
   }
 
   if (!document && !isCreating) {

--- a/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
@@ -251,7 +251,7 @@ export const DocumentEditor = () => {
       <DocumentsErrorState
         title="Couldn’t load document"
         description="Check your connection and try again."
-        onRetry={() => void refetch()}
+        onRetry={refetch}
       />
     );
   }

--- a/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentEditor.tsx
@@ -7,8 +7,17 @@ import {
   ATTRIBUTE_DND_MIME,
   insertAttributeAtPoint,
 } from '@/documents/utils/attributeDnd';
-import { IconFileText, IconLayoutSidebarRightExpand } from '@tabler/icons-react';
-import { Button, BlockEditor, cn, IBlockEditor, useBlockEditor } from 'erxes-ui';
+import {
+  IconFileText,
+  IconLayoutSidebarRightExpand,
+} from '@tabler/icons-react';
+import {
+  Button,
+  BlockEditor,
+  cn,
+  IBlockEditor,
+  useBlockEditor,
+} from 'erxes-ui';
 
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -97,7 +106,9 @@ const EditorController = ({
     >
       <BlockEditor
         editor={editor}
-        className={cn('w-full flex-1 overflow-y-auto overflow-x-hidden px-5 pb-16')}
+        className={cn(
+          'w-full flex-1 overflow-y-auto overflow-x-hidden px-5 pb-16',
+        )}
       >
         <AttributeInEditor
           editor={editor}

--- a/frontend/core-ui/src/modules/documents/components/Documents.tsx
+++ b/frontend/core-ui/src/modules/documents/components/Documents.tsx
@@ -1,10 +1,9 @@
-import { IconFilePlus, IconFilterOff } from '@tabler/icons-react';
 import { useAtomValue } from 'jotai';
-import { useTranslation } from 'react-i18next';
-import { Button, useMultiQueryState } from 'erxes-ui';
+import { useMultiQueryState } from 'erxes-ui';
 import { useDocuments } from '../hooks/useDocuments';
 import { documentsViewAtom } from '../states/documentsViewState';
 import { DocumentFilterState, IDocument } from '../types';
+import { DocumentsEmptyState } from './DocumentsEmptyState';
 import { DocumentsGrid } from './DocumentsGrid';
 import { DocumentsList } from './DocumentsList';
 import { DocumentsErrorState } from './DocumentsErrorState';
@@ -22,57 +21,29 @@ const DOCUMENTS_VIEW_TYPES: Record<
   list: DocumentsList,
 };
 
-function DocumentsContent({ viewType }: Props) {
+type DocumentsContentProps = Props & {
+  hasFilters: boolean;
+  onClearFilters: () => void;
+};
+
+function DocumentsContent({
+  hasFilters,
+  onClearFilters,
+  viewType,
+}: DocumentsContentProps) {
   const { documents, hasError, loading, refetch } = useDocuments();
-  const [filters, setFilters] = useMultiQueryState<DocumentFilterState>([
-    'createdAt',
-    'createdBy',
-    'searchValue',
-    'tagIds',
-  ]);
   const Component = DOCUMENTS_VIEW_TYPES[viewType] ?? DocumentsList;
-  const { t } = useTranslation('documents');
-  const hasFilters = Object.values(filters).some((value) => value !== null);
 
   if (hasError) {
-    return <DocumentsErrorState onRetry={() => void refetch()} />;
+    return <DocumentsErrorState onRetry={refetch} />;
   }
 
   if (viewType === 'grid' && !loading && documents.length === 0) {
     return (
-      <div className="flex h-full min-h-[400px] w-full flex-col items-center justify-center px-8 text-center">
-        <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
-          {hasFilters ? (
-            <IconFilterOff size={28} className="text-muted-foreground" />
-          ) : (
-            <IconFilePlus size={28} className="text-muted-foreground" />
-          )}
-        </div>
-        <h3 className="mb-1 text-lg font-semibold">
-          {hasFilters ? 'No documents found' : t('no-document-title')}
-        </h3>
-        <p className="max-w-sm text-sm text-muted-foreground">
-          {hasFilters
-            ? 'Try changing or clearing your filters.'
-            : t('no-document-description')}
-        </p>
-        {hasFilters && (
-          <Button
-            variant="outline"
-            className="mt-4"
-            onClick={() =>
-              setFilters({
-                createdAt: null,
-                createdBy: null,
-                searchValue: null,
-                tagIds: null,
-              })
-            }
-          >
-            Clear filters
-          </Button>
-        )}
-      </div>
+      <DocumentsEmptyState
+        hasFilters={hasFilters}
+        onClearFilters={onClearFilters}
+      />
     );
   }
 
@@ -85,10 +56,38 @@ function DocumentsContent({ viewType }: Props) {
 
 export function Documents({ viewType }: Props) {
   const documentsView = useAtomValue(documentsViewAtom);
+  const [filters, setFilters] = useMultiQueryState<DocumentFilterState>([
+    'contentType',
+    'createdAt',
+    'createdBy',
+    'searchValue',
+    'tagIds',
+  ]);
+  const hasFilters = Object.values(filters).some((value) => value !== null);
+
+  const clearFilters = () =>
+    setFilters({
+      contentType: null,
+      createdAt: null,
+      createdBy: null,
+      searchValue: null,
+      tagIds: null,
+    });
 
   if (viewType === 'grid' && documentsView === 'list') {
-    return <DocumentsRecordTable />;
+    return (
+      <DocumentsRecordTable
+        hasFilters={hasFilters}
+        onClearFilters={clearFilters}
+      />
+    );
   }
 
-  return <DocumentsContent viewType={viewType} />;
+  return (
+    <DocumentsContent
+      viewType={viewType}
+      hasFilters={hasFilters}
+      onClearFilters={clearFilters}
+    />
+  );
 }

--- a/frontend/core-ui/src/modules/documents/components/Documents.tsx
+++ b/frontend/core-ui/src/modules/documents/components/Documents.tsx
@@ -26,6 +26,7 @@ type DocumentsContentProps = Props & {
   onClearFilters: () => void;
 };
 
+/** Renders a document collection with loading, error, and empty states. */
 function DocumentsContent({
   hasFilters,
   onClearFilters,
@@ -65,6 +66,7 @@ export function Documents({ viewType }: Props) {
   ]);
   const hasFilters = Object.values(filters).some((value) => value !== null);
 
+  /** Clears every query parameter that filters the documents query. */
   const clearFilters = () =>
     setFilters({
       contentType: null,

--- a/frontend/core-ui/src/modules/documents/components/Documents.tsx
+++ b/frontend/core-ui/src/modules/documents/components/Documents.tsx
@@ -26,7 +26,6 @@ type DocumentsContentProps = Props & {
   onClearFilters: () => void;
 };
 
-/** Renders a document collection with loading, error, and empty states. */
 function DocumentsContent({
   hasFilters,
   onClearFilters,
@@ -66,7 +65,6 @@ export function Documents({ viewType }: Props) {
   ]);
   const hasFilters = Object.values(filters).some((value) => value !== null);
 
-  /** Clears every query parameter that filters the documents query. */
   const clearFilters = () =>
     setFilters({
       contentType: null,

--- a/frontend/core-ui/src/modules/documents/components/Documents.tsx
+++ b/frontend/core-ui/src/modules/documents/components/Documents.tsx
@@ -1,11 +1,13 @@
-import { IconFilePlus } from '@tabler/icons-react';
+import { IconFilePlus, IconFilterOff } from '@tabler/icons-react';
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
+import { Button, useMultiQueryState } from 'erxes-ui';
 import { useDocuments } from '../hooks/useDocuments';
 import { documentsViewAtom } from '../states/documentsViewState';
-import { IDocument } from '../types';
+import { DocumentFilterState, IDocument } from '../types';
 import { DocumentsGrid } from './DocumentsGrid';
 import { DocumentsList } from './DocumentsList';
+import { DocumentsErrorState } from './DocumentsErrorState';
 import { DocumentsRecordTable } from './list/DocumentsRecordTable';
 
 type Props = {
@@ -21,20 +23,55 @@ const DOCUMENTS_VIEW_TYPES: Record<
 };
 
 function DocumentsContent({ viewType }: Props) {
-  const { documents, loading } = useDocuments();
+  const { documents, hasError, loading, refetch } = useDocuments();
+  const [filters, setFilters] = useMultiQueryState<DocumentFilterState>([
+    'createdAt',
+    'createdBy',
+    'searchValue',
+    'tagIds',
+  ]);
   const Component = DOCUMENTS_VIEW_TYPES[viewType] ?? DocumentsList;
   const { t } = useTranslation('documents');
+  const hasFilters = Object.values(filters).some((value) => value !== null);
 
-  if (!loading && documents.length === 0) {
+  if (hasError) {
+    return <DocumentsErrorState onRetry={() => void refetch()} />;
+  }
+
+  if (viewType === 'grid' && !loading && documents.length === 0) {
     return (
       <div className="flex h-full min-h-[400px] w-full flex-col items-center justify-center px-8 text-center">
         <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
-          <IconFilePlus size={28} className="text-muted-foreground" />
+          {hasFilters ? (
+            <IconFilterOff size={28} className="text-muted-foreground" />
+          ) : (
+            <IconFilePlus size={28} className="text-muted-foreground" />
+          )}
         </div>
-        <h3 className="mb-1 text-lg font-semibold">{t('no-document-title')}</h3>
+        <h3 className="mb-1 text-lg font-semibold">
+          {hasFilters ? 'No documents found' : t('no-document-title')}
+        </h3>
         <p className="max-w-sm text-sm text-muted-foreground">
-          {t('no-document-description')}
+          {hasFilters
+            ? 'Try changing or clearing your filters.'
+            : t('no-document-description')}
         </p>
+        {hasFilters && (
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() =>
+              setFilters({
+                createdAt: null,
+                createdBy: null,
+                searchValue: null,
+                tagIds: null,
+              })
+            }
+          >
+            Clear filters
+          </Button>
+        )}
       </div>
     );
   }

--- a/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
@@ -7,7 +7,6 @@ type DocumentsEmptyStateProps = Readonly<{
   onClearFilters: () => void;
 }>;
 
-/** Renders the document empty state and lets users clear active filters. */
 export function DocumentsEmptyState({
   hasFilters,
   onClearFilters,

--- a/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
@@ -1,0 +1,40 @@
+import { IconFilePlus, IconFilterOff } from '@tabler/icons-react';
+import { Button, Empty } from 'erxes-ui';
+import { useTranslation } from 'react-i18next';
+
+type DocumentsEmptyStateProps = {
+  hasFilters: boolean;
+  onClearFilters: () => void;
+};
+
+export function DocumentsEmptyState({
+  hasFilters,
+  onClearFilters,
+}: DocumentsEmptyStateProps) {
+  const { t } = useTranslation('documents');
+
+  return (
+    <Empty className="h-full min-h-[400px] border-0 bg-transparent">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          {hasFilters ? <IconFilterOff /> : <IconFilePlus />}
+        </Empty.Media>
+        <Empty.Title>
+          {hasFilters ? 'No documents found' : t('no-document-title')}
+        </Empty.Title>
+        <Empty.Description>
+          {hasFilters
+            ? 'Try changing or clearing your filters.'
+            : t('no-document-description')}
+        </Empty.Description>
+      </Empty.Header>
+      {hasFilters && (
+        <Empty.Content>
+          <Button variant="outline" onClick={onClearFilters}>
+            Clear filters
+          </Button>
+        </Empty.Content>
+      )}
+    </Empty>
+  );
+}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsEmptyState.tsx
@@ -2,11 +2,12 @@ import { IconFilePlus, IconFilterOff } from '@tabler/icons-react';
 import { Button, Empty } from 'erxes-ui';
 import { useTranslation } from 'react-i18next';
 
-type DocumentsEmptyStateProps = {
+type DocumentsEmptyStateProps = Readonly<{
   hasFilters: boolean;
   onClearFilters: () => void;
-};
+}>;
 
+/** Renders the document empty state and lets users clear active filters. */
 export function DocumentsEmptyState({
   hasFilters,
   onClearFilters,
@@ -20,18 +21,18 @@ export function DocumentsEmptyState({
           {hasFilters ? <IconFilterOff /> : <IconFilePlus />}
         </Empty.Media>
         <Empty.Title>
-          {hasFilters ? 'No documents found' : t('no-document-title')}
+          {hasFilters ? t('filtered-empty-title') : t('no-document-title')}
         </Empty.Title>
         <Empty.Description>
           {hasFilters
-            ? 'Try changing or clearing your filters.'
+            ? t('filtered-empty-description')
             : t('no-document-description')}
         </Empty.Description>
       </Empty.Header>
       {hasFilters && (
         <Empty.Content>
           <Button variant="outline" onClick={onClearFilters}>
-            Clear filters
+            {t('clear-filters')}
           </Button>
         </Empty.Content>
       )}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
@@ -1,0 +1,30 @@
+import { IconAlertTriangle, IconRefresh } from '@tabler/icons-react';
+import { Button, Empty } from 'erxes-ui';
+
+export function DocumentsErrorState({
+  description = 'Check your connection and try again.',
+  onRetry,
+  title = 'Couldn’t load documents',
+}: {
+  description?: string;
+  onRetry: () => void;
+  title?: string;
+}) {
+  return (
+    <Empty className="h-full border-0 bg-transparent">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <IconAlertTriangle className="text-destructive" />
+        </Empty.Media>
+        <Empty.Title>{title}</Empty.Title>
+        <Empty.Description>{description}</Empty.Description>
+      </Empty.Header>
+      <Empty.Content>
+        <Button variant="outline" onClick={onRetry}>
+          <IconRefresh />
+          Try again
+        </Button>
+      </Empty.Content>
+    </Empty>
+  );
+}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
@@ -1,15 +1,18 @@
 import { IconAlertTriangle, IconRefresh } from '@tabler/icons-react';
 import { Button, Empty } from 'erxes-ui';
 
+type DocumentsErrorStateProps = Readonly<{
+  description?: string;
+  onRetry: () => void;
+  title?: string;
+}>;
+
+/** Renders a retryable error state for document queries. */
 export function DocumentsErrorState({
   description = 'Check your connection and try again.',
   onRetry,
   title = 'Couldn’t load documents',
-}: {
-  description?: string;
-  onRetry: () => void;
-  title?: string;
-}) {
+}: DocumentsErrorStateProps) {
   return (
     <Empty className="h-full border-0 bg-transparent">
       <Empty.Header>

--- a/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsErrorState.tsx
@@ -7,7 +7,6 @@ type DocumentsErrorStateProps = Readonly<{
   title?: string;
 }>;
 
-/** Renders a retryable error state for document queries. */
 export function DocumentsErrorState({
   description = 'Check your connection and try again.',
   onRetry,

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
@@ -29,7 +29,6 @@ type DocumentsRecordTableProps = Readonly<{
   onClearFilters: () => void;
 }>;
 
-/** Renders the paginated documents table and its query states. */
 export function DocumentsRecordTable({
   hasFilters,
   onClearFilters,

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
@@ -1,25 +1,9 @@
 import { useDocuments } from '@/documents/hooks/useDocuments';
-import { IconFileOff } from '@tabler/icons-react';
-import { Empty, RecordTable } from 'erxes-ui';
+import { RecordTable } from 'erxes-ui';
+import { DocumentsEmptyState } from '../DocumentsEmptyState';
 import { DocumentsErrorState } from '../DocumentsErrorState';
 import { DocumentsColumn } from './DocumentsColumn';
 import { DocumentsRecordTableCommandBar } from './DocumentsRecordTableCommandBar';
-
-function DocumentsEmptyState() {
-  return (
-    <Empty className="h-full border-0 bg-transparent">
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <IconFileOff />
-        </Empty.Media>
-        <Empty.Title>No documents found</Empty.Title>
-        <Empty.Description>
-          There are no documents to display.
-        </Empty.Description>
-      </Empty.Header>
-    </Empty>
-  );
-}
 
 type DocumentsTableProps = {
   handleFetchMore: ReturnType<typeof useDocuments>['handleFetchMore'];
@@ -40,18 +24,31 @@ function DocumentsTable({ handleFetchMore, loading }: DocumentsTableProps) {
   );
 }
 
-export function DocumentsRecordTable() {
+type DocumentsRecordTableProps = {
+  hasFilters: boolean;
+  onClearFilters: () => void;
+};
+
+export function DocumentsRecordTable({
+  hasFilters,
+  onClearFilters,
+}: DocumentsRecordTableProps) {
   const columns = DocumentsColumn();
   const { documents, hasError, loading, handleFetchMore, pageInfo, refetch } =
     useDocuments();
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
 
   if (hasError) {
-    return <DocumentsErrorState onRetry={() => void refetch()} />;
+    return <DocumentsErrorState onRetry={refetch} />;
   }
 
   if (!loading && documents.length === 0) {
-    return <DocumentsEmptyState />;
+    return (
+      <DocumentsEmptyState
+        hasFilters={hasFilters}
+        onClearFilters={onClearFilters}
+      />
+    );
   }
 
   return (

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
@@ -24,11 +24,12 @@ function DocumentsTable({ handleFetchMore, loading }: DocumentsTableProps) {
   );
 }
 
-type DocumentsRecordTableProps = {
+type DocumentsRecordTableProps = Readonly<{
   hasFilters: boolean;
   onClearFilters: () => void;
-};
+}>;
 
+/** Renders the paginated documents table and its query states. */
 export function DocumentsRecordTable({
   hasFilters,
   onClearFilters,

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTable.tsx
@@ -1,6 +1,7 @@
 import { useDocuments } from '@/documents/hooks/useDocuments';
 import { IconFileOff } from '@tabler/icons-react';
 import { Empty, RecordTable } from 'erxes-ui';
+import { DocumentsErrorState } from '../DocumentsErrorState';
 import { DocumentsColumn } from './DocumentsColumn';
 import { DocumentsRecordTableCommandBar } from './DocumentsRecordTableCommandBar';
 
@@ -41,8 +42,13 @@ function DocumentsTable({ handleFetchMore, loading }: DocumentsTableProps) {
 
 export function DocumentsRecordTable() {
   const columns = DocumentsColumn();
-  const { documents, loading, handleFetchMore, pageInfo } = useDocuments();
+  const { documents, hasError, loading, handleFetchMore, pageInfo, refetch } =
+    useDocuments();
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
+
+  if (hasError) {
+    return <DocumentsErrorState onRetry={() => void refetch()} />;
+  }
 
   if (!loading && documents.length === 0) {
     return <DocumentsEmptyState />;
@@ -55,7 +61,7 @@ export function DocumentsRecordTable() {
         data={documents}
         className="m-3 h-full"
         stickyColumns={['more', 'checkbox', 'name']}
-        tableId="documents_record_table"
+        tableId="documents_record_table_v2"
       >
         <RecordTable.CursorProvider
           dataLength={documents.length}

--- a/frontend/core-ui/src/modules/documents/hooks/useDocument.tsx
+++ b/frontend/core-ui/src/modules/documents/hooks/useDocument.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@apollo/client';
+import { NetworkStatus, useMutation, useQuery } from '@apollo/client';
 import { toast, useQueryState } from 'erxes-ui';
 import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -13,14 +13,19 @@ export const useDocument = () => {
 
   const { getValues, setValue } = useFormContext();
 
-  const { data, loading } = useQuery(GET_DOCUMENT_DETAIL, {
-    variables: {
-      _id: cleanDocumentId,
+  const { data, error, loading, networkStatus, refetch } = useQuery(
+    GET_DOCUMENT_DETAIL,
+    {
+      notifyOnNetworkStatusChange: true,
+      variables: {
+        _id: cleanDocumentId,
+      },
+      skip: !cleanDocumentId,
     },
-    skip: !cleanDocumentId,
-  });
+  );
 
   const document = data?.documentsDetail || null;
+  const hasError = Boolean(error || networkStatus === NetworkStatus.error);
 
   useEffect(() => {
     if (data?.documentsDetail) {
@@ -95,7 +100,9 @@ export const useDocument = () => {
     document,
     documentId: cleanDocumentId,
     documentSave,
+    hasError,
     loading,
+    refetch,
     saving,
   };
 };

--- a/frontend/core-ui/src/modules/documents/hooks/useDocuments.tsx
+++ b/frontend/core-ui/src/modules/documents/hooks/useDocuments.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@apollo/client';
+import { NetworkStatus, useQuery } from '@apollo/client';
 import {
   EnumCursorDirection,
   IRecordTableCursorPageInfo,
@@ -59,14 +59,14 @@ export const useDocuments = () => {
     });
   }
 
-  const { data, error, loading, fetchMore } = useQuery<DocumentsQueryResponse>(
-    GET_DOCUMENTS,
-    {
+  const { data, error, loading, fetchMore, networkStatus, refetch } =
+    useQuery<DocumentsQueryResponse>(GET_DOCUMENTS, {
+      notifyOnNetworkStatusChange: true,
       variables,
-    },
-  );
+    });
 
   const { list: documents = [], pageInfo } = data?.documents || {};
+  const hasError = Boolean(error || networkStatus === NetworkStatus.error);
 
   function handleFetchMore({ direction }: { direction: EnumCursorDirection }) {
     if (!pageInfo || !validateFetchMore({ direction, pageInfo })) {
@@ -101,9 +101,10 @@ export const useDocuments = () => {
 
   return {
     documents,
-    error,
+    hasError,
     loading,
     pageInfo,
     handleFetchMore,
+    refetch,
   };
 };

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from 'react';
 import { Button } from 'erxes-ui/components';
+import { IconArrowsDiagonal } from '@tabler/icons-react';
 
 const MIN_WIDTH = 80;
 const MIN_HEIGHT = 30;
@@ -20,7 +21,6 @@ type BarcodeAttributeProps = Readonly<{
   width: number;
 }>;
 
-/** Renders and resizes the product barcode placeholder. */
 export const BarcodeAttribute = ({
   editable,
   height,
@@ -38,7 +38,6 @@ export const BarcodeAttribute = ({
     }
   }, [height, width]);
 
-  /** Calculates bounded dimensions from the active top-right resize drag. */
   const getResizedDimensions = (event: ReactPointerEvent) => {
     const start = dragStart.current;
 
@@ -58,7 +57,6 @@ export const BarcodeAttribute = ({
     };
   };
 
-  /** Starts resizing and captures subsequent pointer movement. */
   const handleResizeStart = (event: ReactPointerEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -70,14 +68,12 @@ export const BarcodeAttribute = ({
     };
   };
 
-  /** Updates the barcode preview while the resize handle is moving. */
   const handleResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (dragStart.current) {
       setSize(getResizedDimensions(event));
     }
   };
 
-  /** Persists the final dimensions in the inline attribute props. */
   const handleResizeEnd = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (!dragStart.current) {
       return;
@@ -128,7 +124,8 @@ export const BarcodeAttribute = ({
           variant="outline"
           size="icon"
           aria-label="Resize barcode"
-          className="absolute -right-1 -top-1 size-3 cursor-nesw-resize rounded-full border border-primary bg-background p-0"
+          title="Drag up to increase height; drag right to increase width"
+          className="absolute -right-1 -top-1 z-10 size-5 touch-none cursor-nesw-resize rounded-full border border-primary bg-background p-0 text-primary"
           onPointerDown={handleResizeStart}
           onPointerMove={handleResize}
           onPointerUp={handleResizeEnd}
@@ -136,7 +133,9 @@ export const BarcodeAttribute = ({
             dragStart.current = null;
             setSize({ width, height });
           }}
-        />
+        >
+          <IconArrowsDiagonal className="size-3" />
+        </Button>
       )}
     </span>
   );

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -1,3 +1,4 @@
+/** Renders a template preview; printing supplies the selected product barcode. */
 export const BarcodeAttribute = () => (
   <span
     contentEditable={false}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -1,4 +1,3 @@
-// Template preview; the existing product replacer supplies the barcode when printing.
 export const BarcodeAttribute = () => (
   <span
     contentEditable={false}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -1,34 +1,139 @@
-/** Renders a template preview; printing supplies the selected product barcode. */
-export const BarcodeAttribute = () => (
-  <span
-    contentEditable={false}
-    title="Barcode preview — prints the selected product’s barcode"
-  >
-    <svg
-      width={150}
-      height={50}
-      viewBox="0 0 202 69"
-      preserveAspectRatio="none"
-      role="img"
-      aria-label="Product barcode preview"
-      className="inline-block align-middle bg-white"
+import {
+  PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Button } from 'erxes-ui/components';
+
+const MIN_WIDTH = 80;
+const MIN_HEIGHT = 30;
+const MAX_WIDTH = 600;
+const MAX_HEIGHT = 300;
+
+type BarcodeSize = Readonly<{ width: number; height: number }>;
+
+type BarcodeAttributeProps = Readonly<{
+  editable: boolean;
+  height: number;
+  onResize: (size: BarcodeSize) => void;
+  width: number;
+}>;
+
+/** Renders and resizes the product barcode placeholder. */
+export const BarcodeAttribute = ({
+  editable,
+  height,
+  onResize,
+  width,
+}: BarcodeAttributeProps) => {
+  const [size, setSize] = useState<BarcodeSize>({ width, height });
+  const dragStart = useRef<
+    (BarcodeSize & { clientX: number; clientY: number }) | null
+  >(null);
+
+  useEffect(() => {
+    if (!dragStart.current) {
+      setSize({ width, height });
+    }
+  }, [height, width]);
+
+  const getResizedDimensions = (event: ReactPointerEvent) => {
+    const start = dragStart.current;
+
+    if (!start) {
+      return size;
+    }
+
+    return {
+      width: Math.min(
+        MAX_WIDTH,
+        Math.max(MIN_WIDTH, start.width + event.clientX - start.clientX),
+      ),
+      height: Math.min(
+        MAX_HEIGHT,
+        Math.max(MIN_HEIGHT, start.height + start.clientY - event.clientY),
+      ),
+    };
+  };
+
+  const handleResizeStart = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragStart.current = {
+      ...size,
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+  };
+
+  const handleResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (dragStart.current) {
+      setSize(getResizedDimensions(event));
+    }
+  };
+
+  const handleResizeEnd = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!dragStart.current) {
+      return;
+    }
+
+    const resizedDimensions = getResizedDimensions(event);
+    dragStart.current = null;
+    setSize(resizedDimensions);
+    onResize(resizedDimensions);
+  };
+
+  return (
+    <span
+      className="relative inline-block align-middle"
+      contentEditable={false}
+      title="Barcode preview — prints the selected product’s barcode"
+      style={size}
     >
-      <path
-        stroke="#000"
-        strokeWidth="4"
-        d="M2 69L2 0M28 69L28 0M58 69L58 0M84 69L84 0M90 69L90 0M112 69L112 0M128 69L128 0M138 69L138 0M168 69L168 0M178 69L178 0M200 69L200 0"
-      />
-      <path
-        stroke="#000"
-        strokeWidth="2"
-        d="M7 69L7 0M23 69L23 0M45 69L45 0M53 69L53 0M79 69L79 0M101 69L101 0M105 69L105 0M133 69L133 0M163 69L163 0M195 69L195 0"
-      />
-      <path
-        stroke="#000"
-        strokeWidth="6"
-        d="M15 69L15 0M37 69L37 0M69 69L69 0M147 69L147 0M157 69L157 0M189 69L189 0"
-      />
-      <path stroke="#000" strokeWidth="8" d="M120 69L120 0" />
-    </svg>
-  </span>
-);
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 202 69"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Product barcode preview"
+        className="block bg-white"
+      >
+        <path
+          stroke="#000"
+          strokeWidth="4"
+          d="M2 69L2 0M28 69L28 0M58 69L58 0M84 69L84 0M90 69L90 0M112 69L112 0M128 69L128 0M138 69L138 0M168 69L168 0M178 69L178 0M200 69L200 0"
+        />
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M7 69L7 0M23 69L23 0M45 69L45 0M53 69L53 0M79 69L79 0M101 69L101 0M105 69L105 0M133 69L133 0M163 69L163 0M195 69L195 0"
+        />
+        <path
+          stroke="#000"
+          strokeWidth="6"
+          d="M15 69L15 0M37 69L37 0M69 69L69 0M147 69L147 0M157 69L157 0M189 69L189 0"
+        />
+        <path stroke="#000" strokeWidth="8" d="M120 69L120 0" />
+      </svg>
+      {editable && (
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Resize barcode"
+          className="absolute -right-1 -top-1 size-3 cursor-nesw-resize rounded-full border border-primary bg-background p-0"
+          onPointerDown={handleResizeStart}
+          onPointerMove={handleResize}
+          onPointerUp={handleResizeEnd}
+          onPointerCancel={() => {
+            dragStart.current = null;
+            setSize({ width, height });
+          }}
+        />
+      )}
+    </span>
+  );
+};

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -38,6 +38,7 @@ export const BarcodeAttribute = ({
     }
   }, [height, width]);
 
+  /** Calculates bounded dimensions from the active top-right resize drag. */
   const getResizedDimensions = (event: ReactPointerEvent) => {
     const start = dragStart.current;
 
@@ -57,6 +58,7 @@ export const BarcodeAttribute = ({
     };
   };
 
+  /** Starts resizing and captures subsequent pointer movement. */
   const handleResizeStart = (event: ReactPointerEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -68,12 +70,14 @@ export const BarcodeAttribute = ({
     };
   };
 
+  /** Updates the barcode preview while the resize handle is moving. */
   const handleResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (dragStart.current) {
       setSize(getResizedDimensions(event));
     }
   };
 
+  /** Persists the final dimensions in the inline attribute props. */
   const handleResizeEnd = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (!dragStart.current) {
       return;

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BarcodeAttribute.tsx
@@ -1,0 +1,34 @@
+// Template preview; the existing product replacer supplies the barcode when printing.
+export const BarcodeAttribute = () => (
+  <span
+    contentEditable={false}
+    title="Barcode preview — prints the selected product’s barcode"
+  >
+    <svg
+      width={150}
+      height={50}
+      viewBox="0 0 202 69"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Product barcode preview"
+      className="inline-block align-middle bg-white"
+    >
+      <path
+        stroke="#000"
+        strokeWidth="4"
+        d="M2 69L2 0M28 69L28 0M58 69L58 0M84 69L84 0M90 69L90 0M112 69L112 0M128 69L128 0M138 69L138 0M168 69L168 0M178 69L178 0M200 69L200 0"
+      />
+      <path
+        stroke="#000"
+        strokeWidth="2"
+        d="M7 69L7 0M23 69L23 0M45 69L45 0M53 69L53 0M79 69L79 0M101 69L101 0M105 69L105 0M133 69L133 0M163 69L163 0M195 69L195 0"
+      />
+      <path
+        stroke="#000"
+        strokeWidth="6"
+        d="M15 69L15 0M37 69L37 0M69 69L69 0M147 69L147 0M157 69L157 0M189 69L189 0"
+      />
+      <path stroke="#000" strokeWidth="8" d="M120 69L120 0" />
+    </svg>
+  </span>
+);

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditor.tsx
@@ -3,6 +3,7 @@ import {
   DefaultReactSuggestionItem,
   getDefaultReactSlashMenuItems,
   SuggestionMenuController,
+  TableHandlesController,
 } from '@blocknote/react';
 import { filterSuggestionItems } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/shadcn';
@@ -16,6 +17,8 @@ import { KeyboardEvent, useState } from 'react';
 import { BlockEditorProps } from '../types';
 import { SlashMenu } from './SlashMenu';
 import { Toolbar } from './Toolbar';
+import { BarcodeAttribute } from './BarcodeAttribute';
+import { TableHandleWithRemove } from './TableHandleWithRemove';
 
 const isEmptyBlock = (block?: any) =>
   !!block &&
@@ -151,6 +154,7 @@ export const BlockEditor = ({
         editable={!readonly && !disabled}
         onChange={onChange}
         formattingToolbar={false}
+        tableHandles={false}
         shadCNComponents={{
           Button: { Button },
           Tooltip: {
@@ -168,6 +172,7 @@ export const BlockEditor = ({
           suggestionMenuComponent={SlashMenu}
         />
         <Toolbar />
+        <TableHandlesController tableHandle={TableHandleWithRemove} />
         {children}
       </BlockNoteView>
     </div>
@@ -210,10 +215,13 @@ export const Attribute = createReactInlineContentSpec(
     content: 'none',
   },
   {
-    render: (props) => (
-      <span className="bg-yellow-50 p-1 rounded font-bold text-sm text-yellow-900 inline-flex items-center">
-        {props.inlineContent.props.name}
-      </span>
-    ),
+    render: (props) =>
+      props.inlineContent.props.value === 'barcode' ? (
+        <BarcodeAttribute />
+      ) : (
+        <span className="bg-yellow-50 p-1 rounded font-bold text-sm text-yellow-900 inline-flex items-center">
+          {props.inlineContent.props.name}
+        </span>
+      ),
   },
 );

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/BlockEditor.tsx
@@ -211,13 +211,29 @@ export const Attribute = createReactInlineContentSpec(
       value: {
         default: '',
       },
+      width: {
+        default: 150,
+      },
+      height: {
+        default: 50,
+      },
     },
     content: 'none',
   },
   {
     render: (props) =>
       props.inlineContent.props.value === 'barcode' ? (
-        <BarcodeAttribute />
+        <BarcodeAttribute
+          editable={props.editor.isEditable}
+          height={props.inlineContent.props.height}
+          width={props.inlineContent.props.width}
+          onResize={({ width, height }) =>
+            props.updateInlineContent({
+              type: 'attribute',
+              props: { ...props.inlineContent.props, width, height },
+            })
+          }
+        />
       ) : (
         <span className="bg-yellow-50 p-1 rounded font-bold text-sm text-yellow-900 inline-flex items-center">
           {props.inlineContent.props.name}

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
@@ -168,7 +168,7 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
   const toggleHeader = () => {
     const block = editor.getBlock(props.block.id);
 
-    if (!block || block.type !== 'table') {
+    if (block?.type !== 'table') {
       return;
     }
 

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
@@ -1,0 +1,221 @@
+import {
+  AddButton,
+  DeleteButton,
+  TableHandle,
+  TableHandleMenu,
+  TableHandleMenuProps,
+  TableHandleProps,
+  useBlockNoteEditor,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { isTableCell, mapTableCell } from '@blocknote/core';
+import { IconGripVertical } from '@tabler/icons-react';
+import { CSSProperties, useMemo } from 'react';
+
+const COLORS = [
+  'default',
+  'gray',
+  'brown',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+] as const;
+
+const ColorIcon = ({
+  backgroundColor = 'default',
+  textColor = 'default',
+}: {
+  backgroundColor?: string;
+  textColor?: string;
+}) => (
+  <span
+    className="bn-color-icon"
+    data-background-color={backgroundColor}
+    data-text-color={textColor}
+    style={
+      {
+        pointerEvents: 'none',
+        fontSize: '13.5px',
+        height: '18px',
+        lineHeight: '18px',
+        textAlign: 'center',
+        width: '18px',
+      } satisfies CSSProperties
+    }
+  >
+    A
+  </span>
+);
+
+const TableColorPicker = (props: TableHandleMenuProps) => {
+  const editor = useBlockNoteEditor();
+  const Components = useComponentsContext();
+  const dictionary = useDictionary();
+  const tableHandles = editor.tableHandles;
+  const currentCells = useMemo(() => {
+    if (!tableHandles) {
+      return [];
+    }
+
+    return props.orientation === 'row'
+      ? tableHandles.getCellsAtRowHandle(props.block, props.index)
+      : tableHandles.getCellsAtColumnHandle(props.block, props.index);
+  }, [props.block, props.index, props.orientation, tableHandles]);
+
+  if (!Components || !tableHandles || !currentCells[0]) {
+    return null;
+  }
+
+  const firstCell = mapTableCell(currentCells[0].cell);
+  const updateColor = (color: string, type: 'text' | 'background') => {
+    const rows = props.block.content.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => mapTableCell(cell)),
+    }));
+
+    currentCells.forEach(({ row, col }) => {
+      if (type === 'text') {
+        rows[row].cells[col].props.textColor = color;
+      } else {
+        rows[row].cells[col].props.backgroundColor = color;
+      }
+    });
+
+    editor.updateBlock(props.block, {
+      content: { ...props.block.content, rows },
+    });
+    editor.setTextCursorPosition(props.block);
+  };
+
+  return (
+    <Components.Generic.Menu.Root position="right" sub>
+      <Components.Generic.Menu.Trigger sub>
+        <Components.Generic.Menu.Item className="bn-menu-item" subTrigger>
+          {dictionary.drag_handle.colors_menuitem}
+        </Components.Generic.Menu.Item>
+      </Components.Generic.Menu.Trigger>
+      <Components.Generic.Menu.Dropdown
+        sub
+        className="bn-menu-dropdown bn-color-picker-dropdown"
+      >
+        <Components.Generic.Menu.Label>
+          {dictionary.color_picker.text_title}
+        </Components.Generic.Menu.Label>
+        {COLORS.map((color) => (
+          <Components.Generic.Menu.Item
+            key={`text-color-${color}`}
+            icon={<ColorIcon textColor={color} />}
+            checked={
+              currentCells.every(
+                ({ cell }) =>
+                  isTableCell(cell) &&
+                  cell.props.textColor === firstCell.props.textColor,
+              ) && firstCell.props.textColor === color
+            }
+            onClick={() => updateColor(color, 'text')}
+          >
+            {dictionary.color_picker.colors[color]}
+          </Components.Generic.Menu.Item>
+        ))}
+        <Components.Generic.Menu.Label>
+          {dictionary.color_picker.background_title}
+        </Components.Generic.Menu.Label>
+        {COLORS.map((color) => (
+          <Components.Generic.Menu.Item
+            key={`background-color-${color}`}
+            icon={<ColorIcon backgroundColor={color} />}
+            checked={
+              currentCells.every(
+                ({ cell }) =>
+                  isTableCell(cell) &&
+                  cell.props.backgroundColor ===
+                    firstCell.props.backgroundColor,
+              ) && firstCell.props.backgroundColor === color
+            }
+            onClick={() => updateColor(color, 'background')}
+          >
+            {dictionary.color_picker.colors[color]}
+          </Components.Generic.Menu.Item>
+        ))}
+      </Components.Generic.Menu.Dropdown>
+    </Components.Generic.Menu.Root>
+  );
+};
+
+const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
+  const editor = useBlockNoteEditor();
+  const Components = useComponentsContext();
+
+  if (!Components) {
+    return null;
+  }
+
+  const isHeader =
+    props.orientation === 'row'
+      ? Boolean(props.block.content.headerRows)
+      : Boolean(props.block.content.headerCols);
+
+  const toggleHeader = () => {
+    const block = editor.getBlock(props.block.id);
+
+    if (!block || block.type !== 'table') {
+      return;
+    }
+
+    editor.updateBlock(block, {
+      content: {
+        ...block.content,
+        ...(props.orientation === 'row'
+          ? { headerRows: isHeader ? undefined : 1 }
+          : { headerCols: isHeader ? undefined : 1 }),
+      },
+    });
+  };
+
+  return (
+    <TableHandleMenu {...props}>
+      <DeleteButton {...props} />
+      {props.orientation === 'row' ? (
+        <>
+          <AddButton {...props} orientation="row" side="above" />
+          <AddButton {...props} orientation="row" side="below" />
+        </>
+      ) : (
+        <>
+          <AddButton {...props} orientation="column" side="left" />
+          <AddButton {...props} orientation="column" side="right" />
+        </>
+      )}
+      {props.index === 0 && (
+        <Components.Generic.Menu.Item
+          className="bn-menu-item"
+          checked={isHeader}
+          onClick={toggleHeader}
+        >
+          {props.orientation === 'row' ? 'Header row' : 'Header column'}
+        </Components.Generic.Menu.Item>
+      )}
+      <TableColorPicker {...props} />
+      <Components.Generic.Menu.Divider />
+      <Components.Generic.Menu.Item
+        className="bn-menu-item"
+        onClick={() => editor.removeBlocks([props.block])}
+      >
+        Delete table
+      </Components.Generic.Menu.Item>
+    </TableHandleMenu>
+  );
+};
+
+export const TableHandleWithRemove = (props: TableHandleProps) => {
+  return (
+    <TableHandle {...props} tableHandleMenu={TableHandleMenuWithRemove}>
+      <IconGripVertical size={24} data-test="tableHandle" />
+    </TableHandle>
+  );
+};

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
@@ -26,6 +26,7 @@ const COLORS = [
   'pink',
 ] as const;
 
+/** Renders the color swatch used by the table cell color menu. */
 const ColorIcon = ({
   backgroundColor = 'default',
   textColor = 'default',
@@ -52,6 +53,7 @@ const ColorIcon = ({
   </span>
 );
 
+/** Renders text and background color controls for the selected table cells. */
 const TableColorPicker = (props: TableHandleMenuProps) => {
   const editor = useBlockNoteEditor();
   const Components = useComponentsContext();
@@ -72,6 +74,7 @@ const TableColorPicker = (props: TableHandleMenuProps) => {
   }
 
   const firstCell = mapTableCell(currentCells[0].cell);
+  /** Applies a text or background color to every selected table cell. */
   const updateColor = (color: string, type: 'text' | 'background') => {
     const rows = props.block.content.rows.map((row) => ({
       ...row,
@@ -147,6 +150,7 @@ const TableColorPicker = (props: TableHandleMenuProps) => {
   );
 };
 
+/** Extends the table handle menu with an action that removes the full table. */
 const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
   const editor = useBlockNoteEditor();
   const Components = useComponentsContext();
@@ -160,6 +164,7 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
       ? Boolean(props.block.content.headerRows)
       : Boolean(props.block.content.headerCols);
 
+  /** Toggles the first row or column as a table header. */
   const toggleHeader = () => {
     const block = editor.getBlock(props.block.id);
 
@@ -212,6 +217,7 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
   );
 };
 
+/** Renders BlockNote's table handle with the extended removal menu. */
 export const TableHandleWithRemove = (props: TableHandleProps) => {
   return (
     <TableHandle {...props} tableHandleMenu={TableHandleMenuWithRemove}>

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
@@ -26,7 +26,6 @@ const COLORS = [
   'pink',
 ] as const;
 
-/** Renders the color swatch used by the table cell color menu. */
 const ColorIcon = ({
   backgroundColor = 'default',
   textColor = 'default',
@@ -53,7 +52,6 @@ const ColorIcon = ({
   </span>
 );
 
-/** Renders text and background color controls for the selected table cells. */
 const TableColorPicker = (props: TableHandleMenuProps) => {
   const editor = useBlockNoteEditor();
   const Components = useComponentsContext();
@@ -74,7 +72,6 @@ const TableColorPicker = (props: TableHandleMenuProps) => {
   }
 
   const firstCell = mapTableCell(currentCells[0].cell);
-  /** Applies a text or background color to every selected table cell. */
   const updateColor = (color: string, type: 'text' | 'background') => {
     const rows = props.block.content.rows.map((row) => ({
       ...row,
@@ -150,12 +147,11 @@ const TableColorPicker = (props: TableHandleMenuProps) => {
   );
 };
 
-/** Extends the table handle menu with an action that removes the full table. */
 const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
   const editor = useBlockNoteEditor();
   const Components = useComponentsContext();
 
-  if (!Components) {
+  if (!Components || !props.block?.content) {
     return null;
   }
 
@@ -164,7 +160,6 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
       ? Boolean(props.block.content.headerRows)
       : Boolean(props.block.content.headerCols);
 
-  /** Toggles the first row or column as a table header. */
   const toggleHeader = () => {
     const block = editor.getBlock(props.block.id);
 
@@ -209,9 +204,19 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
       <Components.Generic.Menu.Divider />
       <Components.Generic.Menu.Item
         className="bn-menu-item"
-        onClick={() =>
-          editor.replaceBlocks([props.block.id], [{ type: 'paragraph' }])
-        }
+        onClick={() => {
+          requestAnimationFrame(() => {
+            const block = editor.getBlock(props.block.id);
+            if (block?.type !== 'table') return;
+
+            const { insertedBlocks } = editor.replaceBlocks(
+              [block],
+              [{ type: 'paragraph' }],
+            );
+            editor.setTextCursorPosition(insertedBlocks[0], 'start');
+            editor.focus();
+          });
+        }}
       >
         Delete table
       </Components.Generic.Menu.Item>
@@ -219,10 +224,14 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
   );
 };
 
-/** Renders BlockNote's table handle with the extended removal menu. */
 export const TableHandleWithRemove = (props: TableHandleProps) => {
   return (
-    <TableHandle {...props} tableHandleMenu={TableHandleMenuWithRemove}>
+    <TableHandle
+      {...props}
+      tableHandleMenu={
+        TableHandleMenuWithRemove as unknown as TableHandleProps['tableHandleMenu']
+      }
+    >
       <IconGripVertical size={24} data-test="tableHandle" />
     </TableHandle>
   );

--- a/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
+++ b/frontend/libs/erxes-ui/src/modules/blocks/components/TableHandleWithRemove.tsx
@@ -209,7 +209,9 @@ const TableHandleMenuWithRemove = (props: TableHandleMenuProps) => {
       <Components.Generic.Menu.Divider />
       <Components.Generic.Menu.Item
         className="bn-menu-item"
-        onClick={() => editor.removeBlocks([props.block])}
+        onClick={() =>
+          editor.replaceBlocks([props.block.id], [{ type: 'paragraph' }])
+        }
       >
         Delete table
       </Components.Generic.Menu.Item>


### PR DESCRIPTION
## Summary

- add reusable retry states for document list and detail query failures
- distinguish filtered document empty states and allow filters to be cleared
- add barcode attribute previews and complete table controls, including table removal

## Validation

- `pnpm nx build core-ui`
- `pnpm nx test core-ui --runInBand` (5 suites, 19 tests passed)
- `pnpm nx lint erxes-ui`
- focused ESLint checks for all nine changed files
- `git diff --check`

## Notes

- Project-wide `core-ui` lint remains blocked by pre-existing violations outside the changed document paths.
- `erxes-ui` has no build target; its test target is the existing placeholder script.

## Summary by Sourcery

Improve document browsing and editing with resilient query states, clearer filtered results, richer barcode attributes, and complete table controls.

New Features:
- Add resizable barcode attribute previews with support for product barcode images and configurable rendered dimensions.
- Extend editor table controls with row and column management, headers, cell colors, and full-table removal.

Bug Fixes:
- Provide retryable error states for document list and detail query failures.
- Differentiate unfiltered and filtered document empty states and allow users to clear active filters.

Enhancements:
- Improve barcode rendering safety and flexibility for document product replacements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry-enabled error states when documents fail to load.
  * Added filter-aware empty states with a “Clear filters” action.
  * Added custom table controls for rows, columns, headers, colors, and tables.
  * Added resizable barcode previews and support for product barcode images.
  * Added configurable barcode sizing.

* **Bug Fixes**
  * Improved document loading error detection and recovery across list and detail views.

* **Localization**
  * Added filtered-empty-state translations in English and Mongolian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->