### PR TITLE
fix: attach per-row cursor in paginate utils; add sessionStorage recovery in RecordTable (#8853)

### DIFF
--- a/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
@@ -1,0 +1,95 @@
+import { cursorPaginate, cursorPaginateAggregation } from './mongoose-utils';
+import { decodeCursor } from './cursor-util';
+
+describe('cursorPaginate per-row cursor generation', () => {
+  const mockItems = [
+    { _id: 'item1', name: 'First Item', createdAt: new Date('2026-01-01') },
+    { _id: 'item2', name: 'Second Item', createdAt: new Date('2026-01-02') },
+    { _id: 'item3', name: 'Third Item', createdAt: new Date('2026-01-03') },
+  ];
+
+  const createMockModel = (items = mockItems) => ({
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([...items]),
+        }),
+      }),
+    }),
+    countDocuments: jest.fn().mockResolvedValue(items.length),
+  });
+
+  const createMockAggregationModel = (items = mockItems) => ({
+    aggregate: jest.fn().mockImplementation((pipeline: any[]) => {
+      // If it's a count pipeline
+      if (pipeline.some((stage) => stage.$count)) {
+        return Promise.resolve([{ totalCount: items.length }]);
+      }
+      return Promise.resolve([...items]);
+    }),
+  });
+
+  test('cursorPaginate attaches an opaque cursor to every returned item in list', async () => {
+    const mockModel = createMockModel();
+    const result = await cursorPaginate<any>({
+      model: mockModel as any,
+      params: { limit: 10, orderBy: { createdAt: 1 } },
+    });
+
+    expect(result.list).toHaveLength(3);
+
+    result.list.forEach((item: any, index: number) => {
+      expect(item).toHaveProperty('cursor');
+      expect(typeof item.cursor).toBe('string');
+      expect(item.cursor.length).toBeGreaterThan(0);
+
+      // Decoding the cursor should yield the item's _id and sort field
+      const decoded = decodeCursor(item.cursor);
+      expect(decoded._id).toBe(mockItems[index]._id);
+      expect(decoded.createdAt).toBe(mockItems[index].createdAt.toISOString());
+    });
+
+    // startCursor and endCursor should match first and last item cursors
+    expect(result.pageInfo.startCursor).toBe((result.list[0] as any).cursor);
+    expect(result.pageInfo.endCursor).toBe(
+      (result.list[result.list.length - 1] as any).cursor,
+    );
+  });
+
+  test('cursorPaginate handles empty results gracefully', async () => {
+    const mockModel = createMockModel([]);
+    const result = await cursorPaginate<any>({
+      model: mockModel as any,
+      params: { limit: 10 },
+    });
+
+    expect(result.list).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.pageInfo.startCursor).toBeNull();
+    expect(result.pageInfo.endCursor).toBeNull();
+  });
+
+  test('cursorPaginateAggregation attaches an opaque cursor to every returned item in list', async () => {
+    const mockModel = createMockAggregationModel();
+    const result = await cursorPaginateAggregation<any>({
+      model: mockModel as any,
+      params: { limit: 10, orderBy: { name: 1 } },
+    });
+
+    expect(result.list).toHaveLength(3);
+
+    result.list.forEach((item: any, index: number) => {
+      expect(item).toHaveProperty('cursor');
+      expect(typeof item.cursor).toBe('string');
+
+      const decoded = decodeCursor(item.cursor);
+      expect(decoded._id).toBe(mockItems[index]._id);
+      expect(decoded.name).toBe(mockItems[index].name);
+    });
+
+    expect(result.pageInfo.startCursor).toBe((result.list[0] as any).cursor);
+    expect(result.pageInfo.endCursor).toBe(
+      (result.list[result.list.length - 1] as any).cursor,
+    );
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
@@ -1,14 +1,23 @@
+import type { Model, PipelineStage } from 'mongoose';
 import { cursorPaginate, cursorPaginateAggregation } from './mongoose-utils';
 import { decodeCursor } from './cursor-util';
 
+interface MockItem {
+  _id: string;
+  name: string;
+  createdAt: Date;
+}
+
+type MockItemWithCursor = MockItem & { cursor: string };
+
 describe('cursorPaginate per-row cursor generation', () => {
-  const mockItems = [
+  const mockItems: MockItem[] = [
     { _id: 'item1', name: 'First Item', createdAt: new Date('2026-01-01') },
     { _id: 'item2', name: 'Second Item', createdAt: new Date('2026-01-02') },
     { _id: 'item3', name: 'Third Item', createdAt: new Date('2026-01-03') },
   ];
 
-  const createMockModel = (items = mockItems) => ({
+  const createMockModel = (items: MockItem[] = mockItems): unknown => ({
     find: jest.fn().mockReturnValue({
       sort: jest.fn().mockReturnValue({
         limit: jest.fn().mockReturnValue({
@@ -19,10 +28,9 @@ describe('cursorPaginate per-row cursor generation', () => {
     countDocuments: jest.fn().mockResolvedValue(items.length),
   });
 
-  const createMockAggregationModel = (items = mockItems) => ({
-    aggregate: jest.fn().mockImplementation((pipeline: any[]) => {
-      // If it's a count pipeline
-      if (pipeline.some((stage) => stage.$count)) {
+  const createMockAggregationModel = (items: MockItem[] = mockItems): unknown => ({
+    aggregate: jest.fn().mockImplementation((pipeline: PipelineStage[]) => {
+      if (pipeline.some((stage) => '$count' in stage)) {
         return Promise.resolve([{ totalCount: items.length }]);
       }
       return Promise.resolve([...items]);
@@ -31,35 +39,36 @@ describe('cursorPaginate per-row cursor generation', () => {
 
   test('cursorPaginate attaches an opaque cursor to every returned item in list', async () => {
     const mockModel = createMockModel();
-    const result = await cursorPaginate<any>({
-      model: mockModel as any,
+    const result = await cursorPaginate<MockItem>({
+      model: mockModel as Model<MockItem>,
       params: { limit: 10, orderBy: { createdAt: 1 } },
     });
 
     expect(result.list).toHaveLength(3);
 
-    result.list.forEach((item: any, index: number) => {
-      expect(item).toHaveProperty('cursor');
-      expect(typeof item.cursor).toBe('string');
-      expect(item.cursor.length).toBeGreaterThan(0);
+    result.list.forEach((item, index) => {
+      const withCursor = item as MockItemWithCursor;
+      expect(withCursor).toHaveProperty('cursor');
+      expect(typeof withCursor.cursor).toBe('string');
+      expect(withCursor.cursor.length).toBeGreaterThan(0);
 
       // Decoding the cursor should yield the item's _id and sort field
-      const decoded = decodeCursor(item.cursor);
+      const decoded = decodeCursor(withCursor.cursor);
       expect(decoded._id).toBe(mockItems[index]._id);
       expect(decoded.createdAt).toBe(mockItems[index].createdAt.toISOString());
     });
 
     // startCursor and endCursor should match first and last item cursors
-    expect(result.pageInfo.startCursor).toBe((result.list[0] as any).cursor);
-    expect(result.pageInfo.endCursor).toBe(
-      (result.list[result.list.length - 1] as any).cursor,
-    );
+    const first = result.list[0] as MockItemWithCursor;
+    const last = result.list[result.list.length - 1] as MockItemWithCursor;
+    expect(result.pageInfo.startCursor).toBe(first.cursor);
+    expect(result.pageInfo.endCursor).toBe(last.cursor);
   });
 
   test('cursorPaginate handles empty results gracefully', async () => {
     const mockModel = createMockModel([]);
-    const result = await cursorPaginate<any>({
-      model: mockModel as any,
+    const result = await cursorPaginate<MockItem>({
+      model: mockModel as Model<MockItem>,
       params: { limit: 10 },
     });
 
@@ -71,25 +80,26 @@ describe('cursorPaginate per-row cursor generation', () => {
 
   test('cursorPaginateAggregation attaches an opaque cursor to every returned item in list', async () => {
     const mockModel = createMockAggregationModel();
-    const result = await cursorPaginateAggregation<any>({
-      model: mockModel as any,
+    const result = await cursorPaginateAggregation<MockItem>({
+      model: mockModel as Model<MockItem>,
       params: { limit: 10, orderBy: { name: 1 } },
     });
 
     expect(result.list).toHaveLength(3);
 
-    result.list.forEach((item: any, index: number) => {
-      expect(item).toHaveProperty('cursor');
-      expect(typeof item.cursor).toBe('string');
+    result.list.forEach((item, index) => {
+      const withCursor = item as MockItemWithCursor;
+      expect(withCursor).toHaveProperty('cursor');
+      expect(typeof withCursor.cursor).toBe('string');
 
-      const decoded = decodeCursor(item.cursor);
+      const decoded = decodeCursor(withCursor.cursor);
       expect(decoded._id).toBe(mockItems[index]._id);
       expect(decoded.name).toBe(mockItems[index].name);
     });
 
-    expect(result.pageInfo.startCursor).toBe((result.list[0] as any).cursor);
-    expect(result.pageInfo.endCursor).toBe(
-      (result.list[result.list.length - 1] as any).cursor,
-    );
+    const first = result.list[0] as MockItemWithCursor;
+    const last = result.list[result.list.length - 1] as MockItemWithCursor;
+    expect(result.pageInfo.startCursor).toBe(first.cursor);
+    expect(result.pageInfo.endCursor).toBe(last.cursor);
   });
 });

--- a/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
@@ -34,7 +34,7 @@ export interface PageInfo {
 }
 
 export interface CursorResult<T> {
-  list: T[];
+  list: (T & { cursor?: string })[];
   totalCount: number;
   pageInfo: PageInfo;
 }

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -95,6 +95,25 @@ export const defaultPaginate = (
   return collection.limit(_limit).skip((_page - 1) * _limit);
 };
 
+/** @internal Shape of a mongoose document or plain lean object accepted by attachCursors. */
+type DocLike = Record<string, unknown> & { toObject?: () => Record<string, unknown> };
+
+/**
+ * Maps a list of mongoose documents or lean objects to plain objects,
+ * each augmented with an opaque base64-encoded `cursor` string.
+ * Extracted as a shared helper to avoid duplication between cursorPaginate
+ * and cursorPaginateAggregation.
+ */
+const attachCursors = <T>(
+  items: T[],
+  sortFields: string[],
+): (Record<string, unknown> & { cursor: string })[] =>
+  items.map((item) => {
+    const doc = item as unknown as DocLike;
+    const plain = typeof doc.toObject === 'function' ? doc.toObject() : doc;
+    return { ...plain, cursor: encodeCursor(doc, sortFields) };
+  });
+
 export const cursorPaginate = async <T extends Document>({
   model,
   params,
@@ -147,10 +166,7 @@ export const cursorPaginate = async <T extends Document>({
     list = list.reverse();
   }
 
-  const listWithCursor = list.map((item: any) => ({
-    ...(typeof item?.toObject === 'function' ? item.toObject() : item),
-    cursor: encodeCursor(item, sortFields),
-  }));
+  const listWithCursor = attachCursors(list, sortFields);
 
   const startCursor =
     listWithCursor.length > 0 ? listWithCursor[0].cursor : null;
@@ -238,10 +254,7 @@ export async function cursorPaginateAggregation<T>({
     list = list.reverse();
   }
 
-  const listWithCursor = list.map((item: any) => ({
-    ...(typeof item?.toObject === 'function' ? item.toObject() : item),
-    cursor: encodeCursor(item, sortFields),
-  }));
+  const listWithCursor = attachCursors(list, sortFields);
 
   const startCursor =
     listWithCursor.length > 0 ? listWithCursor[0].cursor : null;

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -147,10 +147,17 @@ export const cursorPaginate = async <T extends Document>({
     list = list.reverse();
   }
 
+  const listWithCursor = list.map((item: any) => ({
+    ...(typeof item?.toObject === 'function' ? item.toObject() : item),
+    cursor: encodeCursor(item, sortFields),
+  }));
+
   const startCursor =
-    list.length > 0 ? encodeCursor(list[0], sortFields) : null;
+    listWithCursor.length > 0 ? listWithCursor[0].cursor : null;
   const endCursor =
-    list.length > 0 ? encodeCursor(list[list.length - 1], sortFields) : null;
+    listWithCursor.length > 0
+      ? listWithCursor[listWithCursor.length - 1].cursor
+      : null;
 
   const pageInfo: PageInfo = {
     hasNextPage: direction === 'forward' ? hasMore : Boolean(cursor),
@@ -160,7 +167,7 @@ export const cursorPaginate = async <T extends Document>({
   };
 
   return {
-    list: list as T[],
+    list: listWithCursor as T[],
     totalCount,
     pageInfo,
   };
@@ -231,11 +238,17 @@ export async function cursorPaginateAggregation<T>({
     list = list.reverse();
   }
 
-  // --- cursors ---
+  const listWithCursor = list.map((item: any) => ({
+    ...(typeof item?.toObject === 'function' ? item.toObject() : item),
+    cursor: encodeCursor(item, sortFields),
+  }));
+
   const startCursor =
-    list.length > 0 ? encodeCursor(list[0], sortFields) : null;
+    listWithCursor.length > 0 ? listWithCursor[0].cursor : null;
   const endCursor =
-    list.length > 0 ? encodeCursor(list[list.length - 1], sortFields) : null;
+    listWithCursor.length > 0
+      ? listWithCursor[listWithCursor.length - 1].cursor
+      : null;
 
   const pageInfo: PageInfo = {
     hasNextPage: direction === 'forward' ? hasMore : Boolean(cursor),
@@ -245,7 +258,7 @@ export async function cursorPaginateAggregation<T>({
   };
 
   return {
-    list,
+    list: listWithCursor,
     totalCount,
     pageInfo,
   };

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
@@ -37,7 +37,12 @@ export const RecordTableCursorProvider = ({
   const handleScroll = () => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     const firstVisibleRow = scrollRef.current?.querySelector('.in-view');
-    if (firstVisibleRow && sessionKey) {
+    if (
+      firstVisibleRow &&
+      sessionKey &&
+      firstVisibleRow.id &&
+      firstVisibleRow.id.trim() !== ''
+    ) {
       sessionStorage.setItem(sessionKey, firstVisibleRow.id);
     }
     debounceTimer.current = setTimeout(() => {

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.test.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, act } from '@testing-library/react';
+import { isValidCursor, useRecordTableCursor } from './useRecordTableCursor';
+
+describe('useRecordTableCursor and isValidCursor', () => {
+  const validCursorData = { _id: '6a501ddb0bd4990d2351f352', createdAt: '2026-01-01T00:00:00.000Z' };
+  const validBase64Cursor = Buffer.from(JSON.stringify(validCursorData)).toString('base64');
+  const legacyRawId = '6a501ddb0bd4990d2351f352';
+
+  describe('isValidCursor', () => {
+    test('returns true for a valid base64 JSON cursor with _id', () => {
+      expect(isValidCursor(validBase64Cursor)).toBe(true);
+    });
+
+    test('returns false for legacy raw Mongo _id', () => {
+      expect(isValidCursor(legacyRawId)).toBe(false);
+    });
+
+    test('returns false for empty string or whitespace', () => {
+      expect(isValidCursor('')).toBe(false);
+      expect(isValidCursor('   ')).toBe(false);
+    });
+
+    test('returns false for malformed base64 or non-JSON content', () => {
+      expect(isValidCursor('not-base-64!!@@')).toBe(false);
+      const nonJsonBase64 = Buffer.from('hello plain text').toString('base64');
+      expect(isValidCursor(nonJsonBase64)).toBe(false);
+    });
+
+    test('returns false for JSON object missing _id', () => {
+      const missingIdBase64 = Buffer.from(JSON.stringify({ createdAt: '2026-01-01' })).toString('base64');
+      expect(isValidCursor(missingIdBase64)).toBe(false);
+    });
+
+    test('returns false for JSON array or primitive value', () => {
+      const arrayBase64 = Buffer.from(JSON.stringify(['item1', 'item2'])).toString('base64');
+      expect(isValidCursor(arrayBase64)).toBe(false);
+    });
+  });
+
+  describe('useRecordTableCursor sessionStorage recovery', () => {
+    const sessionKey = 'test_customers_table';
+    const scrollKey = `${sessionKey}_scroll`;
+
+    beforeEach(() => {
+      sessionStorage.clear();
+      jest.clearAllMocks();
+    });
+
+    test('loads valid cursor from sessionStorage', () => {
+      sessionStorage.setItem(sessionKey, validBase64Cursor);
+
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe(validBase64Cursor);
+    });
+
+    test('clears legacy raw ID from sessionStorage and falls back to empty cursor', () => {
+      sessionStorage.setItem(sessionKey, legacyRawId);
+      sessionStorage.setItem(scrollKey, '450');
+
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      // Invalid/legacy cursor should be cleared and reset to empty string (first page)
+      expect(result.current.cursor).toBe('');
+      expect(sessionStorage.getItem(sessionKey)).toBeNull();
+      expect(sessionStorage.getItem(scrollKey)).toBeNull();
+    });
+
+    test('clears corrupted string from sessionStorage and falls back to empty cursor', () => {
+      sessionStorage.setItem(sessionKey, 'corrupted_garbage_value');
+      sessionStorage.setItem(scrollKey, '100');
+
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe('');
+      expect(sessionStorage.getItem(sessionKey)).toBeNull();
+      expect(sessionStorage.getItem(scrollKey)).toBeNull();
+    });
+
+    test('initializes with empty cursor when sessionStorage is empty', () => {
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe('');
+    });
+
+    test('allows manually setting cursor', () => {
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      act(() => {
+        result.current.setCursor(validBase64Cursor);
+      });
+
+      expect(result.current.cursor).toBe(validBase64Cursor);
+    });
+  });
+});

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
@@ -1,6 +1,28 @@
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { recordTableCursorAtomFamily } from '../states/RecordTableCursorState';
+
+export const isValidCursor = (cursor: string): boolean => {
+  if (!cursor || typeof cursor !== 'string' || !cursor.trim()) {
+    return false;
+  }
+  try {
+    const jsonStr =
+      typeof window !== 'undefined' && typeof window.atob === 'function'
+        ? window.atob(cursor)
+        : Buffer.from(cursor, 'base64').toString('utf-8');
+    const decoded = JSON.parse(jsonStr);
+    return (
+      typeof decoded === 'object' &&
+      decoded !== null &&
+      !Array.isArray(decoded) &&
+      Boolean(decoded._id)
+    );
+  } catch {
+    return false;
+  }
+};
+
 export const useRecordTableCursor = ({
   sessionKey,
 }: {
@@ -12,7 +34,22 @@ export const useRecordTableCursor = ({
 
   useEffect(() => {
     if (!sessionKey) return;
-    setCursor(sessionStorage.getItem(sessionKey) || '');
+    try {
+      const stored = sessionStorage.getItem(sessionKey);
+      if (!stored) {
+        setCursor('');
+        return;
+      }
+      if (isValidCursor(stored)) {
+        setCursor(stored);
+      } else {
+        sessionStorage.removeItem(sessionKey);
+        sessionStorage.removeItem(`${sessionKey}_scroll`);
+        setCursor('');
+      }
+    } catch {
+      setCursor('');
+    }
   }, [sessionKey, setCursor]);
 
   return {

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
@@ -2,6 +2,14 @@ import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { recordTableCursorAtomFamily } from '../states/RecordTableCursorState';
 
+/**
+ * Validates that a value retrieved from `sessionStorage` is a properly formed
+ * cursor token — a base64-encoded JSON object that contains an `_id` field.
+ *
+ * Returns `false` for legacy raw Mongo ObjectId strings, empty values, JSON
+ * arrays or primitives, and any corrupted or non-base64 content, ensuring the
+ * table always falls back to the first page rather than rendering blank.
+ */
 export const isValidCursor = (cursor: string): boolean => {
   if (!cursor || typeof cursor !== 'string' || !cursor.trim()) {
     return false;


### PR DESCRIPTION
## Summary

Fixes #8853 — RecordTable renders blank when opened at scale due to stale/invalid cursors in `sessionStorage`.

### Root Cause
- `cursorPaginate` and `cursorPaginateAggregation` did not attach a cursor token to each returned item, so rows had no stable cursor identity.
- `useRecordTableCursor` blindly restored any value from `sessionStorage` (including legacy raw Mongo `_id` strings and empty strings), causing the table to request an invalid page and render blank.

### Changes

**Backend (`erxes-api-shared`)**
- `cursorPaginate` / `cursorPaginateAggregation`: Each item in `list` now includes a `cursor` field — an opaque base64-encoded JSON string of its sort fields + `_id`.
- `CursorResult<T>` interface: `list` typed as `(T & { cursor?: string })[]` — backwards-compatible.

**Frontend (`erxes-ui`)**
- `RecordTableCursor.tsx` — `handleScroll`: Added guard to skip `sessionStorage.setItem` when `firstVisibleRow.id` is empty or whitespace.
- `useRecordTableCursor.tsx` — Added `isValidCursor()` helper (exported for testing). On mount, if `sessionStorage` contains an invalid or legacy cursor (e.g. raw Mongo ID like `6a501ddb0bd4990d2351f352`), it is removed along with the paired `_scroll` key and the cursor resets to `''` (first page fallback).

### Tests Added
- `cursor-paginate.test.ts` — verifies per-row cursor attachment and correct decoding for both `cursorPaginate` and `cursorPaginateAggregation`.
- `useRecordTableCursor.test.ts` — verifies `isValidCursor` edge cases and `sessionStorage` recovery flow (valid cursor, legacy raw ID, corrupted string, empty).

### Checklist
- [x] Follows project code style
- [x] No debug/console.log left in production code  
- [x] Backwards-compatible (existing consumers unaffected)
- [x] Tests added for new behavior

## Summary by Sourcery

Stabilize RecordTable cursor pagination by providing row-level cursors and recovering safely from invalid persisted cursor state.

Bug Fixes:
- Prevent RecordTable from rendering blank by rejecting stale, legacy, corrupted, or empty sessionStorage cursors and falling back to the first page.
- Avoid persisting empty row identifiers during RecordTable scrolling.

Enhancements:
- Attach opaque per-row cursors to cursor-paginated and aggregation results and use them for page boundaries.
- Extend cursor result typing to support optional per-row cursor fields.

Tests:
- Add coverage for per-row cursor generation, cursor decoding, empty pagination results, and sessionStorage cursor recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Paginated records now include encoded cursors on individual items, supporting reliable navigation.
  - Saved table cursors are validated and automatically cleared when invalid, outdated, or corrupted.
  - Record-table scrolling no longer saves blank row identifiers.

- **Bug Fixes**
  - Cursor storage errors are handled safely without interrupting navigation.

- **Tests**
  - Expanded coverage for cursor pagination, cursor validation, storage recovery, and scroll-position handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->