### PR TITLE
feat(documents): Lock documents added

### DIFF
--- a/backend/core-api/src/modules/approval/graphql/resolvers/mutations.ts
+++ b/backend/core-api/src/modules/approval/graphql/resolvers/mutations.ts
@@ -14,6 +14,7 @@ import {
 import { ExpectedError } from 'erxes-api-shared/utils';
 import { PipelineStage } from 'mongoose';
 import { IContext } from '~/connectionResolvers';
+import { DOCUMENT_APPROVAL_CONTENT_TYPE } from '~/modules/documents/types';
 
 const unique = (ids: string[]) => [...new Set(ids.filter(Boolean))];
 
@@ -104,10 +105,21 @@ export const approvalMutations = {
   ) {
     await checkPermission('approvalLocksManage');
 
+    let ownerId = input.ownerId;
+    if (input.contentType === DOCUMENT_APPROVAL_CONTENT_TYPE) {
+      await checkPermission('manageDocuments');
+      const document = await models.Documents.getDocument({
+        _id: input.contentTypeId,
+        user,
+        action: 'edit',
+      });
+      ownerId = document.createdUserId;
+    }
+
     return models.ApprovalLocks.createLock({
       contentType: input.contentType,
       contentId: input.contentTypeId,
-      ownerIdSnapshot: input.ownerId,
+      ownerIdSnapshot: ownerId,
       lockedBy: user._id,
       allowedUserIds: unique(input.allowedUserIds || []),
       approverScope: input.scope || APPROVAL_APPROVER_SCOPES.LOCKER_ONLY,

--- a/backend/core-api/src/modules/documents/__tests__/queries.spec.ts
+++ b/backend/core-api/src/modules/documents/__tests__/queries.spec.ts
@@ -1,0 +1,76 @@
+import { cursorPaginate } from 'erxes-api-shared/utils';
+import { IContext } from '~/connectionResolvers';
+import { documentQueries } from '../graphql/queries';
+
+jest.mock('erxes-api-shared/utils', () => ({ cursorPaginate: jest.fn() }));
+jest.mock('~/meta/documents', () => ({ documents: {} }), { virtual: true });
+
+const document = {
+  _id: 'document-1',
+  createdUserId: 'creator-1',
+  name: 'Template',
+  content: 'Private content',
+  replacer: 'Private replacer',
+};
+const getStates = jest.fn();
+const getState = jest.fn();
+const context = {
+  models: { Documents: {}, ApprovalLocks: { getStates, getState } },
+  user: { _id: 'reader-1' },
+  checkPermission: jest.fn(),
+} as unknown as IContext;
+const params = { limit: 20, contentType: 'core:documents' };
+
+/** Missing batch states must be rechecked without implicitly granting access. */
+describe('document list approval access', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(cursorPaginate).mockResolvedValue({
+      list: [document],
+      totalCount: 1,
+      pageInfo: {},
+    } as unknown as Awaited<ReturnType<typeof cursorPaginate>>);
+    getStates.mockResolvedValue([]);
+  });
+
+  it.each([true, false])(
+    'rechecks a missing state with hasAccess=%s',
+    async (hasAccess) => {
+      getState.mockResolvedValue({ contentId: document._id, hasAccess });
+      const result = await documentQueries.documents(
+        undefined,
+        params,
+        context,
+      );
+
+      expect(getState).toHaveBeenCalledWith({
+        user: context.user,
+        contentType: 'core:documents',
+        contentId: document._id,
+        ownerId: document.createdUserId,
+        action: 'view',
+      });
+      expect(result.list[0].content).toBe(hasAccess ? document.content : null);
+      expect(result.list[0].replacer).toBe(
+        hasAccess ? document.replacer : null,
+      );
+      expect(result.totalCount).toBe(1);
+    },
+  );
+
+  it('uses the batch state without another lookup', async () => {
+    getStates.mockResolvedValue([
+      { contentId: document._id, hasAccess: false },
+    ]);
+    const result = await documentQueries.documents(undefined, params, context);
+    expect(getState).not.toHaveBeenCalled();
+    expect(result.list[0].content).toBeNull();
+  });
+
+  it('does not return document content when the fallback check fails', async () => {
+    getState.mockRejectedValue(new Error('Approval unavailable'));
+    await expect(
+      documentQueries.documents(undefined, params, context),
+    ).rejects.toThrow('Approval unavailable');
+  });
+});

--- a/backend/core-api/src/modules/documents/db/models/Documents.ts
+++ b/backend/core-api/src/modules/documents/db/models/Documents.ts
@@ -22,10 +22,13 @@ export interface IDocumentModel extends Model<IDocumentDocument> {
   processDocument(input: DocumentProcessInput): Promise<string>;
 }
 
+const ANONYMOUS_DOCUMENT_USER: DocumentAccessUser = { _id: '' };
+
 export const loadDocumentClass = (models: IModels, subdomain: string) => {
   class Document {
+    /** Exclude documents the acting user cannot access under active approval locks. */
     public static async getAccessFilter(
-      user: DocumentAccessUser = { _id: '' },
+      user: DocumentAccessUser = ANONYMOUS_DOCUMENT_USER,
     ): Promise<FilterQuery<IDocumentDocument>> {
       const locks = await models.ApprovalLocks.find({
         contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
@@ -60,9 +63,10 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
       };
     }
 
+    /** Load a document and enforce approval access for the requested action. */
     public static async getDocument({
       _id,
-      user = { _id: '' },
+      user = ANONYMOUS_DOCUMENT_USER,
       action = 'view',
     }: DocumentReadInput): Promise<IDocumentDocument> {
       const document = await models.Documents.findOne({ _id });
@@ -82,6 +86,7 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
       return document;
     }
 
+    /** Create or edit a document while preserving its owner and enforcing edit access. */
     public static async saveDocument({ _id, doc, user }: DocumentSaveInput) {
       if (_id) {
         const document = await models.Documents.getDocument({
@@ -100,6 +105,7 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
       return await models.Documents.create(doc);
     }
 
+    /** Render a document only after verifying the acting user can view it. */
     public static async processDocument({
       user,
       ...doc

--- a/backend/core-api/src/modules/documents/db/models/Documents.ts
+++ b/backend/core-api/src/modules/documents/db/models/Documents.ts
@@ -1,38 +1,98 @@
+import { APPROVAL_LOCK_STATUSES } from 'erxes-api-shared/core-modules';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
-import { Model } from 'mongoose';
+import { FilterQuery, Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
 import { documents } from '~/meta/documents';
-import { IDocumentDocument } from '~/modules/documents/types';
+import {
+  DOCUMENT_APPROVAL_CONTENT_TYPE,
+  DocumentAccessUser,
+  DocumentReadInput,
+  DocumentSaveInput,
+  DocumentProcessInput,
+  IDocumentDocument,
+} from '~/modules/documents/types';
 import { prepareContent } from '~/modules/documents/utils';
 import { documentSchema } from '../definitions/documents';
 export interface IDocumentModel extends Model<IDocumentDocument> {
-  getDocument({ _id }: { _id: string }): Promise<IDocumentDocument>;
-  saveDocument({ _id, doc }): Promise<IDocumentDocument>;
-  processDocument({ _id, replacerIds, config }): Promise<IDocumentDocument>;
+  getAccessFilter(
+    user?: DocumentAccessUser,
+  ): Promise<FilterQuery<IDocumentDocument>>;
+  getDocument(input: DocumentReadInput): Promise<IDocumentDocument>;
+  saveDocument(input: DocumentSaveInput): Promise<IDocumentDocument>;
+  processDocument(input: DocumentProcessInput): Promise<string>;
 }
 
 export const loadDocumentClass = (models: IModels, subdomain: string) => {
   class Document {
-    public static async getDocument({ _id }: { _id: string }) {
+    public static async getAccessFilter(
+      user: DocumentAccessUser = { _id: '' },
+    ): Promise<FilterQuery<IDocumentDocument>> {
+      const locks = await models.ApprovalLocks.find({
+        contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+        status: APPROVAL_LOCK_STATUSES.ACTIVE,
+      })
+        .select('contentId')
+        .lean();
+
+      if (!locks.length) return {};
+
+      const documents = await models.Documents.find({
+        _id: { $in: locks.map((lock) => lock.contentId) },
+      })
+        .select('_id createdUserId')
+        .lean();
+      const states = await models.ApprovalLocks.getStates({
+        user,
+        contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+        contentIds: documents.map((document) => document._id),
+        ownerIdsByContentId: Object.fromEntries(
+          documents.map((document) => [document._id, document.createdUserId]),
+        ),
+        action: 'view',
+      });
+
+      return {
+        _id: {
+          $nin: states
+            .filter((state) => !state.hasAccess)
+            .map((state) => state.contentId),
+        },
+      };
+    }
+
+    public static async getDocument({
+      _id,
+      user = { _id: '' },
+      action = 'view',
+    }: DocumentReadInput): Promise<IDocumentDocument> {
       const document = await models.Documents.findOne({ _id });
 
       if (!document) {
         throw new Error('Document not found');
       }
 
+      await models.ApprovalLocks.assertAccess({
+        user,
+        contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+        contentId: document._id,
+        ownerId: document.createdUserId,
+        action,
+      });
+
       return document;
     }
 
-    /**
-     * Marks documents as read
-     */
-    public static async saveDocument({ _id, doc }) {
+    public static async saveDocument({ _id, doc, user }: DocumentSaveInput) {
       if (_id) {
-        const document = await models.Documents.getDocument({ _id });
+        const document = await models.Documents.getDocument({
+          _id,
+          user,
+          action: 'edit',
+        });
 
         return await models.Documents.findOneAndUpdate(
           { _id: document._id },
-          { $set: doc },
+          { $set: { ...doc, createdUserId: document.createdUserId } },
           { new: true },
         );
       }
@@ -40,10 +100,13 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
       return await models.Documents.create(doc);
     }
 
-    public static async processDocument(doc) {
+    public static async processDocument({
+      user,
+      ...doc
+    }: DocumentProcessInput) {
       const { _id, config } = doc;
 
-      const document = await models.Documents.getDocument({ _id });
+      const document = await models.Documents.getDocument({ _id, user });
       const { content, contentType } = document;
 
       const [pluginName, moduleName] = contentType.split(':');
@@ -55,6 +118,8 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
           subdomain,
           data: {
             ...(doc || {}),
+            replacerIds: doc.replacerIds || [],
+            config: config || {},
             content,
             contentType: document.contentType,
           },
@@ -62,7 +127,7 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
 
         return prepareContent({
           contents: replacedContents,
-          config,
+          config: config || {},
         });
       }
 
@@ -83,7 +148,7 @@ export const loadDocumentClass = (models: IModels, subdomain: string) => {
 
       return prepareContent({
         contents: replacedContents,
-        config,
+        config: config || {},
       });
     }
   }

--- a/backend/core-api/src/modules/documents/graphql/customResolvers/document.ts
+++ b/backend/core-api/src/modules/documents/graphql/customResolvers/document.ts
@@ -1,9 +1,34 @@
+import { ApprovalLockState } from 'erxes-api-shared/core-modules';
 import { IContext } from '~/connectionResolvers';
-import { IDocumentDocument } from '~/modules/documents/types';
+import {
+  DOCUMENT_APPROVAL_CONTENT_TYPE,
+  IDocumentDocument,
+} from '~/modules/documents/types';
 
 export default {
-  async __resolveReference({ _id }, { models }: IContext) {
-    return models.Documents.findOne({ _id });
+  async __resolveReference(
+    { _id }: { _id: string },
+    { models, user, checkPermission }: IContext,
+  ) {
+    await checkPermission('documentsRead');
+    return models.Documents.getDocument({ _id, user });
+  },
+
+  async approvalLockState(
+    document: IDocumentDocument & { approvalLockState?: ApprovalLockState },
+    _args: undefined,
+    { models, user }: IContext,
+  ): Promise<ApprovalLockState> {
+    return (
+      document.approvalLockState ||
+      models.ApprovalLocks.getState({
+        user,
+        contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+        contentId: document._id,
+        ownerId: document.createdUserId,
+        action: 'view',
+      })
+    );
   },
 
   async createdUser(

--- a/backend/core-api/src/modules/documents/graphql/customResolvers/document.ts
+++ b/backend/core-api/src/modules/documents/graphql/customResolvers/document.ts
@@ -14,11 +14,11 @@ export default {
     return models.Documents.getDocument({ _id, user });
   },
 
-  async approvalLockState(
+  approvalLockState(
     document: IDocumentDocument & { approvalLockState?: ApprovalLockState },
     _args: undefined,
     { models, user }: IContext,
-  ): Promise<ApprovalLockState> {
+  ): ApprovalLockState | Promise<ApprovalLockState> {
     return (
       document.approvalLockState ||
       models.ApprovalLocks.getState({

--- a/backend/core-api/src/modules/documents/graphql/mutations.ts
+++ b/backend/core-api/src/modules/documents/graphql/mutations.ts
@@ -17,17 +17,22 @@ export const documentMutations = {
     return await models.Documents.saveDocument({
       _id,
       doc: { ...doc, createdUserId: user._id },
+      user,
     });
   },
 
   documentsRemove: async (
     _parent: undefined,
     { _id }: { _id: string },
-    { models, checkPermission }: IContext,
+    { models, user, checkPermission }: IContext,
   ) => {
     await checkPermission('removeDocuments');
 
-    const document = await models.Documents.getDocument({ _id });
+    const document = await models.Documents.getDocument({
+      _id,
+      user,
+      action: 'delete',
+    });
 
     return await models.Documents.findOneAndDelete({ _id: document._id });
   },

--- a/backend/core-api/src/modules/documents/graphql/queries.ts
+++ b/backend/core-api/src/modules/documents/graphql/queries.ts
@@ -7,7 +7,12 @@ import {
 import { FilterQuery } from 'mongoose';
 import { IContext } from '~/connectionResolvers';
 import { documents } from '~/meta/documents';
-import { IDocumentDocument, IDocumentFilterQueryParams } from '../types';
+import {
+  DOCUMENT_APPROVAL_CONTENT_TYPE,
+  DocumentProcessInput,
+  IDocumentDocument,
+  IDocumentFilterQueryParams,
+} from '../types';
 
 const generateFilter = (params: IDocumentFilterQueryParams) => {
   const { searchValue, contentType, subType, userIds, dateFilters, tagIds } =
@@ -44,6 +49,9 @@ const generateFilter = (params: IDocumentFilterQueryParams) => {
       const dateFilter = JSON.parse(dateFilters || '{}');
 
       for (const [key, value] of Object.entries(dateFilter)) {
+        if (key !== 'createdAt') {
+          throw new Error('Only createdAt can be used in dateFilters');
+        }
         const { gte, lte } = (value || {}) as { gte?: string; lte?: string };
 
         if (gte || lte) {
@@ -70,9 +78,25 @@ export const documentQueries = {
   documents: async (
     _parent: undefined,
     params: IDocumentFilterQueryParams,
-    { models }: IContext,
+    { models, user, checkPermission }: IContext,
   ) => {
+    await checkPermission('documentsRead');
     const filter = generateFilter(params);
+    // Cursor values are returned to the client, so never sort by template data.
+    const sortFields = new Set([
+      '_id',
+      'name',
+      'createdAt',
+      'createdUserId',
+      'contentType',
+      'subType',
+      'code',
+    ]);
+    if (
+      Object.keys(params.orderBy || {}).some((field) => !sortFields.has(field))
+    ) {
+      throw new Error('Unsupported document sort field');
+    }
 
     const { list, pageInfo, totalCount } =
       await cursorPaginate<IDocumentDocument>({
@@ -81,15 +105,40 @@ export const documentQueries = {
         query: filter,
       });
 
-    return { list, pageInfo, totalCount };
+    const states = await models.ApprovalLocks.getStates({
+      user,
+      contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+      contentIds: list.map((document) => document._id),
+      ownerIdsByContentId: Object.fromEntries(
+        list.map((document) => [document._id, document.createdUserId]),
+      ),
+      action: 'view',
+    });
+    const statesById = new Map(states.map((state) => [state.contentId, state]));
+
+    return {
+      list: list.map((document) => {
+        const approvalLockState = statesById.get(document._id);
+        return {
+          ...document,
+          // Keep locked records discoverable without exposing their templates.
+          content: approvalLockState?.hasAccess ? document.content : null,
+          replacer: approvalLockState?.hasAccess ? document.replacer : null,
+          approvalLockState,
+        };
+      }),
+      pageInfo,
+      totalCount,
+    };
   },
 
   documentsDetail: async (
     _parent: undefined,
     { _id }: { _id: string },
-    { models }: IContext,
+    { models, user, checkPermission }: IContext,
   ) => {
-    return await models.Documents.getDocument({ _id });
+    await checkPermission('documentsRead');
+    return await models.Documents.getDocument({ _id, user });
   },
 
   documentsTypes: async () => {
@@ -155,8 +204,9 @@ export const documentQueries = {
   documentsTotalCount: async (
     _parent: undefined,
     params: IDocumentFilterQueryParams,
-    { models }: IContext,
+    { models, checkPermission }: IContext,
   ) => {
+    await checkPermission('documentsRead');
     const filter = generateFilter(params);
 
     return models.Documents.find(filter).countDocuments();
@@ -164,17 +214,15 @@ export const documentQueries = {
 
   documentsProcess: async (
     _parent: undefined,
-    {
-      _id,
-      replacerIds,
-      config,
-    }: { _id: string; replacerIds: string[]; config },
-    { models }: IContext,
+    { _id, replacerIds, config }: Omit<DocumentProcessInput, 'user'>,
+    { models, user, checkPermission }: IContext,
   ) => {
+    await checkPermission('documentsRead');
     return models.Documents.processDocument({
       _id,
       replacerIds,
       config,
+      user,
     });
   },
 };

--- a/backend/core-api/src/modules/documents/graphql/queries.ts
+++ b/backend/core-api/src/modules/documents/graphql/queries.ts
@@ -117,16 +117,26 @@ export const documentQueries = {
     const statesById = new Map(states.map((state) => [state.contentId, state]));
 
     return {
-      list: list.map((document) => {
-        const approvalLockState = statesById.get(document._id);
-        return {
-          ...document,
-          // Keep locked records discoverable without exposing their templates.
-          content: approvalLockState?.hasAccess ? document.content : null,
-          replacer: approvalLockState?.hasAccess ? document.replacer : null,
-          approvalLockState,
-        };
-      }),
+      list: await Promise.all(
+        list.map(async (document) => {
+          const approvalLockState =
+            statesById.get(document._id) ||
+            (await models.ApprovalLocks.getState({
+              user,
+              contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+              contentId: document._id,
+              ownerId: document.createdUserId,
+              action: 'view',
+            }));
+          return {
+            ...document,
+            // Keep locked records discoverable without exposing their templates.
+            content: approvalLockState?.hasAccess ? document.content : null,
+            replacer: approvalLockState?.hasAccess ? document.replacer : null,
+            approvalLockState,
+          };
+        }),
+      ),
       pageInfo,
       totalCount,
     };

--- a/backend/core-api/src/modules/documents/graphql/schema.ts
+++ b/backend/core-api/src/modules/documents/graphql/schema.ts
@@ -15,6 +15,7 @@ export const types = `
     content: String
     replacer: String
 
+    approvalLockState: ApprovalLockState
     cursor: String
   }
 

--- a/backend/core-api/src/modules/documents/routes.ts
+++ b/backend/core-api/src/modules/documents/routes.ts
@@ -27,7 +27,7 @@ router.get(
           typeof replacerIds === 'string' ? [replacerIds] : replacerIds,
       });
 
-      return res.send(content);
+      res.send(content);
     } catch (error) {
       next(error);
     }

--- a/backend/core-api/src/modules/documents/routes.ts
+++ b/backend/core-api/src/modules/documents/routes.ts
@@ -1,22 +1,37 @@
 import { getSubdomain } from 'erxes-api-shared/utils';
-import { Request, Response, Router } from 'express';
+import { NextFunction, Request, Response, Router } from 'express';
+import { z } from 'zod';
 import { generateModels } from '~/connectionResolvers';
 
 const router: Router = Router();
-
-router.get('/print', async (req: Request, res: Response) => {
-  const subdomain = getSubdomain(req);
-  const models = await generateModels(subdomain);
-
-  const { _id, config, replacerIds } = req.query;
-
-  const document = await models.Documents.processDocument({
-    _id,
-    config,
-    replacerIds,
-  });
-
-  return res.send(document.content);
+const printQuerySchema = z.object({
+  _id: z.string().min(1),
+  config: z.record(z.unknown()).optional(),
+  replacerIds: z.union([z.string(), z.array(z.string())]).optional(),
 });
+
+router.get(
+  '/print',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const subdomain = getSubdomain(req);
+      const models = await generateModels(subdomain);
+      const { _id, config, replacerIds } = printQuerySchema.parse(req.query);
+
+      // This legacy route has no authenticated user. The model denies locked
+      // documents; authenticated printing goes through documentsProcess.
+      const content = await models.Documents.processDocument({
+        _id,
+        config,
+        replacerIds:
+          typeof replacerIds === 'string' ? [replacerIds] : replacerIds,
+      });
+
+      return res.send(content);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
 
 export { router };

--- a/backend/core-api/src/modules/documents/trpc/document.ts
+++ b/backend/core-api/src/modules/documents/trpc/document.ts
@@ -2,8 +2,21 @@ import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 import { CoreTRPCContext } from '~/init-trpc';
 import { agentMeta } from '~/utils/agentMeta';
+import { DocumentAccessUser } from '../types';
 
 const t = initTRPC.context<CoreTRPCContext>().create();
+
+const documentQuerySchema = z.record(z.unknown());
+
+const getDocumentUser = async (
+  ctx: Awaited<ReturnType<CoreTRPCContext>>,
+): Promise<DocumentAccessUser | undefined> => {
+  if (!ctx.userId) return undefined;
+  const user = await ctx.models.Users.findOne({ _id: ctx.userId })
+    .select('_id isOwner')
+    .lean<DocumentAccessUser | null>();
+  return user || undefined;
+};
 
 export const documentTrpcRouter = t.router({
   documents: t.router({
@@ -14,13 +27,16 @@ export const documentTrpcRouter = t.router({
           { module: 'documents', action: 'documentsRead' },
         ),
       )
-      .input(z.any())
+      .input(z.object({ query: documentQuerySchema.optional() }))
       .query(async ({ ctx, input }) => {
-      const { query } = input;
-      const { models } = ctx;
-
-      return await models.Documents.find(query).lean();
-    }),
+        const { query } = input;
+        const { models } = ctx;
+        const user = await getDocumentUser(ctx);
+        const accessFilter = await models.Documents.getAccessFilter(user);
+        return models.Documents.find({
+          $and: [query || {}, accessFilter],
+        }).lean();
+      }),
 
     findOne: t.procedure
       .meta(
@@ -29,17 +45,21 @@ export const documentTrpcRouter = t.router({
           { module: 'documents', action: 'documentsRead' },
         ),
       )
-      .input(z.any())
+      .input(documentQuerySchema)
       .query(async ({ ctx, input }) => {
-      const query = input?.query || input?.selector || input;
-      const { models } = ctx;
+        const query = documentQuerySchema.parse(
+          input.query || input.selector || input,
+        );
+        const { models } = ctx;
 
-      if (!query || !Object.keys(query).length) {
-        return {};
-      }
+        if (!query || !Object.keys(query).length) {
+          return {};
+        }
 
-      return await models.Documents.findOne(query);
-    }),
+        const user = await getDocumentUser(ctx);
+        const accessFilter = await models.Documents.getAccessFilter(user);
+        return models.Documents.findOne({ $and: [query, accessFilter] });
+      }),
 
     print: t.procedure
       .meta(
@@ -48,15 +68,22 @@ export const documentTrpcRouter = t.router({
           { module: 'documents', action: 'documentsRead' },
         ),
       )
-      .input(z.any())
+      .input(
+        z.object({
+          _id: z.string().min(1),
+          replacerIds: z.array(z.string()).optional(),
+          config: z.record(z.unknown()).optional(),
+        }),
+      )
       .query(async ({ ctx, input }) => {
-      const { _id, replacerIds, config } = input;
-      const { models } = ctx;
-      return await models.Documents.processDocument({
-        _id,
-        replacerIds,
-        config,
-      });
-    }),
+        const { _id, replacerIds, config } = input;
+        const { models } = ctx;
+        return await models.Documents.processDocument({
+          _id,
+          replacerIds,
+          config,
+          user: await getDocumentUser(ctx),
+        });
+      }),
   }),
 });

--- a/backend/core-api/src/modules/documents/trpc/document.ts
+++ b/backend/core-api/src/modules/documents/trpc/document.ts
@@ -8,6 +8,7 @@ const t = initTRPC.context<CoreTRPCContext>().create();
 
 const documentQuerySchema = z.record(z.unknown());
 
+/** Resolve the tenant-scoped acting user for document approval checks. */
 const getDocumentUser = async (
   ctx: Awaited<ReturnType<CoreTRPCContext>>,
 ): Promise<DocumentAccessUser | undefined> => {

--- a/backend/core-api/src/modules/documents/types.ts
+++ b/backend/core-api/src/modules/documents/types.ts
@@ -28,3 +28,29 @@ export interface IDocumentFilterQueryParams
   dateFilters?: string;
   tagIds?: string[];
 }
+
+export type DocumentAccessUser = {
+  _id: string;
+  isOwner?: boolean;
+};
+
+export type DocumentReadInput = {
+  _id: string;
+  user?: DocumentAccessUser;
+  action?: 'view' | 'edit' | 'delete';
+};
+
+export type DocumentSaveInput = {
+  _id?: string;
+  doc: IDocument & { createdUserId: string };
+  user?: DocumentAccessUser;
+};
+
+export type DocumentProcessInput = {
+  _id: string;
+  replacerIds?: string[];
+  config?: Record<string, unknown>;
+  user?: DocumentAccessUser;
+};
+
+export const DOCUMENT_APPROVAL_CONTENT_TYPE = 'core:documents';

--- a/backend/core-api/src/modules/tags/db/models/Tags.ts
+++ b/backend/core-api/src/modules/tags/db/models/Tags.ts
@@ -7,6 +7,10 @@ import { ITag, ITagDocument } from 'erxes-api-shared/core-types';
 import { escapeRegExp, sendTRPCMessage } from 'erxes-api-shared/utils';
 import { FilterQuery, Model } from 'mongoose';
 import { IModels } from '~/connectionResolvers';
+import {
+  DocumentAccessUser,
+  DOCUMENT_APPROVAL_CONTENT_TYPE,
+} from '~/modules/documents/types';
 import { taggableTarget } from '../../taggable';
 export interface ITagModel extends Model<ITagDocument> {
   getTag(_id: string): Promise<ITagDocument>;
@@ -17,6 +21,7 @@ export interface ITagModel extends Model<ITagDocument> {
     type: string,
     targetIds: string[],
     tagIds: string[],
+    user?: DocumentAccessUser,
   ): Promise<ITagDocument>;
   fixRelatedRecords(args: {
     type: string;
@@ -223,7 +228,15 @@ export const loadTagClass = (
       type: string,
       targetIds: string[],
       tagIds: string[],
+      user?: DocumentAccessUser,
     ) {
+      if (type === DOCUMENT_APPROVAL_CONTENT_TYPE) {
+        await Promise.all(
+          targetIds.map((_id) =>
+            models.Documents.getDocument({ _id, user, action: 'edit' }),
+          ),
+        );
+      }
       const [pluginName, moduleName] = type.split(':');
 
       if (!pluginName || !moduleName) {

--- a/backend/core-api/src/modules/tags/graphql/mutations.ts
+++ b/backend/core-api/src/modules/tags/graphql/mutations.ts
@@ -38,11 +38,11 @@ export const tagMutations: Record<string, Resolver<any, any, IContext>> = {
       targetIds,
       tagIds,
     }: { type: string; targetIds: string[]; tagIds: string[] },
-    { models, checkPermission }: IContext,
+    { models, user, checkPermission }: IContext,
   ) {
     await checkPermission('tagsTag');
 
-    return await models.Tags.tagsTag(type, targetIds, tagIds);
+    return await models.Tags.tagsTag(type, targetIds, tagIds, user);
   },
 
   /**

--- a/frontend/core-ui/src/modules/documents/components/DocumentSheet.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentSheet.tsx
@@ -1,11 +1,15 @@
+import { useApolloClient } from '@apollo/client';
 import { FormType } from '@/documents/hooks/useDocumentForm';
-import { Button, useQueryState } from 'erxes-ui';
+import { Button, toast, useQueryState } from 'erxes-ui';
 import { useCallback } from 'react';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
+import { ApprovalLockButton } from 'ui-modules';
+import { DOCUMENT_APPROVAL_CONTENT_TYPE } from '../constants';
+import { GET_DOCUMENTS, GET_DOCUMENT_DETAIL } from '../graphql/queries';
 import { useDocument } from '../hooks/useDocument';
 
 export const DocumentSheet = () => {
-  const [documentId, setDocumentId] = useQueryState('documentId');
+  const [documentId, setDocumentId] = useQueryState<string>('documentId');
   const [contentType] = useQueryState<string>('contentType');
 
   const {
@@ -15,7 +19,9 @@ export const DocumentSheet = () => {
     formState,
   } = useFormContext<FormType>();
 
-  const { documentSave } = useDocument();
+  const client = useApolloClient();
+  const { document, documentSave, hasError, loading } = useDocument();
+  const cleanDocumentId = documentId?.trim();
 
   const submitHandler: SubmitHandler<FormType> = useCallback(async () => {
     documentSave();
@@ -43,8 +49,39 @@ export const DocumentSheet = () => {
   }
 
   return (
-    <Button onClick={handleSubmit(submitHandler)} disabled={!hasChanges}>
-      Save Document
-    </Button>
+    <div className="flex items-center gap-2">
+      {cleanDocumentId && document && !hasError && (
+        <ApprovalLockButton
+          contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
+          contentId={cleanDocumentId}
+          ownerId={document.createdUser?._id}
+          action="edit"
+          onChanged={() => {
+            void client
+              .refetchQueries({
+                include: [
+                  GET_DOCUMENTS,
+                  GET_DOCUMENT_DETAIL,
+                  'ApprovalLockState',
+                ],
+              })
+              .catch(() => {
+                toast({
+                  title: 'Could not refresh document access',
+                  description:
+                    'Reload the page to see the latest access state.',
+                  variant: 'destructive',
+                });
+              });
+          }}
+        />
+      )}
+      <Button
+        onClick={handleSubmit(submitHandler)}
+        disabled={!hasChanges || loading || hasError}
+      >
+        Save Document
+      </Button>
+    </div>
   );
 };

--- a/frontend/core-ui/src/modules/documents/components/DocumentSheet.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentSheet.tsx
@@ -57,7 +57,7 @@ export const DocumentSheet = () => {
           ownerId={document.createdUser?._id}
           action="edit"
           onChanged={() => {
-            void client
+            client
               .refetchQueries({
                 include: [
                   GET_DOCUMENTS,

--- a/frontend/core-ui/src/modules/documents/components/DocumentsActions.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsActions.tsx
@@ -45,7 +45,10 @@ type DocumentsActionsMenuProps = {
   variant: 'grid' | 'table';
 };
 
-function DocumentLockMenuItem({ documentItem }: { documentItem: IDocument }) {
+/** Offer approval lock controls in grid and record-table document menus. */
+function DocumentLockMenuItem({
+  documentItem,
+}: Readonly<{ documentItem: IDocument }>) {
   const client = useApolloClient();
   const {
     open,
@@ -62,7 +65,7 @@ function DocumentLockMenuItem({ documentItem }: { documentItem: IDocument }) {
     ownerId: documentItem.createdUser?._id,
     action: 'edit',
     onChanged: () => {
-      void client
+      client
         .refetchQueries({
           include: [GET_DOCUMENTS, GET_DOCUMENT_DETAIL, 'ApprovalLockState'],
         })

--- a/frontend/core-ui/src/modules/documents/components/DocumentsActions.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsActions.tsx
@@ -1,7 +1,10 @@
+import { useApolloClient } from '@apollo/client';
 import { useDocumentRemove } from '@/documents/hooks/useDocumentRemove';
 import {
   IconDotsVertical,
   IconEdit,
+  IconLock,
+  IconLockOpen,
   IconPrinter,
   IconTrash,
 } from '@tabler/icons-react';
@@ -11,11 +14,19 @@ import {
   Command,
   Popover,
   RecordTable,
+  toast,
   useConfirm,
   useSetQueryStateByKey,
 } from 'erxes-ui';
 import { useState } from 'react';
-import { Can, PrintDocument } from 'ui-modules';
+import {
+  ApprovalLockDialog,
+  Can,
+  PrintDocument,
+  useApprovalLock,
+} from 'ui-modules';
+import { DOCUMENT_APPROVAL_CONTENT_TYPE } from '../constants';
+import { GET_DOCUMENTS, GET_DOCUMENT_DETAIL } from '../graphql/queries';
 
 import { IDocument } from '../types';
 import {
@@ -24,6 +35,7 @@ import {
 } from './DocumentPrintDialog';
 
 type DocumentsActionsMenuProps = {
+  documentItem: IDocument;
   loading: boolean;
   open: boolean;
   onDelete: () => void;
@@ -33,14 +45,77 @@ type DocumentsActionsMenuProps = {
   variant: 'grid' | 'table';
 };
 
+function DocumentLockMenuItem({ documentItem }: { documentItem: IDocument }) {
+  const client = useApolloClient();
+  const {
+    open,
+    setOpen,
+    isLocked,
+    canRelease,
+    loading,
+    form,
+    onCreate,
+    onRelease,
+  } = useApprovalLock({
+    contentType: DOCUMENT_APPROVAL_CONTENT_TYPE,
+    contentId: documentItem._id,
+    ownerId: documentItem.createdUser?._id,
+    action: 'edit',
+    onChanged: () => {
+      void client
+        .refetchQueries({
+          include: [GET_DOCUMENTS, GET_DOCUMENT_DETAIL, 'ApprovalLockState'],
+        })
+        .catch(() => {
+          toast({
+            title: 'Could not refresh document access',
+            variant: 'destructive',
+          });
+        });
+    },
+  });
+
+  if (isLocked) {
+    return (
+      <Command.Item
+        value="unlock"
+        disabled={!canRelease || loading}
+        onSelect={onRelease}
+      >
+        <IconLockOpen /> Unlock
+      </Command.Item>
+    );
+  }
+
+  return (
+    <ApprovalLockDialog
+      form={form}
+      loading={loading}
+      onCreate={onCreate}
+      open={open}
+      onOpenChange={setOpen}
+      trigger={
+        <Command.Item
+          value="lock"
+          disabled={loading}
+          onSelect={() => setOpen(true)}
+        >
+          <IconLock /> Lock
+        </Command.Item>
+      }
+    />
+  );
+}
+
 function DocumentsActionsList({
+  documentItem,
   loading,
   onDelete,
   onEdit,
   onPrint,
 }: Pick<
   DocumentsActionsMenuProps,
-  'loading' | 'onDelete' | 'onEdit' | 'onPrint'
+  'documentItem' | 'loading' | 'onDelete' | 'onEdit' | 'onPrint'
 >) {
   return (
     <Command.List>
@@ -52,6 +127,9 @@ function DocumentsActionsList({
       <Command.Item value="print" onSelect={onPrint}>
         <IconPrinter /> Print
       </Command.Item>
+      <Can action="manageDocuments">
+        <DocumentLockMenuItem documentItem={documentItem} />
+      </Can>
       <Can action="removeDocuments">
         <Command.Item
           value="delete"
@@ -67,6 +145,7 @@ function DocumentsActionsList({
 }
 
 function DocumentsActionsMenu({
+  documentItem,
   loading,
   open,
   onDelete,
@@ -94,6 +173,7 @@ function DocumentsActionsMenu({
       <Combobox.Content onClick={(event) => event.stopPropagation()}>
         <Command shouldFilter={false}>
           <DocumentsActionsList
+            documentItem={documentItem}
             loading={loading}
             onDelete={onDelete}
             onEdit={onEdit}
@@ -146,9 +226,14 @@ export function DocumentsActions({
     );
   }
 
+  if (documentItem.approvalLockState?.hasAccess === false) {
+    return null;
+  }
+
   return (
     <>
       <DocumentsActionsMenu
+        documentItem={documentItem}
         loading={loading}
         open={open}
         onDelete={handleDelete}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsGrid.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsGrid.tsx
@@ -1,7 +1,7 @@
 import { IconCalendarPlus, IconFileText } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { Card, RelativeDateDisplay, useSetQueryStateByKey } from 'erxes-ui';
-import { MembersInline } from 'ui-modules';
+import { ApprovalLockedBadge, MembersInline } from 'ui-modules';
 import { DOCUMENTS_TYPES_SET } from '../constants';
 import { IDocument } from '../types';
 import { DocumentPreview } from './DocumentPreview';
@@ -29,7 +29,9 @@ export const DocumentsGrid = ({ documents }: { documents: IDocument[] }) => {
             onClick={() => handleOpenDocument(document)}
           >
             <Card.Content className="relative flex h-40 items-center justify-center overflow-hidden border-b bg-muted/30 p-0">
-              <DocumentPreview document={document} />
+              {document.approvalLockState?.hasAccess !== false && (
+                <DocumentPreview document={document} />
+              )}
               <span
                 className={`text-xs py-1 px-2 ${
                   documentType?.color ?? ''
@@ -51,6 +53,7 @@ export const DocumentsGrid = ({ documents }: { documents: IDocument[] }) => {
                   {document.name || 'Untitled'}
                 </h3>
               </div>
+              <ApprovalLockedBadge state={document.approvalLockState} />
               <DocumentsActions documentItem={document} variant="grid" />
             </div>
 

--- a/frontend/core-ui/src/modules/documents/components/DocumentsHeader.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsHeader.tsx
@@ -54,8 +54,8 @@ export const DocumentsHeader = () => {
               contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
               contentId={cleanDocumentId}
               action="edit"
-              fallback={<></>}
-              loadingFallback={<></>}
+              fallback={<span hidden />}
+              loadingFallback={<span hidden />}
             >
               <DocumentSheet />
             </ApprovalLockGuard>

--- a/frontend/core-ui/src/modules/documents/components/DocumentsHeader.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsHeader.tsx
@@ -4,9 +4,17 @@ import { IconCube } from '@tabler/icons-react';
 
 import { Breadcrumb, Button, Separator, useQueryState } from 'erxes-ui';
 import { Link } from 'react-router-dom';
-import { Can, PageHeader, createFavoriteBreadcrumb } from 'ui-modules';
+import {
+  ApprovalLockGuard,
+  Can,
+  PageHeader,
+  createFavoriteBreadcrumb,
+} from 'ui-modules';
+import { DOCUMENT_APPROVAL_CONTENT_TYPE } from '../constants';
 
 export const DocumentsHeader = () => {
+  const [documentId] = useQueryState<string>('documentId');
+  const cleanDocumentId = documentId?.trim();
   const [contentType] = useQueryState<string>('contentType');
   const { documentsTypes } = useDocumentsTypes();
   const selectedDocumentType = documentsTypes.find(
@@ -41,7 +49,19 @@ export const DocumentsHeader = () => {
 
       <PageHeader.End>
         <Can action="manageDocuments">
-          <DocumentSheet />
+          {cleanDocumentId ? (
+            <ApprovalLockGuard
+              contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
+              contentId={cleanDocumentId}
+              action="edit"
+              fallback={<></>}
+              loadingFallback={<></>}
+            >
+              <DocumentSheet />
+            </ApprovalLockGuard>
+          ) : (
+            <DocumentSheet />
+          )}
         </Can>
       </PageHeader.End>
     </PageHeader>

--- a/frontend/core-ui/src/modules/documents/components/DocumentsLayout.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsLayout.tsx
@@ -17,6 +17,20 @@ export const DocumentsLayout = ({
   const documentId = searchParams.get('documentId');
   const contentType = searchParams.get('contentType');
 
+  const editor = documentId?.trim() ? (
+    <ApprovalLockGuard
+      key={documentId}
+      contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
+      contentId={documentId.trim()}
+      action="view"
+      loadingFallback={<DocumentEditorSkeleton />}
+    >
+      <Editor key={documentId} />
+    </ApprovalLockGuard>
+  ) : (
+    <Editor key={documentId} />
+  );
+
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">
       <div className="w-(--sidebar-width) flex-none overflow-hidden">
@@ -27,23 +41,7 @@ export const DocumentsLayout = ({
         )}
       </div>
       <div className="min-w-0 flex-1 overflow-hidden">
-        {documentId !== null ? (
-          documentId.trim() ? (
-            <ApprovalLockGuard
-              key={documentId}
-              contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
-              contentId={documentId.trim()}
-              action="view"
-              loadingFallback={<DocumentEditorSkeleton />}
-            >
-              <Editor key={documentId} />
-            </ApprovalLockGuard>
-          ) : (
-            <Editor key={documentId} />
-          )
-        ) : (
-          <Documents viewType="grid" />
-        )}
+        {documentId !== null ? editor : <Documents viewType="grid" />}
       </div>
     </div>
   );

--- a/frontend/core-ui/src/modules/documents/components/DocumentsLayout.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsLayout.tsx
@@ -1,4 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
+import { ApprovalLockGuard } from 'ui-modules';
+import { DOCUMENT_APPROVAL_CONTENT_TYPE } from '../constants';
+import { DocumentEditorSkeleton } from './DocumentEditorSkeleton';
 
 export const DocumentsLayout = ({
   Documents,
@@ -25,7 +28,19 @@ export const DocumentsLayout = ({
       </div>
       <div className="min-w-0 flex-1 overflow-hidden">
         {documentId !== null ? (
-          <Editor key={documentId} />
+          documentId.trim() ? (
+            <ApprovalLockGuard
+              key={documentId}
+              contentType={DOCUMENT_APPROVAL_CONTENT_TYPE}
+              contentId={documentId.trim()}
+              action="view"
+              loadingFallback={<DocumentEditorSkeleton />}
+            >
+              <Editor key={documentId} />
+            </ApprovalLockGuard>
+          ) : (
+            <Editor key={documentId} />
+          )
         ) : (
           <Documents viewType="grid" />
         )}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsList.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsList.tsx
@@ -1,7 +1,10 @@
 import { IconArrowLeft } from '@tabler/icons-react';
 import { Sidebar, useQueryState, useRemoveQueryStateByKey } from 'erxes-ui';
 
-export const DocumentsList = ({ documents }: { documents: any }) => {
+import { ApprovalLockedBadge } from 'ui-modules';
+import { IDocument } from '../types';
+
+export const DocumentsList = ({ documents }: { documents: IDocument[] }) => {
   const [documentId, setDocumentId] = useQueryState('documentId');
 
   const removeQuery = useRemoveQueryStateByKey();
@@ -20,13 +23,14 @@ export const DocumentsList = ({ documents }: { documents: any }) => {
         </Sidebar.GroupLabel>
         <Sidebar.GroupContent>
           <Sidebar.Menu>
-            {documents.map(({ _id, name }: any) => (
+            {documents.map(({ _id, name, approvalLockState }) => (
               <Sidebar.MenuItem key={_id}>
                 <Sidebar.MenuButton
                   isActive={_id === documentId}
                   onClick={() => setDocumentId(_id)}
                 >
                   <span className="truncate">{name || 'Untitled'}</span>
+                  <ApprovalLockedBadge state={approvalLockState} />
                 </Sidebar.MenuButton>
               </Sidebar.MenuItem>
             ))}

--- a/frontend/core-ui/src/modules/documents/components/DocumentsList.tsx
+++ b/frontend/core-ui/src/modules/documents/components/DocumentsList.tsx
@@ -4,6 +4,7 @@ import { Sidebar, useQueryState, useRemoveQueryStateByKey } from 'erxes-ui';
 import { ApprovalLockedBadge } from 'ui-modules';
 import { IDocument } from '../types';
 
+/** Show document navigation with approval-lock visibility indicators. */
 export const DocumentsList = ({ documents }: { documents: IDocument[] }) => {
   const [documentId, setDocumentId] = useQueryState('documentId');
 

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsColumn.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsColumn.tsx
@@ -15,7 +15,12 @@ import {
   useSetQueryStateByKey,
 } from 'erxes-ui';
 import { ComponentProps } from 'react';
-import { Can, MembersInline, TagsSelect } from 'ui-modules';
+import {
+  ApprovalLockedBadge,
+  Can,
+  MembersInline,
+  TagsSelect,
+} from 'ui-modules';
 
 import { DOCUMENTS_TYPES_SET } from '../../constants';
 import { IDocument } from '../../types';
@@ -55,6 +60,7 @@ function DocumentNameCell({ document }: { document: IDocument }) {
     <RecordTableInlineCell onClick={handleClick}>
       <div className="flex items-center justify-between w-full gap-2">
         <span className="truncate">{document.name || 'Untitled'}</span>
+        <ApprovalLockedBadge state={document.approvalLockState} />
       </div>
     </RecordTableInlineCell>
   );
@@ -126,17 +132,20 @@ export function DocumentsColumn(): ColumnDef<IDocument>[] {
       id: 'tagIds',
       accessorKey: 'tagIds',
       header: () => <RecordTable.InlineHead label="Tags" icon={IconTags} />,
-      cell: ({ row }) => (
-        <Can action="tagsTag">
-          <TagsSelect.InlineCell
-            type="core:documents"
-            mode="multiple"
-            targetIds={[row.original._id]}
-            value={row.original.tagIds || []}
-            options={getDocumentsTagOptions([row.original._id])}
-          />
-        </Can>
-      ),
+      cell: ({ row }) =>
+        row.original.approvalLockState?.hasAccess === false ? (
+          <RecordTableInlineCell>Locked</RecordTableInlineCell>
+        ) : (
+          <Can action="tagsTag">
+            <TagsSelect.InlineCell
+              type="core:documents"
+              mode="multiple"
+              targetIds={[row.original._id]}
+              value={row.original.tagIds || []}
+              options={getDocumentsTagOptions([row.original._id])}
+            />
+          </Can>
+        ),
       size: 240,
     },
     {

--- a/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTableCommandBar.tsx
+++ b/frontend/core-ui/src/modules/documents/components/list/DocumentsRecordTableCommandBar.tsx
@@ -23,20 +23,24 @@ export function DocumentsRecordTableCommandBar(): ReactElement {
     <CommandBar open={selectedRows.length > 0}>
       <CommandBar.Bar>
         <CommandBar.Value>{selectedRows.length} selected</CommandBar.Value>
-        <Can action="tagsTag">
-          <>
-            <Separator.Inline />
-            <TagsSelect
-              type="core:documents"
-              mode="multiple"
-              targetIds={documentIds}
-              value={tagIds}
-              options={getDocumentsTagOptions(documentIds)}
-              variant="secondary"
-              className="shadow-none"
-            />
-          </>
-        </Can>
+        {selectedRows.every(
+          (row) => row.original.approvalLockState?.hasAccess !== false,
+        ) && (
+          <Can action="tagsTag">
+            <>
+              <Separator.Inline />
+              <TagsSelect
+                type="core:documents"
+                mode="multiple"
+                targetIds={documentIds}
+                value={tagIds}
+                options={getDocumentsTagOptions(documentIds)}
+                variant="secondary"
+                className="shadow-none"
+              />
+            </>
+          </Can>
+        )}
       </CommandBar.Bar>
     </CommandBar>
   );

--- a/frontend/core-ui/src/modules/documents/constants.ts
+++ b/frontend/core-ui/src/modules/documents/constants.ts
@@ -45,3 +45,5 @@ export const DOCUMENTS_TYPES_SET: Record<string, DocumentTypeConfig> = {
     color: 'bg-green-100 text-green-800 border-green-200',
   },
 };
+
+export const DOCUMENT_APPROVAL_CONTENT_TYPE = 'core:documents';

--- a/frontend/core-ui/src/modules/documents/graphql/queries.ts
+++ b/frontend/core-ui/src/modules/documents/graphql/queries.ts
@@ -54,6 +54,12 @@ export const GET_DOCUMENTS = gql(`
         name
         content
         replacer
+        approvalLockState {
+          contentType
+          contentId
+          locked
+          hasAccess
+        }
       }
       ${GQL_PAGE_INFO}
     }
@@ -72,6 +78,7 @@ export const GET_DOCUMENT_DETAIL = gql(`
       code
       createdAt
       createdUser {
+        _id
         details {
           avatar
           lastName

--- a/frontend/core-ui/src/modules/documents/hooks/useDocument.tsx
+++ b/frontend/core-ui/src/modules/documents/hooks/useDocument.tsx
@@ -17,6 +17,7 @@ export const useDocument = () => {
     GET_DOCUMENT_DETAIL,
     {
       notifyOnNetworkStatusChange: true,
+      fetchPolicy: 'network-only',
       variables: {
         _id: cleanDocumentId,
       },

--- a/frontend/core-ui/src/modules/documents/types.ts
+++ b/frontend/core-ui/src/modules/documents/types.ts
@@ -1,10 +1,11 @@
-import type { IUser } from 'ui-modules';
+import type { ApprovalLockState, IUser } from 'ui-modules';
 
 export type IDocument = {
   _id: string;
   contentType: string;
   name?: string;
-  content?: string;
+  content?: string | null;
+  approvalLockState?: ApprovalLockState;
   createdAt?: string;
   createdUser?: IUser;
   tagIds?: string[];


### PR DESCRIPTION
## Summary by Sourcery

Protect documents with approval locks across backend access paths and surface their access state and controls in the user interface.

New Features:
- Add approval-lock support for documents, including lock state reporting and lock or unlock controls in the document interface.

Bug Fixes:
- Prevent users without approval access from viewing, editing, deleting, tagging, or printing locked documents while keeping locked records discoverable without exposing their content.

Enhancements:
- Enforce document permissions and approval checks consistently across GraphQL, REST, and tRPC access paths.
- Restrict document filtering and sorting inputs to supported fields and validate document print requests.

Tests:
- Add coverage for document list access handling, including fallback approval-state checks and content redaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added approval-lock status indicators to document lists, grids, tables, and detail views.
  * Users can lock or unlock documents for editing from document actions and editors.
  * Document details now show lock ownership and access status.

* **Access Control**
  * Viewing, editing, deleting, processing, and tagging documents now respect approval-lock permissions.
  * Restricted documents hide content and unavailable editing or tagging actions.

* **Bug Fixes**
  * Improved document printing and processing validation, including clearer handling of invalid requests and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->