### PR TITLE
fix(msdynamics): show synced order details

### DIFF
--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -61,14 +61,17 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
     return;
   }
 
-  const configsMap = dynamicConfigs.reduce((acc, conf) => {
-    const sub = conf.subId || 'noBrand';
-    acc[sub] = conf.value;
-    if (sub === 'noBrand' && typeof conf.value === 'object') {
-      Object.assign(acc, conf.value);
-    }
-    return acc;
-  }, {} as Record<string, any>);
+  const configsMap = dynamicConfigs.reduce(
+    (acc, conf) => {
+      const sub = conf.subId || 'noBrand';
+      acc[sub] = conf.value;
+      if (sub === 'noBrand' && typeof conf.value === 'object') {
+        Object.assign(acc, conf.value);
+      }
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
 
   const contentId = updatedDocument?._id || object?._id;
 

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -1,7 +1,7 @@
 import { generateModels } from '~/connectionResolvers';
 import { customerToDynamic } from './utilsCustomer';
 import { dealToDynamic, orderToDynamic } from './utils';
-
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
 const allowTypes: Record<string, string[]> = {
   'core:customer': ['create'],
   'core:company': ['create'],
@@ -95,7 +95,22 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
 
         const updatedDoc = updatedDocument || object;
-        const brandId = updatedDoc?.scopeBrandIds?.[0];
+        let brandId = updatedDoc?.scopeBrandIds?.[0];
+
+        if (!brandId && updatedDoc?.posId) {
+          const pos = await sendTRPCMessage({
+            subdomain,
+            pluginName: 'sales',
+            module: 'pos',
+            action: 'findOne',
+            input: {
+              query: { _id: updatedDoc.posId },
+            },
+            defaultValue: null,
+          });
+
+          brandId = pos?.scopeBrandIds?.[0];
+        }
 
         const config = configsMap[brandId || 'noBrand'];
 
@@ -109,6 +124,7 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
             brandId,
           );
         }
+
         break;
       }
 

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -100,7 +100,14 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         const config = configsMap[brandId || 'noBrand'];
 
         if (config && !config.useBoard) {
-          await orderToDynamic(subdomain, models, syncLog, updatedDoc, config, brandId);
+          await orderToDynamic(
+            subdomain,
+            models,
+            syncLog,
+            updatedDoc,
+            config,
+            brandId,
+          );
         }
         break;
       }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -100,7 +100,7 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
         const config = configsMap[brandId || 'noBrand'];
 
         if (config && !config.useBoard) {
-          await orderToDynamic(subdomain, models, syncLog, updatedDoc, config);
+          await orderToDynamic(subdomain, models, syncLog, updatedDoc, config, brandId);
         }
         break;
       }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/afterMutation.ts
@@ -8,7 +8,44 @@ const allowTypes: Record<string, string[]> = {
   'pos:order': ['synced'],
   'sales:deal': ['update'],
 };
+const handlePosOrder = async (
+  subdomain: string,
+  models: any,
+  updatedDocument: any,
+  object: any,
+  syncLogDoc: any,
+  configsMap: Record<string, any>,
+) => {
+  const updatedDoc = updatedDocument || object;
+  let brandId = updatedDoc?.scopeBrandIds?.[0];
 
+  if (!brandId && updatedDoc?.posId) {
+    const pos = await sendTRPCMessage({
+      subdomain,
+      pluginName: 'sales',
+      module: 'pos',
+      action: 'findOne',
+      input: {
+        query: { _id: updatedDoc.posId },
+      },
+      defaultValue: null,
+    });
+
+    brandId = pos?.scopeBrandIds?.[0];
+  }
+
+  const config = configsMap[brandId || 'noBrand'];
+
+  if (!config || config.useBoard) {
+    return;
+  }
+
+  const syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
+
+  await orderToDynamic(subdomain, models, syncLog, updatedDoc, config, brandId);
+
+  return syncLog;
+};
 export const afterMutationHandlers = async (subdomain: string, params: any) => {
   const { type, action, user, object, updatedDocument } = params;
 
@@ -24,17 +61,14 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
     return;
   }
 
-  const configsMap = dynamicConfigs.reduce(
-    (acc, conf) => {
-      const sub = conf.subId || 'noBrand';
-      acc[sub] = conf.value;
-      if (sub === 'noBrand' && typeof conf.value === 'object') {
-        Object.assign(acc, conf.value);
-      }
-      return acc;
-    },
-    {} as Record<string, any>,
-  );
+  const configsMap = dynamicConfigs.reduce((acc, conf) => {
+    const sub = conf.subId || 'noBrand';
+    acc[sub] = conf.value;
+    if (sub === 'noBrand' && typeof conf.value === 'object') {
+      Object.assign(acc, conf.value);
+    }
+    return acc;
+  }, {} as Record<string, any>);
 
   const contentId = updatedDocument?._id || object?._id;
 
@@ -92,38 +126,14 @@ export const afterMutationHandlers = async (subdomain: string, params: any) => {
       }
 
       case 'pos:order': {
-        syncLog = await models.SyncLogsMSD.syncLogsAdd(syncLogDoc);
-
-        const updatedDoc = updatedDocument || object;
-        let brandId = updatedDoc?.scopeBrandIds?.[0];
-
-        if (!brandId && updatedDoc?.posId) {
-          const pos = await sendTRPCMessage({
-            subdomain,
-            pluginName: 'sales',
-            module: 'pos',
-            action: 'findOne',
-            input: {
-              query: { _id: updatedDoc.posId },
-            },
-            defaultValue: null,
-          });
-
-          brandId = pos?.scopeBrandIds?.[0];
-        }
-
-        const config = configsMap[brandId || 'noBrand'];
-
-        if (config && !config.useBoard) {
-          await orderToDynamic(
-            subdomain,
-            models,
-            syncLog,
-            updatedDoc,
-            config,
-            brandId,
-          );
-        }
+        syncLog = await handlePosOrder(
+          subdomain,
+          models,
+          updatedDocument,
+          object,
+          syncLogDoc,
+          configsMap,
+        );
 
         break;
       }

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/checkDynamic.ts
@@ -89,7 +89,6 @@ const comparePrices = async ({
       const foundProduct = productsByCode[itemNo];
 
       if (!foundProduct) {
-        console.log('[MSD] Product not found in erxes:', itemNo);
         result.create.items.push({
           Item_No: itemNo,
           Unit_Price: resPrice,
@@ -111,9 +110,6 @@ const comparePrices = async ({
       };
 
       if (foundProduct.unitPrice === resPrice) {
-        console.log(
-          `[MSD] Match: ${itemNo} | erxes=${foundProduct.unitPrice} | BC=${resPrice}`,
-        );
         result.match.items.push(item);
       } else {
         result.update.items.push(item);
@@ -302,7 +298,6 @@ export const msdynamicCheckMutations = {
         },
       },
     ).then((res) => res.json());
-    console.log('[MSD] BC price records:', response?.value?.length);
     const groupedItems = groupItemsByCode(response?.value);
     const productsByCode = mapProductsByCode(products);
     const dynamicCodes = new Set(Object.keys(groupedItems));

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/graphql/resolvers/mutations/syncDynamic.ts
@@ -8,7 +8,6 @@ import { sendTRPCMessage } from 'erxes-api-shared/utils';
  */
 const getDynamicConfig = async (models: any, brandId?: string) => {
   const configs = await models.Configs.getConfigs('DYNAMIC');
-
   if (!configs?.length) {
     throw new Error('MS Dynamic config not found.');
   }
@@ -131,7 +130,26 @@ export const msdynamicSyncMutations = {
 
     for (const order of orders) {
       try {
-        const config = await getDynamicConfig(models, order.scopeBrandIds?.[0]);
+        let brandId = order.scopeBrandIds?.[0];
+
+        if (!brandId && order.posId) {
+          const pos = await sendTRPCMessage({
+            subdomain,
+            pluginName: 'sales',
+            module: 'pos',
+            action: 'findOne',
+            input: {
+              query: {
+                _id: order.posId,
+              },
+            },
+            defaultValue: null,
+          });
+
+          brandId = pos?.scopeBrandIds?.[0];
+        }
+
+        const config = await getDynamicConfig(models, brandId);
 
         const syncLog = await models.SyncLogsMSD.syncLogsAdd({
           contentType: 'pos:order',
@@ -148,6 +166,7 @@ export const msdynamicSyncMutations = {
           syncLog,
           order,
           config,
+          brandId,
         );
 
         results.push({

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/utils.ts
@@ -582,9 +582,8 @@ export const orderToDynamic = async (
   syncLog: ISyncLogDocument,
   order: any,
   config: any,
+  brandId: string,
 ) => {
-  const brandId = order.scopeBrandIds[0];
-
   let msdCustomer: any = {};
 
   let orderMsdNo: string;
@@ -682,7 +681,6 @@ export const orderToDynamic = async (
     if (!order.items.length) {
       throw new Error('Has not items order');
     }
-
     const responseSale = await fetch(`${salesApi}${urlParam}`, {
       method: postMethod,
       headers: postHeaders,

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/utilsCustomer.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/utilsCustomer.ts
@@ -206,8 +206,17 @@ export const getMsdCustomerInfo = async (
     filterStr = `Phone_No eq '${customer.primaryPhone}'`;
     msdCustomer = await checkSend(customer, config, filterStr);
   } else if (customer?.primaryEmail) {
-    filterStr = `E_Mail eq '${customer.primaryEmail}'`;
+    const email = customer.primaryEmail.replace(/'/g, "''");
+
+    filterStr = `E_Mail eq '${email}'`;
     msdCustomer = await checkSend(customer, config, filterStr);
+  }
+
+  if (!msdCustomer?.No) {
+    return {
+      relation: null,
+      customer,
+    };
   }
   const brandIds = customer?.scopeBrandIds || [];
 

--- a/backend/plugins/mongolian_api/src/modules/msdynamic/utilsCustomer.ts
+++ b/backend/plugins/mongolian_api/src/modules/msdynamic/utilsCustomer.ts
@@ -191,7 +191,6 @@ export const getMsdCustomerInfo = async (
   }).lean();
 
   const customer = await getCustomer(subdomain, customerId, customerType);
-
   if (relation) {
     const dayBefore = Math.round(
       (now.getTime() - relation.modifiedAt.getTime()) / (1000 * 3600 * 24),
@@ -203,11 +202,13 @@ export const getMsdCustomerInfo = async (
 
     filterStr = `No eq '${relation.no}'`;
     msdCustomer = await checkSend(customer, config, filterStr);
-  } else {
+  } else if (customer?.primaryPhone) {
     filterStr = `Phone_No eq '${customer.primaryPhone}'`;
     msdCustomer = await checkSend(customer, config, filterStr);
+  } else if (customer?.primaryEmail) {
+    filterStr = `E_Mail eq '${customer.primaryEmail}'`;
+    msdCustomer = await checkSend(customer, config, filterStr);
   }
-
   const brandIds = customer?.scopeBrandIds || [];
 
   if (!brandIds.includes(brandId)) {
@@ -232,7 +233,6 @@ export const getMsdCustomerInfo = async (
       });
     }
   }
-
   await models.CustomerRelations.updateOne(
     { customerId, brandId },
     {

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
@@ -97,28 +97,51 @@ const CheckSyncedOrders = () => {
   useEffect(() => {
     if (!orders?.length) return;
 
+    let active = true;
     const orderIds = orders.map((order) => order._id);
 
-    void toCheckMsdSynced({
-      variables: { ids: orderIds },
-    }).then((response) => {
-      const statuses = response.data?.toCheckMsdSynced || [];
-
-      const syncedInfos: Record<string, ISyncedOrderInfo> = {};
-
-      statuses
-        .filter((s) => s.isSynced)
-        .forEach((item) => {
-          syncedInfos[item._id] = {
-            syncedBillNumber: item.syncedBillNumber || '',
-            syncedDate: item.syncedDate || '',
-            syncedCustomer: item.syncedCustomer || '',
-          };
+    const checkSyncedOrders = async () => {
+      try {
+        const response = await toCheckMsdSynced({
+          variables: { ids: orderIds },
         });
 
-      setSyncedOrderInfos(syncedInfos);
-    });
-  }, [orders, toCheckMsdSynced]);
+        if (!active) return;
+
+        const statuses = response.data?.toCheckMsdSynced || [];
+        const syncedInfos: Record<string, ISyncedOrderInfo> = {};
+
+        statuses
+          .filter((s) => s.isSynced)
+          .forEach((item) => {
+            syncedInfos[item._id] = {
+              syncedBillNumber: item.syncedBillNumber || '',
+              syncedDate: item.syncedDate || '',
+              syncedCustomer: item.syncedCustomer || '',
+            };
+          });
+
+        setSyncedOrderInfos(syncedInfos);
+      } catch (error) {
+        if (!active) return;
+
+        toast({
+          title: t('failed-to-check-orders'),
+          description:
+            error instanceof Error
+              ? error.message
+              : t('please-try-again-later'),
+          variant: 'destructive',
+        });
+      }
+    };
+
+    checkSyncedOrders();
+
+    return () => {
+      active = false;
+    };
+  }, [orders, toCheckMsdSynced, toast, t]);
 
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
 
@@ -132,7 +155,14 @@ const CheckSyncedOrders = () => {
         });
 
         const item = response.data?.toSendMsdOrders?.[0];
-
+        if (!item) {
+          toast({
+            title: t('failed-to-resend-order'),
+            description: t('please-try-again-later'),
+            variant: 'destructive',
+          });
+          return;
+        }
         if (!item) return;
 
         if (!item.isSynced) {

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrders.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { gql, useMutation } from '@apollo/client';
 import { RecordTable, useToast } from 'erxes-ui';
 import { IconInbox } from '@tabler/icons-react';
@@ -17,7 +17,7 @@ type TCheckSyncedOrdersResponse = {
 };
 
 type TSendMsdOrdersResponse = {
-  toSendMsdOrders: ICheckSyncedOrderStatus;
+  toSendMsdOrders: ICheckSyncedOrderStatus[];
 };
 
 /** Empty ued synced order list deer message gargana. */
@@ -43,7 +43,6 @@ const CheckSyncedOrders = () => {
   const [syncedOrderInfos, setSyncedOrderInfos] = useState<
     Record<string, ISyncedOrderInfo>
   >({});
-
   const [toCheckMsdSynced, { loading: checkingSyncedOrders }] = useMutation<
     TCheckSyncedOrdersResponse,
     { ids: string[] }
@@ -95,6 +94,31 @@ const CheckSyncedOrders = () => {
       });
     }
   };
+  useEffect(() => {
+    if (!orders?.length) return;
+
+    const orderIds = orders.map((order) => order._id);
+
+    void toCheckMsdSynced({
+      variables: { ids: orderIds },
+    }).then((response) => {
+      const statuses = response.data?.toCheckMsdSynced || [];
+
+      const syncedInfos: Record<string, ISyncedOrderInfo> = {};
+
+      statuses
+        .filter((s) => s.isSynced)
+        .forEach((item) => {
+          syncedInfos[item._id] = {
+            syncedBillNumber: item.syncedBillNumber || '',
+            syncedDate: item.syncedDate || '',
+            syncedCustomer: item.syncedCustomer || '',
+          };
+        });
+
+      setSyncedOrderInfos(syncedInfos);
+    });
+  }, [orders, toCheckMsdSynced]);
 
   const { hasPreviousPage, hasNextPage } = pageInfo || {};
 
@@ -107,18 +131,31 @@ const CheckSyncedOrders = () => {
           variables: { orderIds: [orderId] },
         });
 
-        const item = response.data?.toSendMsdOrders;
+        const item = response.data?.toSendMsdOrders?.[0];
 
         if (!item) return;
 
-        setSyncedOrderInfos((prev) => ({
-          ...prev,
-          [item._id]: {
-            syncedBillNumber: item.syncedBillNumber || '',
-            syncedDate: item.syncedDate || '',
-            syncedCustomer: item.syncedCustomer || '',
-          },
-        }));
+        if (!item.isSynced) {
+          toast({
+            title: t('failed-to-resend-order'),
+            description: t('please-try-again-later'),
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        setSyncedOrderInfos((prev) => {
+          const next = {
+            ...prev,
+            [item._id]: {
+              syncedBillNumber: item.syncedBillNumber || '',
+              syncedDate: item.syncedDate || '',
+              syncedCustomer: item.syncedCustomer || '',
+            },
+          };
+          return next;
+        });
+
         toast({
           title: t('order-resent-successfully'),
           variant: 'success',
@@ -134,7 +171,6 @@ const CheckSyncedOrders = () => {
         });
       }
     };
-
     return getCheckSyncedOrdersColumns({
       syncedOrderInfos,
       onResend: resend,

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersColumns.tsx
@@ -128,7 +128,7 @@ export const getCheckSyncedOrdersColumns = ({
           <TextOverflowTooltip
             value={
               syncedInfo?.syncedDate
-                ? dayjs(syncedInfo.syncedDate).format('LL')
+                ? dayjs(syncedInfo.syncedDate).format('YYYY-MM-DD')
                 : ''
             }
           />

--- a/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersColumns.tsx
+++ b/frontend/plugins/mongolian_ui/src/modules/msdynamic/msdynamic-check-orders/components/CheckSyncedOrdersColumns.tsx
@@ -67,7 +67,9 @@ export const getCheckSyncedOrdersColumns = ({
   {
     id: 'number',
     accessorKey: 'number',
-    header: () => <RecordTable.InlineHead icon={IconHash} label={t('number')} />,
+    header: () => (
+      <RecordTable.InlineHead icon={IconHash} label={t('number')} />
+    ),
     cell: ({ cell }) => (
       <RecordTableInlineCell>
         <TextOverflowTooltip value={cell.getValue() as string} />
@@ -139,7 +141,10 @@ export const getCheckSyncedOrdersColumns = ({
   {
     id: 'syncedBillNumber',
     header: () => (
-      <RecordTable.InlineHead icon={IconLabel} label={t('synced-bill-number')} />
+      <RecordTable.InlineHead
+        icon={IconLabel}
+        label={t('synced-bill-number')}
+      />
     ),
     cell: ({ row }) => {
       const syncedInfo = syncedOrderInfos[row.original._id];


### PR DESCRIPTION
## Summary by Sourcery

Show synchronized order details reliably by improving brand and customer resolution and updating the synced-orders interface.

New Features:
- Display synced bill number, date, and customer details for all synced orders when the order-checking view loads.
- Support resending orders with explicit success and failure feedback.

Bug Fixes:
- Resolve the applicable Microsoft Dynamics brand configuration from the order's POS when the order lacks a direct brand assignment.
- Improve Microsoft Dynamics customer lookup by falling back from phone to email when available.

Enhancements:
- Standardize synced-order dates to YYYY-MM-DD and remove diagnostic logging from synchronization checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order synchronization by using the order’s brand configuration, including POS fallback scenarios.
  * Customer processing now safely handles email addresses containing apostrophes and unresolved Dynamics customers.
  * Resending orders now verifies synchronization status and shows a failure notification when unavailable.

* **Enhancements**
  * Sync statuses are checked automatically when orders load or change.
  * Synced dates now use the consistent `YYYY-MM-DD` format.
  * Improved handling of synchronization results for more reliable order status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->