### PR TITLE
fix(core): Exclude already-visible activities from navigation More popover

### DIFF
--- a/frontend/core-ui/src/modules/navigation/components/MainNavigationBar.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/MainNavigationBar.tsx
@@ -40,8 +40,8 @@ export const MainNavigationBar = () => {
       : undefined;
   const hasNavigationPanel = Boolean(
     isSettings ||
-      activeNavigationGroup?.contents.length ||
-      activeNavigationGroup?.subGroups.length,
+    activeNavigationGroup?.contents.length ||
+    activeNavigationGroup?.subGroups.length,
   );
 
   useEffect(() => {

--- a/frontend/core-ui/src/modules/navigation/components/MainNavigationBar.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/MainNavigationBar.tsx
@@ -14,8 +14,12 @@ import { useLocation, useNavigate } from 'react-router-dom';
 export const MainNavigationBar = () => {
   const activities = useNavigationActivities();
   const navigationGroups = usePluginsNavigationGroups();
-  const { isActivityPinned, setActivityPinned, visibleActivities } =
-    usePinnedNavigationActivities(activities);
+  const {
+    isActivityPinned,
+    setActivityPinned,
+    visibleActivities,
+    hiddenActivities,
+  } = usePinnedNavigationActivities(activities);
   const [activeActivityId, setActiveActivityId] = useAtom(activePluginState);
   const setSearchOpen = useSetAtom(globalSearchOpenState);
   const { pathname } = useLocation();
@@ -79,6 +83,7 @@ export const MainNavigationBar = () => {
         activities={activities}
         activeActivityId={isInboxActive ? null : activeActivity?.id || null}
         isInboxActive={isInboxActive}
+        hiddenActivities={hiddenActivities}
         isActivityPinned={isActivityPinned}
         isSettings={isSettings}
         mobileExpanded={!hasNavigationPanel}

--- a/frontend/core-ui/src/modules/navigation/components/NavigationActivityRail.tsx
+++ b/frontend/core-ui/src/modules/navigation/components/NavigationActivityRail.tsx
@@ -13,6 +13,7 @@ import { cn, Sidebar } from 'erxes-ui';
 export const NavigationActivityRail = ({
   activities,
   activeActivityId,
+  hiddenActivities,
   isInboxActive,
   isActivityPinned,
   isSettings,
@@ -25,6 +26,7 @@ export const NavigationActivityRail = ({
 }: Readonly<{
   activities: INavigationActivity[];
   activeActivityId: string | null;
+  hiddenActivities: INavigationActivity[];
   isInboxActive: boolean;
   isActivityPinned: (activityId: string) => boolean;
   isSettings: boolean;
@@ -38,8 +40,9 @@ export const NavigationActivityRail = ({
   const { isMobile, state } = Sidebar.useSidebar();
   const expanded = isMobile ? mobileExpanded : state === 'expanded';
   const hoverEnabled = !expanded && !isMobile;
-  const { promoted, rest } = splitPromotedNavigationActivities(activities);
+  const { promoted } = splitPromotedNavigationActivities(activities);
   const visibleRest = splitPromotedNavigationActivities(visibleActivities).rest;
+  const hiddenRest = splitPromotedNavigationActivities(hiddenActivities).rest;
   const usePromotedRail = promoted.length > 0;
 
   return (
@@ -101,7 +104,7 @@ export const NavigationActivityRail = ({
           onSelectActivity={onSelectActivity}
         />
         <NavigationActivityMore
-          activities={usePromotedRail ? rest : activities}
+          activities={usePromotedRail ? hiddenRest : hiddenActivities}
           expanded={expanded}
           isActivityPinned={isActivityPinned}
           onPinnedChange={onActivityPinnedChange}

--- a/frontend/core-ui/src/modules/navigation/hooks/usePinnedNavigationActivities.ts
+++ b/frontend/core-ui/src/modules/navigation/hooks/usePinnedNavigationActivities.ts
@@ -43,6 +43,9 @@ export const usePinnedNavigationActivities = (
   const visibleActivities = activities.filter((activity) =>
     visibleActivityIdSet.has(activity.id),
   );
+  const hiddenActivities = activities.filter(
+    (activity) => !visibleActivityIdSet.has(activity.id),
+  );
 
   const setActivityPinned = useCallback(
     (activityId: string, pinned: boolean) => {
@@ -67,5 +70,6 @@ export const usePinnedNavigationActivities = (
     isActivityPinned,
     setActivityPinned,
     visibleActivities,
+    hiddenActivities,
   };
 };


### PR DESCRIPTION
## Summary by Sourcery

Prevent the navigation More popover from listing activities that are already visible in the navigation rail.

Bug Fixes:
- Exclude activities already displayed in the navigation rail from the More popover.

Enhancements:
- Pass and use the set of hidden navigation activities when rendering the More menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved navigation activity organization by separating visible, promoted, and hidden activities.
  - Updated the More menu to display hidden activities that are not already promoted.
  - Preserved existing navigation panel behavior while ensuring activity visibility and pinning states are reflected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->