### PR TITLE
Fix/sales products table row edit permission

### DIFF
--- a/backend/plugins/sales_api/src/meta/permissions.ts
+++ b/backend/plugins/sales_api/src/meta/permissions.ts
@@ -24,6 +24,11 @@ export const permissions: IPermissionConfig = {
         { title: 'Add deals', name: 'dealsAdd', description: 'Create deals' },
         { title: 'Edit deals', name: 'dealsEdit', description: 'Edit deals' },
         {
+          title: 'Edit deal products',
+          name: 'dealsProductsEdit',
+          description: 'Add, edit, and remove products on deals',
+        },
+        {
           title: 'Remove deals',
           name: 'dealsRemove',
           description: 'Delete deals',
@@ -272,6 +277,7 @@ export const permissions: IPermissionConfig = {
             'showDeals',
             'dealsAdd',
             'dealsEdit',
+            'dealsProductsEdit',
             'dealsRemove',
             'dealsWatch',
             'dealsArchive',

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/deals.ts
@@ -27,6 +27,11 @@ export const dealMutations: Record<string, Resolver> = {
     { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('dealsAdd');
+
+    if (doc.productsData !== undefined) {
+      await checkPermission('dealsProductsEdit');
+    }
+
     return await addDeal({ models, subdomain, user, doc });
   },
 
@@ -39,6 +44,11 @@ export const dealMutations: Record<string, Resolver> = {
     { user, models, subdomain, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
+
+    if (doc.productsData !== undefined) {
+      await checkPermission('dealsProductsEdit');
+    }
+
     return await editDeal({ models, subdomain, _id, processId, doc, user });
   },
 
@@ -157,6 +167,10 @@ export const dealMutations: Record<string, Resolver> = {
       throw new Error('No Item Found');
     }
 
+    if (item.productsData?.length) {
+      await checkPermission('dealsProductsEdit');
+    }
+
     const doc = {
       ...item,
       _id: undefined,
@@ -267,6 +281,7 @@ export const dealMutations: Record<string, Resolver> = {
     { models, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
+    await checkPermission('dealsProductsEdit');
     return createProductsData({ models, processId, dealId, docs });
   },
 
@@ -286,6 +301,7 @@ export const dealMutations: Record<string, Resolver> = {
     { models, user, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
+    await checkPermission('dealsProductsEdit');
     const deal = await models.Deals.getDeal(dealId);
 
     if (!deal.productsData?.length) {
@@ -469,6 +485,7 @@ export const dealMutations: Record<string, Resolver> = {
     { models, user, checkPermission }: IContext,
   ) {
     await checkPermission('dealsEdit');
+    await checkPermission('dealsProductsEdit');
     const deal = await models.Deals.getDeal(dealId);
 
     const oldPData = (deal.productsData || []).filter(

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/product-table/ProductNameCell.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/components/product-table/ProductNameCell.tsx
@@ -1,14 +1,11 @@
-import { Badge, Input, Popover, RecordTableInlineCell, cn } from 'erxes-ui';
-import { useEffect, useRef, useState } from 'react';
+import { Badge, RecordTableInlineCell, cn } from 'erxes-ui';
 
 import { Cell } from '@tanstack/table-core';
 import { IProductData } from 'ui-modules';
 import { productRowActionsAtom } from '../../productTableAtom';
 import { useAtomValue } from 'jotai';
-import { useUpdateProductRecord } from '../../hooks/useProductRecord';
 
 const DUPLICATE_PRODUCT_CELL_CLASS = 'bg-pink-50/80 dark:bg-pink-950/30';
-const SINGLE_CLICK_DELAY_MS = 200;
 
 export const getProductId = (productData: IProductData) =>
   productData.productId || productData.product?._id || '';
@@ -36,124 +33,21 @@ export const ProductNameCell = ({
   hasDuplicateProduct: boolean;
 }) => {
   const product = cell.row.original.product;
-  const getCellName = () => (cell.getValue() as string | undefined) ?? '';
-  const [open, setOpen] = useState(false);
-  const [name, setName] = useState(getCellName);
-  const singleClickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const cancelledRef = useRef(false);
-  const { updateProductName } = useUpdateProductRecord();
   const actions = useAtomValue(productRowActionsAtom);
 
-  const clearSingleClickTimeout = () => {
-    if (singleClickTimeoutRef.current) {
-      clearTimeout(singleClickTimeoutRef.current);
-      singleClickTimeoutRef.current = null;
-    }
-  };
-
-  useEffect(
-    () => () => {
-      if (singleClickTimeoutRef.current) {
-        clearTimeout(singleClickTimeoutRef.current);
-      }
-    },
-    [],
-  );
-
-  const onSave = () => {
-    clearSingleClickTimeout();
-    const trimmedName = name.trim();
-    if (trimmedName && trimmedName !== getCellName() && product) {
-      void updateProductName(cell.row.original, trimmedName);
-    }
-    setOpen(false);
-  };
-
-  const cancelEdit = () => {
-    cancelledRef.current = true;
-    setName(getCellName());
-    setOpen(false);
-  };
-
-  const openEditSheet = () => {
-    clearSingleClickTimeout();
-    setOpen(false);
-    actions?.onEdit(cell.row.original);
-  };
-
-  const scheduleInlineEdit = () => {
-    clearSingleClickTimeout();
-    singleClickTimeoutRef.current = setTimeout(() => {
-      singleClickTimeoutRef.current = null;
-      // Re-seed the draft: the product may have been replaced or renamed
-      // since this cell's state was initialized.
-      setName(getCellName());
-      setOpen(true);
-    }, SINGLE_CLICK_DELAY_MS);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      onSave();
-    }
-    if (event.key === 'Escape') {
-      cancelEdit();
-    }
-  };
-
   return (
-    <Popover
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (nextOpen) {
-          return;
-        }
-        if (cancelledRef.current) {
-          cancelledRef.current = false;
-          return;
-        }
-        onSave();
+    <RecordTableInlineCell
+      className={cn(hasDuplicateProduct && DUPLICATE_PRODUCT_CELL_CLASS)}
+      onDoubleClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        actions?.onEdit(cell.row.original);
       }}
     >
-      <RecordTableInlineCell.Trigger
-        className={cn(hasDuplicateProduct && DUPLICATE_PRODUCT_CELL_CLASS)}
-        onClick={scheduleInlineEdit}
-        onDoubleClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          openEditSheet();
-        }}
-      >
-        <div className="flex gap-1.5 items-center min-w-0">
-          {product?.code && (
-            <Badge
-              variant="secondary"
-              onClick={(event) => {
-                event.stopPropagation();
-                scheduleInlineEdit();
-              }}
-            >
-              {product.code}
-            </Badge>
-          )}
-          <span>{product?.name}</span>
-        </div>
-      </RecordTableInlineCell.Trigger>
-      <RecordTableInlineCell.Content
-        onEscapeKeyDown={() => {
-          cancelledRef.current = true;
-          setName(getCellName());
-        }}
-      >
-        <Input
-          value={name}
-          onChange={(event) => setName(event.currentTarget.value)}
-          onKeyDown={handleKeyDown}
-        />
-      </RecordTableInlineCell.Content>
-    </Popover>
+      <div className="flex gap-1.5 items-center min-w-0">
+        {product?.code && <Badge variant="secondary">{product.code}</Badge>}
+        <span>{product?.name}</span>
+      </div>
+    </RecordTableInlineCell>
   );
 };

--- a/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useProductRecord.tsx
+++ b/frontend/plugins/sales_ui/src/modules/deals/cards/components/detail/product/hooks/useProductRecord.tsx
@@ -1,37 +1,12 @@
-import { useMutation } from '@apollo/client';
-import { useToast } from 'erxes-ui';
 import { onLocalChangeAtom } from '../productTableAtom';
 import { useAtomValue } from 'jotai';
-import { useRef } from 'react';
 import { useDealsEditProductData } from './mutations/useDealsEditProductData';
 import { IProductData } from 'ui-modules';
-import { PRODUCTS_EDIT } from 'ui-modules/modules/products/graphql/mutations/productMutations';
-import { useTranslation } from 'react-i18next';
-
-import { DEAL_TOAST_OPTIONS } from '@/deals/constants/toast';
-
-interface ProductsEditData {
-  productsEdit: {
-    __typename: 'Product';
-    _id: string;
-    name: string;
-  };
-}
-
-interface ProductsEditVariables {
-  _id: string;
-  name: string;
-}
 
 export const useUpdateProductRecord = () => {
   const { editDealsProductData } = useDealsEditProductData();
-  const [productsEdit] = useMutation<ProductsEditData, ProductsEditVariables>(
-    PRODUCTS_EDIT,
-  );
+  const processId = localStorage.getItem('processId') || '';
   const onLocalChange = useAtomValue(onLocalChangeAtom);
-  const { toast } = useToast();
-  const { t } = useTranslation('sales');
-  const latestNameEditRef = useRef<Record<string, number>>({});
 
   const updateRecord = (
     product: IProductData,
@@ -71,67 +46,5 @@ export const useUpdateProductRecord = () => {
     return request;
   };
 
-  const updateProductName = async (productData: IProductData, name: string) => {
-    const product = productData.product;
-
-    if (!product) {
-      return;
-    }
-
-    const productId = productData.productId || product._id;
-    const nextProduct = { ...product, _id: productId, name };
-
-    const operationId = (latestNameEditRef.current[productId] || 0) + 1;
-    latestNameEditRef.current[productId] = operationId;
-
-    if (onLocalChange && productData._id) {
-      onLocalChange(
-        productData._id,
-        { product: nextProduct },
-        { syncProductId: productId },
-      );
-    }
-
-    try {
-      await productsEdit({
-        variables: {
-          _id: productId,
-          name,
-        },
-        optimisticResponse: {
-          productsEdit: {
-            __typename: 'Product',
-            _id: productId,
-            name,
-          },
-        },
-      });
-
-      toast({
-        title: t('success'),
-        variant: 'success',
-        ...DEAL_TOAST_OPTIONS,
-      });
-    } catch (error) {
-      const isLatestEdit = latestNameEditRef.current[productId] === operationId;
-
-      if (isLatestEdit && onLocalChange && productData._id) {
-        onLocalChange(
-          productData._id,
-          { product },
-          { syncProductId: productId },
-        );
-      }
-
-      toast({
-        title: t('error'),
-        description:
-          error instanceof Error ? error.message : t('update-failed'),
-        variant: 'destructive',
-        ...DEAL_TOAST_OPTIONS,
-      });
-    }
-  };
-
-  return { updateProductName, updateRecord };
+  return { updateRecord };
 };


### PR DESCRIPTION
## Summary by Sourcery

Control deal product modifications with a dedicated permission and route product row edits through the standard editing flow.

New Features:
- Add a dedicated permission for adding, editing, and removing products on deals.

Bug Fixes:
- Enforce deal product edit permission across deal creation, editing, copying, and product mutations.
- Prevent product names in the deal table from being edited inline without using the product edit flow.

Enhancements:
- Simplify deal product name cells to display-only content with double-click editing handled through the existing row action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added team-specific GitHub settings for connecting, changing, and disconnecting repositories.
  - Added GitHub organization installation flow with connection refresh and repository selection.
  - Added permission controls for GitHub settings and deal product editing.
  - Added support for editing deal products with the new permission.

- **Bug Fixes**
  - Improved GitHub validation to prevent duplicate repositories and inaccessible selections.
  - GitHub connection and configuration lists now require appropriate access and sort consistently.

- **Changes**
  - Removed the previous GitHub Issues repository-linking section and organization disconnect flow.
  - Product names in deal tables are now edited by double-clicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->