### PR TITLE
fix: attach per-row cursor in paginate utils; add sessionStorage recovery in RecordTable (#8853)

### DIFF
--- a/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-paginate.test.ts
@@ -1,0 +1,98 @@
+import type { Model, PipelineStage } from 'mongoose';
+import { cursorPaginate, cursorPaginateAggregation } from './mongoose-utils';
+import { decodeCursor } from './cursor-util';
+
+interface MockItem {
+  _id: string;
+  name: string;
+  createdAt: Date;
+}
+
+type MockItemWithCursor = MockItem & { cursor: string };
+
+describe('cursorPaginate per-row cursor generation', () => {
+  const mockItems: MockItem[] = [
+    { _id: 'item1', name: 'First Item', createdAt: new Date('2026-01-01') },
+    { _id: 'item2', name: 'Second Item', createdAt: new Date('2026-01-02') },
+    { _id: 'item3', name: 'Third Item', createdAt: new Date('2026-01-03') },
+  ];
+
+  const createMockModel = (items: MockItem[] = mockItems): unknown => ({
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([...items]),
+        }),
+      }),
+    }),
+    countDocuments: jest.fn().mockResolvedValue(items.length),
+  });
+
+  const createMockAggregationModel = (items: MockItem[] = mockItems): unknown => ({
+    aggregate: jest.fn().mockImplementation((pipeline: PipelineStage[]) => {
+      if (pipeline.some((stage) => '$count' in stage)) {
+        return Promise.resolve([{ totalCount: items.length }]);
+      }
+      return Promise.resolve([...items]);
+    }),
+  });
+
+  const verifyListWithCursors = (
+    result: { list: unknown[]; pageInfo: { startCursor: string | null; endCursor: string | null } },
+    assertCustomField: (decoded: Record<string, unknown>, index: number) => void,
+  ) => {
+    expect(result.list).toHaveLength(mockItems.length);
+    result.list.forEach((item, index) => {
+      const withCursor = item as MockItemWithCursor;
+      expect(withCursor).toHaveProperty('cursor');
+      expect(typeof withCursor.cursor).toBe('string');
+      expect(withCursor.cursor.length).toBeGreaterThan(0);
+
+      const decoded = decodeCursor(withCursor.cursor);
+      expect(decoded._id).toBe(mockItems[index]._id);
+      assertCustomField(decoded, index);
+    });
+
+    const first = result.list[0] as MockItemWithCursor;
+    const last = result.list[result.list.length - 1] as MockItemWithCursor;
+    expect(result.pageInfo.startCursor).toBe(first.cursor);
+    expect(result.pageInfo.endCursor).toBe(last.cursor);
+  };
+
+  test('cursorPaginate attaches an opaque cursor to every returned item in list', async () => {
+    const mockModel = createMockModel();
+    const result = await cursorPaginate<MockItem>({
+      model: mockModel as Model<MockItem>,
+      params: { limit: 10, orderBy: { createdAt: 1 } },
+    });
+
+    verifyListWithCursors(result, (decoded, index) => {
+      expect(decoded.createdAt).toBe(mockItems[index].createdAt.toISOString());
+    });
+  });
+
+  test('cursorPaginate handles empty results gracefully', async () => {
+    const mockModel = createMockModel([]);
+    const result = await cursorPaginate<MockItem>({
+      model: mockModel as Model<MockItem>,
+      params: { limit: 10 },
+    });
+
+    expect(result.list).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.pageInfo.startCursor).toBeNull();
+    expect(result.pageInfo.endCursor).toBeNull();
+  });
+
+  test('cursorPaginateAggregation attaches an opaque cursor to every returned item in list', async () => {
+    const mockModel = createMockAggregationModel();
+    const result = await cursorPaginateAggregation<MockItem>({
+      model: mockModel as Model<MockItem>,
+      params: { limit: 10, orderBy: { name: 1 } },
+    });
+
+    verifyListWithCursors(result, (decoded, index) => {
+      expect(decoded.name).toBe(mockItems[index].name);
+    });
+  });
+});

--- a/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/cursor-util.ts
@@ -34,7 +34,7 @@ export interface PageInfo {
 }
 
 export interface CursorResult<T> {
-  list: T[];
+  list: (T & { cursor?: string })[];
   totalCount: number;
   pageInfo: PageInfo;
 }

--- a/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
+++ b/backend/erxes-api-shared/src/utils/mongo/mongoose-utils.ts
@@ -95,6 +95,75 @@ export const defaultPaginate = (
   return collection.limit(_limit).skip((_page - 1) * _limit);
 };
 
+/** @internal Shape of a mongoose document or plain lean object accepted by attachCursors. */
+type DocLike = Record<string, unknown> & { toObject?: () => Record<string, unknown> };
+
+/**
+ * Maps a list of mongoose documents or lean objects to plain objects,
+ * each augmented with an opaque base64-encoded `cursor` string.
+ */
+const attachCursors = <T>(
+  items: T[],
+  sortFields: string[],
+): (Record<string, unknown> & { cursor: string })[] =>
+  items.map((item) => {
+    const doc = item as unknown as DocLike;
+    const plain = typeof doc.toObject === 'function' ? doc.toObject() : doc;
+    return { ...plain, cursor: encodeCursor(doc, sortFields) };
+  });
+
+interface BuildCursorResultParams<T> {
+  rawItems: T[];
+  limit: number;
+  totalCount: number;
+  sortFields: string[];
+  direction: 'forward' | 'backward';
+  cursor?: string;
+}
+
+/**
+ * Constructs a standardized CursorResult<T> with boundary cursors,
+ * per-item cursors, and forward/backward pagination indicators.
+ * Shared by cursorPaginate and cursorPaginateAggregation to eliminate duplication.
+ */
+const buildCursorResult = <T>({
+  rawItems,
+  limit,
+  totalCount,
+  sortFields,
+  direction,
+  cursor,
+}: BuildCursorResultParams<T>): CursorResult<T> => {
+  const hasMore = rawItems.length > limit;
+  let list = hasMore ? rawItems.slice(0, limit) : rawItems;
+
+  if (direction === 'backward') {
+    list = list.reverse();
+  }
+
+  const listWithCursor = attachCursors(list, sortFields);
+
+  const startCursor =
+    listWithCursor.length > 0 ? listWithCursor[0].cursor : null;
+  const endCursor =
+    listWithCursor.length > 0
+      ? listWithCursor[listWithCursor.length - 1].cursor
+      : null;
+
+  const pageInfo: PageInfo = {
+    hasNextPage: direction === 'forward' ? hasMore : Boolean(cursor),
+    hasPreviousPage: direction === 'backward' ? hasMore : Boolean(cursor),
+    startCursor,
+    endCursor,
+  };
+
+  return {
+    list: listWithCursor as unknown as (T & { cursor?: string })[],
+    totalCount,
+    pageInfo,
+  };
+};
+
 export const cursorPaginate = async <T extends Document>({
   model,
   params,
@@ -140,30 +209,14 @@ export const cursorPaginate = async <T extends Document>({
     model.countDocuments(query as FilterQuery<T>),
   ]);
 
-  const hasMore = items.length > limit;
-  let list = hasMore ? items.slice(0, limit) : items;
-
-  if (direction === 'backward') {
-    list = list.reverse();
-  }
-
-  const startCursor =
-    list.length > 0 ? encodeCursor(list[0], sortFields) : null;
-  const endCursor =
-    list.length > 0 ? encodeCursor(list[list.length - 1], sortFields) : null;
-
-  const pageInfo: PageInfo = {
-    hasNextPage: direction === 'forward' ? hasMore : Boolean(cursor),
-    hasPreviousPage: direction === 'backward' ? hasMore : Boolean(cursor),
-    startCursor,
-    endCursor,
-  };
-
-  return {
-    list: list as T[],
+  return buildCursorResult<T>({
+    rawItems: items as unknown as T[],
+    limit,
     totalCount,
-    pageInfo,
-  };
+    sortFields,
+    direction,
+    cursor,
+  });
 };
 
 export async function cursorPaginateAggregation<T>({
@@ -224,31 +277,14 @@ export async function cursorPaginateAggregation<T>({
   const totalCount = countResult[0]?.totalCount ?? 0;
 
   // --- slice list for hasNextPage ---
-  const hasMore = listRaw.length > limit;
-  let list = hasMore ? listRaw.slice(0, limit) : listRaw;
-
-  if (direction === 'backward') {
-    list = list.reverse();
-  }
-
-  // --- cursors ---
-  const startCursor =
-    list.length > 0 ? encodeCursor(list[0], sortFields) : null;
-  const endCursor =
-    list.length > 0 ? encodeCursor(list[list.length - 1], sortFields) : null;
-
-  const pageInfo: PageInfo = {
-    hasNextPage: direction === 'forward' ? hasMore : Boolean(cursor),
-    hasPreviousPage: direction === 'backward' ? hasMore : Boolean(cursor),
-    startCursor,
-    endCursor,
-  };
-
-  return {
-    list,
+  return buildCursorResult<T>({
+    rawItems: listRaw,
+    limit,
     totalCount,
-    pageInfo,
-  };
+    sortFields,
+    direction,
+    cursor,
+  });
 }
 
 export const checkCollectionCodeDuplication = async (

--- a/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/components/RecordTableCursor.tsx
@@ -37,7 +37,12 @@ export const RecordTableCursorProvider = ({
   const handleScroll = () => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     const firstVisibleRow = scrollRef.current?.querySelector('.in-view');
-    if (firstVisibleRow && sessionKey) {
+    if (
+      firstVisibleRow &&
+      sessionKey &&
+      firstVisibleRow.id &&
+      firstVisibleRow.id.trim() !== ''
+    ) {
       sessionStorage.setItem(sessionKey, firstVisibleRow.id);
     }
     debounceTimer.current = setTimeout(() => {

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.test.ts
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, act } from '@testing-library/react';
+import { isValidCursor, useRecordTableCursor } from './useRecordTableCursor';
+
+describe('useRecordTableCursor and isValidCursor', () => {
+  const validCursorData = { _id: '6a501ddb0bd4990d2351f352', createdAt: '2026-01-01T00:00:00.000Z' };
+  const validBase64Cursor = Buffer.from(JSON.stringify(validCursorData)).toString('base64');
+  const legacyRawId = '6a501ddb0bd4990d2351f352';
+
+  describe('isValidCursor', () => {
+    test('returns true for a valid base64 JSON cursor with _id', () => {
+      expect(isValidCursor(validBase64Cursor)).toBe(true);
+    });
+
+    test.each([
+      ['numeric _id 0', Buffer.from(JSON.stringify({ _id: 0 })).toString('base64')],
+      ['positive numeric _id', Buffer.from(JSON.stringify({ _id: 12345 })).toString('base64')],
+    ])('returns true for cursor with %s', (_, cursor) => {
+      expect(isValidCursor(cursor)).toBe(true);
+    });
+
+    test.each([
+      ['legacy raw Mongo _id', legacyRawId],
+      ['empty string', ''],
+      ['whitespace string', '   '],
+      ['malformed base64', 'not-base-64!!@@'],
+      ['non-JSON base64', Buffer.from('hello plain text').toString('base64')],
+      ['missing _id field', Buffer.from(JSON.stringify({ createdAt: '2026-01-01' })).toString('base64')],
+      ['JSON array', Buffer.from(JSON.stringify(['item1', 'item2'])).toString('base64')],
+      ['boolean _id', Buffer.from(JSON.stringify({ _id: true })).toString('base64')],
+      ['object _id', Buffer.from(JSON.stringify({ _id: {} })).toString('base64')],
+      ['blank string _id', Buffer.from(JSON.stringify({ _id: '   ' })).toString('base64')],
+    ])('returns false for invalid cursor: %s', (_, cursor) => {
+      expect(isValidCursor(cursor)).toBe(false);
+    });
+  });
+
+  describe('useRecordTableCursor sessionStorage recovery', () => {
+    const sessionKey = 'test_customers_table';
+    const scrollKey = `${sessionKey}_scroll`;
+
+    beforeEach(() => {
+      sessionStorage.clear();
+      jest.clearAllMocks();
+    });
+
+    test('loads valid cursor from sessionStorage', () => {
+      sessionStorage.setItem(sessionKey, validBase64Cursor);
+
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe(validBase64Cursor);
+    });
+
+    test.each([
+      ['legacy raw Mongo _id', legacyRawId, '450'],
+      ['corrupted string', 'corrupted_garbage_value', '100'],
+      ['empty string', '', '200'],
+    ])('clears %s from sessionStorage and falls back to empty cursor', (_, invalidCursor, scrollVal) => {
+      sessionStorage.setItem(sessionKey, invalidCursor);
+      sessionStorage.setItem(scrollKey, scrollVal);
+
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe('');
+      expect(sessionStorage.getItem(sessionKey)).toBeNull();
+      expect(sessionStorage.getItem(scrollKey)).toBeNull();
+    });
+
+    test('initializes with empty cursor when sessionStorage is empty', () => {
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      expect(result.current.cursor).toBe('');
+    });
+
+    test('allows manually setting cursor', () => {
+      const { result } = renderHook(() => useRecordTableCursor({ sessionKey }));
+
+      act(() => {
+        result.current.setCursor(validBase64Cursor);
+      });
+
+      expect(result.current.cursor).toBe(validBase64Cursor);
+    });
+  });
+});

--- a/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
+++ b/frontend/libs/erxes-ui/src/modules/record-table/hooks/useRecordTableCursor.tsx
@@ -1,6 +1,44 @@
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { recordTableCursorAtomFamily } from '../states/RecordTableCursorState';
+
+/**
+ * Validates that a value retrieved from `sessionStorage` is a properly formed
+ * cursor token — a base64-encoded JSON object with an own `_id` property that
+ * is a valid non-empty string or number.
+ *
+ * Returns `false` for legacy raw Mongo ObjectId strings, empty values, JSON
+ * arrays or primitives, non-string/non-numeric `_id` values, and any corrupted
+ * or non-base64 content, ensuring the table always falls back to the first page.
+ */
+export const isValidCursor = (cursor: string): boolean => {
+  if (!cursor || typeof cursor !== 'string' || !cursor.trim()) {
+    return false;
+  }
+  try {
+    const jsonStr =
+      typeof window !== 'undefined' && typeof window.atob === 'function'
+        ? window.atob(cursor)
+        : Buffer.from(cursor, 'base64').toString('utf-8');
+    const decoded = JSON.parse(jsonStr);
+    if (
+      typeof decoded !== 'object' ||
+      decoded === null ||
+      Array.isArray(decoded) ||
+      !Object.prototype.hasOwnProperty.call(decoded, '_id')
+    ) {
+      return false;
+    }
+    const id = decoded._id;
+    return (
+      (typeof id === 'string' && id.trim().length > 0) ||
+      (typeof id === 'number' && !Number.isNaN(id))
+    );
+  } catch {
+    return false;
+  }
+};
+
 export const useRecordTableCursor = ({
   sessionKey,
 }: {
@@ -12,7 +50,22 @@ export const useRecordTableCursor = ({
 
   useEffect(() => {
     if (!sessionKey) return;
-    setCursor(sessionStorage.getItem(sessionKey) || '');
+    try {
+      const stored = sessionStorage.getItem(sessionKey);
+      if (stored === null) {
+        setCursor('');
+        return;
+      }
+      if (isValidCursor(stored)) {
+        setCursor(stored);
+      } else {
+        sessionStorage.removeItem(sessionKey);
+        sessionStorage.removeItem(`${sessionKey}_scroll`);
+        setCursor('');
+      }
+    } catch {
+      setCursor('');
+    }
   }, [sessionKey, setCursor]);
 
   return {


### PR DESCRIPTION
## Summary

Fixes #8853 – RecordTable renders blank when opened at scale due to stale/invalid cursors in sessionStorage.

### Root Cause
- cursorPaginate and cursorPaginateAggregation did not attach a cursor token to each returned item, so rows had no stable cursor identity for virtualized scrolling.
- useRecordTableCursor blindly restored any value from sessionStorage (including legacy raw Mongo _id strings and empty strings), causing the table to request an invalid page and render blank.

### Changes

**Backend (erxes-api-shared)**
- mongoose-utils.ts: Extracted ttachCursors helper to map and attach opaque base64-encoded cursor tokens to each item in list across both standard and aggregation queries without duplication.
- cursor-util.ts: Updated CursorResult<T> interface: list typed as (T & { cursor?: string })[] (fully backwards-compatible).

**Frontend (erxes-ui)**
- RecordTableCursor.tsx (handleScroll): Added guard to skip sessionStorage.setItem when irstVisibleRow.id is empty or whitespace.
- useRecordTableCursor.tsx: Added documented isValidCursor() helper. On mount, if sessionStorage contains an invalid, legacy, or corrupted cursor (e.g. raw Mongo ID like 6a501ddb0bd4990d2351f352), it is automatically removed along with the paired _scroll key and the cursor resets to '' (first page fallback).

### Tests Added
- cursor-paginate.test.ts: Verifies per-row cursor attachment and correct decoding for both cursorPaginate and cursorPaginateAggregation. Fully typed with zero ny assertions.
- useRecordTableCursor.test.ts: Verifies isValidCursor edge cases and sessionStorage recovery flow (valid cursor, legacy raw ID, corrupted string, empty value).

### Checklist
- [x] Follows project code style & zero any types
- [x] No code duplication across pagination utilities
- [x] Full JSDoc documentation on exported helper
- [x] Backwards-compatible (existing consumers unaffected)
- [x] Unit tests added and passing

## Summary by Sourcery

Ensure cursor-based pagination and RecordTable state recovery remain stable when restoring and virtualizing rows.

Bug Fixes:
- Prevent RecordTable from rendering blank pages by recovering from invalid, legacy, or corrupted sessionStorage cursors and falling back to the first page.
- Persist stable per-row cursor identities for virtualized RecordTable scrolling.

Enhancements:
- Share cursor result construction across standard and aggregation pagination while exposing per-item opaque cursors and consistent page boundaries.

Tests:
- Add coverage for per-row cursor generation, cursor decoding, empty pagination results, and sessionStorage cursor recovery edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opaque cursors to paginated records, including per-record, start, and end page cursors.
  * Added validation and recovery for saved table cursors, automatically clearing invalid or legacy values.

* **Bug Fixes**
  * Prevented invalid row IDs from being saved as the first visible table row.
  * Improved consistent cursor handling across paginated results.

* **Tests**
  * Added coverage for cursor pagination, cursor validation, session recovery, and empty result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->