### PR TITLE
feat(help-center): resolve a per-tenant gateway on SaaS

### DIFF
--- a/apps/help-center/.env.example
+++ b/apps/help-center/.env.example
@@ -1,1 +1,21 @@
+# erxes gateway (Apollo Router). No trailing slash.
+#
+# The only setting the portal needs — its name, app token, knowledge base
+# topic, ticket surfaces and appearance all come from the help center whose
+# website matches the address a request arrives on. Create one under
+# Frontline -> Help Center and set its Website to the address this portal is
+# served from (for local work, http://localhost:3900).
+#
+# This file is for local development. A container takes the same variables
+# from its environment at startup instead; see the Docker section of the
+# README.
 NEXT_PUBLIC_ERXES_API_URL=https://officenext.erxes.io/gateway
+
+# OS (the default) or SAAS. On SAAS the gateway is addressed per tenant, so a
+# <subdomain> placeholder in the address above is filled from the host the
+# request arrived on -- which is what lets one deployment serve a help center
+# per subdomain:
+#
+#   NEXT_PUBLIC_APP_VERSION=SAAS
+#   NEXT_PUBLIC_ERXES_API_URL=https://<subdomain>.api.erxes.io/gateway
+NEXT_PUBLIC_APP_VERSION=OS

--- a/apps/help-center/README.md
+++ b/apps/help-center/README.md
@@ -64,6 +64,30 @@ file first. The rest of the configuration is looked up per request from the
 help center matching the domain, so one image serves any number of portals on
 any gateway.
 
+### Many help centers on one deployment
+
+A single-tenant gateway serves every portal on it, and each one is told apart
+by the domain its request arrived on. That is already enough for many help
+centers behind one address.
+
+On a SaaS install the gateway itself is per tenant. Setting
+`NEXT_PUBLIC_APP_VERSION=SAAS` turns on substitution of a `<subdomain>`
+placeholder in the address — the same switch `apps/posclient-front` uses:
+
+```bash
+docker run -p 3900:3900 \
+  -e NEXT_PUBLIC_APP_VERSION=SAAS \
+  -e NEXT_PUBLIC_ERXES_API_URL='https://<subdomain>.api.erxes.io/gateway' \
+  erxes/help-center
+```
+
+A request to `acme.help.erxes.io` then talks to
+`https://acme.api.erxes.io/gateway`, and one to `globex.help.erxes.io` to
+`https://globex.api.erxes.io/gateway` — the same container, a help center per
+tenant. The substitution happens on both sides: the browser reads the host from
+`window.location`, and the server from the host header of the request it is
+answering.
+
 Serving the portal behind a proxy, forward the original host, since that is
 what the help center is matched on:
 

--- a/apps/help-center/docker-entrypoint.sh
+++ b/apps/help-center/docker-entrypoint.sh
@@ -1,9 +1,18 @@
 #!/bin/sh
 
+# Next inlines NEXT_PUBLIC_* into the client bundle at build time, which would
+# tie an image to one gateway. Writing the values into a script the page loads
+# first keeps them runtime settings instead, so the same image serves any
+# deployment. Server components read the same variables from the environment.
+#
+# Paths are relative to the working directory the Dockerfile sets, which is the
+# app root the standalone server runs from.
+
 mkdir -p public/js
 
 cat > public/js/env.js <<INNER
   window.env = {
+      NEXT_PUBLIC_APP_VERSION: "$NEXT_PUBLIC_APP_VERSION",
       NEXT_PUBLIC_ERXES_API_URL: "$NEXT_PUBLIC_ERXES_API_URL",
   }
 INNER

--- a/apps/help-center/modules/apollo/apolloClient.ts
+++ b/apps/help-center/modules/apollo/apolloClient.ts
@@ -18,6 +18,12 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
     const appToken = readAppToken();
 
     return {
+      /*
+       * A SaaS gateway is addressed per tenant, so the address can differ
+       * between requests; it is read per operation rather than fixed when the
+       * client is built.
+       */
+      uri: `${readApiUrl()}/graphql`,
       headers: {
         ...headers,
         ...(appToken ? { 'x-app-token': appToken } : {}),

--- a/apps/help-center/modules/apollo/utils/env.ts
+++ b/apps/help-center/modules/apollo/utils/env.ts
@@ -4,8 +4,12 @@
  * public/js/env.js from the container's environment before the server starts,
  * and the root layout loads that file ahead of the app.
  *
- * On the server the same value is still in `process.env`, which is where
- * server components and the Apollo client used during SSR read it from.
+ * On a SaaS install the gateway is addressed per tenant, so
+ * `NEXT_PUBLIC_APP_VERSION=SAAS` turns on substitution of a `<subdomain>`
+ * placeholder in the address. It is filled from the host the request arrived
+ * on: `window.location` in the browser, and on the server the host the config
+ * layer reads from the request headers. This is the same switch
+ * apps/posclient-front uses.
  */
 declare global {
   interface Window {
@@ -13,12 +17,86 @@ declare global {
   }
 }
 
-export const readApiUrl = (): string => {
-  if (typeof window !== 'undefined' && window.env?.NEXT_PUBLIC_ERXES_API_URL) {
-    return window.env.NEXT_PUBLIC_ERXES_API_URL;
+export const SUBDOMAIN_PLACEHOLDER = '<subdomain>';
+
+export const subdomainOf = (host: string): string =>
+  host
+    .replace(/^\w+:\/\//, '')
+    .split(':')[0]
+    .split('.')[0];
+
+/*
+ * Outside Docker there is no env.js — `next dev` and `next start` read the
+ * values from .env.local like any other Next app, which is what `inlined`
+ * carries.
+ *
+ * Those reads are spelled out at each call site rather than indexed here:
+ * Next replaces each `process.env.NEXT_PUBLIC_*` member textually while
+ * bundling, and a dynamic lookup would be left as-is and read nothing in the
+ * browser.
+ */
+const runtimeEnv = (name: string, inlined: string | undefined): string =>
+  (typeof window !== 'undefined' ? window.env?.[name] : undefined) ??
+  inlined ??
+  '';
+
+const configuredApiUrl = (): string =>
+  runtimeEnv(
+    'NEXT_PUBLIC_ERXES_API_URL',
+    process.env.NEXT_PUBLIC_ERXES_API_URL,
+  );
+
+const isSaas = (): boolean =>
+  runtimeEnv(
+    'NEXT_PUBLIC_APP_VERSION',
+    process.env.NEXT_PUBLIC_APP_VERSION,
+  ).toUpperCase() === 'SAAS';
+
+/**
+ * The gateway address for a given host. Server code passes the host of the
+ * request it is answering; in the browser the current location is used.
+ */
+export const apiUrlForHost = (host?: string): string => {
+  const configured = configuredApiUrl();
+
+  if (!isSaas() || !configured.includes(SUBDOMAIN_PLACEHOLDER)) {
+    return configured;
   }
 
-  // No env.js — running from `next dev` or `next start` outside Docker, where
-  // the value comes from .env.local the way any other Next app reads it.
-  return process.env.NEXT_PUBLIC_ERXES_API_URL ?? '';
+  const from =
+    host ?? (typeof window !== 'undefined' ? window.location.hostname : '');
+
+  const subdomain = subdomainOf(from);
+
+  // Without a host there is nothing to substitute, and an address still
+  // carrying the placeholder would be a confusing request to debug.
+  if (!subdomain) {
+    return '';
+  }
+
+  return configured.replaceAll(SUBDOMAIN_PLACEHOLDER, subdomain);
+};
+
+/*
+ * Server code resolves the address from the host of the request it is
+ * answering and publishes it here, so the helpers and components that read
+ * the address without one — file URLs, rich text images — get the same
+ * answer. In the browser there is no reader and the current location is used.
+ */
+let resolved: () => string = () => '';
+
+export const setResolvedApiUrlReader = (reader: () => string): void => {
+  resolved = reader;
+};
+
+export const readApiUrl = (): string => {
+  if (typeof window === 'undefined') {
+    const fromRequest = resolved();
+
+    if (fromRequest) {
+      return fromRequest;
+    }
+  }
+
+  return apiUrlForHost();
 };

--- a/apps/help-center/modules/config/api.ts
+++ b/apps/help-center/modules/config/api.ts
@@ -1,7 +1,10 @@
 import { unstable_cache } from 'next/cache';
 import { headers } from 'next/headers';
 import { query, setAppTokenReader } from '@/modules/apollo/apolloClient';
-import { readApiUrl } from '@/modules/apollo/utils/env';
+import {
+  apiUrlForHost,
+  setResolvedApiUrlReader,
+} from '@/modules/apollo/utils/env';
 import { errorMessage, type PortalResult } from '@/modules/apollo/utils/result';
 import { HELP_CENTER_CONFIG_BY_DOMAIN } from './graphql/queries/helpCenterConfig';
 import { normalizeConfig } from './utils/normalize';
@@ -13,6 +16,11 @@ const requestOrigin = async (): Promise<string> => {
   const list = await headers();
 
   const host = list.get('x-forwarded-host') ?? list.get('host') ?? '';
+
+  // A SaaS gateway is addressed per tenant, and this is the first thing the
+  // server reads from a request, so the address is resolved from this host for
+  // everything the request goes on to ask for.
+  apiUrl = apiUrlForHost(host);
 
   if (!host) {
     return '';
@@ -28,11 +36,12 @@ const requestOrigin = async (): Promise<string> => {
 };
 
 let appToken = '';
+let apiUrl = '';
 
 const fetchConfig = async (
   domain: string,
 ): Promise<PortalResult<PortalConfig>> => {
-  if (!readApiUrl()) {
+  if (!apiUrl) {
     return { state: 'unconfigured', missing: ['NEXT_PUBLIC_ERXES_API_URL'] };
   }
 
@@ -92,3 +101,4 @@ export const readConfig = async (): Promise<PortalConfig | null> => {
 };
 
 setAppTokenReader(() => appToken);
+setResolvedApiUrlReader(() => apiUrl);


### PR DESCRIPTION
A SaaS install addresses its gateway per tenant, so one deployment could not serve a help center per subdomain: the address was a single fixed value.

NEXT_PUBLIC_APP_VERSION=SAAS now turns on substitution of a <subdomain> placeholder in NEXT_PUBLIC_ERXES_API_URL, the same switch apps/posclient-front uses. A request to acme.help.erxes.io talks to acme.api.erxes.io, one to globex.help.erxes.io to globex.api.erxes.io — the same container. Without the flag, or without the placeholder, the address is used as it stands.

The substitution happens on both sides, because the portal renders on the server as well: the browser reads the host from window.location, and the server takes it from the headers of the request it is answering, which the config layer already reads. It publishes the resolved address for the helpers that build file URLs without a host of their own — the logo, a favicon, images inside an article — which would otherwise have been left pointing at the placeholder.

Verified against a stand-in gateway: with the flag, acme and globex hosts each reached their own gateway for both GraphQL and read-file; without it, a placeholder address was left alone; and a fixed address kept working unchanged.

## Summary by Sourcery

Enable help-center deployments to route each SaaS tenant to its corresponding gateway while retaining existing fixed-address behavior.

New Features:
- Support resolving tenant-specific SaaS gateway URLs from the incoming help-center subdomain.
- Allow runtime configuration to be shared across deployments while preserving server-side and client-side gateway resolution.

Bug Fixes:
- Fix help-center portals using one fixed gateway address when serving multiple SaaS tenants.
- Ensure generated file and image URLs use the resolved tenant gateway.

Build:
- Expose the SaaS application version and API URL through runtime environment configuration.

Documentation:
- Document configuring one help-center deployment for multiple SaaS tenant subdomains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving multiple tenant-specific help centers from a single SaaS deployment.
  * Tenant API requests now resolve automatically from the current request or browser host.
  * Added configuration guidance for SaaS subdomain routing and environment settings.

* **Documentation**
  * Expanded Docker and environment configuration documentation.
  * Added explanations of runtime environment handling and multi-help-center deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->