### PR TITLE
fix(help-center): keep the portal app token reachable after a failed …

### DIFF
--- a/apps/help-center/modules/apollo/apolloClient.ts
+++ b/apps/help-center/modules/apollo/apolloClient.ts
@@ -14,16 +14,13 @@ export const setAppTokenReader = (reader: () => string): void => {
 };
 
 export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
-  const authLink = new SetContextLink(({ headers }) => {
+  const authLink = new SetContextLink(({ headers, apiUrl }) => {
     const appToken = readAppToken();
 
+    const resolved: string = apiUrl || readApiUrl();
+
     return {
-      /*
-       * A SaaS gateway is addressed per tenant, so the address can differ
-       * between requests; it is read per operation rather than fixed when the
-       * client is built.
-       */
-      uri: `${readApiUrl()}/graphql`,
+      uri: `${resolved}/graphql`,
       headers: {
         ...headers,
         ...(appToken ? { 'x-app-token': appToken } : {}),

--- a/apps/help-center/modules/config/api.ts
+++ b/apps/help-center/modules/config/api.ts
@@ -7,6 +7,12 @@ import {
 } from '@/modules/apollo/utils/env';
 import { errorMessage, type PortalResult } from '@/modules/apollo/utils/result';
 import { HELP_CENTER_CONFIG_BY_DOMAIN } from './graphql/queries/helpCenterConfig';
+import {
+  readScopedApiUrl,
+  readScopedAppToken,
+  writeScopedApiUrl,
+  writeScopedAppToken,
+} from './requestScope';
 import { normalizeConfig } from './utils/normalize';
 import type { HelpCenterConfig, PortalConfig } from './types';
 
@@ -20,7 +26,7 @@ const requestOrigin = async (): Promise<string> => {
   // A SaaS gateway is addressed per tenant, and this is the first thing the
   // server reads from a request, so the address is resolved from this host for
   // everything the request goes on to ask for.
-  apiUrl = apiUrlForHost(host);
+  writeScopedApiUrl(apiUrlForHost(host));
 
   if (!host) {
     return '';
@@ -35,10 +41,8 @@ const requestOrigin = async (): Promise<string> => {
   return `${proto}://${host}`;
 };
 
-let appToken = '';
-let apiUrl = '';
-
 const fetchConfig = async (
+  apiUrl: string,
   domain: string,
 ): Promise<PortalResult<PortalConfig>> => {
   if (!apiUrl) {
@@ -54,6 +58,7 @@ const fetchConfig = async (
       query: HELP_CENTER_CONFIG_BY_DOMAIN,
       variables: { domain },
       errorPolicy: 'all',
+      context: { apiUrl },
     });
 
     if (error) {
@@ -74,21 +79,24 @@ const fetchConfig = async (
 
 const CONFIG_TTL_SECONDS = 60;
 
-const cachedByDomain = unstable_cache(fetchConfig, ['portal-help-center'], {
-  revalidate: CONFIG_TTL_SECONDS,
-});
+const cachedByDomain = (apiUrl: string, domain: string) =>
+  unstable_cache(fetchConfig, ['portal-help-center'], {
+    revalidate: CONFIG_TTL_SECONDS,
+  })(apiUrl, domain);
 
 export const getPortalConfig = async (): Promise<
   PortalResult<PortalConfig>
 > => {
   const domain = await requestOrigin();
+  const apiUrl = readScopedApiUrl();
 
-  const cached = await cachedByDomain(domain);
+  const cached = await cachedByDomain(apiUrl, domain);
 
-  const result = cached.state === 'error' ? await fetchConfig(domain) : cached;
+  const result =
+    cached.state === 'ready' ? cached : await fetchConfig(apiUrl, domain);
 
   if (result.state === 'ready') {
-    appToken = result.data.appToken;
+    writeScopedAppToken(result.data.appToken);
   }
 
   return result;
@@ -100,5 +108,5 @@ export const readConfig = async (): Promise<PortalConfig | null> => {
   return result.state === 'ready' ? result.data : null;
 };
 
-setAppTokenReader(() => appToken);
-setResolvedApiUrlReader(() => apiUrl);
+setAppTokenReader(() => readScopedAppToken());
+setResolvedApiUrlReader(() => readScopedApiUrl());

--- a/apps/help-center/modules/config/requestScope.ts
+++ b/apps/help-center/modules/config/requestScope.ts
@@ -1,0 +1,31 @@
+import { cache } from 'react';
+
+/*
+ * The gateway address and the portal's app token are resolved from the host of
+ * the request being answered, so on a SaaS install they differ between
+ * tenants. `cache()` gives each request its own store, which keeps a value
+ * written while answering one request from being read while answering another
+ * — the hazard module-level variables carry once anything between the write
+ * and the read suspends.
+ *
+ * These are only ever written from server code, which is where the request
+ * host is known.
+ */
+type RequestScope = {
+  apiUrl: string;
+  appToken: string;
+};
+
+const requestScope = cache((): RequestScope => ({ apiUrl: '', appToken: '' }));
+
+export const readScopedApiUrl = (): string => requestScope().apiUrl;
+
+export const writeScopedApiUrl = (apiUrl: string): void => {
+  requestScope().apiUrl = apiUrl;
+};
+
+export const readScopedAppToken = (): string => requestScope().appToken;
+
+export const writeScopedAppToken = (appToken: string): void => {
+  requestScope().appToken = appToken;
+};


### PR DESCRIPTION
…config load

The portal's `erxesAppToken` travels to the gateway as `x-app-token`, which is what resolves `context.clientPortal`. Without it every guarded operation fails with "Client portal required" — sign-up among them.

Two things kept that token from being set:

- Every config state was cached, so an `unpublished` or `unconfigured` result stood for the whole 60s TTL. During that window the config was never re-fetched and the token was never assigned, so the header went out empty long after the portal was reachable again. Only a resolved config is cached now; the other states re-fetch.

- The token and the resolved gateway address lived in module-level variables shared by every request the server answered. They are held per request now, so a value written while answering one request cannot be read while answering another.

`fetchConfig` takes the gateway address as an argument and passes it through the operation context rather than reading it from the request scope: a cached function may not reach for request data, and the address belongs in what identifies the cached result, since one host's config must never answer another's.

## Summary by Sourcery

Keep help-center portal authentication state reliable across configuration retries and concurrent tenant requests.

Bug Fixes:
- Ensure portal app tokens remain available after transient or unsuccessful configuration loads so guarded portal operations can recover correctly.
- Prevent gateway addresses and app tokens from leaking between concurrent requests or tenants.

Enhancements:
- Make configuration caching tenant-aware and cache only successfully resolved configurations, allowing other states to be retried.
- Pass the resolved gateway address through Apollo operation context and request-scoped state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request handling so portal configuration and GraphQL requests consistently use the API URL associated with the current request.
  - Improved configuration reliability by fetching current settings when cached results are unavailable or incomplete.
  - Improved support for environments where API endpoints vary by request host, reducing the risk of configuration being shared across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->