### PR TITLE
fix(ci): run the help-center workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/ci-apps-help-center.yml
+++ b/.github/workflows/ci-apps-help-center.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           node-version: 22.19.0
 
+      - name: Set environment variables
+        run: |
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+
       - name: Build
         run: |
           cd apps/help-center
@@ -41,5 +46,9 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          DOCKER_BUILDKIT=1 docker build -t erxes/help-center:latest -f apps/help-center/Dockerfile .
+          DOCKER_BUILDKIT=1 docker build \
+            -t erxes/help-center:latest \
+            -t "erxes/help-center:$DATE-$SHORT_SHA" \
+            -f apps/help-center/Dockerfile .
           docker push erxes/help-center:latest
+          docker push "erxes/help-center:$DATE-$SHORT_SHA"

--- a/.github/workflows/ci-apps-help-center.yml
+++ b/.github/workflows/ci-apps-help-center.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   help-center:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

Update the help-center CI workflow to use the latest Ubuntu runner and publish uniquely tagged Docker images.

Bug Fixes:
- Run the help-center CI workflow on the latest Ubuntu runner.

Enhancements:
- Publish help-center Docker images with date-and-commit tags in addition to the latest tag.

CI:
- Add workflow metadata for uniquely versioned help-center image builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the help center’s build environment.
  - Added date- and commit-based image tags alongside the existing `latest` tag.
  - Published builds using the new versioned image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->